### PR TITLE
fix(web): secure auth cookies on HTTPS requests

### DIFF
--- a/oryxos-web/src/main/java/io/oryxos/web/controller/AuthApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/AuthApiController.java
@@ -53,30 +53,33 @@ public class AuthApiController {
   /** 登录：验账密 → 建 session → 设 cookie。失败 401（"Invalid username or password"，不区分原因防枚举）。 */
   @PostMapping("/login")
   public ApiResponse<AuthMeView> login(
-      @RequestBody LoginRequest request, HttpServletResponse response) {
-    if (request == null
-        || request.username() == null
-        || request.password() == null
-        || request.username().isBlank()
-        || request.password().isBlank()) {
+      @RequestBody LoginRequest loginRequest,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+    if (loginRequest == null
+        || loginRequest.username() == null
+        || loginRequest.password() == null
+        || loginRequest.username().isBlank()
+        || loginRequest.password().isBlank()) {
       response.setStatus(HttpStatus.BAD_REQUEST.value());
       return ApiResponse.error(
           HttpStatus.BAD_REQUEST.value(), "username and password are required");
     }
-    if (!userService.verify(request.username(), request.password())) {
+    if (!userService.verify(loginRequest.username(), loginRequest.password())) {
       response.setStatus(HttpStatus.UNAUTHORIZED.value());
       return ApiResponse.error(HttpStatus.UNAUTHORIZED.value(), "Invalid username or password");
     }
-    WebSession session = sessionService.create(request.username());
-    response.addHeader(HttpHeaders.SET_COOKIE, buildCookie(session.getSessionId(), -1));
-    return ApiResponse.ok(new AuthMeView(request.username()));
+    WebSession session = sessionService.create(loginRequest.username());
+    response.addHeader(
+        HttpHeaders.SET_COOKIE, buildCookie(session.getSessionId(), -1, request.isSecure()));
+    return ApiResponse.ok(new AuthMeView(loginRequest.username()));
   }
 
   /** 登出：清当前 session + 清 cookie。幂等（无 session 也成功）。 */
   @PostMapping("/logout")
   public ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response) {
     findSessionId(request).ifPresent(sessionService::delete);
-    response.addHeader(HttpHeaders.SET_COOKIE, buildCookie("", 0));
+    response.addHeader(HttpHeaders.SET_COOKIE, buildCookie("", 0, request.isSecure()));
     return ApiResponse.ok(null);
   }
 
@@ -109,12 +112,13 @@ public class AuthApiController {
         .findFirst();
   }
 
-  /** 构 Set-Cookie 头。maxAge=0 表示清 cookie。 */
-  private static String buildCookie(String sessionId, int maxAge) {
+  /** 构 Set-Cookie 头。maxAge=0 表示清 cookie；HTTPS 请求附加 Secure。 */
+  private static String buildCookie(String sessionId, int maxAge, boolean secure) {
     ResponseCookie cookie =
         ResponseCookie.from(SESSION_COOKIE, sessionId)
             .path("/")
             .httpOnly(true)
+            .secure(secure)
             .sameSite("Strict")
             .maxAge(maxAge)
             .build();

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/AuthApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/AuthApiControllerTest.java
@@ -45,7 +45,7 @@ class AuthApiControllerTest {
   }
 
   @Test
-  @DisplayName("login_对账密_200+Set-Cookie(HttpOnly+SameSite=Strict+Path=/)")
+  @DisplayName("login_HTTP对账密_200+Set-Cookie(HttpOnly+SameSite=Strict+Path=/且无Secure)")
   void login_correctCredentials_setsCookie() throws Exception {
     when(userService.verify("admin", "s3cret-pw")).thenReturn(true);
     WebSession session = newSession("admin", "sid-123");
@@ -66,7 +66,28 @@ class AuthApiControllerTest {
         .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("HttpOnly")))
         .andExpect(
             header().string("Set-Cookie", org.hamcrest.Matchers.containsString("SameSite=Strict")))
-        .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("Path=/")));
+        .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("Path=/")))
+        .andExpect(
+            header()
+                .string(
+                    "Set-Cookie",
+                    org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("Secure"))));
+  }
+
+  @Test
+  @DisplayName("login_HTTPS对账密_Set-Cookie包含Secure")
+  void login_https_setsSecureCookie() throws Exception {
+    when(userService.verify("admin", "s3cret-pw")).thenReturn(true);
+    WebSession session = newSession("admin", "sid-123");
+    when(sessionService.create("admin")).thenReturn(session);
+
+    mvc.perform(
+            post("/api/v1/auth/login")
+                .secure(true)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"admin\",\"password\":\"s3cret-pw\"}"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("Secure")));
   }
 
   @Test
@@ -96,14 +117,15 @@ class AuthApiControllerTest {
   }
 
   @Test
-  @DisplayName("logout_有cookie_清session+清cookie")
+  @DisplayName("logout_HTTPS有cookie_清session+清Cookie且保留Secure")
   void logout_withCookie_clearsSession() throws Exception {
     mvc.perform(
             post("/api/v1/auth/logout")
+                .secure(true)
                 .cookie(new jakarta.servlet.http.Cookie("oryxos_session", "sid-123")))
         .andExpect(status().isOk())
-        .andExpect(
-            header().string("Set-Cookie", org.hamcrest.Matchers.containsString("Max-Age=0")));
+        .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("Max-Age=0")))
+        .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("Secure")));
     verify(sessionService).delete("sid-123");
   }
 


### PR DESCRIPTION
## Summary

- add the `Secure` attribute to authentication cookies when the current request uses HTTPS
- preserve the existing HTTP behavior for local development and HTTP-only deployments
- clear HTTPS session cookies with the same `Secure` attribute during logout
- add coverage for HTTP login, HTTPS login, and HTTPS logout behavior

## Verification

`JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home mvn -B -pl oryxos-web -am verify`

The `oryxos-core`, `oryxos-storage`, and `oryxos-web` reactor modules completed successfully. `oryxos-web` ran 66 tests with no failures or errors; Checkstyle, Spotless, PMD, and SpotBugs also passed.