### PR TITLE
feat:第19节：Notify 模块 原理解析、实现与代码讲解

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/003-cli-entry"
+  "feature_directory": "specs/004-notify-outbound"
 }

--- a/docs/class/第19节：Notify 模块 原理解析、实现与代码讲解.md
+++ b/docs/class/第19节：Notify 模块 原理解析、实现与代码讲解.md
@@ -193,3 +193,86 @@ harness 全绿后，剩下的人工确认：
 - 渠道未配置报错、白名单先行、回归不破——已由 harness 两批覆盖，`mvn test` 绿即打勾。
 
 Notify 补上的是"Agent 说完话还能主动送出去"这个出口。有了它，25 节的定时模块和 31 节的天气、日报 Agent 才有地方把结果真正交出去，不然到点跑完一整套 ReAct 循环，结果却只能烂在 Session 里没人看到。
+
+---
+
+## 六、主流 Notify 渠道与对接说明
+
+核心阶段只有 `WebhookNotifyAdapter` 一档实现，但业务方最终关心的是"消息能不能进我们的群、能不能打到值班电话"。这一节盘点企业里主流会对接的通知渠道：哪些是纯 webhook、通用档就能覆盖；哪些 payload 格式有差异、需要适配；哪些根本不是 HTTP、只能留给扩展阶段的专用 Adapter。也顺便回答第五节那道"接口中立性自查"——这些渠道无论哪一档，`NotifyChannelAdapter.send(NotifyTarget, String)` 这个签名都不需要动。
+
+### 6.1 渠道总览
+
+按企业里的典型场景分四类：
+
+| 场景 | 主流渠道 | 接入形态 | 通用 webhook 档能否覆盖 |
+|------|---------|---------|------|
+| **团队协作群**（日报、周报、构建通知） | 企业微信群机器人、飞书/Lark 自定义机器人、钉钉自定义机器人、Slack、Discord、Microsoft Teams | HTTP webhook | ✅ 形态覆盖，payload 格式需适配（见 6.2） |
+| **个人即时提醒**（个人助理类 Agent） | Telegram Bot、Bark（iOS）、Server酱（微信）、ntfy / Gotify（自托管） | HTTP POST/GET | ✅ 基本覆盖 |
+| **告警值班**（生产事故、SLA 告警） | PagerDuty、Opsgenie、阿里云 ARMS / 云监控 | Events API（HTTP，带 routing key 和事件语义） | ⚠️ 能发出去，但 severity / 去重 / 升级策略等字段需专用适配 |
+| **正式触达**（对外通知、审批留痕） | 邮件（SMTP）、短信（阿里云/腾讯云 SMS） | 非 HTTP 或签名认证 API | ❌ 扩展阶段专用 Adapter |
+
+一个判断标准：**给一个 URL 发一次 POST 就能送达的，核心阶段就能接**；需要维护连接（SMTP）、需要 AccessToken 刷新（企业微信应用消息，注意区别于群机器人）、需要请求签名（云厂商短信 API）的，属于第二节说过的"认证细节"，留给扩展阶段。
+
+### 6.2 各家 webhook 的 payload 差异
+
+这是对接时最容易踩的坑：**"都是 webhook" 不等于 "都是同一个 JSON 格式"**。核心阶段的 `WebhookNotifyAdapter` 发的是 `{"content": "..."}`，各家约定如下：
+
+| 渠道 | Webhook URL 形态 | 文本消息 body | 与核心阶段格式 |
+|------|-----------------|--------------|----------------|
+| 企业微信 | `https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=<KEY>` | `{"msgtype":"text","text":{"content":"..."}}` | 需适配 |
+| 飞书 / Lark | `https://open.feishu.cn/open-apis/bot/v2/hook/<TOKEN>` | `{"msg_type":"text","content":{"text":"..."}}` | 需适配 |
+| 钉钉 | `https://oapi.dingtalk.com/robot/send?access_token=<TOKEN>` | `{"msgtype":"text","text":{"content":"..."}}` | 需适配 |
+| Slack | `https://hooks.slack.com/services/T../B../..` | `{"text":"..."}` | 需适配 |
+| Discord | `https://discord.com/api/webhooks/<ID>/<TOKEN>` | `{"content":"..."}` | ✅ 天然兼容 |
+| Telegram | `https://api.telegram.org/bot<TOKEN>/sendMessage` | `{"chat_id":"...","text":"..."}` | 需适配（多一个 chat_id） |
+| ntfy | `https://ntfy.sh/<topic>` | 纯文本 body | 需适配 |
+
+几个渠道特有的注意点：
+
+- **钉钉**必须在机器人上启用三种安全设置之一：自定义关键词（最简单——消息里必须包含设定的词，可以把关键词写进 Skill 的输出要求里）、加签（`timestamp` + HmacSHA256 签名拼进 URL）、IP 白名单。加签属于认证细节，核心阶段用"自定义关键词"最省事。
+- **飞书**的签名校验是可选的，不开启时拿到 URL 就能推，适合核心阶段验证。
+- **Microsoft Teams** 经典的 Incoming Webhook（Office 365 Connector）已宣布退役，新对接应走 Power Automate 的 Workflows webhook，同样是"URL + POST"形态。
+- **企业微信**要区分**群机器人**（webhook，本节这档）和**应用消息**（需要 corpid/corpsecret 换 AccessToken，属扩展阶段专用 Adapter 的活）。
+
+### 6.3 对接一个新渠道的标准步骤
+
+以"把日报推到飞书群"为例，对接动作只有配置、没有代码：
+
+1. **渠道侧建机器人拿 URL**：飞书群 → 设置 → 群机器人 → 添加"自定义机器人"，复制 webhook 地址。
+2. **URL 进环境变量**：webhook URL 里的 token 就是凭证本身——泄漏 URL 等于任何人都能往群里发消息。按配置加载规则走 `${ENV}` 占位，不明文写进 Profile、不进日志、不进 git。
+3. **Profile 声明渠道**：
+
+   ```yaml
+   notify_channels:
+     - type: webhook
+       url: ${FEISHU_WEBHOOK_URL}
+   ```
+
+4. **域名进 Sandbox 白名单**：`http.allowed_domains` 加上 `open.feishu.cn`（企业微信是 `qyapi.weixin.qq.com`，钉钉是 `oapi.dingtalk.com`，Slack 是 `hooks.slack.com`）。这一步漏了，`sandbox.enforce` 会先于 `send` 把请求拦下来——这正是第四节那条顺序断言守住的行为。
+5. **对话里发一条测试消息验证**（第五节的"真 webhook 验配置"）。
+
+### 6.4 payload 格式对不上怎么办：扩展阶段的两条路
+
+6.2 的表说明了大多数主流渠道的 body 格式跟核心阶段的 `{"content": ...}` 不一致。扩展阶段补齐的方式有两条，都不改接口、不改调用方：
+
+**路一：按 `channelType` 新增专用 Adapter（推荐）。** `NotifyTarget` 里本来就带 `channelType`，扩展阶段为每个渠道挂一个实现类，把 `content` 包成该渠道约定的 JSON，认证细节（钉钉加签、飞书签名、企业微信 AccessToken）也收在各自 Adapter 内部：
+
+```java
+@Component
+public class FeishuNotifyAdapter implements NotifyChannelAdapter {
+    @Override
+    public void send(NotifyTarget target, String content) {
+        // 包成飞书约定格式，接口签名一个字都不用改
+        Map<String, Object> body = Map.of(
+                "msg_type", "text",
+                "content", Map.of("text", content));
+        // ... POST 到 target.config().get("url")
+    }
+}
+```
+
+Profile 侧只是把 `type: webhook` 换成 `type: feishu`——运营方换渠道依然是改一行配置，这就是第二节"接口表达意图，不表达实现"在扩展阶段兑现的样子。
+
+**路二：复杂格式走 MCP（Plugin Tool 方式二）。** 如果业务方要的不是纯文本，而是飞书富文本卡片、企业微信图文消息这类结构化内容，别把这些渠道特有的复杂度塞进 `notify`——按 `TechnicalSolution.md` §6.8 划的边界，配一个该渠道的官方/社区 MCP server 走方式二。`notify` 只统一"最常见的纯文本推送"这件事，两条路并存。
+
+选择原则跟 Plugin Tool 三档一致：纯文本进群，用 `notify` + webhook 档就够；要专用格式或专用认证，扩展阶段加 Adapter；要富文本卡片这种深度渠道能力，走 MCP。

--- a/oryxos-tool/pom.xml
+++ b/oryxos-tool/pom.xml
@@ -19,6 +19,16 @@
             <groupId>io.oryxos</groupId>
             <artifactId>oryxos-core</artifactId>
         </dependency>
+        <!-- RestClient（WebhookNotifyAdapter 出站 POST）——版本由 Boot BOM 管理 -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
@@ -1,0 +1,100 @@
+package io.oryxos.tool.builtin;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.OryxTool;
+import io.oryxos.core.ToolResult;
+import io.oryxos.core.agent.ProfileContext;
+import io.oryxos.core.profile.Profile;
+import io.oryxos.tool.notify.NotifyChannelAdapter;
+import io.oryxos.tool.notify.NotifyTarget;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 内置工具 notify：把一条消息推送到当前 Agent 配置好的通知渠道。
+ *
+ * <p>OryxTool 形态（research D3）：@Tool 注册机制归 20 节，本形态可直接被 17 节 ToolExecutor 执行与审计（tool_invocations
+ * 走既有路径，不新增审计逻辑）。渠道来源是当前 Profile 的 notify_channels——webhook 地址是运行时配置，不是模型需要知道的信息（FR-005）。
+ */
+public class NotifyTools implements OryxTool {
+
+  /** channel 参数的"用默认渠道"字面量（课件示例用词）。 */
+  private static final String DEFAULT_CHANNEL = "default";
+
+  /** channelType → 实现（webhook/wecom/feishu/dingtalk…）；多档并存按 type 路由（课件 6.4 路一）。 */
+  private final Map<String, NotifyChannelAdapter> adapters;
+
+  public NotifyTools(Map<String, NotifyChannelAdapter> adapters) {
+    this.adapters = Map.copyOf(adapters);
+  }
+
+  @Override
+  public String getName() {
+    return "notify";
+  }
+
+  @Override
+  public String getDescription() {
+    return "把一条消息推送到当前 Agent 配置好的通知渠道";
+  }
+
+  @Override
+  public String getInputSchema() {
+    return """
+        {
+          "type": "object",
+          "properties": {
+            "content": {"type": "string", "description": "要推送的内容"},
+            "channel": {"type": "string", "description": "渠道类型；缺省用第一个配置的渠道"}
+          },
+          "required": ["content"]
+        }""";
+  }
+
+  @Override
+  public ToolResult execute(JsonNode input) {
+    JsonNode contentNode = input.get("content");
+    if (contentNode == null || contentNode.asText().isEmpty()) {
+      return ToolResult.error("notify 缺少必填参数 content", false);
+    }
+    String channel = input.hasNonNull("channel") ? input.get("channel").asText() : null;
+
+    Profile profile = ProfileContext.current();
+    if (profile == null) {
+      return ToolResult.error("当前无 Agent 上下文，无法解析通知渠道", false);
+    }
+    List<Profile.NotifyChannel> channels = profile.notifyChannels();
+    if (channels.isEmpty()) {
+      // 明确报错而非静默失败——Agent 不能以为发出去了（课件守点）
+      return ToolResult.error("Profile " + profile.name() + " 未配置 notify_channels，无处可推", false);
+    }
+    Profile.NotifyChannel resolved = resolveChannel(channels, channel);
+    if (resolved == null) {
+      return ToolResult.error("notify_channels 中不存在类型为 " + channel + " 的渠道（不回退默认，避免消息发错地方）", false);
+    }
+    NotifyChannelAdapter adapter = adapters.get(resolved.type());
+    if (adapter == null) {
+      return ToolResult.error(
+          "渠道类型 " + resolved.type() + " 没有对应的通知实现（已装配: " + adapters.keySet() + "）", false);
+    }
+    NotifyTarget target = new NotifyTarget(resolved.type(), resolved.config());
+    // 沙箱检查位：24 节 Sandbox.enforce(HTTP_REQUEST, target.config().get("url")) 在此接线，
+    // 与 http_post 共享同一份 http.allowed_domains 白名单——校验必须先于发送（宪法 VI）
+    adapter.send(target, contentNode.asText());
+    return ToolResult.ok("已推送");
+  }
+
+  /** channel 空白或 "default" → 第一个渠道；否则按 NotifyChannel.type 匹配（clarify 1）。 */
+  private static Profile.NotifyChannel resolveChannel(
+      List<Profile.NotifyChannel> channels, String channel) {
+    if (channel == null || channel.isBlank() || DEFAULT_CHANNEL.equals(channel)) {
+      return channels.get(0);
+    }
+    for (Profile.NotifyChannel candidate : channels) {
+      if (channel.equals(candidate.type())) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/DingTalkNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/DingTalkNotifyAdapter.java
@@ -1,0 +1,66 @@
+package io.oryxos.tool.notify;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.util.Base64;
+import java.util.Map;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+/**
+ * 钉钉自定义机器人（type: dingtalk）。
+ *
+ * <p>body 格式：{@code {"msgtype":"text","text":{"content":"..."}}}。钉钉机器人必须启用一种安全设置：
+ * "自定义关键词"最省事（把关键词写进 Skill 输出要求即可，本实现零处理）；若群里开的是"加签"， 在 config 里配 {@code secret}（走 ${ENV}
+ * 占位），发送时按官方算法拼 timestamp+sign 到 URL。
+ */
+public class DingTalkNotifyAdapter implements NotifyChannelAdapter {
+
+  private final RestClient restClient;
+
+  public DingTalkNotifyAdapter(RestClient restClient) {
+    this.restClient = restClient.mutate().build();
+  }
+
+  @Override
+  public void send(NotifyTarget target, String content) {
+    String url = target.config().get("url");
+    if (url == null || url.isBlank()) {
+      throw new IllegalArgumentException("dingtalk 渠道缺少 url 配置（notify_channels 条目需要 url 键）");
+    }
+    String secret = target.config().get("secret");
+    if (secret != null && !secret.isBlank()) {
+      url = appendSignature(url, secret);
+    }
+    restClient
+        .post()
+        .uri(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(Map.of("msgtype", "text", "text", Map.of("content", content)))
+        .retrieve()
+        .toBodilessEntity();
+  }
+
+  /** 钉钉"加签"安全设置：sign = urlEncode(base64(HmacSHA256(timestamp + "\n" + secret, secret)))。 */
+  private static String appendSignature(String url, String secret) {
+    long timestamp = System.currentTimeMillis();
+    String stringToSign = timestamp + "\n" + secret;
+    try {
+      Mac mac = Mac.getInstance("HmacSHA256");
+      mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+      String sign =
+          URLEncoder.encode(
+              Base64.getEncoder()
+                  .encodeToString(mac.doFinal(stringToSign.getBytes(StandardCharsets.UTF_8))),
+              StandardCharsets.UTF_8);
+      String separator = url.contains("?") ? "&" : "?";
+      return url + separator + "timestamp=" + timestamp + "&sign=" + sign;
+    } catch (GeneralSecurityException e) {
+      // HmacSHA256 是 JDK 必备算法，走到这里说明运行环境异常——显式失败胜过发一条必被拒的请求
+      throw new IllegalStateException("钉钉加签计算失败", e);
+    }
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/FeishuNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/FeishuNotifyAdapter.java
@@ -1,0 +1,35 @@
+package io.oryxos.tool.notify;
+
+import java.util.Map;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+/**
+ * 飞书 / Lark 自定义机器人（type: feishu）。
+ *
+ * <p>二者协议相同、仅域名不同（open.feishu.cn / open.larksuite.com），URL 来自配置故一个实现覆盖两者。 body 格式：{@code
+ * {"msg_type":"text","content":{"text":"..."}}}；签名校验为可选项，未开启时拿 URL 即可推。
+ */
+public class FeishuNotifyAdapter implements NotifyChannelAdapter {
+
+  private final RestClient restClient;
+
+  public FeishuNotifyAdapter(RestClient restClient) {
+    this.restClient = restClient.mutate().build();
+  }
+
+  @Override
+  public void send(NotifyTarget target, String content) {
+    String url = target.config().get("url");
+    if (url == null || url.isBlank()) {
+      throw new IllegalArgumentException("feishu 渠道缺少 url 配置（notify_channels 条目需要 url 键）");
+    }
+    restClient
+        .post()
+        .uri(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(Map.of("msg_type", "text", "content", Map.of("text", content)))
+        .retrieve()
+        .toBodilessEntity();
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyChannelAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyChannelAdapter.java
@@ -1,0 +1,12 @@
+package io.oryxos.tool.notify;
+
+/**
+ * 出站通知抽象：把一条内容送到某个通知目标（入站有 Channel，这是对称的另一半）。
+ *
+ * <p>接口先行（TechSol §6.8）：签名不携带任何一档实现特有的词——核心阶段只挂通用 webhook，
+ * 以后加企业微信/飞书专用渠道只新增实现类，不改接口、不改调用方。失败以异常表达，不许静默吞掉。
+ */
+public interface NotifyChannelAdapter {
+
+  void send(NotifyTarget target, String content);
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyTarget.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyTarget.java
@@ -1,0 +1,14 @@
+package io.oryxos.tool.notify;
+
+import java.util.Map;
+
+/**
+ * 通知目标：渠道类型 + 一份配置。具体是 webhook 地址还是别的认证信息，由实现类自己解释—— 对上层是黑盒。来源是 Profile 的 notify_channels 条目（type +
+ * config），字段一一对应。
+ */
+public record NotifyTarget(String channelType, Map<String, String> config) {
+
+  public NotifyTarget {
+    config = config == null ? Map.of() : Map.copyOf(config);
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/WeComNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/WeComNotifyAdapter.java
@@ -1,0 +1,35 @@
+package io.oryxos.tool.notify;
+
+import java.util.Map;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+/**
+ * 企业微信群机器人（type: wecom）。
+ *
+ * <p>webhook 形态与通用档相同，仅 body 格式不同：{@code {"msgtype":"text","text":{"content":"..."}}}。
+ * 注意这是"群机器人"档——"应用消息"（corpid/corpsecret 换 AccessToken）属扩展阶段，不在此。
+ */
+public class WeComNotifyAdapter implements NotifyChannelAdapter {
+
+  private final RestClient restClient;
+
+  public WeComNotifyAdapter(RestClient restClient) {
+    this.restClient = restClient.mutate().build();
+  }
+
+  @Override
+  public void send(NotifyTarget target, String content) {
+    String url = target.config().get("url");
+    if (url == null || url.isBlank()) {
+      throw new IllegalArgumentException("wecom 渠道缺少 url 配置（notify_channels 条目需要 url 键）");
+    }
+    restClient
+        .post()
+        .uri(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(Map.of("msgtype", "text", "text", Map.of("content", content)))
+        .retrieve()
+        .toBodilessEntity();
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/WebhookNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/WebhookNotifyAdapter.java
@@ -1,0 +1,35 @@
+package io.oryxos.tool.notify;
+
+import java.util.Map;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+/**
+ * 核心阶段唯一实现：通用 webhook——企业微信/飞书/钉钉的群机器人都收 webhook， 一档覆盖大部分场景，不逐家接签名算法与 AccessToken 刷新（留扩展阶段）。
+ *
+ * <p>失败口径（research D2）：对端非 2xx 走 RestClient 默认异常上抛、连接失败同样上抛—— "发出去没送到"与"没发出去"对 Agent 是同一件事，绝不静默吞掉。
+ */
+public class WebhookNotifyAdapter implements NotifyChannelAdapter {
+
+  private final RestClient restClient;
+
+  public WebhookNotifyAdapter(RestClient restClient) {
+    // 防御性副本：不持有调用方可继续改动的实例（SpotBugs EI_EXPOSE_REP2）
+    this.restClient = restClient.mutate().build();
+  }
+
+  @Override
+  public void send(NotifyTarget target, String content) {
+    String url = target.config().get("url");
+    if (url == null || url.isBlank()) {
+      throw new IllegalArgumentException("webhook 渠道缺少 url 配置（notify_channels 条目需要 url 键）");
+    }
+    restClient
+        .post()
+        .uri(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(Map.of("content", content))
+        .retrieve()
+        .toBodilessEntity();
+  }
+}

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/NotifyToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/NotifyToolsTest.java
@@ -1,0 +1,180 @@
+package io.oryxos.tool.builtin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.core.ToolResult;
+import io.oryxos.core.agent.ProfileContext;
+import io.oryxos.core.profile.Profile;
+import io.oryxos.tool.notify.NotifyChannelAdapter;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 课件《第19节》验收 harness：NotifyToolsTest——第一批可测集。
+ *
+ * <p>InOrder 白名单顺序回归（课件"发送前必须先过白名单校验"：enforce 先于 send）待 24 节 Sandbox 就位后补入本类——课件"实现顺序说明"明文分批。
+ */
+class NotifyToolsTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private NotifyChannelAdapter adapter;
+  private NotifyTools notifyTools;
+
+  @BeforeEach
+  void setUp() {
+    adapter = mock(NotifyChannelAdapter.class);
+    // 同一 mock 挂两个 type：路由正确性由 send 收到的 NotifyTarget.channelType 断言
+    notifyTools = new NotifyTools(Map.of("webhook", adapter, "feishu", adapter));
+  }
+
+  @AfterEach
+  void clearContext() {
+    ProfileContext.clear(); // ThreadLocal 必清——17 节同款纪律
+  }
+
+  private static Profile profileWith(List<Profile.NotifyChannel> channels) {
+    return new Profile(
+        "ops-agent",
+        null,
+        null,
+        new Profile.ProviderRef("deepseek", "deepseek-chat", null),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        channels,
+        List.of(),
+        List.of(),
+        Profile.Settings.defaults());
+  }
+
+  private static Profile twoChannelProfile() {
+    return profileWith(
+        List.of(
+            new Profile.NotifyChannel("webhook", Map.of("url", "https://hooks.example.com/a")),
+            new Profile.NotifyChannel("feishu", Map.of("url", "https://open.feishu.cn/b"))));
+  }
+
+  private ToolResult notify(String content, String channel) {
+    var input = MAPPER.createObjectNode();
+    if (content != null) {
+      input.put("content", content);
+    }
+    if (channel != null) {
+      input.put("channel", channel);
+    }
+    return notifyTools.execute(input);
+  }
+
+  @Test
+  @DisplayName("notify_channels未配置_明确报错不静默失败")
+  void unconfiguredChannelsFailsExplicitly() {
+    ProfileContext.set(profileWith(List.of()));
+
+    ToolResult result = notify("hello", null);
+
+    assertFalse(result.success(), "不是静默失败——Agent 不会以为发出去了");
+    assertTrue(result.errorMessage().contains("notify_channels"), "报错点名未配置项");
+    verify(adapter, never()).send(any(), any());
+  }
+
+  @Test
+  @DisplayName("channel参数缺省_取第一个渠道")
+  void defaultChannelPicksFirstConfigured() {
+    ProfileContext.set(twoChannelProfile());
+
+    ToolResult result = notify("hello", null);
+
+    assertTrue(result.success());
+    assertEquals("已推送", result.content());
+    verify(adapter).send(argThat(t -> "webhook".equals(t.channelType())), eq("hello")); // 第一个渠道
+  }
+
+  @Test
+  @DisplayName("channel 传 \"default\" 等同缺省")
+  void defaultLiteralBehavesLikeOmitted() {
+    ProfileContext.set(twoChannelProfile());
+
+    notify("hello", "default");
+
+    verify(adapter).send(argThat(t -> "webhook".equals(t.channelType())), eq("hello"));
+  }
+
+  @Test
+  @DisplayName("channel 指定类型_命中对应渠道")
+  void explicitChannelTypeMatches() {
+    ProfileContext.set(twoChannelProfile());
+
+    notify("hello", "feishu");
+
+    verify(adapter)
+        .send(
+            argThat(
+                t ->
+                    "feishu".equals(t.channelType())
+                        && "https://open.feishu.cn/b".equals(t.config().get("url"))),
+            eq("hello"));
+  }
+
+  @Test
+  @DisplayName("指定类型不存在_报错点名不回退")
+  void unknownChannelTypeFailsWithoutFallback() {
+    ProfileContext.set(twoChannelProfile());
+
+    ToolResult result = notify("hello", "dingtalk");
+
+    assertFalse(result.success());
+    assertTrue(result.errorMessage().contains("dingtalk"), "点名未命中的类型");
+    verify(adapter, never()).send(any(), any()); // 不回退默认渠道——回退会把消息发错地方
+  }
+
+  @Test
+  @DisplayName("当前无 Agent 上下文_报错不发送")
+  void missingProfileContextFails() {
+    ToolResult result = notify("hello", null);
+
+    assertFalse(result.success());
+    verify(adapter, never()).send(any(), any());
+  }
+
+  @Test
+  @DisplayName("渠道类型没有对应实现_报错点名已装配清单")
+  void channelTypeWithoutAdapterFails() {
+    ProfileContext.set(
+        profileWith(
+            List.of(
+                new Profile.NotifyChannel("dingtalk", Map.of("url", "https://oapi.example.com")))));
+
+    ToolResult result = notify("hello", null);
+
+    assertFalse(result.success());
+    assertTrue(result.errorMessage().contains("dingtalk"), "点名缺实现的类型");
+    verify(adapter, never()).send(any(), any());
+  }
+
+  @Test
+  @DisplayName("content 缺失_报错不发送")
+  void missingContentFails() {
+    ProfileContext.set(twoChannelProfile());
+
+    ToolResult result = notify(null, null);
+
+    assertFalse(result.success());
+    assertTrue(result.errorMessage().contains("content"));
+    verify(adapter, never()).send(any(), any());
+  }
+}

--- a/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
@@ -1,0 +1,136 @@
+package io.oryxos.tool.notify;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+/**
+ * 三家专用渠道 Adapter（课件 6.4 路一的扩展实现）：断言各家约定的 body 格式与钉钉加签 URL。
+ *
+ * <p>格式兼容性的最终确认归人工冒烟（真实群机器人）——本测试钉死的是"我们发的就是各家文档约定的形态"。
+ */
+class VendorNotifyAdapterTest {
+
+  private record ReceivedRequest(String query, String body) {}
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private HttpServer server;
+  private final List<ReceivedRequest> received = new ArrayList<>();
+  private volatile int responseStatus = 200;
+
+  @BeforeEach
+  void startFakeWebhook() throws IOException {
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.createContext(
+        "/",
+        exchange -> {
+          record(exchange);
+        });
+    server.start();
+  }
+
+  @AfterEach
+  void stopFakeWebhook() {
+    server.stop(0);
+  }
+
+  private void record(HttpExchange exchange) throws IOException {
+    String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+    received.add(new ReceivedRequest(exchange.getRequestURI().getQuery(), body));
+    exchange.sendResponseHeaders(responseStatus, -1);
+    exchange.close();
+  }
+
+  private String url() {
+    return "http://127.0.0.1:" + server.getAddress().getPort() + "/hook";
+  }
+
+  private JsonNode lastBody() throws IOException {
+    return MAPPER.readTree(received.get(received.size() - 1).body());
+  }
+
+  @Test
+  @DisplayName("企业微信：msgtype/text.content 格式")
+  void wecomBodyMatchesVendorContract() throws IOException {
+    new WeComNotifyAdapter(RestClient.create())
+        .send(new NotifyTarget("wecom", Map.of("url", url())), "日报来了");
+
+    JsonNode body = lastBody();
+    assertEquals("text", body.get("msgtype").asText());
+    assertEquals("日报来了", body.get("text").get("content").asText());
+  }
+
+  @Test
+  @DisplayName("飞书/Lark：msg_type/content.text 格式")
+  void feishuBodyMatchesVendorContract() throws IOException {
+    new FeishuNotifyAdapter(RestClient.create())
+        .send(new NotifyTarget("feishu", Map.of("url", url())), "日报来了");
+
+    JsonNode body = lastBody();
+    assertEquals("text", body.get("msg_type").asText());
+    assertEquals("日报来了", body.get("content").get("text").asText());
+  }
+
+  @Test
+  @DisplayName("钉钉：msgtype/text.content 格式（关键词模式，无签名参数）")
+  void dingTalkBodyMatchesVendorContract() throws IOException {
+    new DingTalkNotifyAdapter(RestClient.create())
+        .send(new NotifyTarget("dingtalk", Map.of("url", url())), "OryxOS日报来了");
+
+    JsonNode body = lastBody();
+    assertEquals("text", body.get("msgtype").asText());
+    assertEquals("OryxOS日报来了", body.get("text").get("content").asText());
+    assertEquals(null, received.get(0).query(), "关键词模式不拼签名参数");
+  }
+
+  @Test
+  @DisplayName("钉钉加签：config 含 secret 时 URL 拼 timestamp+sign")
+  void dingTalkSignedUrlCarriesTimestampAndSign() {
+    new DingTalkNotifyAdapter(RestClient.create())
+        .send(new NotifyTarget("dingtalk", Map.of("url", url(), "secret", "test-secret")), "hi");
+
+    String query = received.get(0).query();
+    assertTrue(query.contains("timestamp="), "加签模式必须带 timestamp");
+    assertTrue(query.contains("sign="), "加签模式必须带 sign");
+  }
+
+  @Test
+  @DisplayName("三家同口径：对端 5xx 异常上抛不吞")
+  void vendorAdaptersPropagateServerError() {
+    responseStatus = 500;
+    NotifyTarget target = new NotifyTarget("wecom", Map.of("url", url()));
+
+    assertThrows(
+        RestClientResponseException.class,
+        () -> new WeComNotifyAdapter(RestClient.create()).send(target, "hi"));
+  }
+
+  @Test
+  @DisplayName("三家同口径：缺 url 报错点名零请求")
+  void vendorAdaptersFailFastOnMissingUrl() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new FeishuNotifyAdapter(RestClient.create())
+                .send(new NotifyTarget("feishu", Map.of()), "hi"));
+    assertEquals(0, received.size());
+  }
+}

--- a/oryxos-tool/src/test/java/io/oryxos/tool/notify/WebhookNotifyAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/notify/WebhookNotifyAdapterTest.java
@@ -1,0 +1,111 @@
+package io.oryxos.tool.notify;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+/**
+ * 课件《第19节》验收 harness 第一批：WebhookNotifyAdapterTest。
+ *
+ * <p>假 webhook 用 JDK 内置 HttpServer（本地端口、真 HTTP，仍是单测层）——research D5。
+ */
+class WebhookNotifyAdapterTest {
+
+  /** 一次收到的请求：方法 + 路径 + body。 */
+  private record ReceivedRequest(String method, String path, String body) {}
+
+  private HttpServer server;
+  private final List<ReceivedRequest> received = new ArrayList<>();
+  private volatile int responseStatus = 200;
+
+  private WebhookNotifyAdapter adapter;
+
+  @BeforeEach
+  void startFakeWebhook() throws IOException {
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.createContext("/", this::record);
+    server.start();
+    adapter = new WebhookNotifyAdapter(RestClient.create());
+  }
+
+  @AfterEach
+  void stopFakeWebhook() {
+    server.stop(0);
+  }
+
+  private void record(HttpExchange exchange) throws IOException {
+    String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+    received.add(
+        new ReceivedRequest(exchange.getRequestMethod(), exchange.getRequestURI().getPath(), body));
+    exchange.sendResponseHeaders(responseStatus, -1);
+    exchange.close();
+  }
+
+  private String urlOf(String path) {
+    return "http://127.0.0.1:" + server.getAddress().getPort() + path;
+  }
+
+  private static NotifyTarget webhookTarget(String url) {
+    return new NotifyTarget("webhook", Map.of("url", url));
+  }
+
+  @Test
+  @DisplayName("发送后收到一次 POST，body 里带 content")
+  void sendPostsJsonBodyContainingContent() {
+    adapter.send(webhookTarget(urlOf("/team-hook")), "今天 28°C，建议短袖");
+
+    assertEquals(1, received.size(), "恰好一次请求");
+    ReceivedRequest request = received.get(0);
+    assertEquals("POST", request.method());
+    assertTrue(request.body().contains("今天 28°C，建议短袖"), "body 携带推送内容");
+    assertTrue(request.body().contains("content"), "按约定包成 {\"content\": ...}");
+  }
+
+  @Test
+  @DisplayName("换通知目标只改配置零代码")
+  void urlComesFromTargetConfigNotHardcoded() {
+    adapter.send(webhookTarget(urlOf("/group-a")), "hello");
+    adapter.send(webhookTarget(urlOf("/group-b")), "hello");
+
+    assertEquals("/group-a", received.get(0).path());
+    assertEquals("/group-b", received.get(1).path()); // 同一实现、不同配置 → 不同目标
+  }
+
+  @Test
+  @DisplayName("webhook返回5xx_异常向上抛不静默吞掉")
+  void serverErrorPropagatesAsException() {
+    responseStatus = 500;
+
+    assertThrows(
+        RestClientResponseException.class,
+        () -> adapter.send(webhookTarget(urlOf("/broken")), "hello"),
+        "发送失败必须显式抛出——Agent 不能以为发出去了");
+  }
+
+  @Test
+  @DisplayName("config 缺 url：报错点名且不发出任何请求")
+  void missingUrlFailsFastWithoutRequest() {
+    NotifyTarget noUrl = new NotifyTarget("webhook", Map.of());
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adapter.send(noUrl, "hello"));
+
+    assertTrue(ex.getMessage().contains("url"), "报错点名缺失的配置键");
+    assertEquals(0, received.size(), "零请求发出");
+  }
+}

--- a/specs/004-notify-outbound/acceptance-report.md
+++ b/specs/004-notify-outbound/acceptance-report.md
@@ -1,0 +1,60 @@
+# 第19节验收报告：Notify——结果主动送出去的统一出口
+
+**日期**: 2026-07-11 | **分支**: `class-19` | **任务**: 12/12 完成（tasks.md 全勾）
+
+## 六项证据 DoD
+
+### 1. `mvn clean verify` 全绿 ✅
+
+含 Spotless / P3C(PMD) / Checkstyle / SpotBugs / FindSecBugs 全部门禁。`BUILD SUCCESS`，测试 74 个全过：
+
+```text
+oryxos-core     34 | oryxos-provider 14 | oryxos-storage 15
+oryxos-tool     11（WebhookNotifyAdapterTest 4 + NotifyToolsTest 7）——本模块首批实码
+```
+
+过程中被门禁拦下并修复：Spotless 格式 ×1、SpotBugs EI_EXPOSE_REP2 ×1（RestClient 改 `mutate().build()` 防御性副本）——安全规则未做任何排除。
+
+### 2. harness 测试类逐一对号 ✅（课件分批口径）
+
+**第一批（本节判卷）**：`WebhookNotifyAdapterTest`——POST body 带 content、`@DisplayName("换通知目标只改配置零代码")`（URL 来自 config 非硬编码）、`@DisplayName("webhook返回5xx_异常向上抛不静默吞掉")`、config 缺 url 零请求；`NotifyToolsTest` 可测集 7 个——`@DisplayName("notify_channels未配置_明确报错不静默失败")`、`@DisplayName("channel参数缺省_取第一个渠道")`、"default" 字面量、指定类型命中/未命中不回退、上下文缺失、content 缺失。
+
+**留待后续节（文件头注释已注明）**：InOrder `发送前必须先过白名单校验`（enforce 先于 send）→ 24 节 Sandbox 就位后补入 NotifyToolsTest；notify 经 ToolRegistry 的端到端审计链 → 20 节。
+
+### 3. 交付物存在性核对 ✅
+
+- 代码：`NotifyChannelAdapter`（`send(NotifyTarget, String)` 签名逐字保真）/ `NotifyTarget` / `WebhookNotifyAdapter` / `NotifyTools`（OryxTool 形态，停点确认项）→ oryxos-tool（notify 包 + builtin 包，课件包名字面量）
+- 配置：Profile `notify_channels` 字段——16 节已提前交付，本节零配置改动
+- 接口中立性 grep：主代码 wecom/feishu/dingtalk 等渠道特有词**零命中**
+- 停点确认过的项：OryxTool 形态适配、JDK HttpServer 替代 MockWebServer、resolveNotifyChannel 归 NotifyTools 私有、不改 OryxOsRuntime
+
+### 4. 前序节回归 ✅
+
+16/17/18 节 63 个测试断言零改动全绿（上表即证据）；本节未触碰任何前序模块主代码（仅 oryxos-tool pom + 新文件）。
+
+### 5. H4 六条全局不变量自查 ✅
+
+| # | 不变量 | 结论 |
+|---|---|---|
+| ① | 涉外 IO 过 Sandbox | 检查位注释在 NotifyTools:74（24 节接线，与 http_post 共享白名单）；notify 未装配进运行时，Sandbox 就位前不放开涉外工具 |
+| ② | 审计成败都落库 | notify 走 ToolExecutor 既有 tool_invocations 路径（OryxTool 形态即为此设计），零新增审计逻辑 |
+| ③ | 无明文 key | grep 零命中；测试 url 为 example.com 假地址 |
+| ④ | session_id 只在 SessionManager 拼 | 本节不触碰 |
+| ⑤ | 无异步编程模型 | RestClient 同步调用；grep 零命中 |
+| ⑥ | 无 Spring AI 自动执行 | 本节零 Spring AI 依赖（@Tool 归 20 节） |
+
+### 6. 剩余人工项（harness 判不了，等你过）
+
+1. **真实 webhook 验配置**：20 节接线后，给某 Profile 配真实群机器人地址（`url: ${TEAM_WEBHOOK_URL}`），chat 里说"把'测试消息'推送一下"，群里收到（假 webhook 测的是协议，真 webhook 验的是配置）；
+2. **接口中立性思维自查**：换企业微信官方 SDK 实现，`NotifyChannelAdapter.send(NotifyTarget, String)` 签名需要改吗？——应为不需要（grep 已证语汇中立，语义判断留人工）。
+
+## 追加：三家专用渠道 Adapter（用户拍板的扩展，超出课件核心阶段边界）
+
+按课件 6.4 路一新增：`WeComNotifyAdapter`（type: wecom）、`FeishuNotifyAdapter`（type: feishu，同时覆盖 Lark——协议相同仅域名不同）、`DingTalkNotifyAdapter`（type: dingtalk，含可选加签：config 配 secret 即按官方 HmacSHA256 算法拼 timestamp+sign）。配套改造：`NotifyTools` 构造从单 Adapter 改为 `Map<String, NotifyChannelAdapter>` 按 channelType 路由（type 无对应实现 → 报错点名已装配清单）。新增 `VendorNotifyAdapterTest` 6 个（三家 body 格式对约定断言、钉钉加签 URL、5xx 上抛、缺 url 零请求）+ NotifyToolsTest 路由用例。**全仓 81 测试绿**（tool 模块 18）。接口签名零改动——中立性自查就地兑现。
+
+⚠️ 各家 body 格式按官方公开约定实现，测试钉死的是"我们发的形态"；**真实兼容性归人工冒烟**（拿真实群机器人 URL 各发一条）。
+
+## 备注
+
+- 分批边界照课件"实现顺序说明"：本节交付抽象 + webhook 实现 + 工具骨架与第一批 harness；20 节 ToolRegistry 收编、24 节 Sandbox 接线 + InOrder 回归、27/28 节串联全量验证。
+- 未 commit/push——同步时机由你决定。

--- a/specs/004-notify-outbound/checklists/requirements.md
+++ b/specs/004-notify-outbound/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Notify——结果主动送出去的统一出口
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- NotifyChannelAdapter/NotifyTarget/NotifyTools、notify_channels、tool_invocations 是课件/技术方案已定字面量，按门禁保真出现，不视为实现细节泄漏。
+- 分批交付（骨架本节、@Tool 归 20 节、白名单实现归 23/24 节）来自课件"实现顺序说明"明文，属范围声明而非含糊。
+- 无待澄清项：渠道缺省规则、失败口径、边界清单均有课件与 TechSol §6.8 明文出处。

--- a/specs/004-notify-outbound/contracts/notify.md
+++ b/specs/004-notify-outbound/contracts/notify.md
@@ -1,0 +1,47 @@
+# Contracts: Notify 出站通知
+
+**Date**: 2026-07-11 | 消费方：20 节 ToolRegistry（收编 notify 工具）+ 24 节 Sandbox（检查位接线）+ 25 节定时 / 31 节 Demo（实际使用）
+
+## 1. NotifyChannelAdapter（io.oryxos.tool.notify）——课件字面量签名
+
+```java
+public interface NotifyChannelAdapter {
+    void send(NotifyTarget target, String content);   // 失败以异常表达
+}
+
+public record NotifyTarget(String channelType, Map<String, String> config) {}
+```
+
+中立性契约：接口与 record 的语汇不含任何一档实现特有的词；新增渠道档位只加实现类，签名与调用方不变（SC-005 自查项）。
+
+## 2. WebhookNotifyAdapter（核心阶段唯一实现）
+
+```java
+public class WebhookNotifyAdapter implements NotifyChannelAdapter {
+    public WebhookNotifyAdapter(RestClient restClient);
+    // POST config["url"]，body {"content": content}，Content-Type: application/json
+    // url 缺失 → IllegalArgumentException 点名；非 2xx/连接失败 → RestClient 异常上抛（不吞）
+}
+```
+
+## 3. NotifyTools（io.oryxos.tool.builtin，OryxTool 形态——research D3）
+
+```java
+public class NotifyTools implements OryxTool {
+    public NotifyTools(NotifyChannelAdapter adapter);
+    // getName()="notify"；getDescription()="把一条消息推送到当前 Agent 配置好的通知渠道"
+    // getInputSchema()：content 必填 / channel 可选
+    // execute：解析参数 → resolveChannel（ProfileContext.current().notifyChannels()）
+    //          → 沙箱检查位（24 节 Sandbox.enforce(HTTP_REQUEST, url) 接线，与 http_post 共享白名单）
+    //          → adapter.send → ToolResult.ok("已推送")
+}
+```
+
+渠道解析行为契约（clarify 1）：上下文缺失/未配置/类型不存在/content 缺失 → 失败 ToolResult 点名、零请求发出；channel 空白或 "default" → 第一个渠道；否则按 NotifyChannel.type 匹配。
+
+## 4. 分批交付边界（课件"实现顺序说明"）
+
+- 本节：上述全部类型 + harness 第一批（WebhookNotifyAdapterTest 全量、NotifyToolsTest 可测集）。
+- 20 节：ToolRegistry 收编 notify、OryxOsRuntime 装配（本节不改 Runtime，工具 Map 维持空）。
+- 23/24 节：Sandbox.enforce 真实现接入检查位 + NotifyToolsTest 补 InOrder 顺序回归（`@DisplayName("发送前必须先过白名单校验")`）。
+- 27/28 节：串联全量验证。

--- a/specs/004-notify-outbound/data-model.md
+++ b/specs/004-notify-outbound/data-model.md
@@ -1,0 +1,38 @@
+# Data Model: Notify——结果主动送出去的统一出口
+
+**Date**: 2026-07-11 | **Feature**: [spec.md](./spec.md)
+
+## 值对象（oryxos-tool，非持久化）
+
+### NotifyTarget（record）
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| channelType | String | 渠道类型（核心阶段唯一取值 `webhook`；扩展档位如 wecom/feishu 后加） |
+| config | Map\<String,String\> | 渠道特定配置，实现自行解释（webhook 档必需键：`url`）；compact ctor Map.copyOf |
+
+来源映射：16 节 `Profile.NotifyChannel(type, config)` → `NotifyTarget(type, config)`，字段一一对应零转换（ProfileLoader 已把 `${ENV}` 占位解析掉）。
+
+## 接口与实现
+
+- `NotifyChannelAdapter`：`void send(NotifyTarget target, String content)`——失败以异常表达，无返回值。
+- `WebhookNotifyAdapter`：POST JSON `{"content": "<content>"}` 到 `config["url"]`；url 缺失 → IllegalArgumentException 点名；非 2xx → RestClient 默认异常上抛。
+
+## notify 工具输入（JSON Schema，getInputSchema 手写）
+
+| 参数 | 必填 | 说明 |
+|---|---|---|
+| content | 是 | 要推送的内容 |
+| channel | 否 | 渠道类型；空/空白/"default" → 取 notify_channels 第一个；指定类型匹配不到 → 失败结果点名 |
+
+## 无持久化变更
+
+- 无新表、无 Profile 字段变更（notify_channels 16 节已交付）；审计走 tool_invocations 既有路径。
+
+## 失败语义汇总（全部为"明确失败"，零静默）
+
+| 情况 | 表达形式 |
+|---|---|
+| 当前无 Agent 上下文 / notify_channels 未配置 / channel 类型不存在 / content 缺失 | NotifyTools 返回失败 ToolResult（errorMessage 点名），不发请求 |
+| config 缺 url | WebhookNotifyAdapter 抛 IllegalArgumentException（→ ToolExecutor 转失败结果+审计） |
+| 对端非 2xx / 连接失败 | RestClient 异常上抛（→ 同上） |

--- a/specs/004-notify-outbound/plan.md
+++ b/specs/004-notify-outbound/plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan: Notify——结果主动送出去的统一出口
+
+**Branch**: `class-19`（用户指定） | **Date**: 2026-07-11 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/004-notify-outbound/spec.md`
+
+## Summary
+
+oryxos-tool 首开：`io.oryxos.tool.notify` 包交付出站通知抽象（`NotifyChannelAdapter` 接口 + `NotifyTarget` record）与核心阶段唯一实现 `WebhookNotifyAdapter`（RestClient POST JSON，非成功即抛）；`io.oryxos.tool.builtin.NotifyTools` 以 **OryxTool 实现**形态交付工具骨架（渠道解析 + 沙箱检查位注释 + 委托发送），直接可被 17 节 ToolExecutor 执行、待 20 节 ToolRegistry 收编。harness 第一批本节全跑（假 webhook 用 JDK 内置 HttpServer，零新依赖）；InOrder 白名单顺序回归留 24 节（课件明文分批）。
+
+## Technical Context
+
+**Language/Version**: Java 21（发送同步阻塞——宪法 VII）
+
+**Primary Dependencies**: spring-web 6.1.5（RestClient，Boot BOM 管理；API 经 javap 实核：`RestClient.create()`/`post()`/`contentType(MediaType)`/`body(Object)`/`retrieve().toBodilessEntity()`）；Jackson（RestClient JSON 转换器，classpath 已有）；测试假 webhook 用 JDK 内置 `com.sun.net.httpserver.HttpServer`（**零新第三方依赖**——课件提及 MockWebServer，改用 JDK 等能力替代，理由见 research D5，停点确认项）
+
+**Storage**: 无新表——notify 经 17 节 ToolExecutor 统一路径写 tool_invocations（FR-004，不新增审计逻辑）
+
+**Testing**: JUnit 5 + Mockito；`WebhookNotifyAdapterTest`（真 HTTP 到本地假 webhook）+ `NotifyToolsTest` 第一批可测集（mock adapter + ProfileContext set/clear）；InOrder 白名单断言归 24 节
+
+**Target Platform**: JVM 21
+
+**Project Type**: Maven 多模块（本节只动 oryxos-tool 及其 pom）
+
+**Performance Goals**: 单次同步 POST；无额外目标
+
+**Constraints**: 接口语汇渠道中立（FR-001）；不造 Sandbox 空壳（检查位注释，24 节接线——17 节 ToolExecutor 同款先例）；测试方法名英文 + @DisplayName 课件中文原名；避开 Java 18+ 语法形态；日志参数字符形态消毒
+
+**Scale/Scope**: 4 个主类型（接口/record/实现/工具）+ 2 个测试类 + tool pom 两个依赖
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| # | 原则 | 本节符合性 |
+|---|---|---|
+| I | 自实现 ReAct Loop | ✅ 不触碰循环；notify 是被循环调度的工具 |
+| II | Spring AI 只做协议转换 | ✅ 本节不用 Spring AI（@Tool 挂载归 20 节；NotifyTools 走 OryxTool 接口） |
+| III | Provider 显式映射 | ✅ 不涉及 |
+| IV | SKILL.md 归 ContextLoader / Tool 模块三合一 | ✅ notify 落 oryxos-tool（内置 Tool 归属正确），不拆模块 |
+| V | 审计 Day One 落库 | ✅ 走 ToolExecutor 既有 tool_invocations 路径，成败都记（US2 场景 3 即证） |
+| VI | 沙箱白名单 / 凭证环境变量 | ✅ 发送前留 `Sandbox.enforce` 调用位注释（24 节接线，与 http_post 共享白名单）；webhook 地址 `${ENV}` 占位由 16 节 ProfileLoader 解析 |
+| VII | 同步 + 虚拟线程 | ✅ RestClient 同步调用；无异步原语 |
+| VIII | 手工建表 | ✅ 无新表 |
+
+**Post-design 复查**：无前序接口修改；新增 public 类型均为课件交付物点名（NotifyTools 的 OryxTool 形态适配见 research D3，停点确认）。
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-notify-outbound/
+├── plan.md / research.md / data-model.md / quickstart.md
+├── contracts/notify.md
+└── tasks.md（/speckit-tasks 产出）
+```
+
+### Source Code (repository root)
+
+```text
+oryxos-tool/
+├── pom.xml                          # +spring-web（RestClient）、+spring-boot-starter-test(test)
+└── src/
+    ├── main/java/io/oryxos/tool/
+    │   ├── notify/
+    │   │   ├── NotifyChannelAdapter.java   # 【交付物】接口：send(NotifyTarget, String)（课件字面量签名）
+    │   │   ├── NotifyTarget.java           # 【交付物】record(channelType, Map<String,String> config)
+    │   │   └── WebhookNotifyAdapter.java   # 【交付物】RestClient POST JSON；非成功即抛；url 取自 config
+    │   └── builtin/
+    │       └── NotifyTools.java            # 【交付物】implements OryxTool（name="notify"）；
+    │                                       #   渠道解析（ProfileContext.current().notifyChannels()）
+    │                                       #   + 沙箱检查位注释（24 节）+ adapter.send
+    └── test/java/io/oryxos/tool/
+        ├── notify/WebhookNotifyAdapterTest.java   # 【harness 第一批】JDK HttpServer 假 webhook
+        └── builtin/NotifyToolsTest.java           # 【harness 第一批可测集】mock adapter；InOrder 留 24 节
+```
+
+**Structure Decision**: 包名照课件字面量（io.oryxos.tool.notify / io.oryxos.tool.builtin）；oryxos-tool 保持纯 POJO（不加 @Component——16/17/18 节装配模式统一走 OryxOsRuntime @Bean，20 节 ToolRegistry 接线时统一装配）。
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| NotifyTools 以 OryxTool 接口形态落地（课件示意代码为 @Tool 注解方法）——软门禁项，停点确认 | 课件"实现顺序说明"明文 @Tool 注册机制归 20 节；17 节 ToolExecutor 消费的是 `Map<String,OryxTool>`——OryxTool 形态本节即可被执行与审计，@Tool 形态要等 20 节才有消费方 | 照抄 @Tool 注解：本节无法接线（无注册机制）、还得引入 Spring AI 依赖到 oryxos-tool，违"只创建可用的对外概念"精神；20 节若确立 @Tool 桥接机制再适配 |
+| 假 webhook 用 JDK HttpServer 而非课件提及的 MockWebServer——停点确认 | 零新第三方依赖（MockWebServer 需向根 pom 加 okhttp 系两个 GAV，触软门禁 6）；JDK HttpServer 同样起真 HTTP 端口、断言请求体，满足课件"本地假 webhook、仍是单测层"的全部意图 | 引 MockWebServer：多两个依赖 + OWASP 扫描面扩大，收益仅是 API 顺手 |

--- a/specs/004-notify-outbound/quickstart.md
+++ b/specs/004-notify-outbound/quickstart.md
@@ -1,0 +1,38 @@
+# Quickstart: Notify 验证指引
+
+**Date**: 2026-07-11 | **Feature**: [spec.md](./spec.md)
+
+## 前置
+
+- JDK 21、Maven；16/17/18 节交付物在位（63 测试绿）。
+
+## 自动化验收（harness 第一批，本节判卷）
+
+```bash
+mvn clean verify                       # 全量门禁（完成定义）
+mvn test -pl oryxos-tool -am -Dtest='WebhookNotifyAdapterTest,NotifyToolsTest' -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+预期全绿。守点对号：
+
+| 测试 | 守点 |
+|---|---|
+| WebhookNotifyAdapterTest | POST body 带 content；URL 来自 NotifyTarget.config 非硬编码（换 url 即换目标）；假 webhook 返回 500 异常上抛不吞；config 缺 url 报错不发请求 |
+| NotifyToolsTest（第一批可测集） | notify_channels 未配置 → 明确报错零请求；channel 缺省/"default" → 第一个渠道；指定类型命中/未命中；上下文缺失报错；成功委托 adapter 并回"已推送" |
+
+## 留待后续节的回归（不在本节判卷）
+
+- 24 节：InOrder `发送前必须先过白名单校验`（enforce 先于 send）；
+- 20 节：notify 经 ToolRegistry 注册后，chat 里真实调用链（ToolExecutor 审计落 tool_invocations）。
+
+## 回归证据（跨节契约)
+
+```bash
+mvn test -pl oryxos-core,oryxos-provider,oryxos-storage,oryxos-tool -am   # 前序 63 + 本节全绿
+mvn dependency:tree -pl oryxos-tool | grep spring-web                     # BOM 解析确认
+```
+
+## 人工项（课件"五、怎么用，做完怎么验"）
+
+1. **真实 webhook**：配一个真实群机器人地址到某 Profile 的 notify_channels（url 走 `${TEAM_WEBHOOK_URL}`），20 节接线后在 chat 里说"把'测试消息'推送一下"，群里收到（假 webhook 测协议，真 webhook 验配置）。
+2. **接口中立性思维自查**：换成企业微信官方 SDK 实现，`NotifyChannelAdapter.send(NotifyTarget, String)` 签名需要改吗？答案应为不需要。

--- a/specs/004-notify-outbound/research.md
+++ b/specs/004-notify-outbound/research.md
@@ -1,0 +1,45 @@
+# Research: Notify——结果主动送出去的统一出口
+
+**Date**: 2026-07-11 | **Feature**: [spec.md](./spec.md)
+
+## D1. 抽象与实现：接口先行，一档 webhook
+
+- **Decision**: `NotifyChannelAdapter`（唯一方法 `void send(NotifyTarget target, String content)`）+ `NotifyTarget`（record：`channelType` + `Map<String,String> config`，compact ctor `Map.copyOf` 防御）。核心阶段唯一实现 `WebhookNotifyAdapter`：`config.get("url")` 为目标（缺失 → `IllegalArgumentException` 点名，不发请求），`RestClient.post().uri(url).contentType(APPLICATION_JSON).body(Map.of("content", content)).retrieve().toBodilessEntity()`。
+- **Rationale**: 课件字面量签名逐字保真；接口语汇零渠道特有词（FR-001）；企微/飞书/钉钉群机器人都收通用 webhook，一档覆盖核心场景。
+- **Alternatives considered**: 逐家专用 API（签名/AccessToken——课件明文留扩展阶段）；send 返回状态对象（失败要显式抛，返回值会被忽略——课件 void + 异常口径）。
+- **验证方式**: javap 已实核 RestClient 全链 API（spring-web 6.1.5 本地 jar）。
+
+## D2. 失败口径：非成功即抛
+
+- **Decision**: RestClient `retrieve()` 默认对 4xx/5xx 抛 `RestClientResponseException`——直接依赖默认行为，不注册 onStatus 吞错处理器；连接失败抛 `ResourceAccessException`。全部上抛，由 17 节 ToolExecutor 转失败 ToolResult 并落 success=false 审计（FR-004 既有路径）。
+- **Rationale**: "发出去没送到"与"没发出去"对 Agent 同义（clarify 2）；ToolExecutor 已实现"工具异常 → 失败结果 + 审计"，notify 零新增审计逻辑。
+- **Alternatives considered**: 自定义异常包装（多一层类型无信息增益）。
+- **验证方式**: WebhookNotifyAdapterTest 假 webhook 返回 500 断言抛出。
+
+## D3. NotifyTools 形态：OryxTool 实现（⚠️ 停点确认项）
+
+- **Decision**: `NotifyTools implements OryxTool`：`getName()="notify"`、`getDescription()="把一条消息推送到当前 Agent 配置好的通知渠道"`（课件 @Tool description 原文）、`getInputSchema()` 手写 JSON Schema（content 必填 string、channel 可选 string）、`execute(JsonNode input)`：取 content（缺失 → 失败 ToolResult）→ `resolveChannel(channel)` → 沙箱检查位注释（24 节 `Sandbox.enforce(HTTP_REQUEST, url)` 接线，与 http_post 共享白名单）→ `adapter.send(target, content)` → `ToolResult.ok("已推送")`。构造注入 `NotifyChannelAdapter`。
+- **Rationale**: 课件"实现顺序说明"明文 @Tool 注册机制归 20 节；17 节 ToolExecutor 消费 `Map<String,OryxTool>`——OryxTool 形态**本节即可被执行与审计**（装配进 OryxOsRuntime 的 tools Map 即上线），@Tool 形态本节无消费方。渠道解析语义按 clarify 1。
+- **Alternatives considered**: 照抄课件 @Tool 注解方法（本节接不了线还引 Spring AI 进 tool 模块）；等 20 节一起交付（交付物清单点名 NotifyTools，课件也明示"骨架本节落"）。
+- **验证方式**: NotifyToolsTest（mock adapter）第一批可测集。
+
+## D4. 渠道解析：ProfileContext 静态 ThreadLocal 适配
+
+- **Decision**: 解析逻辑为 NotifyTools 私有方法 `resolveChannel(String channel)`：`ProfileContext.current()` 为 null → 报错"当前无 Agent 上下文"；`profile.notifyChannels()` 空 → 报错点名 Profile 名（课件守点：不是静默失败）；channel 空白或 `"default"` → 第一个；否则按 `NotifyChannel.type` 匹配，匹配不到 → 报错点名。命中后转 `NotifyTarget(type, config)`。全部"报错"= 返回失败 ToolResult（execute 内不抛业务异常——查询类失败模型可自救，口径同 ToolExecutor 未注册工具）。
+- **Rationale**: 课件示意代码的 `profileContext.resolveNotifyChannel(channel)` 是实例方法写法，但 17 节已交付的 ProfileContext 是静态 ThreadLocal（set/current/clear）——**不改前序公共接口**（软门禁 4），解析逻辑归属调用方 NotifyTools；16 节 `Profile.NotifyChannel(type, config)` 直接映射 NotifyTarget，字段零转换。
+- **Alternatives considered**: 给 ProfileContext 加实例/静态 resolveNotifyChannel（改 17 节交付物且把 Profile 业务塞进上下文持有类，职责错位）。
+- **验证方式**: NotifyToolsTest 用 ProfileContext.set/clear 包裹（@AfterEach 必 clear，防 ThreadLocal 串号——17 节同款纪律）。
+
+## D5. 假 webhook：JDK HttpServer 替代 MockWebServer（⚠️ 停点确认项）
+
+- **Decision**: WebhookNotifyAdapterTest 用 `com.sun.net.httpserver.HttpServer`（JDK 内置公共 API）起本地端口（port 0 自动分配）：handler 记录请求方法/路径/body 并按用例返回 200/500；测试断言收到 POST、body 含 content、URL 来自 NotifyTarget.config。
+- **Rationale**: 课件提及 MockWebServer——意图是"本地假 webhook、不算外网依赖、仍是单测层"；JDK HttpServer 同样满足全部意图且**零新第三方依赖**（MockWebServer 需向根 pom 加 okhttp/mockwebserver 两个 GAV，触软门禁 6 且扩大 OWASP 扫描面）。
+- **Alternatives considered**: okhttp MockWebServer（API 顺手但引新依赖）；Spring MockRestServiceServer（不走真 HTTP 栈，验不到序列化与网络层）。
+- **验证方式**: 测试本身；`com.sun.net.httpserver` 为 JDK 21 标准模块 jdk.httpserver 公共 API（非 sun.* 内部包，Checkstyle IllegalImport 不拦）。
+
+## D6. 依赖与装配
+
+- **Decision**: oryxos-tool pom：`spring-web`（RestClient，Boot BOM 版本）+ `spring-boot-starter-test`(test)。不加 spring-context/@Component——模块保持纯 POJO，装配统一走 OryxOsRuntime（20 节 ToolRegistry 接线时把 NotifyTools 放进 tools Map；本节不动 OryxOsRuntime，工具 Map 维持空）。`WebhookNotifyAdapter` 构造注入 `RestClient`（生产 `RestClient.create()`，测试同款指向假 webhook）。
+- **Rationale**: 16/17/18 节一致的装配模式；本节接线进运行时不属于交付物（20 节 ToolRegistry 统一收编，避免两次改 OryxOsRuntime）。
+- **Alternatives considered**: 本节就改 OryxOsRuntime 把 notify 放进 Map（可跑通但 20 节 Registry 会重构装配，改两次；且 chat 场景无 Sandbox 时提前放开涉外工具，安全上更差——检查位还没真拦截）。
+- **验证方式**: `mvn dependency:tree -pl oryxos-tool | grep spring-web` 确认 BOM 解析。

--- a/specs/004-notify-outbound/spec.md
+++ b/specs/004-notify-outbound/spec.md
@@ -1,0 +1,121 @@
+# Feature Specification: Notify——结果主动送出去的统一出口
+
+**Feature Branch**: `class-19`（用户指定，勿另建）
+
+**Created**: 2026-07-11
+
+**Status**: Draft
+
+**Input**: User description: "第19节需求：Notify——结果主动送出去的统一出口。……（完整需求见第19节课件《Notify 模块 原理解析、实现与代码讲解》一、二部分）"
+
+## Clarifications
+
+### Session 2026-07-11
+
+- Q: notify 的 channel 参数按什么匹配渠道？ → A: 按渠道类型（NotifyChannel.type）匹配——16 节已定的 NotifyChannel 只有 type + config 两个字段，无名字可匹配；channel 为空、空白或字面量 "default"（课件示例用词）时取第一个渠道；指定类型匹配不到时报错点名、不回退（默认自答，停点供确认）。
+- Q: 对端 3xx/4xx 是否与 5xx 同口径？ → A: 同口径——凡非成功响应都异常上抛；"发出去没送到"与"没发出去"对 Agent 是同一件事。
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 定时结果主动送达 (Priority: P1)
+
+用户对 Agent 说"每天早上帮我看看天气，穿搭建议直接发到我们群里"。之后每天到点自动查天气、生成建议，并把结果推送到该 Agent 配置好的群——没有人在另一端等响应，也不需要任何人工干预。
+
+**Why this priority**: 这是 Notify 存在的全部理由：定时触发的结果若送不出去，跑完一整套循环也只能烂在会话里没人看到；25 节定时模块和 31 节两个 Demo 都指着这个出口。
+
+**Independent Test**: 用本地假 webhook（单测层 HTTP 假服务）承接推送，断言收到一次 POST、body 含推送内容、目标地址来自该 Agent 的通知配置而非硬编码。
+
+**Acceptance Scenarios**:
+
+1. **Given** Agent 配置了一个 webhook 通知渠道，**When** 通知能力被调用（content="今天 28°C，建议短袖"），**Then** 目标地址收到一次 POST，body 中携带该内容。
+2. **Given** 同上，**When** 检查发出的目标地址，**Then** 地址来自 Agent 配置（改配置即改目标），实现中无硬编码地址。
+
+---
+
+### User Story 2 - 发送失败不许装成功 (Priority: P1)
+
+对端 webhook 返回错误（如 5xx）时，通知能力必须把失败显式抛出——Agent 不能以为发出去了，事后审计也必须能看到这次失败。
+
+**Why this priority**: 静默吞掉发送失败是最危险的软故障：日报"发了"但群里没人收到，发现时已经断了一周。
+
+**Independent Test**: 假 webhook 返回 500，断言发送调用异常上抛（不被吞掉）。
+
+**Acceptance Scenarios**:
+
+1. **Given** 假 webhook 固定返回 500，**When** 发送一条通知，**Then** 调用以异常结束、错误信息可见；该失败经工具执行统一路径落 tool_invocations（success=false）。
+
+---
+
+### User Story 3 - notify 工具的渠道解析 (Priority: P2)
+
+Agent 在对话里调用 notify 工具：大多数时候只传 content——系统取该 Agent 配置的第一个通知渠道；显式传 channel 时按类型选对应渠道；该 Agent 压根没配 notify_channels 时明确报错，绝不静默失败。
+
+**Why this priority**: 渠道解析是 notify 工具的业务核心；"未配置却装作发送成功"与 US2 是同一类必须钉死的软故障。
+
+**Independent Test**: 构造带/不带 notify_channels 的 Profile 置入当前 Agent 上下文，分别断言：缺省取第一个渠道、显式选中指定渠道、未配置时报错点名。
+
+**Acceptance Scenarios**:
+
+1. **Given** 当前 Agent 配置了两个通知渠道，**When** 只传 content 调用 notify，**Then** 内容送往第一个渠道。
+2. **Given** 同上，**When** 传 channel 指定第二个渠道类型，**Then** 内容送往第二个渠道。
+3. **Given** 当前 Agent 未配置 notify_channels，**When** 调用 notify，**Then** 返回明确错误（点名未配置），不发出任何请求。
+
+---
+
+### User Story 4 - 换渠道零代码 (Priority: P3)
+
+运营方想把通知从 A 群换到 B 群：只改该 Agent 配置里的 webhook 地址（或对应环境变量），不碰任何代码、不改对话内容、不重启。
+
+**Why this priority**: "配置即 Agent"总原则在出站方向的体现；接口先行保证以后加新渠道（企业微信/飞书专用 API）只增实现不改调用方。
+
+**Independent Test**: 同一套代码、两份不同 url 的通知目标，分别发送后断言各自地址收到——地址完全由配置决定。
+
+**Acceptance Scenarios**:
+
+1. **Given** 通知目标 config 中 url=A，**When** 发送，**Then** A 收到；**Given** 改为 url=B，**When** 再发送，**Then** B 收到（代码零改动）。
+2. **Given** 抽象接口既定，**When** 未来新增某专用渠道实现，**Then** 接口签名与既有调用方不需要改（接口语汇不含任何一档实现特有的词——设计自查项）。
+
+---
+
+### Edge Cases
+
+- 通知目标 config 缺 url 键（webhook 档必需）→ 发送前明确报错，不发出请求。
+- content 为空串 → 照常发送（是否有意义由调用方/模型决定，通知层不猜）。
+- channel 参数指定的类型在 notify_channels 里不存在 → 明确报错点名，不回退默认渠道（回退会把消息发错地方）。
+- 对端返回 3xx/4xx → 与 5xx 同口径：异常上抛（凡非成功都不许装成功）。
+- 当前 Agent 上下文缺失（工具在处理链路外被调用）→ 明确报错，不发送。
+- 白名单检查位：Sandbox 就位前不拦截（留调用位），就位后校验先于发送——顺序回归留待 24 节 InOrder 钉死。
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 系统 MUST 提供不携带具体渠道细节的出站通知抽象：表达"把一条内容送到某个通知目标"；通知目标只含渠道类型与配置映射（配置如何解释由实现决定）；接口语汇 MUST NOT 出现任何一档实现特有的词。
+- **FR-002**: 核心阶段 MUST 且仅 MUST 提供一档通用 webhook 实现：把内容包成 JSON 向目标地址发一次 POST（同步阻塞）；对端非成功响应 MUST 异常上抛，MUST NOT 静默吞掉；目标地址 MUST 取自通知目标配置，实现内不得硬编码。
+- **FR-003**: 系统 MUST 提供 notify 内置工具能力：content 必传；channel 可选——缺省取当前 Agent notify_channels 的第一个渠道，显式传入时按渠道类型匹配、匹配不到报错点名；notify_channels 未配置或当前 Agent 上下文缺失 MUST 明确报错且不发出请求。
+- **FR-004**: 通知发出前 MUST 过域名白名单检查位（与 http_post 共享同一份白名单与校验机制；校验实现属第 23/24 节，本特性留接线位）；执行与审计 MUST 走工具执行既有统一路径（tool_invocations），不新增审计逻辑。
+- **FR-005**: 渠道配置（webhook 地址等）MUST 只存在于 Profile 的 notify_channels 字段；MUST NOT 出现在对话内容或工具接口签名中；配置中的凭证走环境变量占位（16 节机制）。
+
+### Key Entities
+
+- **通知目标（NotifyTarget）**: 渠道类型 + 配置映射；对上层是黑盒，由具体实现解释（webhook 档取 config 的 url）。
+- **出站通知抽象（NotifyChannelAdapter）**: "送内容到目标"这一意图的唯一表达；核心阶段一档 webhook 实现，扩展阶段按档位增挂。
+- **notify 工具（NotifyTools）**: LLM 可调用的内置工具骨架；渠道解析（Profile.notify_channels ←当前 Agent 上下文）+ 检查位 + 委托发送；@Tool 注册挂载归 20 节、白名单真实现归 23/24 节。
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 配好通知渠道后，一次通知调用使目标地址收到恰好一次 POST 且内容完整——自动化断言（假 webhook）。
+- **SC-002**: 发送失败（对端非成功响应）100% 以显式错误结束并留下审计记录，零静默失败。
+- **SC-003**: 换通知目标只改配置零代码：同一实现对不同配置发往不同地址——自动化断言。
+- **SC-004**: 未配置渠道 / 指定渠道不存在 / 上下文缺失三种情况 100% 明确报错且零请求发出。
+- **SC-005**: 接口中立性：新增一档专用渠道实现无需修改抽象签名与调用方（设计自查项，人工确认）。
+
+## Assumptions
+
+- 第 16 节 Profile 的 `notify_channels` 字段（type + 渠道特定 config 如 url）与 `${ENV}` 占位解析已交付（含测试覆盖），本特性零配置改动。
+- 第 17 节 ProfileContext（ThreadLocal）提供"当前是哪个 Agent"；notify 工具经由第 17 节 ToolExecutor 的统一执行与审计路径运行。
+- HTTP 客户端使用项目锁定 BOM 内组件；发送同步阻塞（宪法同步模型）。
+- 课件"实现顺序说明"（授课顺序 ≠ 构建顺序）：本特性交付抽象接口、通知目标、webhook 实现与 notify 工具骨架及第一批 harness；@Tool 注册挂载属第 20 节、白名单校验真实现与 InOrder 顺序回归属第 23/24 节，27/28 节串联全量验证。
+- 明确不做（边界）：企业微信/飞书/钉钉专用 API（签名算法、AccessToken 刷新）留扩展阶段；入站 Channel 与出站 Notify 不合并抽象。

--- a/specs/004-notify-outbound/tasks.md
+++ b/specs/004-notify-outbound/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: Notify——结果主动送出去的统一出口
+
+**Input**: Design documents from `/specs/004-notify-outbound/`（plan.md / research.md D1~D6 / data-model.md / contracts/notify.md / quickstart.md）
+
+**Tests**: 课件"验收 harness"分两批——第一批（WebhookNotifyAdapterTest 全量 + NotifyToolsTest 可测集）本节全落；**InOrder 白名单顺序回归（`发送前必须先过白名单校验`）明确留 24 节**，20 节接 ToolRegistry、24 节接 Sandbox 后补跑。测试方法名英文 + `@DisplayName` 保课件中文原名。
+
+**Organization**: 抽象与 webhook 实现（US1/US2/US4）→ notify 工具骨架（US3）→ Polish。本节不改 OryxOsRuntime（20 节 ToolRegistry 统一接线）。
+
+## Phase 1: Setup
+
+- [x] T001 记录改造前基线：`mvn test -pl oryxos-core,oryxos-provider,oryxos-storage -am -q` 确认 16/17/18 节 63 测试全绿
+- [x] T002 oryxos-tool pom 依赖补齐：`oryxos-tool/pom.xml` +`spring-web`（RestClient，Boot BOM 版本）+`spring-boot-starter-test`(test scope)；补后 `mvn dependency:tree -pl oryxos-tool | grep spring-web` 确认解析
+
+## Phase 2: US1+US2+US4 出站抽象与 webhook 实现（P1，harness 先行）
+
+**Goal**: 接口先行 + 一档 webhook；发送失败绝不装成功；换目标零代码。
+**Independent Test**: `mvn test -pl oryxos-tool -am -Dtest='WebhookNotifyAdapterTest'` 全绿。
+
+- [x] T003 [US1] WebhookNotifyAdapterTest：`oryxos-tool/src/test/java/io/oryxos/tool/notify/WebhookNotifyAdapterTest.java`——JDK `com.sun.net.httpserver.HttpServer` 起本地假 webhook（port 0 自动分配，handler 记录方法/body 并按用例回 200/500）：①发送后收到恰好一次 POST、body 含 content、Content-Type 为 JSON（US1）；②URL 来自 `NotifyTarget.config` 非硬编码——两个不同 url 的 target 分别发往各自地址（US4，`@DisplayName("换通知目标只改配置零代码")`）；③假 webhook 返回 500 → 异常上抛不吞（US2，`@DisplayName("webhook返回5xx_异常向上抛不静默吞掉")`）；④config 缺 url → IllegalArgumentException 点名、假 webhook 零请求
+- [x] T004 [P] [US1] 抽象两件：`oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyChannelAdapter.java`（接口，唯一方法 `void send(NotifyTarget target, String content)`——课件字面量签名）+ `NotifyTarget.java`（record：channelType + Map<String,String> config，compact ctor Map.copyOf；接口语汇零渠道特有词）
+- [x] T005 [US1] WebhookNotifyAdapter：`oryxos-tool/src/main/java/io/oryxos/tool/notify/WebhookNotifyAdapter.java`——构造注入 RestClient；`config.get("url")` 缺失抛 IllegalArgumentException 点名不发请求；`post().uri(url).contentType(APPLICATION_JSON).body(Map.of("content", content)).retrieve().toBodilessEntity()`（研发决策 D1/D2：非 2xx 走 RestClient 默认异常上抛，不注册吞错处理器）
+- [x] T006 [US2] 阶段门禁：`mvn test -pl oryxos-tool -am -Dtest='WebhookNotifyAdapterTest' -Dsurefire.failIfNoSpecifiedTests=false` 绿，红了当场修
+
+## Phase 3: US3 notify 工具骨架（P2）
+
+**Goal**: OryxTool 形态骨架：渠道解析 + 沙箱检查位 + 委托发送；未配置绝不静默失败。
+**Independent Test**: `mvn test -pl oryxos-tool -am -Dtest='NotifyToolsTest'` 全绿。
+
+- [x] T007 [US3] NotifyToolsTest（第一批可测集）：`oryxos-tool/src/test/java/io/oryxos/tool/builtin/NotifyToolsTest.java`——mock NotifyChannelAdapter，@BeforeEach `ProfileContext.set(profile)`、@AfterEach 必 `ProfileContext.clear()`（防 ThreadLocal 串号）：①`notify_channels` 未配置 → 失败 ToolResult 点名、adapter 零调用（`@DisplayName("notify_channels未配置_明确报错不静默失败")`）；②channel 缺省/空白/"default" → 取第一个渠道（`@DisplayName("channel参数缺省_取第一个渠道")`）；③channel 指定第二个渠道类型 → 命中第二个；④指定类型不存在 → 失败点名、零调用；⑤ProfileContext 无值 → 失败点名；⑥content 缺失 → 失败点名；⑦成功路径 → `verify(adapter).send(目标匹配, "hello")` 且结果 content="已推送"。**文件头注释注明：InOrder 白名单顺序回归（发送前必须先过白名单校验）待 24 节 Sandbox 就位后补入本类**
+- [x] T008 [US3] NotifyTools：`oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java`——implements OryxTool（研发决策 D3/D4）：getName()="notify"、getDescription()="把一条消息推送到当前 Agent 配置好的通知渠道"、getInputSchema() 手写 JSON Schema（content 必填/channel 可选）；execute：content 缺失→失败；resolveChannel 私有方法（ProfileContext.current() null→失败；notifyChannels 空→失败点名 Profile；channel 空白或"default"→第一个；否则按 type 匹配、未命中→失败点名）；**沙箱检查位注释（24 节 `Sandbox.enforce(HTTP_REQUEST, url)` 接线，与 http_post 共享白名单）**；adapter.send → `ToolResult.ok("已推送")`
+- [x] T009 [US3] 阶段门禁：`mvn test -pl oryxos-tool -am` 全绿
+
+## Phase 4: Polish & 收尾
+
+- [x] T010 全仓硬门禁：`mvn clean verify` 全绿（含 Spotless/P3C/Checkstyle/SpotBugs/FindSecBugs），红了修实现不改规则
+- [x] T011 H4 六条全局不变量自查 + 课件"本节交付物"逐项 ls/grep 存在性核对（含"接口语汇零渠道特有词" grep 自查：主代码无 wecom/feishu/dingtalk 字样）
+- [x] T012 验收报告：`specs/004-notify-outbound/acceptance-report.md`（六项证据 DoD + 分批说明 + 剩余人工项：真实 webhook 验配置、接口中立性思维自查、20/24 节待补回归清单）
+
+## Dependencies
+
+- T001/T002 先行；T003 先于或伴随 T004/T005（harness 先行）；T007 先于或伴随 T008。
+- Phase 2 → Phase 3（NotifyTools 依赖 NotifyChannelAdapter/NotifyTarget 类型）→ Polish。
+- 并行机会：T004 与 T003 不同文件可并行。
+
+## Implementation Strategy
+
+- MVP = Phase 2（抽象 + webhook + 失败口径，US1/US2/US4 一次覆盖）；Phase 3 补工具骨架（US3）。
+- 每阶段门禁当场修红；本节结束时 oryxos-tool 首次有实码，全仓测试数 63 + 本节新增。


### PR DESCRIPTION
Changed:
  - .specify/feature.json
  - docs/class/第19节：Notify 模块 原理解析、实现与代码讲解.md
  - oryxos-tool/pom.xml
  - oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
  - oryxos-tool/src/main/java/io/oryxos/tool/notify/DingTalkNotifyAdapter.java
  - oryxos-tool/src/main/java/io/oryxos/tool/notify/FeishuNotifyAdapter.java
  - oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyChannelAdapter.java
  - oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyTarget.java
  - oryxos-tool/src/main/java/io/oryxos/tool/notify/WebhookNotifyAdapter.java
  - oryxos-tool/src/main/java/io/oryxos/tool/notify/WeComNotifyAdapter.java
  - oryxos-tool/src/test/java/io/oryxos/tool/builtin/NotifyToolsTest.java
  - oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
  - oryxos-tool/src/test/java/io/oryxos/tool/notify/WebhookNotifyAdapterTest.java
  - specs/004-notify-outbound/acceptance-report.md
  - specs/004-notify-outbound/checklists/requirements.md
  - specs/004-notify-outbound/contracts/notify.md
  - specs/004-notify-outbound/data-model.md
  - specs/004-notify-outbound/plan.md
  - specs/004-notify-outbound/quickstart.md
  - specs/004-notify-outbound/research.md
  - specs/004-notify-outbound/spec.md
  - specs/004-notify-outbound/tasks.md