### PR TITLE
fix(web): restore admin console authentication

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -71,8 +71,18 @@ oryxos:
     - name: codex
       api-key: ""                # ← 可选：填入 Codex / OpenAI API Key（不用可删掉本条）
       base-url: https://ai.soulecho.cc   # codex 中转代理；OryxOS 运行时走 /v1/chat/completions
-    - name: mock                 # 内置假模型：不连真实模型、无需 key，无 key 自测全链路（生产可删）
+    # 内置 mock provider：不连真实模型、无需 key，用于无 key 自测全链路。
+    # 用它建/配一个 provider: mock 的 Agent，发一条"记住…"消息，即可在管理台看到
+    # 会话/记忆/工具端点被填充（一次 save_memory 工具调用 + 两轮 ReAct）。生产可删。
+    - name: mock
   # 「一句话生成 Agent 草稿」调 LLM 用的作者模型；provider 缺省取 providers 第一个
   author:
     provider: deepseek
     model: deepseek-v4-flash     # deepseek-chat 已废弃；可选 deepseek-v4-flash（快/省）| deepseek-v4-pro（强）
+  # 管理台 Basic Auth（012-web-auth）。默认关=裸内网现状不变；
+  # 开启后 /admin/** 需账密（/api/v1/** REST 不受影响）。
+  # 开启前先跑 `oryxos user add <username>` 建账号，否则启动阻断。
+  # web:
+  #   auth:
+  #     enabled: true
+  #     realm: OryxOS

--- a/oryxos-boot/src/main/resources/application.yml
+++ b/oryxos-boot/src/main/resources/application.yml
@@ -70,6 +70,13 @@ oryxos:
   author:
     provider: deepseek
     model: deepseek-chat
+  # 管理台 Basic Auth（012-web-auth）。默认关=假设内网现状不变（SC-001）；
+  # 开启后 /admin/** 需账密，/api/v1/** 不受影响（REST 不做 Basic Auth）。
+  # 开启前先 oryxos user add <username> 建账号，否则启动阻断（FR-006）。
+  web:
+    auth:
+      enabled: false
+      realm: OryxOS
 
 # Observability: Actuator + Micrometer/Prometheus
 management:

--- a/oryxos-cli/pom.xml
+++ b/oryxos-cli/pom.xml
@@ -65,6 +65,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- 012-web-auth: PasswordEncoder 接口（webUserService bean 装配需；bean 本身由 oryxos-web 的 PasswordEncoderFactory 声明） -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsCli.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsCli.java
@@ -9,6 +9,7 @@ import io.oryxos.cli.command.ServeCommand;
 import io.oryxos.cli.command.SessionListCommand;
 import io.oryxos.cli.command.StatusCommand;
 import io.oryxos.cli.command.ToolListCommand;
+import io.oryxos.cli.command.UserCommand;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IVersionProvider;
@@ -33,7 +34,8 @@ import picocli.CommandLine.IVersionProvider;
       ProfileCommand.class,
       ProviderListCommand.class,
       ToolListCommand.class,
-      SessionListCommand.class
+      SessionListCommand.class,
+      UserCommand.class
     })
 public class OryxOsCli implements Runnable {
 

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -63,6 +63,10 @@ import io.oryxos.storage.ScheduledTaskRepository;
 import io.oryxos.storage.SessionRepository;
 import io.oryxos.storage.TaskExecutionRepository;
 import io.oryxos.storage.ToolInvocationRepository;
+import io.oryxos.storage.WebSessionRepository;
+import io.oryxos.storage.WebSessionService;
+import io.oryxos.storage.WebUserRepository;
+import io.oryxos.storage.WebUserService;
 import io.oryxos.tool.ToolRegistry;
 import io.oryxos.tool.builtin.FileTools;
 import io.oryxos.tool.builtin.HttpTools;
@@ -99,6 +103,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -464,6 +469,24 @@ public class OryxOsRuntime {
   @Bean
   SessionManager sessionManager(SessionRepository repository) {
     return new JpaSessionManager(repository);
+  }
+
+  /** 012-web-auth：管理台 Basic Auth 账号管理（密码哈希由 PasswordEncoderFactory 的 bean 提供）。 */
+  @Bean
+  WebUserService webUserService(WebUserRepository repository, PasswordEncoder passwordEncoder) {
+    return new WebUserService(repository, passwordEncoder);
+  }
+
+  /**
+   * 012-web-auth US3：浏览器登录 session 管理（create/findValid 惰性清过期/delete）。ttl 走 @Value 读字面量，避免 cli 引
+   * oryxos-web 的 WebAuthProperties 类。
+   */
+  @Bean
+  WebSessionService webSessionService(
+      WebSessionRepository repository,
+      @org.springframework.beans.factory.annotation.Value("${oryxos.web.auth.session-ttl:12h}")
+          java.time.Duration sessionTtl) {
+    return new WebSessionService(repository, sessionTtl);
   }
 
   @Bean

--- a/oryxos-cli/src/main/java/io/oryxos/cli/command/UserCommand.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/command/UserCommand.java
@@ -1,0 +1,179 @@
+package io.oryxos.cli.command;
+
+import io.oryxos.cli.OryxOsRuntime;
+import io.oryxos.storage.WebUser;
+import io.oryxos.storage.WebUserService;
+import java.io.Console;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.springframework.boot.Banner;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/**
+ * 重命令组：管理台账号管理（012-web-auth）。每个 leaf 自启 Spring（镜像 {@link ChatCommand}）， 通过 {@code
+ * context.getBean(WebUserService.class)} 干活。密码输入不回显（{@link Console#readPassword}）。
+ */
+@Command(
+    name = "user",
+    description = "管理管理台账号（Basic Auth）",
+    mixinStandardHelpOptions = true,
+    subcommands = {
+      UserCommand.AddCommand.class,
+      UserCommand.ListCommand.class,
+      UserCommand.DeleteCommand.class,
+      UserCommand.PasswdCommand.class,
+      UserCommand.DisableCommand.class,
+      UserCommand.EnableCommand.class
+    })
+public class UserCommand implements Runnable {
+
+  /** 密码最小长度（P3C：提常量避免魔法值）。 */
+  private static final int MIN_PASSWORD_LENGTH = 8;
+
+  @Override
+  public void run() {
+    new picocli.CommandLine(this).usage(System.out);
+  }
+
+  /** 起一次性 Spring 上下文，跑完即退。 */
+  private static void withService(java.util.function.Consumer<WebUserService> action) {
+    try (ConfigurableApplicationContext context =
+        new SpringApplicationBuilder(OryxOsRuntime.class)
+            .web(WebApplicationType.NONE)
+            .bannerMode(Banner.Mode.OFF)
+            .run()) {
+      action.accept(context.getBean(WebUserService.class));
+    }
+  }
+
+  /** 读密码（不回显）；两次一致且 ≥8 字符返回，否则抛 IllegalStateException。无 console 报错。 */
+  private static String readConfirmedPassword() {
+    Console console = System.console();
+    if (console == null) {
+      throw new IllegalStateException("no interactive console available (stdin piped?)");
+    }
+    char[] first = console.readPassword("Password (>= 8 chars): ");
+    char[] confirm = console.readPassword("Confirm: ");
+    String a = first == null ? "" : new String(first);
+    String b = confirm == null ? "" : new String(confirm);
+    if (first != null) {
+      java.util.Arrays.fill(first, '\0');
+    }
+    if (confirm != null) {
+      java.util.Arrays.fill(confirm, '\0');
+    }
+    if (!a.equals(b)) {
+      throw new IllegalStateException("passwords do not match");
+    }
+    if (a.length() < MIN_PASSWORD_LENGTH) {
+      throw new IllegalStateException("password must be at least 8 characters");
+    }
+    return a;
+  }
+
+  @Command(name = "add", description = "创建账号（交互输密码）", mixinStandardHelpOptions = true)
+  static class AddCommand implements Runnable {
+    @Parameters(index = "0", description = "用户名（≤64 字符，无空格）")
+    String username;
+
+    @Override
+    public void run() {
+      String password = readConfirmedPassword();
+      withService(
+          service -> {
+            service.create(username, password);
+            System.out.println("Created user '" + username + "'");
+          });
+    }
+  }
+
+  @Command(name = "list", description = "列出账号（不显密码）", mixinStandardHelpOptions = true)
+  static class ListCommand implements Runnable {
+    @Override
+    public void run() {
+      withService(
+          service -> {
+            List<WebUser> users = service.list();
+            if (users.isEmpty()) {
+              System.out.println("No users found. Run 'oryxos user add <username>' to create one.");
+              return;
+            }
+            DateTimeFormatter fmt = DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.systemDefault());
+            System.out.printf("%-24s %-8s %s%n", "USERNAME", "ENABLED", "CREATED_AT");
+            for (WebUser u : users) {
+              System.out.printf(
+                  "%-24s %-8s %s%n",
+                  u.getUsername(),
+                  u.isEnabled(),
+                  u.getCreatedAt() == null ? "" : fmt.format(u.getCreatedAt()));
+            }
+          });
+    }
+  }
+
+  @Command(name = "delete", description = "删除账号", mixinStandardHelpOptions = true)
+  static class DeleteCommand implements Runnable {
+    @Parameters(index = "0", description = "用户名")
+    String username;
+
+    @Override
+    public void run() {
+      withService(
+          service -> {
+            service.delete(username);
+            System.out.println("Deleted user '" + username + "'");
+          });
+    }
+  }
+
+  @Command(name = "passwd", description = "改密码（交互输新密码）", mixinStandardHelpOptions = true)
+  static class PasswdCommand implements Runnable {
+    @Parameters(index = "0", description = "用户名")
+    String username;
+
+    @Override
+    public void run() {
+      String password = readConfirmedPassword();
+      withService(
+          service -> {
+            service.changePassword(username, password);
+            System.out.println("Password updated for '" + username + "'");
+          });
+    }
+  }
+
+  @Command(name = "disable", description = "禁用账号", mixinStandardHelpOptions = true)
+  static class DisableCommand implements Runnable {
+    @Parameters(index = "0", description = "用户名")
+    String username;
+
+    @Override
+    public void run() {
+      withService(
+          service -> {
+            service.disable(username);
+            System.out.println("Disabled user '" + username + "'");
+          });
+    }
+  }
+
+  @Command(name = "enable", description = "启用账号", mixinStandardHelpOptions = true)
+  static class EnableCommand implements Runnable {
+    @Parameters(index = "0", description = "用户名")
+    String username;
+
+    @Override
+    public void run() {
+      withService(
+          service -> {
+            service.enable(username);
+            System.out.println("Enabled user '" + username + "'");
+          });
+    }
+  }
+}

--- a/oryxos-storage/pom.xml
+++ b/oryxos-storage/pom.xml
@@ -36,6 +36,17 @@
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-community-dialects</artifactId>
         </dependency>
+        <!-- 012-web-auth: 密码哈希用 DelegatingPasswordEncoder（{bcrypt} 前缀），单 jar，非 spring-boot-starter-security 全套 -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
+        <!-- 012-web-auth US3: @SuppressFBWarnings 注解（provided 不进运行时，跟 oryxos-web 一致） -->
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/oryxos-storage/src/main/java/io/oryxos/storage/WebSession.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/WebSession.java
@@ -1,0 +1,71 @@
+package io.oryxos.storage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/** 浏览器登录 session——表结构以手工 schema.sql 为唯一权威。 */
+@Entity
+@Table(name = "web_sessions")
+public class WebSession {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "session_id", nullable = false, unique = true)
+  private String sessionId;
+
+  @Column(name = "username", nullable = false)
+  private String username;
+
+  @Column(name = "expires_at", nullable = false)
+  private Instant expiresAt;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @PrePersist
+  void onCreate() {
+    if (createdAt == null) {
+      createdAt = Instant.now();
+    }
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getSessionId() {
+    return sessionId;
+  }
+
+  public void setSessionId(String sessionId) {
+    this.sessionId = sessionId;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public Instant getExpiresAt() {
+    return expiresAt;
+  }
+
+  public void setExpiresAt(Instant expiresAt) {
+    this.expiresAt = expiresAt;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/oryxos-storage/src/main/java/io/oryxos/storage/WebSessionRepository.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/WebSessionRepository.java
@@ -1,0 +1,12 @@
+package io.oryxos.storage;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** web_sessions 的访问通道；按 session_id 查用于 cookie 校验。 */
+public interface WebSessionRepository extends JpaRepository<WebSession, Long> {
+
+  Optional<WebSession> findBySessionId(String sessionId);
+
+  void deleteBySessionId(String sessionId);
+}

--- a/oryxos-storage/src/main/java/io/oryxos/storage/WebSessionService.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/WebSessionService.java
@@ -1,0 +1,77 @@
+package io.oryxos.storage;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 浏览器登录 session 管理（012-web-auth US3）：创建/查询有效 session/登出/过期判定。
+ *
+ * <p>session id 用 {@link UUID#randomUUID()}（不可预测）。过期时间 = 创建时间 + sessionTtl（由构造注入的 {@link
+ * Duration}，从 {@code WebAuthProperties.sessionTtl} 读，但本类不引 oryxos-web 类避免 storage→web 反向依赖）。
+ *
+ * <p>惰性清过期行：{@link #findValid(String)} 查到过期行时顺手 {@code delete}（无后台定时线程）。
+ *
+ * <p>plain class（非 @Service），构造注入 repository + ttl，由 {@code OryxOsRuntime} @Bean 装配。镜像 {@code
+ * WebUserService} 风格。只依赖 {@link Duration}（JDK）+ {@link WebSessionRepository}。
+ */
+public class WebSessionService {
+
+  private final WebSessionRepository repository;
+  private final Duration sessionTtl;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "repository 为 Spring 注入的共享单例，构造注入存同一引用正是意图（镜像既有 WebUserService / Controller 的 SuppressFBWarnings 模式）。")
+  public WebSessionService(WebSessionRepository repository, Duration sessionTtl) {
+    this.repository = repository;
+    this.sessionTtl = sessionTtl;
+  }
+
+  /** 建 session。session id = UUID，expires_at = now + sessionTtl。 */
+  @Transactional(rollbackFor = Exception.class)
+  public WebSession create(String username) {
+    WebSession session = new WebSession();
+    session.setSessionId(UUID.randomUUID().toString());
+    session.setUsername(username);
+    Instant now = Instant.now();
+    session.setExpiresAt(now.plus(sessionTtl));
+    return repository.save(session);
+  }
+
+  /**
+   * 查有效 session：命中且未过期返；过期行顺手 delete（惰性清）。不查 user enabled（Clarifications Q1 B： 改密/禁用后旧 session
+   * 仍有效到过期）。
+   */
+  @Transactional(rollbackFor = Exception.class)
+  public Optional<WebSession> findValid(String sessionId) {
+    if (sessionId == null || sessionId.isBlank()) {
+      return Optional.empty();
+    }
+    Optional<WebSession> found = repository.findBySessionId(sessionId);
+    if (found.isEmpty()) {
+      return Optional.empty();
+    }
+    WebSession session = found.get();
+    if (isExpired(session)) {
+      repository.deleteBySessionId(sessionId);
+      return Optional.empty();
+    }
+    return Optional.of(session);
+  }
+
+  /** 登出：删 session 行。未登录（无 session）也幂等成功。 */
+  @Transactional(rollbackFor = Exception.class)
+  public void delete(String sessionId) {
+    if (sessionId != null && !sessionId.isBlank()) {
+      repository.deleteBySessionId(sessionId);
+    }
+  }
+
+  public boolean isExpired(WebSession session) {
+    return session.getExpiresAt() == null || session.getExpiresAt().isBefore(Instant.now());
+  }
+}

--- a/oryxos-storage/src/main/java/io/oryxos/storage/WebUser.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/WebUser.java
@@ -1,0 +1,85 @@
+package io.oryxos.storage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/** 管理台 Basic Auth 账号——表结构以手工 schema.sql 为唯一权威。 */
+@Entity
+@Table(name = "web_users")
+public class WebUser {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "username", nullable = false, unique = true)
+  private String username;
+
+  @Column(name = "password_hash", nullable = false)
+  private String passwordHash;
+
+  @Column(nullable = false)
+  private boolean enabled;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  @PrePersist
+  void onCreate() {
+    if (createdAt == null) {
+      createdAt = Instant.now();
+    }
+    if (updatedAt == null) {
+      updatedAt = createdAt;
+    }
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getPasswordHash() {
+    return passwordHash;
+  }
+
+  public void setPasswordHash(String passwordHash) {
+    this.passwordHash = passwordHash;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(Instant updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+}

--- a/oryxos-storage/src/main/java/io/oryxos/storage/WebUserRepository.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/WebUserRepository.java
@@ -1,0 +1,12 @@
+package io.oryxos.storage;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** web_users 的访问通道；按 username 查用于 Basic Auth 校验。 */
+public interface WebUserRepository extends JpaRepository<WebUser, Long> {
+
+  Optional<WebUser> findByUsername(String username);
+
+  boolean existsByUsername(String username);
+}

--- a/oryxos-storage/src/main/java/io/oryxos/storage/WebUserService.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/WebUserService.java
@@ -1,0 +1,126 @@
+package io.oryxos.storage;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * 管理台账号管理（012-web-auth）：创建/删除/改密/禁用/列出/校验。
+ *
+ * <p>密码哈希走 {@link PasswordEncoder}（由 oryxos-web 的 PasswordEncoderFactory 提供的
+ * DelegatingPasswordEncoder，{@code {bcrypt}} 前缀，将来升 Argon2 无迁移）。明文密码 NEVER 落库/日志（宪法 VI）。
+ *
+ * <p>plain class（非 @Service），构造注入 repository + encoder，由 {@code OryxOsRuntime} @Bean 装配。 镜像 storage
+ * 模块既有 {@code Jpa*Manager}/{@code Jpa*Store} 风格。只依赖 {@link PasswordEncoder}
+ * 接口（spring-security-crypto，storage pom 已加），不引 oryxos-web 类（避免 storage→web 反向依赖）。
+ */
+public class WebUserService {
+
+  private static final int MIN_PASSWORD_LENGTH = 8;
+  private static final int MAX_USERNAME_LENGTH = 64;
+
+  private final WebUserRepository repository;
+  private final PasswordEncoder passwordEncoder;
+
+  public WebUserService(WebUserRepository repository, PasswordEncoder passwordEncoder) {
+    this.repository = repository;
+    this.passwordEncoder = passwordEncoder;
+  }
+
+  /** 创建账号；哈希密码后落库。重名/弱密码/用户名非法抛 IllegalArgumentException。 */
+  public WebUser create(String username, String rawPassword) {
+    validateUsername(username);
+    validatePassword(rawPassword);
+    if (repository.existsByUsername(username)) {
+      throw new IllegalArgumentException("user '" + username + "' already exists");
+    }
+    WebUser user = new WebUser();
+    user.setUsername(username.strip());
+    user.setPasswordHash(passwordEncoder.encode(rawPassword));
+    user.setEnabled(true);
+    return repository.save(user);
+  }
+
+  /** 删账号；不存在抛 IllegalArgumentException。 */
+  public void delete(String username) {
+    WebUser user = mustFind(username);
+    repository.delete(user);
+  }
+
+  /** 改密码；用户不存在/弱密码抛 IllegalArgumentException。 */
+  public void changePassword(String username, String rawPassword) {
+    validatePassword(rawPassword);
+    WebUser user = mustFind(username);
+    user.setPasswordHash(passwordEncoder.encode(rawPassword));
+    user.setUpdatedAt(Instant.now());
+    repository.save(user);
+  }
+
+  /** 禁用账号；不存在抛 IllegalArgumentException。 */
+  public void disable(String username) {
+    WebUser user = mustFind(username);
+    user.setEnabled(false);
+    user.setUpdatedAt(Instant.now());
+    repository.save(user);
+  }
+
+  /** 启用账号（对称 disable）；不存在抛 IllegalArgumentException。 */
+  public void enable(String username) {
+    WebUser user = mustFind(username);
+    user.setEnabled(true);
+    user.setUpdatedAt(Instant.now());
+    repository.save(user);
+  }
+
+  /** 列全部账号（按 username 排序）；仅返回实体（list 命令负责不显 hash）。 */
+  public List<WebUser> list() {
+    return repository.findAll().stream()
+        .sorted(Comparator.comparing(WebUser::getUsername))
+        .toList();
+  }
+
+  /** 校验账密；用户不存在/密码错/禁用均返 false（不区分原因，防用户名枚举）。 */
+  public boolean verify(String username, String rawPassword) {
+    if (username == null || rawPassword == null) {
+      return false;
+    }
+    return repository
+        .findByUsername(username)
+        .filter(WebUser::isEnabled)
+        .map(user -> passwordEncoder.matches(rawPassword, user.getPasswordHash()))
+        .orElse(false);
+  }
+
+  /** 启动校验用：是否存在 enabled 账号（FR-006，auth.enabled=true 但无 enabled 账号阻断启动）。 */
+  public boolean hasEnabledAccount() {
+    return repository.findAll().stream().anyMatch(WebUser::isEnabled);
+  }
+
+  private WebUser mustFind(String username) {
+    return repository
+        .findByUsername(username)
+        .orElseThrow(() -> new IllegalArgumentException("user '" + username + "' not found"));
+  }
+
+  private static void validateUsername(String username) {
+    if (username == null || username.isBlank()) {
+      throw new IllegalArgumentException("username must not be empty");
+    }
+    String trimmed = username.strip();
+    if (trimmed.length() > MAX_USERNAME_LENGTH) {
+      throw new IllegalArgumentException(
+          "username must be at most " + MAX_USERNAME_LENGTH + " characters");
+    }
+    if (trimmed.chars().anyMatch(Character::isWhitespace)) {
+      throw new IllegalArgumentException("username must not contain whitespace");
+    }
+  }
+
+  private static void validatePassword(String rawPassword) {
+    if (rawPassword == null || rawPassword.length() < MIN_PASSWORD_LENGTH) {
+      throw new IllegalArgumentException(
+          "password must be at least " + MIN_PASSWORD_LENGTH + " characters");
+    }
+  }
+}

--- a/oryxos-storage/src/main/resources/schema.sql
+++ b/oryxos-storage/src/main/resources/schema.sql
@@ -130,3 +130,27 @@ CREATE TABLE IF NOT EXISTS sandbox_whitelist (
     created_at TIMESTAMP NOT NULL,
     UNIQUE (category, entry_value)
 );
+
+-- web_users：管理台 Basic Auth 账号（012-web-auth）
+-- 密码哈希存储（{bcrypt} 前缀 + hash），绝不存明文（宪法 VI 凭证不落地）
+CREATE TABLE IF NOT EXISTS web_users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username VARCHAR(64) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT 1,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_web_users_username ON web_users (username);
+
+-- web_sessions：浏览器登录 session（012-web-auth US3）
+-- session_id = UUID（cookie 值）；expires_at = created_at + session-ttl（默认 12h）
+-- 惰性清：filter 查到过期行顺手 delete，无后台定时线程
+CREATE TABLE IF NOT EXISTS web_sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id VARCHAR(64) NOT NULL UNIQUE,
+    username VARCHAR(64) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_web_sessions_session ON web_sessions (session_id);

--- a/oryxos-storage/src/test/java/io/oryxos/storage/WebSessionServiceTest.java
+++ b/oryxos-storage/src/test/java/io/oryxos/storage/WebSessionServiceTest.java
@@ -1,0 +1,136 @@
+package io.oryxos.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+/**
+ * 012-web-auth US3 验收 harness：WebSessionServiceTest——session 创建/查有效/过期惰性清/登出 钉死。 镜像
+ * WebUserServiceTest 的 @DataJpaTest + @DynamicPropertySource 模式。
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class WebSessionServiceTest {
+
+  @TempDir static Path dbDir;
+
+  @DynamicPropertySource
+  static void sqliteProperties(DynamicPropertyRegistry registry) {
+    registry.add(
+        "spring.datasource.url", () -> "jdbc:sqlite:" + dbDir.resolve("websession-test.db"));
+    registry.add("spring.datasource.driver-class-name", () -> "org.sqlite.JDBC");
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+    registry.add(
+        "spring.jpa.database-platform", () -> "org.hibernate.community.dialect.SQLiteDialect");
+    registry.add("spring.sql.init.mode", () -> "always");
+  }
+
+  @Autowired private WebSessionRepository repository;
+
+  private WebSessionService service() {
+    return new WebSessionService(repository, Duration.ofHours(12));
+  }
+
+  @Test
+  @DisplayName("create_生成UUID_sessionId且expires_at为now+12h")
+  void create_generatesUuidAndExpiry() {
+    WebSessionService svc = service();
+    WebSession s = svc.create("admin");
+
+    assertTrue(s.getSessionId() != null && s.getSessionId().length() > 10);
+    assertTrue(s.getExpiresAt().isAfter(Instant.now()));
+    assertEquals("admin", s.getUsername());
+  }
+
+  @Test
+  @DisplayName("findValid_未过期session命中返")
+  void findValid_unexpired_returnsSession() {
+    WebSessionService svc = service();
+    WebSession created = svc.create("admin");
+
+    assertTrue(svc.findValid(created.getSessionId()).isPresent());
+  }
+
+  @Test
+  @DisplayName("findValid_不存在的sessionId返empty")
+  void findValid_missing_returnsEmpty() {
+    assertTrue(service().findValid("nonexistent-uuid").isEmpty());
+  }
+
+  @Test
+  @DisplayName("findValid_null或blank返empty")
+  void findValid_nullOrBlank_returnsEmpty() {
+    WebSessionService svc = service();
+    assertTrue(svc.findValid(null).isEmpty());
+    assertTrue(svc.findValid("").isEmpty());
+    assertTrue(svc.findValid("   ").isEmpty());
+  }
+
+  @Test
+  @DisplayName("findValid_过期session返empty且顺手删除行（惰性清）")
+  void findValid_expired_returnsEmptyAndDeletes() {
+    // 用 0 ttl 建 service，让所有 session 立即过期
+    WebSessionService svc = new WebSessionService(repository, Duration.ZERO);
+    WebSession created = svc.create("admin");
+
+    // 过期 → findValid 返 empty
+    assertTrue(svc.findValid(created.getSessionId()).isEmpty());
+    // 惰性清：行已删
+    assertFalse(repository.findBySessionId(created.getSessionId()).isPresent());
+  }
+
+  @Test
+  @DisplayName("isExpired_过期判定")
+  void isExpired_correctJudgment() throws Exception {
+    WebSessionService svc = service();
+    WebSession s = svc.create("admin");
+    assertFalse(svc.isExpired(s));
+
+    // 手动把过期时间设过去
+    s.setExpiresAt(Instant.now().minusSeconds(60));
+    assertTrue(svc.isExpired(s));
+  }
+
+  @Test
+  @DisplayName("delete_删行")
+  void delete_removesRow() {
+    WebSessionService svc = service();
+    WebSession created = svc.create("admin");
+    assertTrue(repository.findBySessionId(created.getSessionId()).isPresent());
+
+    svc.delete(created.getSessionId());
+    assertFalse(repository.findBySessionId(created.getSessionId()).isPresent());
+  }
+
+  @Test
+  @DisplayName("delete_null或不存在的sessionId幂等不崩")
+  void delete_missingIdOrNull_isIdempotent() {
+    WebSessionService svc = service();
+    svc.delete(null);
+    svc.delete("");
+    svc.delete("nonexistent");
+    // 不抛异常即通过
+    assertTrue(true);
+  }
+
+  @Test
+  @DisplayName("多次create生成不同sessionId")
+  void create_multipleDistinctSessionIds() {
+    WebSessionService svc = service();
+    WebSession a = svc.create("admin");
+    WebSession b = svc.create("admin");
+    assertFalse(a.getSessionId().equals(b.getSessionId()));
+  }
+}

--- a/oryxos-storage/src/test/java/io/oryxos/storage/WebUserServiceTest.java
+++ b/oryxos-storage/src/test/java/io/oryxos/storage/WebUserServiceTest.java
@@ -1,0 +1,175 @@
+package io.oryxos.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+/**
+ * 012-web-auth 验收 harness：WebUserServiceTest——账号管理口径（哈希非明文、校验对错、禁用失效、 重名/弱密码/用户名非法）在此钉死。镜像
+ * SessionManagerTest 的 @DataJpaTest + @DynamicPropertySource 模式。
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class WebUserServiceTest {
+
+  @TempDir static Path dbDir;
+
+  @DynamicPropertySource
+  static void sqliteProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", () -> "jdbc:sqlite:" + dbDir.resolve("webauth-test.db"));
+    registry.add("spring.datasource.driver-class-name", () -> "org.sqlite.JDBC");
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "none"); // 不许 Hibernate 自动建表
+    registry.add(
+        "spring.jpa.database-platform", () -> "org.hibernate.community.dialect.SQLiteDialect");
+    registry.add("spring.sql.init.mode", () -> "always"); // 建表走手工 schema.sql
+  }
+
+  @Autowired private WebUserRepository repository;
+
+  private final PasswordEncoder encoder =
+      PasswordEncoderFactories.createDelegatingPasswordEncoder();
+
+  private WebUserService service() {
+    return new WebUserService(repository, encoder);
+  }
+
+  @Test
+  @DisplayName("create_密码哈希非明文_且每次salt不同")
+  void create_hashesPasswordNotPlaintext() {
+    WebUserService svc = service();
+    WebUser u1 = svc.create("alice", "password1");
+    WebUser u2 = svc.create("bob", "password1");
+
+    // hash 非明文
+    assertNotEquals("password1", u1.getPasswordHash());
+    assertTrue(u1.getPasswordHash().startsWith("{bcrypt}"));
+    // 相同密码不同 salt → hash 不同
+    assertNotEquals(u1.getPasswordHash(), u2.getPasswordHash());
+    assertTrue(u1.isEnabled());
+  }
+
+  @Test
+  @DisplayName("verify_正确密码返回true_错误密码返回false")
+  void verify_correctPasswordTrue_wrongFalse() {
+    WebUserService svc = service();
+    svc.create("alice", "password1");
+
+    assertTrue(svc.verify("alice", "password1"));
+    assertFalse(svc.verify("alice", "wrong-password"));
+    assertFalse(svc.verify("nobody", "password1")); // 不存在不区分原因（防枚举）
+  }
+
+  @Test
+  @DisplayName("disable_后_verify返回false")
+  void disable_blocksLogin() {
+    WebUserService svc = service();
+    svc.create("alice", "password1");
+    svc.disable("alice");
+
+    assertFalse(svc.verify("alice", "password1"));
+  }
+
+  @Test
+  @DisplayName("hasEnabledAccount_空时false_有enabled时true")
+  void hasEnabledAccount_reflectsEnabledAccounts() {
+    WebUserService svc = service();
+    assertFalse(svc.hasEnabledAccount()); // 空
+
+    svc.create("alice", "password1");
+    assertTrue(svc.hasEnabledAccount());
+
+    svc.disable("alice");
+    assertFalse(svc.hasEnabledAccount()); // 全禁用
+  }
+
+  @Test
+  @DisplayName("重名_create抛错且不覆盖原密码")
+  void create_duplicateThrows() {
+    WebUserService svc = service();
+    svc.create("alice", "password1");
+
+    assertThrows(IllegalArgumentException.class, () -> svc.create("alice", "password2"));
+    // 原密码仍可用
+    assertTrue(svc.verify("alice", "password1"));
+    assertFalse(svc.verify("alice", "password2"));
+  }
+
+  @Test
+  @DisplayName("changePassword_旧密码失效_新密码生效")
+  void changePassword_rotatesCredential() {
+    WebUserService svc = service();
+    svc.create("alice", "password1");
+    svc.changePassword("alice", "newpassword2");
+
+    assertFalse(svc.verify("alice", "password1"));
+    assertTrue(svc.verify("alice", "newpassword2"));
+  }
+
+  @Test
+  @DisplayName("delete_后再verify返回false")
+  void delete_removesAccount() {
+    WebUserService svc = service();
+    svc.create("alice", "password1");
+    svc.delete("alice");
+
+    assertFalse(svc.verify("alice", "password1"));
+    assertFalse(repository.existsByUsername("alice"));
+  }
+
+  @Test
+  @DisplayName("list_按username排序且不含密码字段")
+  void list_sortedByUsername() {
+    WebUserService svc = service();
+    svc.create("charlie", "password1");
+    svc.create("alice", "password1");
+    svc.create("bob", "password1");
+
+    var users = svc.list();
+    assertEquals(3, users.size());
+    assertEquals("alice", users.get(0).getUsername());
+    assertEquals("bob", users.get(1).getUsername());
+    assertEquals("charlie", users.get(2).getUsername());
+  }
+
+  @Test
+  @DisplayName("弱密码_短于8抛错")
+  void create_shortPasswordThrows() {
+    assertThrows(IllegalArgumentException.class, () -> service().create("alice", "short"));
+  }
+
+  @Test
+  @DisplayName("空用户名抛错")
+  void create_emptyUsernameThrows() {
+    assertThrows(IllegalArgumentException.class, () -> service().create("", "password1"));
+    assertThrows(IllegalArgumentException.class, () -> service().create("  ", "password1"));
+  }
+
+  @Test
+  @DisplayName("用户名含空格抛错")
+  void create_usernameWithWhitespaceThrows() {
+    assertThrows(IllegalArgumentException.class, () -> service().create("has space", "password1"));
+  }
+
+  @Test
+  @DisplayName("delete/passwd/disable_不存在用户抛错")
+  void mutateMissingUser_throws() {
+    WebUserService svc = service();
+    assertThrows(IllegalArgumentException.class, () -> svc.delete("nobody"));
+    assertThrows(IllegalArgumentException.class, () -> svc.changePassword("nobody", "password2"));
+    assertThrows(IllegalArgumentException.class, () -> svc.disable("nobody"));
+  }
+}

--- a/oryxos-web/pom.xml
+++ b/oryxos-web/pom.xml
@@ -39,6 +39,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <!-- 012-web-auth: 声明 PasswordEncoder bean（DelegatingPasswordEncoder，{bcrypt} 前缀）；单 jar，非 starter-security 全套 -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
         <!-- OpenAPI / Swagger UI -->
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -3,6 +3,44 @@ import { ref, reactive, computed } from 'vue'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import logoUrl from './assets/logo.svg'
+import LoginView from './views/LoginView.vue'
+
+// —— 012-web-auth US3：登录守卫 —— 未登录先查 /api/v1/auth/me；登录页 LoginView 调 /auth/login
+const auth = reactive({ checking: true, enabled: true, username: null })
+async function checkAuth() {
+  auth.checking = true
+  try {
+    const res = await fetch('/api/v1/auth/me')
+    const body = await res.json()
+    if (res.status === 200 && body.code === 0) {
+      auth.enabled = body.data?.authenticationEnabled !== false
+      auth.username = body.data?.username || null
+    } else {
+      auth.enabled = true
+      auth.username = null
+    }
+  } catch (e) {
+    auth.enabled = true
+    auth.username = null
+  } finally {
+    auth.checking = false
+  }
+}
+checkAuth()
+
+function onLogined(username) {
+  auth.username = username
+}
+
+async function logout() {
+  try {
+    await fetch('/api/v1/auth/logout', { method: 'POST' })
+  } catch (e) {
+    /* 忽略，仍跳登录页 */
+  }
+  auth.username = null
+  active.value = 'overview'
+}
 
 // 顶层：概览 / Agent 列表 / 定时任务。「OS 运行时」下收纳 Provider/Tool/Sandbox/长期记忆/会话——
 // 这些都是底座本身的运行时状态，跟业务 Agent 管理分层展示（31 节：侧边栏重分组）。
@@ -1150,7 +1188,12 @@ const outputRows = computed(() =>
 </script>
 
 <template>
-  <div class="layout">
+  <!-- 012-web-auth US3：未登录先显登录页；检查中显骨架屏（避免突兀的"加载中"文字） -->
+  <div v-if="auth.checking" class="boot-splash" aria-busy="true" aria-live="polite">
+    <div class="boot-spinner" aria-hidden="true"></div>
+  </div>
+  <LoginView v-else-if="auth.enabled && !auth.username" @logined="onLogined" />
+  <div v-else class="layout">
     <aside class="nav">
       <div class="brand">
         <img :src="logoUrl" alt="OryxOS" class="logo" />
@@ -1182,7 +1225,10 @@ const outputRows = computed(() =>
         </button>
       </template>
 
-      <div class="readonly">管理台</div>
+      <div class="auth-foot">
+        <span class="mono">{{ auth.username || '认证已关闭' }}</span>
+        <button v-if="auth.enabled" class="btn" @click="logout">登出</button>
+      </div>
     </aside>
 
     <main class="content">
@@ -2087,7 +2133,8 @@ const outputRows = computed(() =>
 .nav-group { display: flex; align-items: center; justify-content: space-between; }
 .chevron { color: var(--text-3); font-size: 11px; }
 .nav-sub { padding-left: 22px; font-size: 13px; }
-.readonly { margin-top: auto; color: var(--text-3); font-size: 12px; padding: 8px; }
+.auth-foot { margin-top: auto; display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--text-3); font-size: 12px; padding: 8px; }
+.auth-foot .mono { color: var(--text-2); }
 .content { flex: 1; padding: 24px 32px; overflow-x: auto; }
 h2 { font-weight: 600; margin: 0 0 16px; }
 .page-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
@@ -2242,4 +2289,23 @@ th { color: var(--text-2); font-weight: 500; }
 .chat-send-hint { font-size: 12px; }
 
 @media (max-width: 640px) { .layout { flex-direction: column; } .nav { width: auto; flex-direction: row; flex-wrap: wrap; } .readonly { display: none; } .ws { flex-direction: column; } .ws-tree { width: auto; } }
+
+/* 启动闪屏：黑底居中 spinner，与登录页/管理台同色调，避免突兀文字 */
+.boot-splash {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+}
+.boot-spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid var(--border);
+  border-top-color: var(--brand);
+  border-radius: 50%;
+  animation: boot-spin 0.7s linear infinite;
+}
+@keyframes boot-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .boot-spinner { animation: none; } }
 </style>

--- a/oryxos-web/src/main/frontend/src/views/LoginView.vue
+++ b/oryxos-web/src/main/frontend/src/views/LoginView.vue
@@ -1,0 +1,640 @@
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import logoUrl from '../assets/logo.svg'
+
+const emit = defineEmits(['logined'])
+
+const form = reactive({ username: '', password: '' })
+const busy = ref(false)
+const error = ref(null)
+const showPassword = ref(false)
+const userInput = ref(null)
+
+const features = [
+  {
+    icon: 'M4 7h16M4 12h16M4 17h10',
+    title: '多模型路由',
+    desc: 'DeepSeek / Qwen / Kimi / Ollama 间切换，零代码修改，显式映射',
+  },
+  {
+    icon: 'M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83',
+    title: '自实现 ReAct 循环',
+    desc: '手写推理–行动循环，工具调度完全可控，不依赖框架抽象',
+  },
+  {
+    icon: 'M12 2l8 4v6c0 5-3.5 8-8 10-4.5-2-8-5-8-10V6l8-4z M9 12l2 2 4-4',
+    title: '分层记忆系统',
+    desc: '会话 + 长期记忆，自动注入 system prompt，跨会话一致',
+  },
+]
+
+async function submit() {
+  if (busy.value) return
+  if (!form.username.trim() || !form.password) {
+    error.value = '请输入用户名和密码'
+    return
+  }
+  busy.value = true
+  error.value = null
+  try {
+    const res = await fetch('/api/v1/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: form.username.trim(), password: form.password }),
+    })
+    const body = await res.json()
+    if (res.status === 401 || body.code === 401) {
+      error.value = '用户名或密码错误'
+      form.password = ''
+      return
+    }
+    if (body.code !== 0) throw new Error(body.message || '登录失败')
+    emit('logined', body.data?.username || form.username.trim())
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    busy.value = false
+  }
+}
+
+// 输入即清错误（主流登录页行为）
+function clearError() {
+  if (error.value) error.value = null
+}
+
+// 首屏自动聚焦用户名输入框
+onMounted(() => {
+  userInput.value?.focus()
+})
+</script>
+
+<template>
+  <div class="login-split">
+    <!-- 左栏：品牌 + 卖点 -->
+    <aside class="brand-panel">
+      <div class="glow glow-1" aria-hidden="true" />
+      <div class="glow glow-2" aria-hidden="true" />
+      <div class="brand-center">
+        <header class="brand-head">
+          <img :src="logoUrl" alt="OryxOS" class="logo" />
+        </header>
+        <div class="brand-body">
+          <p class="brand-eyebrow"><span class="eyebrow-comment">// </span>开源 · 私有部署 · Apache 2.0</p>
+          <h1 class="brand-title">DISTRIBUTED<br />AI AGENT OS</h1>
+          <p class="brand-sub">基于 Java 21 构建的分布式 AI Agent OS——私有部署在你自己的 K8s 或服务器上，让一群业务 Agent 像进程跑在操作系统上一样，可靠地运行和协同。</p>
+          <ul class="features">
+            <li v-for="(f, i) in features" :key="f.title" class="feature">
+              <span class="feature-num mono">{{ String(i + 1).padStart(2, '0') }}</span>
+              <div>
+                <div class="feature-title">{{ f.title }}</div>
+                <div class="feature-desc">{{ f.desc }}</div>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <footer class="brand-foot">
+        <a
+          class="gh-link"
+          href="https://github.com/oryx-labs/oryxos"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+            <path
+              fill="currentColor"
+              d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.87 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.78 1.2 1.78 1.2 1.04 1.78 2.73 1.27 3.4.97.1-.75.4-1.27.73-1.56-2.56-.29-5.26-1.28-5.26-5.7 0-1.26.45-2.29 1.2-3.1-.12-.3-.52-1.46.1-3.05 0 0 .98-.31 3.2 1.18a11.1 11.1 0 0 1 5.82 0c2.22-1.49 3.2-1.18 3.2-1.18.62 1.59.22 2.75.1 3.05.75.81 1.2 1.84 1.2 3.1 0 4.43-2.7 5.4-5.27 5.69.41.36.78 1.05.78 2.12v3.14c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5Z"
+            />
+          </svg>
+          <span>GitHub</span>
+        </a>
+      </footer>
+    </aside>
+
+    <!-- 右栏：登录卡 -->
+    <main class="form-panel">
+      <div class="card">
+        <h2 class="title">欢迎登录</h2>
+        <p class="sub">管理台管理 Agent、会话、工具与定时任务</p>
+
+        <form class="form" @submit.prevent="submit" novalidate>
+          <div class="field">
+            <label for="login-user" class="label">用户名</label>
+            <div class="input-row">
+              <span class="input-ico">
+                <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+                  <path
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.6"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"
+                  />
+                  <circle cx="12" cy="7" r="4" fill="none" stroke="currentColor" stroke-width="1.6" />
+                </svg>
+              </span>
+              <input
+                id="login-user"
+                ref="userInput"
+                v-model="form.username"
+                class="input"
+                type="text"
+                autocomplete="username"
+                :disabled="busy"
+                @input="clearError"
+              />
+            </div>
+          </div>
+
+          <div class="field">
+            <label for="login-pass" class="label">密码</label>
+            <div class="input-row">
+              <span class="input-ico">
+                <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+                  <rect
+                    x="3"
+                    y="11"
+                    width="18"
+                    height="10"
+                    rx="2"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.6"
+                  />
+                  <path
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.6"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M7 11V7a5 5 0 0 1 10 0v4"
+                  />
+                </svg>
+              </span>
+              <input
+                id="login-pass"
+                v-model="form.password"
+                class="input"
+                :type="showPassword ? 'text' : 'password'"
+                autocomplete="current-password"
+                :disabled="busy"
+                @input="clearError"
+              />
+              <button
+                type="button"
+                class="toggle"
+                :aria-label="showPassword ? '隐藏密码' : '显示密码'"
+                :title="showPassword ? '隐藏密码' : '显示密码'"
+                @click="showPassword = !showPassword"
+              >
+                <svg v-if="showPassword" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+                  <path
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.6"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7Z"
+                  />
+                  <circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="1.6" />
+                </svg>
+                <svg v-else viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+                  <path
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.6"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M9.9 4.24A9.1 9.1 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72 6.72A9.1 9.1 0 0 1 12 22c-7 0-11-8-11-8a18.5 18.5 0 0 1 4.06-4.95m3.1 3.1a3 3 0 1 0 4.68-3.68M1 1l22 22"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <p v-if="error" class="error" role="alert">{{ error }}</p>
+
+          <button class="btn-primary" type="submit" :disabled="busy">
+            <span v-if="busy" class="spinner" aria-hidden="true" />
+            {{ busy ? '登录中…' : '登录' }}
+          </button>
+        </form>
+      </div>
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.login-split {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  background: var(--bg);
+}
+
+/* —— 左栏：品牌区 —— */
+.brand-panel {
+  position: relative;
+  background:
+    linear-gradient(160deg, #0a0a0a 0%, #141414 60%, #0d0d0d 100%);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  padding: 56px 72px;
+  overflow: hidden;
+}
+/* 细网格背景（科技感，极淡，不抢内容） */
+.brand-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: 48px 48px;
+  -webkit-mask-image: radial-gradient(ellipse at center, #000 30%, transparent 80%);
+  mask-image: radial-gradient(ellipse at center, #000 30%, transparent 80%);
+  pointer-events: none;
+  z-index: 0;
+}
+.glow {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(100px);
+  pointer-events: none;
+}
+.glow-1 {
+  width: 620px;
+  height: 620px;
+  background: rgba(249, 115, 22, 0.18);
+  top: -200px;
+  right: -160px;
+}
+.glow-2 {
+  width: 460px;
+  height: 460px;
+  background: rgba(249, 115, 22, 0.1);
+  bottom: -160px;
+  left: -100px;
+}
+.brand-head {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin-bottom: 32px;
+}
+.logo {
+  width: 250px;
+  height: auto;
+}
+.brand-name {
+  font-size: 19px;
+  font-weight: 600;
+  color: var(--text-1);
+  letter-spacing: 0.02em;
+}
+.brand-center {
+  margin-top: auto;
+  margin-bottom: auto;
+  position: relative;
+  z-index: 1;
+  text-align: center;
+}
+.brand-body {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+}
+.brand-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-2);
+  margin: 0 0 22px;
+  letter-spacing: 0.02em;
+}
+.eyebrow-comment {
+  color: var(--brand);
+}
+.brand-title {
+  font-size: 48px;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 22px;
+  color: var(--text-1);
+}
+.brand-sub {
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--text-2);
+  max-width: min(520px, 90%);
+  margin: 0 auto 40px;
+}
+.features {
+  list-style: none;
+  padding: 0;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 540px;
+}
+.feature {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px 20px;
+  text-align: left;
+}
+.feature-ico {
+  flex: none;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--brand);
+  border-radius: 10px;
+}
+.feature-num {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--brand);
+  letter-spacing: 0.1em;
+  padding-top: 1px;
+}
+.feature-ico svg {
+  width: 24px;
+  height: 24px;
+}
+.feature-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-1);
+}
+.feature-desc {
+  font-size: 14px;
+  color: var(--text-2);
+  margin-top: 3px;
+  line-height: 1.4;
+}
+.brand-foot {
+  position: relative;
+  z-index: 1;
+  margin-top: 40px;
+  display: flex;
+  justify-content: center;
+}
+.gh-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-2);
+  font-size: 14px;
+  text-decoration: none;
+  padding: 8px 16px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.03);
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+.gh-link:hover {
+  color: var(--text-1);
+  border-color: var(--brand);
+  background: var(--brand-soft);
+}
+.gh-link:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+/* —— 右栏：登录卡 —— */
+.form-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  background: radial-gradient(ellipse at top, #1f1f1f 0%, #161616 50%, #121212 100%);
+  position: relative;
+  overflow: hidden;
+}
+.form-panel::before {
+  content: '';
+  position: absolute;
+  top: -120px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 420px;
+  height: 420px;
+  border-radius: 50%;
+  background: rgba(249, 115, 22, 0.07);
+  filter: blur(90px);
+  pointer-events: none;
+}
+.form-panel::after {
+  content: '';
+  position: absolute;
+  bottom: -160px;
+  right: -80px;
+  width: 300px;
+  height: 300px;
+  border-radius: 50%;
+  background: rgba(249, 115, 22, 0.03);
+  filter: blur(70px);
+  pointer-events: none;
+}
+.card {
+  width: 100%;
+  max-width: 460px;
+  position: relative;
+  z-index: 1;
+  background: rgba(20, 20, 20, 0.6);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 44px 40px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+}
+/* 顶部高光边（模拟光照，玻璃拟态卡质感） */
+.card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 16px;
+  right: 16px;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(249, 115, 22, 0.5),
+    transparent
+  );
+  pointer-events: none;
+}
+.title {
+  font-size: 30px;
+  font-weight: 600;
+  margin: 0 0 8px;
+  letter-spacing: -0.01em;
+}
+.sub {
+  color: var(--text-2);
+  font-size: 15px;
+  margin: 0 0 36px;
+}
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.label {
+  font-size: 14px;
+  color: var(--text-2);
+  font-weight: 500;
+}
+.input-row {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.input-ico {
+  position: absolute;
+  left: 16px;
+  color: var(--text-3);
+  display: flex;
+  pointer-events: none;
+}
+.input-ico svg {
+  width: 20px;
+  height: 20px;
+}
+.input {
+  width: 100%;
+  background: var(--bg-mute);
+  color: var(--text-1);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px 50px 16px 48px;
+  font-size: 16px;
+  font-family: var(--font-base);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.input:focus {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px var(--brand-soft);
+}
+.input:disabled {
+  opacity: 0.5;
+}
+.toggle {
+  position: absolute;
+  right: 6px;
+  background: none;
+  border: none;
+  color: var(--text-3);
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s ease;
+}
+.toggle:hover {
+  color: var(--text-1);
+}
+.toggle:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+.error {
+  color: var(--err);
+  font-size: 13px;
+  margin: 0;
+  padding: 8px 12px;
+  background: rgba(239, 68, 68, 0.08);
+  border-radius: 6px;
+}
+.btn-primary {
+  background: linear-gradient(180deg, #fb923c 0%, #f97316 50%, #ea6a00 100%);
+  color: #000;
+  border: none;
+  border-radius: 8px;
+  padding: 15px 0;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.35),
+    0 1px 2px rgba(0, 0, 0, 0.3),
+    0 4px 12px rgba(249, 115, 22, 0.25);
+  transition: background 0.15s ease, transform 0.1s ease, box-shadow 0.15s ease;
+}
+.btn-primary:hover:not(:disabled) {
+  background: linear-gradient(180deg, #fb923c 0%, #f97316 45%, #d85f00 100%);
+  transform: translateY(-1px);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    0 2px 4px rgba(0, 0, 0, 0.3),
+    0 6px 16px rgba(249, 115, 22, 0.35);
+}
+.btn-primary:active:not(:disabled) {
+  transform: scale(0.99);
+}
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(0, 0, 0, 0.3);
+  border-top-color: #000;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* —— 响应式：窄屏隐藏左栏 —— */
+@media (max-width: 960px) {
+  .login-split {
+    grid-template-columns: 1fr;
+  }
+  .brand-panel {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .input,
+  .toggle,
+  .btn-primary,
+  .spinner {
+    transition: none;
+    animation: none;
+  }
+}
+</style>

--- a/oryxos-web/src/main/java/io/oryxos/web/config/AuthFilterConfig.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/config/AuthFilterConfig.java
@@ -1,0 +1,36 @@
+package io.oryxos.web.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.storage.WebSessionService;
+import io.oryxos.storage.WebUserService;
+import io.oryxos.web.security.BasicAuthFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+/**
+ * BasicAuthFilter 注册（012-web-auth）。
+ *
+ * <p>{@code addUrlPatterns("/admin/*")} 精确限定只拦管理台 SPA；{@code /api/v1/**} 不在模式内、 天然不受影响（SC-003），
+ * {@code /api/v1/health} 亦免认证（FR-008）。filter 在 DispatcherServlet 之前跑，不依赖
+ * {@code @RestControllerAdvice}。 {@code /admin/login} 放行在 filter 内部判路径（{@link
+ * BasicAuthFilter#doFilterInternal}）。
+ */
+@Configuration
+public class AuthFilterConfig {
+
+  @Bean
+  FilterRegistrationBean<BasicAuthFilter> basicAuthFilter(
+      WebUserService userService,
+      WebSessionService sessionService,
+      WebAuthProperties properties,
+      ObjectMapper objectMapper) {
+    FilterRegistrationBean<BasicAuthFilter> registration = new FilterRegistrationBean<>();
+    registration.setFilter(
+        new BasicAuthFilter(userService, sessionService, properties, objectMapper));
+    registration.addUrlPatterns("/admin/*");
+    registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 10);
+    return registration;
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/config/WebAuthConfig.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/config/WebAuthConfig.java
@@ -1,0 +1,15 @@
+package io.oryxos.web.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 管理台认证配置装配（012-web-auth）。
+ *
+ * <p>web 模块自注册 {@link WebAuthProperties}——因 {@code OryxOsRuntime}（cli）不依赖 web 模块， 无法像 provider/tool
+ * 的 properties 那样在 cli 的 {@code @EnableConfigurationProperties} 列表里显式注册。 web 自管自注册，cli 靠 {@code
+ * scanBasePackages="io.oryxos"} 运行时发现本类即可。
+ */
+@Configuration
+@EnableConfigurationProperties(WebAuthProperties.class)
+public class WebAuthConfig {}

--- a/oryxos-web/src/main/java/io/oryxos/web/config/WebAuthProperties.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/config/WebAuthProperties.java
@@ -1,0 +1,50 @@
+package io.oryxos.web.config;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
+
+/**
+ * 管理台 Basic Auth 配置（012-web-auth）。
+ *
+ * <p>{@code oryxos.web.auth.enabled} 默认 {@code false}——假设内网现状不变（宪法核心阶段边界）； 置 {@code true} 后 {@code
+ * /admin/**} 启用认证（浏览器走 session/cookie + 登录页，curl 走 Basic Auth）， {@code /api/v1/**} 不受影响。
+ */
+@ConfigurationProperties(prefix = "oryxos.web.auth")
+public class WebAuthProperties {
+
+  /** 是否启用管理台认证。默认关：保持"假设内网"现状。 */
+  private boolean enabled = false;
+
+  /** Basic Auth realm 文案（curl 401 时 WWW-Authenticate 用）。默认 "OryxOS"。 */
+  private String realm = "OryxOS";
+
+  /** session 过期时间（web_sessions.expires_at = created_at + ttl）。默认 12 小时。 */
+  @DurationUnit(ChronoUnit.HOURS)
+  private Duration sessionTtl = Duration.ofHours(12);
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getRealm() {
+    return realm;
+  }
+
+  public void setRealm(String realm) {
+    this.realm = realm;
+  }
+
+  public Duration getSessionTtl() {
+    return sessionTtl;
+  }
+
+  public void setSessionTtl(Duration sessionTtl) {
+    this.sessionTtl = sessionTtl;
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/config/WebConfig.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/config/WebConfig.java
@@ -28,6 +28,8 @@ public class WebConfig implements WebMvcConfigurer {
     registry.addRedirectViewController("/admin", "/admin/");
     // /admin/（入口）转发到 index.html——ResourceHttpRequestHandler 对空路径不走 resolver，必须显式转发
     registry.addViewController("/admin/").setViewName("forward:/admin/index.html");
+    // / （根）重定向到 /admin/——管理台是主入口，直接访问根即进管理台（012-web-auth US3 体验优化）
+    registry.addRedirectViewController("/", "/admin/");
   }
 
   @Override

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/AuthApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/AuthApiController.java
@@ -1,0 +1,134 @@
+package io.oryxos.web.controller;
+
+import io.oryxos.storage.WebSession;
+import io.oryxos.storage.WebSessionService;
+import io.oryxos.storage.WebUserService;
+import io.oryxos.web.common.ApiResponse;
+import io.oryxos.web.config.WebAuthProperties;
+import io.oryxos.web.controller.dto.AuthMeView;
+import io.oryxos.web.controller.dto.LoginRequest;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.Optional;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 管理台认证端点（012-web-auth US3）：浏览器登录页配套的 session/cookie 认证。
+ *
+ * <p>归 {@code /api/v1/auth/**} 子树（REST API 不受 {@code /admin/**} filter 拦，这些端点靠 controller 自身校验
+ * session）。复用 {@link WebUserService#verify} 验账密 + {@link WebSessionService} 管 session。
+ *
+ * <p>cookie 属性：{@code oryxos_session} = session id（UUID），HttpOnly + SameSite=Strict + Path=/（HTTPS
+ * 时加 Secure）。
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = {"SPRING_ENDPOINT", "EI_EXPOSE_REP2"},
+    justification =
+        "auth 端点是有意暴露的 Spring Controller（012-web-auth US3，浏览器登录页配套）；"
+            + "userService/sessionService 为 Spring 注入的共享单例，构造注入存同一引用正是意图"
+            + "（镜像既有 Controller 的 SuppressFBWarnings 模式）。")
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthApiController {
+
+  /** cookie 名。 */
+  static final String SESSION_COOKIE = "oryxos_session";
+
+  private final WebUserService userService;
+  private final WebSessionService sessionService;
+  private final WebAuthProperties properties;
+
+  public AuthApiController(
+      WebUserService userService, WebSessionService sessionService, WebAuthProperties properties) {
+    this.userService = userService;
+    this.sessionService = sessionService;
+    this.properties = properties;
+  }
+
+  /** 登录：验账密 → 建 session → 设 cookie。失败 401（"Invalid username or password"，不区分原因防枚举）。 */
+  @PostMapping("/login")
+  public ApiResponse<AuthMeView> login(
+      @RequestBody LoginRequest loginRequest,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+    if (loginRequest == null
+        || loginRequest.username() == null
+        || loginRequest.password() == null
+        || loginRequest.username().isBlank()
+        || loginRequest.password().isBlank()) {
+      response.setStatus(HttpStatus.BAD_REQUEST.value());
+      return ApiResponse.error(
+          HttpStatus.BAD_REQUEST.value(), "username and password are required");
+    }
+    if (!userService.verify(loginRequest.username(), loginRequest.password())) {
+      response.setStatus(HttpStatus.UNAUTHORIZED.value());
+      return ApiResponse.error(HttpStatus.UNAUTHORIZED.value(), "Invalid username or password");
+    }
+    WebSession session = sessionService.create(loginRequest.username());
+    response.addHeader(
+        HttpHeaders.SET_COOKIE, buildCookie(session.getSessionId(), -1, request.isSecure()));
+    return ApiResponse.ok(new AuthMeView(properties.isEnabled(), loginRequest.username()));
+  }
+
+  /** 登出：清当前 session + 清 cookie。幂等（无 session 也成功）。 */
+  @PostMapping("/logout")
+  public ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+    findSessionId(request).ifPresent(sessionService::delete);
+    response.addHeader(HttpHeaders.SET_COOKIE, buildCookie("", 0, request.isSecure()));
+    return ApiResponse.ok(null);
+  }
+
+  /** 查当前登录用户。认证关闭时 200 返开关状态；认证开启时，已登录返用户名、未登录 401。 */
+  @GetMapping("/me")
+  public ApiResponse<AuthMeView> me(HttpServletRequest request, HttpServletResponse response) {
+    if (!properties.isEnabled()) {
+      return ApiResponse.ok(new AuthMeView(false, null));
+    }
+    Optional<String> sessionId = findSessionId(request);
+    if (sessionId.isEmpty()) {
+      response.setStatus(HttpStatus.UNAUTHORIZED.value());
+      return ApiResponse.error(HttpStatus.UNAUTHORIZED.value(), "Not authenticated");
+    }
+    Optional<WebSession> session = sessionService.findValid(sessionId.get());
+    if (session.isEmpty()) {
+      response.setStatus(HttpStatus.UNAUTHORIZED.value());
+      return ApiResponse.error(HttpStatus.UNAUTHORIZED.value(), "Not authenticated");
+    }
+    return ApiResponse.ok(new AuthMeView(true, session.get().getUsername()));
+  }
+
+  /** 从请求 cookie 里取 session id。 */
+  private Optional<String> findSessionId(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) {
+      return Optional.empty();
+    }
+    return Arrays.stream(cookies)
+        .filter(c -> SESSION_COOKIE.equals(c.getName()))
+        .map(Cookie::getValue)
+        .filter(v -> v != null && !v.isBlank())
+        .findFirst();
+  }
+
+  /** 构 Set-Cookie 头。maxAge=0 表示清 cookie；HTTPS 请求附加 Secure。 */
+  private static String buildCookie(String sessionId, int maxAge, boolean secure) {
+    ResponseCookie cookie =
+        ResponseCookie.from(SESSION_COOKIE, sessionId)
+            .path("/")
+            .httpOnly(true)
+            .secure(secure)
+            .sameSite("Strict")
+            .maxAge(maxAge)
+            .build();
+    return cookie.toString();
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/AuthMeView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/AuthMeView.java
@@ -1,0 +1,9 @@
+package io.oryxos.web.controller.dto;
+
+/**
+ * 当前登录用户信息（012-web-auth US3，GET /api/v1/auth/me 返回）。
+ *
+ * @param authenticationEnabled 管理台认证是否启用
+ * @param username 当前用户名；认证关闭时为空
+ */
+public record AuthMeView(boolean authenticationEnabled, String username) {}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/LoginRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package io.oryxos.web.controller.dto;
+
+/**
+ * 登录请求体（012-web-auth US3）。
+ *
+ * @param username 用户名
+ * @param password 明文密码（仅请求传输，服务端校验后不存）
+ */
+public record LoginRequest(String username, String password) {}

--- a/oryxos-web/src/main/java/io/oryxos/web/provider/ProviderModelsService.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/provider/ProviderModelsService.java
@@ -27,6 +27,7 @@ public class ProviderModelsService {
   private static final String SLASH = "/";
   private static final String PATH_V1 = "/v1";
   private static final String PATH_MODELS = "/models";
+  private static final String VERSIONED_PATH_PATTERN = ".*/v\\d+$";
 
   private final ProviderRegistry registry;
   private final RestClient restClient;
@@ -71,8 +72,8 @@ public class ProviderModelsService {
   /**
    * 拼 OpenAI 兼容标准的 {@code /v1/models} 地址：先剥离 baseUrl 末尾的 {@code /} 与 {@code /v1}（用户填带或不带 /v1 都正确），
    * 再统一追加 {@code /v1/models}。与 {@code OpenAiApi} 内部追加 {@code /v1/chat/completions} 的预期对齐： Provider
-   * baseUrl 约定不含 {@code /v1}，两个消费者各自补完整 API 路径。 例外：剥离后仍以版本段结尾（如 GLM 的 {@code /api/paas/v4}）
-   * 说明版本在 baseUrl 里，只补 {@code /models}——与 {@code ProviderChatModelFactory} 的判断规则保持一致。
+   * baseUrl 约定不含 {@code /v1}，两个消费者各自补完整 API 路径。 例外：剥离后仍以版本段结尾（如 GLM 的 {@code /api/paas/v4}） 说明版本在
+   * baseUrl 里，只补 {@code /models}——与 {@code ProviderChatModelFactory} 的判断规则保持一致。
    */
   private static String modelsUrl(String baseUrl) {
     String u = baseUrl.strip();
@@ -83,7 +84,7 @@ public class ProviderModelsService {
         u = u.substring(0, u.length() - PATH_V1.length());
       }
     }
-    if (u.matches(".*/v\\d+$")) {
+    if (u.matches(VERSIONED_PATH_PATTERN)) {
       return u + PATH_MODELS;
     }
     return u + PATH_V1 + PATH_MODELS;

--- a/oryxos-web/src/main/java/io/oryxos/web/security/AuthStartupCheck.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/AuthStartupCheck.java
@@ -1,0 +1,52 @@
+package io.oryxos.web.security;
+
+import io.oryxos.storage.WebUserService;
+import io.oryxos.web.config.WebAuthProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.stereotype.Component;
+
+/**
+ * 启动校验（012-web-auth，FR-006）：{@code auth.enabled=true} 但无 enabled 账号时阻断启动， 不静默裸奔。提示先跑 {@code oryxos
+ * user add}。
+ *
+ * <p>用 {@link ApplicationRunner}（context 就绪后跑，比 @Bean init 可靠）。放 oryxos-web 与 filter 同模块。
+ *
+ * <p>只在 SERVLET web 模式（serve/gateway）跑——{@code oryxos user add} 等管理命令用 {@code
+ * WebApplicationType.NONE}（不起 web server），装上它会死循环（user add 自身启动被无账号阻断，永远建不了首账号）。 {@link
+ * ConditionalOnWebApplication} 限定只 SERVLET 模式装配，CLI 管理命令不受影响。
+ */
+@Component
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+public class AuthStartupCheck implements ApplicationRunner {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AuthStartupCheck.class);
+
+  private final WebAuthProperties properties;
+  private final WebUserService userService;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = {"EI_EXPOSE_REP2"},
+      justification =
+          "properties/userService 均为 Spring 注入的共享单例，构造注入存同一引用正是意图"
+              + "（镜像既有 Controller 的 SuppressFBWarnings 模式）。")
+  public AuthStartupCheck(WebAuthProperties properties, WebUserService userService) {
+    this.properties = properties;
+    this.userService = userService;
+  }
+
+  @Override
+  public void run(ApplicationArguments args) {
+    if (properties.isEnabled() && !userService.hasEnabledAccount()) {
+      String msg =
+          "Web auth enabled (oryxos.web.auth.enabled=true) but no enabled account found. "
+              + "Run 'oryxos user add <username>' before starting serve.";
+      LOG.error(msg);
+      throw new IllegalStateException(msg);
+    }
+    LOG.debug("Auth startup check passed (enabled={}, accounts present)", properties.isEnabled());
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/security/BasicAuthFilter.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/BasicAuthFilter.java
@@ -1,0 +1,183 @@
+package io.oryxos.web.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.storage.WebSessionService;
+import io.oryxos.storage.WebUserService;
+import io.oryxos.web.common.ApiResponse;
+import io.oryxos.web.config.WebAuthProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * 管理台认证过滤器（012-web-auth）。
+ *
+ * <p>仅拦 {@code /admin/**}（由 {@link AuthFilterConfig} 的 {@code FilterRegistrationBean} 限定 URL 模式）；
+ * {@code /api/v1/**} 不在模式内、天然不受影响（FR-002），{@code /api/v1/health} 亦免认证（FR-008）。
+ *
+ * <p>校验两条路径（任一通过即放行，FR-005）：
+ *
+ * <ol>
+ *   <li>Session——取 {@code oryxos_session} cookie → {@link WebSessionService#findValid} → 有效放行 （不查
+ *       user enabled，Clarifications Q1 B：改密/禁用后旧 session 仍有效到过期）。
+ *   <li>Basic Auth——取 {@code Authorization: Basic} 头 → Base64 解码拆 user/pass → {@link
+ *       WebUserService#verify} → 放行。
+ * </ol>
+ *
+ * <p>都无/都失败：浏览器（{@code Accept} 头含 {@code text/html}）→ 302 跳 {@code /admin/login}； curl/自动化 → 401
+ * JSON（统一信封）+ {@code WWW-Authenticate: Basic realm="<配置值>"}。
+ *
+ * <p>{@code /admin/login} 路径（含其静态资源）放行——未登录也要能访问登录页（FR-017）。
+ *
+ * <p>{@code auth.enabled=false} 直接放行（默认关，SC-001 回归零破坏）。不抛异常——{@code @RestControllerAdvice} 捕不到
+ * filter 异常（filter 在 DispatcherServlet 之前），故直接写响应。
+ */
+public class BasicAuthFilter extends OncePerRequestFilter {
+
+  /** Basic Auth scheme 前缀（RFC 7617），含尾随空格——凭据紧随其后。P3C：提常量避免魔法值。 */
+  private static final String BASIC_PREFIX = "Basic ";
+
+  /** Basic Auth scheme 名（用于 WWW-Authenticate 挑战头）。 */
+  private static final String BASIC_SCHEME = "Basic";
+
+  /** 401 响应业务码（统一信封 ApiResponse.code）。 */
+  private static final int UNAUTHORIZED_CODE = HttpStatus.UNAUTHORIZED.value();
+
+  /** 401 响应文案。 */
+  private static final String UNAUTHORIZED_MESSAGE = "Unauthorized";
+
+  /** session cookie 名。 */
+  static final String SESSION_COOKIE = "oryxos_session";
+
+  /** 登录页路径前缀（放行）。 */
+  private static final String LOGIN_PATH = "/admin/login";
+
+  private final WebUserService userService;
+  private final WebSessionService sessionService;
+  private final WebAuthProperties properties;
+  private final ObjectMapper objectMapper;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = {"EI_EXPOSE_REP2", "PZLA_PREFER_ZERO_LENGTH_ARRAYS"},
+      justification =
+          "userService/sessionService/properties/objectMapper 均为 Spring 注入的共享单例，构造注入存同一引用正是意图"
+              + "（镜像既有 Controller 的 SuppressFBWarnings 模式）；decode 返 null 表"
+              + " \"Base64 解码或 user:pass 拆分失败\"，与零长数组语义不同。")
+  public BasicAuthFilter(
+      WebUserService userService,
+      WebSessionService sessionService,
+      WebAuthProperties properties,
+      ObjectMapper objectMapper) {
+    this.userService = userService;
+    this.sessionService = sessionService;
+    this.properties = properties;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    if (!properties.isEnabled()) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+    // 登录页路径放行（FR-017）
+    if (isLoginPath(request.getRequestURI())) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+    // (1) session cookie 路径
+    if (authenticatedBySession(request)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+    // (2) Basic Auth 路径
+    if (authenticatedByBasic(request)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+    // 都无/都失败：浏览器跳登录页，curl 401
+    reject(request, response);
+  }
+
+  private boolean isLoginPath(String uri) {
+    return uri != null && uri.startsWith(LOGIN_PATH);
+  }
+
+  private boolean authenticatedBySession(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) {
+      return false;
+    }
+    return Arrays.stream(cookies)
+        .filter(c -> SESSION_COOKIE.equals(c.getName()))
+        .map(Cookie::getValue)
+        .filter(v -> v != null && !v.isBlank())
+        .findFirst()
+        .flatMap(sessionService::findValid)
+        .isPresent();
+  }
+
+  private boolean authenticatedByBasic(HttpServletRequest request) {
+    String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (header == null || !header.startsWith(BASIC_PREFIX)) {
+      return false;
+    }
+    String[] credentials = decode(header.substring(BASIC_PREFIX.length()));
+    return credentials != null
+        && credentials.length == 2
+        && userService.verify(credentials[0], credentials[1]);
+  }
+
+  private void reject(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    if (isBrowser(request)) {
+      response.setStatus(HttpStatus.FOUND.value());
+      response.setHeader(HttpHeaders.LOCATION, LOGIN_PATH);
+      return;
+    }
+    response.setStatus(UNAUTHORIZED_CODE);
+    response.setHeader(
+        HttpHeaders.WWW_AUTHENTICATE, BASIC_SCHEME + " realm=\"" + properties.getRealm() + "\"");
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    response
+        .getWriter()
+        .write(
+            objectMapper.writeValueAsString(
+                ApiResponse.error(UNAUTHORIZED_CODE, UNAUTHORIZED_MESSAGE)));
+  }
+
+  /** 浏览器判定：Accept 头含 text/html（Clarifications Q2 A 分流）。 */
+  private static boolean isBrowser(HttpServletRequest request) {
+    String accept = request.getHeader(HttpHeaders.ACCEPT);
+    return accept != null && accept.contains("text/html");
+  }
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "PZLA_PREFER_ZERO_LENGTH_ARRAYS",
+      justification = "decode 返 null 表\"Base64 解码或 user:pass 拆分失败\"，与零长数组语义不同；" + "调用方已判 null。")
+  private static String[] decode(String base64) {
+    try {
+      byte[] decoded = Base64.getDecoder().decode(base64);
+      String pair = new String(decoded, StandardCharsets.UTF_8);
+      int idx = pair.indexOf(':');
+      if (idx < 0) {
+        return null;
+      }
+      return new String[] {pair.substring(0, idx), pair.substring(idx + 1)};
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/security/PasswordEncoderFactory.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/PasswordEncoderFactory.java
@@ -1,0 +1,23 @@
+package io.oryxos.web.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * 密码哈希装配（012-web-auth）。
+ *
+ * <p>提供 {@link DelegatingPasswordEncoder}（{@code {bcrypt}} 前缀，将来升 Argon2 无迁移——FR-009）。 单 jar {@code
+ * spring-security-crypto}，非 {@code spring-boot-starter-security} 全套（无 filter chain / autoconfig /
+ * RBAC），不违"自实现核心"宪法精神。component scan（{@code OryxOsRuntime} 扫 {@code io.oryxos}）自动注册此 @Bean。
+ */
+@Configuration
+public class PasswordEncoderFactory {
+
+  @Bean
+  PasswordEncoder passwordEncoder() {
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+  }
+}

--- a/oryxos-web/src/test/java/io/oryxos/web/config/WebAuthPropertiesTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/config/WebAuthPropertiesTest.java
@@ -1,0 +1,42 @@
+package io.oryxos.web.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * 012-web-auth 验收 harness：WebAuthPropertiesTest——配置绑定（默认关、yml 覆盖生效）钉死。 用
+ * ApplicationContextRunner（轻量，不起完整 server）。
+ */
+class WebAuthPropertiesTest {
+
+  @Test
+  @DisplayName("默认_enabled=false_realm=OryxOS")
+  void defaults_enabledFalse_realmOryxOS() {
+    new ApplicationContextRunner()
+        .withUserConfiguration(WebAuthConfig.class)
+        .run(
+            context -> {
+              WebAuthProperties props = context.getBean(WebAuthProperties.class);
+              assertFalse(props.isEnabled());
+              assertEquals("OryxOS", props.getRealm());
+            });
+  }
+
+  @Test
+  @DisplayName("yml覆盖_enabled=true_realm自定义生效")
+  void override_ymlTakesEffect() {
+    new ApplicationContextRunner()
+        .withUserConfiguration(WebAuthConfig.class)
+        .withPropertyValues("oryxos.web.auth.enabled=true", "oryxos.web.auth.realm=Custom")
+        .run(
+            context -> {
+              WebAuthProperties props = context.getBean(WebAuthProperties.class);
+              assertEquals(true, props.isEnabled());
+              assertEquals("Custom", props.getRealm());
+            });
+  }
+}

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/AuthApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/AuthApiControllerTest.java
@@ -1,0 +1,200 @@
+package io.oryxos.web.controller;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.oryxos.storage.WebSession;
+import io.oryxos.storage.WebSessionService;
+import io.oryxos.storage.WebUserService;
+import io.oryxos.web.GlobalExceptionHandler;
+import io.oryxos.web.config.WebAuthProperties;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * 012-web-auth US3 验收 harness：AuthApiControllerTest——login/logout/me 端点钉死。 standalone MockMvc +
+ * mock WebUserService/WebSessionService，不碰 DB。
+ */
+class AuthApiControllerTest {
+
+  private WebUserService userService;
+  private WebSessionService sessionService;
+  private WebAuthProperties properties;
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setUp() {
+    userService = mock(WebUserService.class);
+    sessionService = mock(WebSessionService.class);
+    properties = new WebAuthProperties();
+    properties.setEnabled(true);
+    mvc =
+        MockMvcBuilders.standaloneSetup(
+                new AuthApiController(userService, sessionService, properties))
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+  }
+
+  @Test
+  @DisplayName("login_HTTP对账密_200+Set-Cookie(HttpOnly+SameSite=Strict+Path=/且无Secure)")
+  void login_correctCredentials_setsCookie() throws Exception {
+    when(userService.verify("admin", "s3cret-pw")).thenReturn(true);
+    WebSession session = newSession("admin", "sid-123");
+    when(sessionService.create("admin")).thenReturn(session);
+
+    mvc.perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"admin\",\"password\":\"s3cret-pw\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(0))
+        .andExpect(jsonPath("$.data.authenticationEnabled").value(true))
+        .andExpect(jsonPath("$.data.username").value("admin"))
+        .andExpect(header().exists("Set-Cookie"))
+        .andExpect(
+            header()
+                .string(
+                    "Set-Cookie", org.hamcrest.Matchers.containsString("oryxos_session=sid-123")))
+        .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("HttpOnly")))
+        .andExpect(
+            header().string("Set-Cookie", org.hamcrest.Matchers.containsString("SameSite=Strict")))
+        .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("Path=/")))
+        .andExpect(
+            header()
+                .string(
+                    "Set-Cookie",
+                    org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("Secure"))));
+  }
+
+  @Test
+  @DisplayName("login_HTTPS对账密_Set-Cookie包含Secure")
+  void login_https_setsSecureCookie() throws Exception {
+    when(userService.verify("admin", "s3cret-pw")).thenReturn(true);
+    WebSession session = newSession("admin", "sid-123");
+    when(sessionService.create("admin")).thenReturn(session);
+
+    mvc.perform(
+            post("/api/v1/auth/login")
+                .secure(true)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"admin\",\"password\":\"s3cret-pw\"}"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("Secure")));
+  }
+
+  @Test
+  @DisplayName("login_错账密_401+不区分原因（防枚举）+不建session")
+  void login_wrongCredentials_401NoSession() throws Exception {
+    when(userService.verify("admin", "wrong")).thenReturn(false);
+
+    mvc.perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"admin\",\"password\":\"wrong\"}"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value(401))
+        .andExpect(jsonPath("$.message").value("Invalid username or password"));
+    verify(sessionService, never()).create(anyString());
+  }
+
+  @Test
+  @DisplayName("login_缺字段_400")
+  void login_missingFields_400() throws Exception {
+    mvc.perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"\",\"password\":\"\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(400));
+  }
+
+  @Test
+  @DisplayName("logout_HTTPS有cookie_清session+清Cookie且保留Secure")
+  void logout_withCookie_clearsSession() throws Exception {
+    mvc.perform(
+            post("/api/v1/auth/logout")
+                .secure(true)
+                .cookie(new jakarta.servlet.http.Cookie("oryxos_session", "sid-123")))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("Max-Age=0")))
+        .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("Secure")));
+    verify(sessionService).delete("sid-123");
+  }
+
+  @Test
+  @DisplayName("logout_无cookie_幂等200仍清cookie")
+  void logout_noCookie_idempotent() throws Exception {
+    mvc.perform(post("/api/v1/auth/logout")).andExpect(status().isOk());
+    verify(sessionService, never()).delete(anyString());
+  }
+
+  @Test
+  @DisplayName("me_认证关闭_200返开关状态且不要求session")
+  void me_authDisabled_200() throws Exception {
+    properties.setEnabled(false);
+
+    mvc.perform(get("/api/v1/auth/me"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(0))
+        .andExpect(jsonPath("$.data.authenticationEnabled").value(false))
+        .andExpect(jsonPath("$.data.username").doesNotExist());
+    verify(sessionService, never()).findValid(anyString());
+  }
+
+  @Test
+  @DisplayName("me_有有效session_200返用户名")
+  void me_validSession_200() throws Exception {
+    when(sessionService.findValid("sid-123"))
+        .thenReturn(Optional.of(newSession("admin", "sid-123")));
+
+    mvc.perform(
+            get("/api/v1/auth/me")
+                .cookie(new jakarta.servlet.http.Cookie("oryxos_session", "sid-123")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(0))
+        .andExpect(jsonPath("$.data.authenticationEnabled").value(true))
+        .andExpect(jsonPath("$.data.username").value("admin"));
+  }
+
+  @Test
+  @DisplayName("me_无cookie_401")
+  void me_noCookie_401() throws Exception {
+    mvc.perform(get("/api/v1/auth/me"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value(401));
+  }
+
+  @Test
+  @DisplayName("me_session过期_401")
+  void me_expiredSession_401() throws Exception {
+    when(sessionService.findValid("sid-123")).thenReturn(Optional.empty());
+
+    mvc.perform(
+            get("/api/v1/auth/me")
+                .cookie(new jakarta.servlet.http.Cookie("oryxos_session", "sid-123")))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value(401));
+  }
+
+  private static WebSession newSession(String username, String sessionId) {
+    WebSession s = new WebSession();
+    s.setSessionId(sessionId);
+    s.setUsername(username);
+    s.setExpiresAt(Instant.now().plusSeconds(3600));
+    return s;
+  }
+}

--- a/oryxos-web/src/test/java/io/oryxos/web/security/BasicAuthFilterTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/security/BasicAuthFilterTest.java
@@ -1,0 +1,201 @@
+package io.oryxos.web.security;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.storage.WebSession;
+import io.oryxos.storage.WebSessionService;
+import io.oryxos.storage.WebUserService;
+import io.oryxos.web.config.WebAuthProperties;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * 012-web-auth 验收 harness：BasicAuthFilterTest——filter 校验口径钉死（Basic + session 两路径 + Accept 分流）。 用
+ * standalone MockMvc + stub controller 映射 /admin/** 返 200（filter 放行后要有 handler，否则 404 误判）， mock
+ * WebUserService/WebSessionService。 守：enabled=false 放行、Basic 对/错、session 有效放行/过期 401、 浏览器未登录跳
+ * /admin/login、curl 未登录 401+WWW-Authenticate、/admin/login 放行。
+ */
+class BasicAuthFilterTest {
+
+  private WebUserService userService;
+  private WebSessionService sessionService;
+  private WebAuthProperties properties;
+  private MockMvc mvc;
+
+  @Controller
+  static class StubController {
+    @GetMapping("/admin/")
+    public void adminRoot() {}
+
+    @GetMapping("/admin/login")
+    public void adminLogin() {}
+  }
+
+  @BeforeEach
+  void setUp() {
+    userService = mock(WebUserService.class);
+    sessionService = mock(WebSessionService.class);
+    properties = new WebAuthProperties();
+    BasicAuthFilter filter =
+        new BasicAuthFilter(userService, sessionService, properties, new ObjectMapper());
+    mvc = MockMvcBuilders.standaloneSetup(new StubController()).addFilter(filter).build();
+  }
+
+  @Test
+  @DisplayName("enabled=false_无凭据放行_200")
+  void disabled_passesThrough() throws Exception {
+    properties.setEnabled(false);
+    mvc.perform(get("/admin/")).andExpect(status().isOk());
+    verify(userService, never()).verify(anyString(), anyString());
+  }
+
+  @Test
+  @DisplayName("enabled=true_无凭据_curl(Accept=application/json)_401+WWW-Authenticate")
+  void enabledNoCredentials_curl_401WithChallenge() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(get("/admin/").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized())
+        .andExpect(header().string("WWW-Authenticate", "Basic realm=\"OryxOS\""))
+        .andExpect(jsonPath("$.code").value(401));
+  }
+
+  @Test
+  @DisplayName("enabled=true_无凭据_浏览器(Accept=text/html)_302跳/admin/login")
+  void enabledNoCredentials_browser_redirectsToLogin() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(get("/admin/").accept(MediaType.TEXT_HTML))
+        .andExpect(status().isFound())
+        .andExpect(header().string("Location", "/admin/login"));
+  }
+
+  @Test
+  @DisplayName("enabled=true_正确Basic凭据_200")
+  void enabledCorrectBasicCredentials_200() throws Exception {
+    properties.setEnabled(true);
+    when(userService.verify("admin", "s3cret-pw")).thenReturn(true);
+
+    mvc.perform(get("/admin/").header("Authorization", basic("admin", "s3cret-pw")))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("enabled=true_错误Basic凭据_curl_401")
+  void enabledWrongBasicCredentials_401() throws Exception {
+    properties.setEnabled(true);
+    when(userService.verify("admin", "wrong")).thenReturn(false);
+
+    mvc.perform(
+            get("/admin/")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", basic("admin", "wrong")))
+        .andExpect(status().isUnauthorized())
+        .andExpect(header().string("WWW-Authenticate", "Basic realm=\"OryxOS\""));
+  }
+
+  @Test
+  @DisplayName("enabled=true_有效session_cookie_200")
+  void enabledValidSession_200() throws Exception {
+    properties.setEnabled(true);
+    WebSession session = newSession("admin");
+    when(sessionService.findValid("sid-123")).thenReturn(Optional.of(session));
+
+    mvc.perform(get("/admin/").cookie(new jakarta.servlet.http.Cookie("oryxos_session", "sid-123")))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("enabled=true_过期session_浏览器_302跳登录")
+  void enabledExpiredSession_browser_redirectsToLogin() throws Exception {
+    properties.setEnabled(true);
+    when(sessionService.findValid("sid-123")).thenReturn(Optional.empty());
+
+    mvc.perform(
+            get("/admin/")
+                .accept(MediaType.TEXT_HTML)
+                .cookie(new jakarta.servlet.http.Cookie("oryxos_session", "sid-123")))
+        .andExpect(status().isFound())
+        .andExpect(header().string("Location", "/admin/login"));
+  }
+
+  @Test
+  @DisplayName("enabled=true_禁用账号_Basic_401（verify返false）")
+  void enabledDisabledAccount_401() throws Exception {
+    properties.setEnabled(true);
+    when(userService.verify("admin", "s3cret-pw")).thenReturn(false);
+
+    mvc.perform(
+            get("/admin/")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", basic("admin", "s3cret-pw")))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("/admin/login_放行（未登录也能访问）")
+  void loginPath_passesThrough() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(get("/admin/login")).andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("非Basic头_401")
+  void nonBasicHeader_401() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(
+            get("/admin/")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer some-token"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("格式错的Basic头_401")
+  void malformedBasic_401() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(
+            get("/admin/")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Basic !!!notbase64!!!"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("自定义realm_WWW-Authenticate头带自定义值")
+  void customRealm_appearsInChallenge() throws Exception {
+    properties.setEnabled(true);
+    properties.setRealm("MySystem");
+    mvc.perform(get("/admin/").accept(MediaType.APPLICATION_JSON))
+        .andExpect(header().string("WWW-Authenticate", "Basic realm=\"MySystem\""));
+  }
+
+  private static String basic(String user, String pass) {
+    return "Basic "
+        + java.util.Base64.getEncoder()
+            .encodeToString((user + ":" + pass).getBytes(java.nio.charset.StandardCharsets.UTF_8));
+  }
+
+  private static WebSession newSession(String username) {
+    WebSession s = new WebSession();
+    s.setSessionId("sid-123");
+    s.setUsername(username);
+    s.setExpiresAt(Instant.now().plusSeconds(3600));
+    return s;
+  }
+}

--- a/specs/012-web-auth/checklists/requirements.md
+++ b/specs/012-web-auth/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Web Service 认证机制（最小 Auth）
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- 需求已与用户对齐 5 条关键决策：REST API 不做 Basic Auth / spring-security-crypto / 新表 web_users / CLI user 命令加入 / auth.enabled 默认关。
+- 关于"实现细节泄漏"的判定：spec 中出现 `spring-security-crypto`、`DelegatingPasswordEncoder`、`Picocli`、`schema.sql`、`BasicAuth`、`BCrypt` 等。这些是项目宪法与既有技术栈已锁定的实现约束（constitution 原则 II/VI/VIII、现有 9 模块、Picocli CLI、SQLite+JPA），属"项目既定技术决策"而非"在本 feature 内新引入的实现选型"，因此保留。constitution 明确要求凭证不落地、手工建表不依赖 Hibernate auto，spec 引用这些是合规约束的体现。
+- 如 maintainer 要求纯技术无关 spec，可剥离具体库名为"标准密码哈希库（带算法升级机制）"等表述，再在 plan 阶段定库。
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`。

--- a/specs/012-web-auth/contracts/cli-auth.md
+++ b/specs/012-web-auth/contracts/cli-auth.md
@@ -1,0 +1,86 @@
+# CLI Contract: `oryxos user`
+
+**Feature**: 012-web-auth | **Date**: 2026-07-22
+
+`oryxos user` 子命令组契约。所有 leaf 都是 heavy command（自启 `OryxOsRuntime` Spring 上下文，`WebApplicationType.NONE`，`context.getBean(WebUserService.class)` 干活）。镜像 `ProfileCommand`（group + static nested leaf）+ `ChatCommand`（heavy 启动）。
+
+## 命令树
+
+```
+oryxos user
+  ├── add    <username>            创建账号（交互输密码）
+  ├── list                          列账号（不显密码）
+  ├── delete <username>             删账号
+  ├── passwd <username>             改密码（交互输新密码）
+  ├── disable <username>            禁用账号
+  └── enable  <username>            启用账号
+```
+
+parent `oryxos user`（无参数）打 usage 退出 0。
+
+## 子命令契约
+
+### `oryxos user add <username>`
+
+- **参数**: `@Parameters(index="0") String username`（必填，1-64 字符，无空格）
+- **交互**: 提示 `Password: `（`System.console().readPassword`，不回显）→ `Confirm: `（再读一次）
+- **校验**: username 非空/无空格/≤64；password ≥8 字符；两次一致；username 未存在
+- **行为**: `WebUserService.create(username, rawPassword)` → BCrypt 哈希 → 存 `web_users`（enabled=true）
+- **成功**: stdout `Created user '<username>'`，退出码 0
+- **失败**:
+  - username 已存在 → stderr `Error: user '<username>' already exists`，退出码 1
+  - password <8 → stderr `Error: password must be at least 8 characters`，退出码 1
+  - 两次不一致 → stderr `Error: passwords do not match`，退出码 1
+  - `System.console()==null`（piped stdin）→ stderr `Error: no interactive console available`，退出码 1
+- **安全**: 明文密码 NEVER 打印/日志（宪法 VI）
+
+### `oryxos user list`
+
+- **参数**: 无
+- **行为**: `WebUserService.list()` → 排序（按 username 或 createdAt）
+- **输出**（表格或对齐文本，**不含密码/hash**）:
+  ```
+  USERNAME    ENABLED  CREATED_AT
+  admin       true     2026-07-22T10:30:00Z
+  alice       true     2026-07-22T11:00:00Z
+  ```
+- **空表**: stdout `No users found. Run 'oryxos user add <username>' to create one.`，退出码 0
+- **安全**: 输出 0% 含 `password_hash` / 明文（SC-004）
+
+### `oryxos user delete <username>`
+
+- **参数**: `@Parameters(index="0") String username`
+- **行为**: `WebUserService.delete(username)` → 删 `web_users` 行
+- **成功**: stdout `Deleted user '<username>'`，退出码 0
+- **失败**: username 不存在 → stderr `Error: user '<username>' not found`，退出码 1
+
+### `oryxos user passwd <username>`
+
+- **参数**: `@Parameters(index="0") String username`
+- **交互**: `New password: `（不回显）→ `Confirm: `
+- **校验**: password ≥8；两次一致；username 存在
+- **行为**: `WebUserService.changePassword(username, rawPassword)` → 更新 `password_hash` + `updated_at`
+- **成功**: stdout `Password updated for '<username>'`，退出码 0
+- **失败**: 用户不存在 / 密码太短 / 不一致 / 无 console → stderr + 退出码 1
+
+### `oryxos user disable <username>`
+
+- **参数**: `@Parameters(index="0") String username`
+- **行为**: `WebUserService.disable(username)` → `enabled=false` + `updated_at`
+- **成功**: stdout `Disabled user '<username>'`，退出码 0
+- **失败**: 用户不存在 → stderr，退出码 1
+
+### `oryxos user enable <username>`
+
+- **参数**: `@Parameters(index="0") String username`
+- **行为**: `WebUserService.enable(username)` → `enabled=true` + `updated_at`（对称 disable，禁用后可恢复）
+- **成功**: stdout `Enabled user '<username>'`，退出码 0
+- **失败**: 用户不存在 → stderr，退出码 1
+
+## 通用约定
+
+- 所有 leaf `mixinStandardHelpOptions = true`（`-h`/`--help`）
+- 退出码：成功 0，失败 1
+- 错误到 stderr，结果到 stdout（便于脚本管道）
+- heavy command：try-with-resources 起停 Spring，一次性退出
+- 不缓存账号：每次命令重读 DB（FR-007 同精神，加账号后下次命令即可用）

--- a/specs/012-web-auth/contracts/rest-auth.md
+++ b/specs/012-web-auth/contracts/rest-auth.md
@@ -1,0 +1,58 @@
+# REST Contract: `/api/v1/auth/*`
+
+**Feature**: 012-web-auth | **Date**: 2026-07-22
+
+浏览器登录页配套的 session 认证端点。归 `/api/v1/auth/**` 子树（REST API 不受 `/admin/**` filter 限制，但 auth 端点本身是认证专用）。复用 `web_users` 账号 + `WebUserService.verify`。
+
+## 端点
+
+### `POST /api/v1/auth/login`
+
+登录，建 session，设 cookie。
+
+- **请求体**: `{"username": "<user>", "password": "<pass>"}`
+- **成功** (200):
+  - `Set-Cookie: oryxos_session=<uuid>; Path=/; HttpOnly; SameSite=Strict`（HTTPS 加 `Secure`）
+  - body: `{"code":0,"message":"success","data":{"username":"<user>"},"timestamp":...}`（统一信封）
+- **失败** (401): 账密错/用户不存在/禁用 → `{"code":401,"message":"Invalid username or password","data":null,...}`（不区分原因，防枚举）
+- **不设 WWW-Authenticate**: 登录端点不挑 Basic（避免浏览器弹窗）
+
+### `POST /api/v1/auth/logout`
+
+登出，清当前 session + 清 cookie。
+
+- **请求**: 无 body（从 cookie 取 session id）
+- **成功** (200): `Set-Cookie: oryxos_session=; Path=/; Max-Age=0`（清 cookie）+ body `{"code":0,"message":"success",...}`
+- **未登录** (200): 仍返 200（幂等，无 session 也算登出成功）
+
+### `GET /api/v1/auth/me`
+
+查当前登录用户。
+
+- **认证关闭** (200): `{"code":0,"...","data":{"authenticationEnabled":false,"username":null}}`，前端直接进入管理台
+- **认证开启且已登录** (200): `{"code":0,"...","data":{"authenticationEnabled":true,"username":"<user>"}}`
+- **认证开启且未登录** (401): `{"code":401,"message":"Not authenticated",...}`
+
+## filter 放行
+
+`/api/v1/auth/login` 与 `/admin/login` 都在 filter 放行名单（未登录可访问）。认证开启时，
+`/api/v1/auth/logout`、`/api/v1/auth/me` 需有效 session（但 `/api/v1/**` 本就不被
+`/admin/**` filter 拦，这两个端点靠 controller 自身校验 session）。
+
+## cookie 属性
+
+| 属性 | 值 | 理由 |
+|---|---|---|
+| `Name` | `oryxos_session` | |
+| `Value` | UUID（session id） | 不可预测 |
+| `Path` | `/` | 全域（含 `/admin/` + `/api/v1/auth/*`） |
+| `HttpOnly` | 是 | 防 JS 偷（XSS） |
+| `SameSite` | `Strict` | 防 CSRF |
+| `Secure` | HTTPS 时加 | 公网防嗅探 |
+| `Max-Age` | `sessionTtl`（12h 默认） | 过期时间 |
+
+## 错误码
+
+- 200 成功
+- 401 未认证/账密错/禁用
+- 400 请求体格式错（缺字段）

--- a/specs/012-web-auth/data-model.md
+++ b/specs/012-web-auth/data-model.md
@@ -1,0 +1,129 @@
+# Data Model: Web Service 认证机制（最小 Auth）
+
+**Feature**: 012-web-auth | **Date**: 2026-07-22
+
+依据 spec Key Entities + FR-003/FR-009/FR-010 + research §1/§2。
+
+## 实体：WebUser
+
+管理员账号。一个 WebUser = 一个可登录管理台的账号。
+
+### 关系图
+
+```
+WebUser (web_users 表, SQLite)
+  └─ 无外键关联其他实体（独立账号表，不连 Session/Agent/审计表）
+```
+
+`web_users` 不关联现有 `sessions`/`llm_calls`/`tool_invocations`/`scheduled_tasks`/`memory_entries`。auth 是横切关注点，账号表独立。
+
+### 字段
+
+| 字段（Java） | 列名 | 类型 | 约束 | 说明 |
+|---|---|---|---|---|
+| `id` | `id` | `Long` | PK，`GENERATIONTYPE.IDENTITY`，auto-increment | surrogate key，非业务键 |
+| `username` | `username` | `String` | `NOT NULL UNIQUE`，1-64 字符，无空格 | 登录名，业务唯一键 |
+| `passwordHash` | `password_hash` | `String` | `NOT NULL`，`{bcrypt}` 前缀 + hash | BCrypt 哈希，**非明文**（宪法 VI） |
+| `enabled` | `enabled` | `boolean` | `NOT NULL DEFAULT TRUE` | 禁用账号登录 401（US1 场景 6） |
+| `createdAt` | `created_at` | `Instant` | `NOT NULL` | `@PrePersist` 设 `Instant.now()`，无 setter（不可变） |
+| `updatedAt` | `updated_at` | `Instant` | `NOT NULL` | service 每次改动手动 `setUpdatedAt(Instant.now())` |
+
+### DDL（追加进 `oryxos-storage/src/main/resources/schema.sql`）
+
+```sql
+CREATE TABLE IF NOT EXISTS web_users (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    username      VARCHAR(64) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,   -- {bcrypt} 前缀 + hash
+    enabled       BOOLEAN NOT NULL DEFAULT 1,
+    created_at    TIMESTAMP NOT NULL,
+    updated_at    TIMESTAMP NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_web_users_username ON web_users (username);
+```
+
+镜像现有 `llm_calls`/`sessions` 块风格（`INTEGER PRIMARY KEY AUTOINCREMENT` + `TIMESTAMP` + `BOOLEAN NOT NULL` + `CREATE INDEX IF NOT EXISTS`）。
+
+### 验证规则（FR-011，在 `WebUserService` / CLI 落实）
+
+- username：非空、无空格、≤64 字符
+- rawPassword：≥8 字符、非空
+- 两次输入一致（`add`/`passwd`）
+- 重名拒绝（`existsByUsername`）
+
+### 状态转换
+
+```
+[新建] --add--> enabled=TRUE --disable--> enabled=FALSE --enable(后续)--> TRUE
+                                          \--delete--> [删除行]
+```
+
+核心阶段只做 `disable`（置 false），不做 `enable` 子命令（spec US2 无 enable，YAGNI）。删 = 整行删。
+
+## 配置实体：WebAuthProperties
+
+非持久化，`@ConfigurationProperties(prefix = "oryxos.web.auth")`。
+
+| 字段 | YAML 键 | 类型 | 默认 | 说明 |
+|---|---|---|---|---|
+| `enabled` | `oryxos.web.auth.enabled` | `boolean` | `false` | 总开关，关=现状裸内网（SC-001） |
+| `realm` | `oryxos.web.auth.realm` | `String` | `"OryxOS"` | Basic Auth realm 文案（curl 401 时 `WWW-Authenticate` 用） |
+| `sessionTtl` | `oryxos.web.auth.session-ttl` | `Duration` | `12h` | session 过期时间（`web_sessions.expires_at` = `created_at + ttl`） |
+
+无 `exclude-paths`（`/admin/**` scope 已天然排除 `/api/v1/**`，`/api/v1/health` 不在 `/admin/**` 内自动免认证，`/admin/login` 在 filter 内显式放行）。
+
+## 实体：WebSession
+
+浏览器登录 session。一个 WebSession = 一次登录会话。
+
+### 关系图
+
+```
+WebSession (web_sessions 表, SQLite)
+  └─ username → WebUser.username（逻辑关联，不建外键——删用户不级联清 session，
+                                      核心阶段简化；扩展阶段可加级联或级联校验）
+```
+
+### 字段
+
+| 字段（Java） | 列名 | 类型 | 约束 | 说明 |
+|---|---|---|---|---|
+| `id` | `id` | `Long` | PK，`GenerationType.IDENTITY`，auto-increment | surrogate key |
+| `sessionId` | `session_id` | `String` | `NOT NULL UNIQUE`，UUID | cookie 值，安全随机生成 |
+| `username` | `username` | `String` | `NOT NULL` | 关联 `web_users.username` |
+| `expiresAt` | `expires_at` | `Instant` | `NOT NULL` | 过期时间 = `createdAt + sessionTtl` |
+| `createdAt` | `created_at` | `Instant` | `NOT NULL` | `@PrePersist` 设 `Instant.now()` |
+
+### DDL（追加进 `oryxos-storage/src/main/resources/schema.sql`）
+
+```sql
+CREATE TABLE IF NOT EXISTS web_sessions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id  VARCHAR(64) NOT NULL UNIQUE,
+    username    VARCHAR(64) NOT NULL,
+    expires_at  TIMESTAMP NOT NULL,
+    created_at  TIMESTAMP NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_web_sessions_session ON web_sessions (session_id);
+```
+
+### 验证规则
+
+- `session_id` 由 `java.security.SecureRandom` 或 `UUID.randomUUID` 生成（不可预测）
+- `expires_at` = `createdAt + sessionTtl`，filter 查到 `expires_at < now` 视为无效
+
+### 状态转换
+
+```
+[登录成功] --create--> 有效(expires_at>now) --过期/登出--> [删除行]
+```
+
+核心阶段不做 session 续期（滑动续期留扩展阶段）。登出 = 删行。过期 = filter 当无效。
+
+## 契约实体：登录凭据
+
+非持久化。`POST /api/v1/auth/login` 接 JSON `{username, password}`，返 200 + `Set-Cookie: oryxos_session=<uuid>; HttpOnly; SameSite=Strict; Secure(HTTPS); Path=/`。后续请求浏览器自动带 cookie。
+
+## 契约实体：BasicAuth 凭据
+
+非持久化，运行时 HTTP 头 `Authorization: Basic <Base64(user:pass)>`。filter 拆解 → `WebUserService.verify(user, pass)` → 200 或 401。curl/自动化路径，与 session 并存。无独立存储。

--- a/specs/012-web-auth/plan.md
+++ b/specs/012-web-auth/plan.md
@@ -1,0 +1,158 @@
+# Implementation Plan: Web Service 认证机制（最小 Auth）
+
+**Branch**: `012-web-auth` | **Date**: 2026-07-22 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/012-web-auth/spec.md`
+
+**Note**: This template is filled in by the `/speckit-plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+给 OryxOS 管理台（`/admin/**`）加最小认证，feature flag `oryxos.web.auth.enabled` 默认关，不破"假设内网"宪法前提。账号存 SQLite 新表 `web_users`，密码用 `spring-security-crypto` 的 `DelegatingPasswordEncoder`（`{bcrypt}` 前缀）哈希，绝不存明文。浏览器走 session/cookie + 登录页（`/admin/login`），curl/自动化走 Basic Auth，两者并存 filter 都认。session 存 SQLite 新表 `web_sessions`（过期 12h 可配，惰性清）。CLI 加 `oryxos user add/list/delete/passwd/disable/enable` 子命令组管账号。REST API `/api/v1/**` 不做认证（`/api/v1/auth/*` 子树是认证专用端点：login/logout/me）。不加新 Maven 模块，不引 Spring Security 全套。
+
+## Technical Context
+
+**Language/Version**: Java 21（虚拟线程），Spring Boot 3.3.5，Maven 多模块（9 模块）
+
+**Primary Dependencies**:
+- `info.picocli:picocli` 4.7.6（CLI）
+- `org.springframework.boot:spring-boot-starter-web`（oryxos-web）
+- `org.springframework.boot:spring-boot-starter-data-jpa`（oryxos-storage）
+- `org.xerial:sqlite-jdbc` 3.46.1.0
+- `org.hibernate.orm:hibernate-community-dialects`（`SQLiteDialect`）
+- **新增** `org.springframework.security:spring-security-crypto`（单 jar，非 `spring-boot-starter-security`；版本由 Spring Boot parent BOM 管）
+
+**Storage**: SQLite，数据源 `jdbc:sqlite:oryxos.db`（工作目录根，**非** spec 所写 `.oryxos/oryxos.db`——以 `oryxos-boot/src/main/resources/application.yml:18-19` 实际为准，plan 对齐实际）。`spring.jpa.hibernate.ddl-auto: none` + `spring.sql.init.mode: always`（启动跑 `schema.sql`，幂等 `CREATE TABLE IF NOT EXISTS`）。
+
+**Testing**: JUnit 5 + Spring Boot Test（`@DataJpaTest` 切片 + `@WebMvcTest`/`MockMvc`）。镜像现有 `LlmCallRepositoryTest`、`SessionApiControllerTest`。
+
+**Target Platform**: Linux 主流发行版（也跑 Win/macOS 开发机），单可执行 fat JAR，装企业自有 K8s/VM/物理机。
+
+**Project Type**: web-service + cli（Java 单体，Spring Boot + Picocli）
+
+**Performance Goals**: 单节点 ≥10 Agent、≥100 并发 Session（沿用既有目标，auth filter 每请求查 DB 不缓存，BCrypt 校验 ~50ms 可接受，不破并发目标）
+
+**Constraints**:
+- 宪法原则 VI：凭证不落地，明文密码 NEVER 入代码/配置/日志/git
+- 宪法原则 VIII：表结构手工 `schema.sql` 唯一权威，不依赖 Hibernate auto 迁移
+- 默认关（`auth.enabled=false`），回归零破坏（SC-001）
+- `/api/v1/**` 不拦，`/api/v1/health` 免认证（SC-003）
+- 不引 Spring Security 全套（无 filter chain / autoconfig / RBAC）
+- 不加新 Maven 模块（塞 storage + web + cli）
+
+**Scale/Scope**: 1 新表 + 1 新实体 + 1 新 repo + 1 新 service + 1 新 filter + 1 新配置类 + 1 新 CLI 命令组（5 leaf）+ schema.sql 追加 + 2 处 pom 依赖 + application.yml 配置 + 测试 + 文档。约 15-20 个文件改动。
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+逐条核对 `.specify/memory/constitution.md`（v1.1.0）八原则 + 技术栈约束 + 开发流程：
+
+| 原则 | 结论 | 说明 |
+|---|---|---|
+| I. 自实现 ReAct 循环 | ✅ 不涉及 | auth 不碰 ReActLoop |
+| II. Spring AI 仅协议转换+Schema | ✅ 不涉及 | auth 不碰 Spring AI |
+| III. Provider 显式映射 | ✅ 不涉及 | auth 不碰 Provider |
+| IV. 一个目录=一个 Agent | ✅ 不涉及 | auth 不碰 Agent 目录/ContextLoader |
+| V. 审计 Day One 落库 | ✅ 不涉及 | auth 不碰 tool_invocations/llm_calls；`web_users` 是账号表非审计表，不触发该原则 |
+| VI. 安全是地基，不用 SecurityManager | ✅ 通过 | 用 `spring-security-crypto` 做密码哈希（非 `SecurityManager`，JDK 21 已弃用 SecurityManager）；凭证走环境变量/哈希，明文不落配置/日志/git；`BasicAuthFilter` 是应用层 filter 非安全器 |
+| VII. 同步执行+虚拟线程，不引入异步 | ✅ 通过 | `BasicAuthFilter` 同步阻塞，不引 Reactor/WebFlux/CompletableFuture |
+| VIII. 配置即 Agent，实例无状态、状态外置 | ✅ 通过 | `web_users` 走 SQLite 外置状态；表结构走手工 `schema.sql`（FR-010），不依赖 `ddl-auto=update` |
+
+**技术栈约束**:
+- Java 21 + Spring Boot 3.x + Maven 多模块 ✅
+- 不加新模块：WebUser/repo/service 进 `oryxos-storage`，filter/配置进 `oryxos-web`，CLI 进 `oryxos-cli` ✅（无需声明新模块理由）
+- 持久化 SQLite + Spring Data JPA ✅
+- 日志 Logback + SLF4J，禁 `System.out`（CLI 输出除外，命令本就用 stdout）✅
+- 敏感配置 `${ENV_VAR}` 占位，启动校验走 `@Component implements ApplicationRunner`（oryxos-web，`AuthStartupCheck`），context 就绪后判 enabled 账号数（FR-006）✅
+
+**开发流程约束**:
+- Spec-Driven Development：constitution → specify → plan → tasks → analyze → implement ✅（当前在 plan 阶段）
+- 质量门禁全绿：Spotless + P3C + Checkstyle + SpotBugs/FSB + OWASP Dep-Check，接 `mvn verify` ✅（实现时须过门禁）
+
+**无违宪项**。无需 Complexity Tracking。
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-web-auth/
+├── plan.md              # 本文件
+├── research.md          # Phase 0 产出
+├── data-model.md        # Phase 1 产出
+├── quickstart.md        # Phase 1 产出
+├── contracts/           # Phase 1 产出
+│   └── cli-auth.md
+└── checklists/
+    └── requirements.md  # specify 阶段已产出
+```
+
+### Source Code (repository root)
+
+```text
+oryxos-storage/
+├── src/main/java/io/oryxos/storage/
+│   ├── WebUser.java                          # 新：@Entity web_users
+│   ├── WebUserRepository.java               # 新：JpaRepository<WebUser,Long>
+│   └── WebUserService.java                   # 新：账号 CRUD + 密码校验（plain class，@Bean 装配）
+├── src/main/resources/schema.sql             # 改：追加 web_users 建表块
+└── pom.xml                                   # 改：加 spring-security-crypto
+└── src/test/java/io/oryxos/storage/
+    └── WebUserServiceTest.java               # 新
+
+oryxos-web/
+├── src/main/java/io/oryxos/web/
+│   ├── config/
+│   │   ├── WebAuthProperties.java            # 改：加 sessionTtl 字段（Duration，默认 12h）
+│   │   └── AuthFilterConfig.java             # 改：FilterRegistrationBean<AuthFilter>（原 BasicAuthFilter 扩为认 Basic+session）
+│   ├── security/
+│   │   ├── BasicAuthFilter.java               # 改：保留类名（保 T011 测试引用 + SpotBugs 注解），扩两条路径——先查 session cookie 放行，无则查 Basic 头，都无按 Accept 头分流（浏览器 302 / curl 401）。/admin/login 路径内部放行
+│   │   ├── PasswordEncoderFactory.java       # 不动：DelegatingPasswordEncoder bean（{bcrypt}）
+│   │   └── AuthStartupCheck.java              # 不动：@ConditionalOnWebApplication(SERVLET)
+│   └── controller/
+│       └── AuthApiController.java            # 新：POST /api/v1/auth/login + /logout + GET /me
+├── src/main/resources/application.yml (in oryxos-boot，见下)
+├── src/main/frontend/src/                     # Vue SPA
+│   ├── views/LoginView.vue                    # 新：/admin/login 页（居中卡片+logo+表单，复用 tokens.css）
+│   ├── router.js (或等价)                      # 改：加 /admin/login 路由 + 全局前置守卫（未登录跳 login）
+│   └── styles/tokens.css                      # 复用：深色+橙+Space Grotesk
+└── pom.xml                                   # 不动（spring-security-crypto 已加）
+└── src/test/java/io/oryxos/web/
+    ├── security/BasicAuthFilterTest.java      # 改：扩 session 路径测试（cookie 有效放行、过期跳登录、curl 401）
+    ├── controller/AuthApiControllerTest.java  # 新：login/logout/me 端点
+    └── config/WebAuthPropertiesTest.java      # 改：加 sessionTtl 绑定测试
+
+oryxos-storage/
+├── src/main/java/io/oryxos/storage/
+│   ├── WebSession.java                        # 新：@Entity web_sessions（session_id/username/expires_at/created_at）
+│   ├── WebSessionRepository.java             # 新：JpaRepository<WebSession,Long>，findBySessionId
+│   └── WebUserService.java                   # 改：加 createSession/findBySessionId/deleteSession/isExpired（或新建 WebSessionService 分离）
+├── src/main/resources/schema.sql             # 改：追加 web_sessions 建表块
+└── src/test/java/io/oryxos/storage/
+    └── WebSessionServiceTest.java             # 新：session CRUD + 过期判定
+
+oryxos-cli/
+├── src/main/java/io/oryxos/cli/
+│   ├── command/UserCommand.java              # 不动（add/list/delete/passwd/disable/enable 已齐）
+│   └── OryxOsCli.java                        # 不动（UserCommand 已注册）
+│   └── OryxOsRuntime.java                    # 改：@Bean 装配 WebSessionRepository + WebSessionService（若新建）
+└── pom.xml                                   # 不动
+└── src/test/java/io/oryxos/cli/command/
+    └── UserCommandTest.java                  # 新
+
+oryxos-boot/
+└── src/main/resources/application.yml        # 改：加 oryxos.web.auth.session-ttl: 12h
+
+config/
+└── application.yml.example                   # 改：加 oryxos.web.auth.session-ttl 示例
+
+website/docs/ (或 website/zh/docs/)
+└── auth.md                                   # 改：补登录页/session/登出说明（中英）
+```
+
+**Structure Decision**: 不加新 Maven 模块。WebUser/repo/service + WebSession/repo 进 `oryxos-storage`；filter/配置/AuthApiController/LoginView 进 `oryxos-web`；CLI 进 `oryxos-cli`。`OryxOsRuntime` 已扫 `io.oryxos.storage`，实体/repo 自动发现。session 服务可并入 `WebUserService`（加 session 方法）或新建 `WebSessionService`——**推荐新建 `WebSessionService`**（职责分离：账号 vs 会话，各自单一职责，测试独立）。
+
+## Complexity Tracking
+
+> 无违宪项，本表留空。

--- a/specs/012-web-auth/quickstart.md
+++ b/specs/012-web-auth/quickstart.md
@@ -1,0 +1,120 @@
+# Quickstart: Web Service 认证机制（最小 Auth）
+
+**Feature**: 012-web-auth | **Date**: 2026-07-22
+
+端到端验证脚本，证明 feature 跑通。前置：JDK 21、Maven、`oryxos init` 已跑（`.oryxos/` 存在）。
+
+## 场景一：默认关，回归零破坏（SC-001）
+
+```bash
+# 1. 构建
+mvn -q clean package -DskipTests  # 或 mvn -q verify 过全门禁
+
+# 2. 起 serve（auth 默认 false）
+java -jar oryxos-boot/target/oryxos-boot-*.jar serve --port 8080
+
+# 3. 访问管理台——不弹认证，直接进
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/admin/
+# 期望: 200（或 302→/admin/）
+
+# 4. 访问 REST——不弹认证
+curl -s http://localhost:8080/api/v1/health
+# 期望: {"code":0,"message":"success","data":{"status":"ok"},"timestamp":...}
+```
+
+## 场景二：开 auth，保护管理台（US1）
+
+```bash
+# 1. 配置开 auth（改 jar 内 application.yml 或 config/application.yml 覆盖）
+#    oryxos:
+#      web:
+#        auth:
+#          enabled: true
+#          realm: OryxOS
+
+# 2. 首次开 auth 但无账号 → 启动阻断（SC-006）
+java -jar oryxos-boot/target/oryxos-boot-*.jar serve --port 8080
+# 期望: 启动失败，stderr 提示 "No enabled web user found. Run 'oryxos user add <username>'"
+
+# 3. 加 admin 账号
+java -jar oryxos-boot/target/oryxos-boot-*.jar user add admin
+# 交互输密码（不回显）+ 确认
+# 期望: Created user 'admin'
+
+# 4. 列账号（不显密码，SC-004）
+java -jar oryxos-boot/target/oryxos-boot-*.jar user list
+# 期望:
+# USERNAME  ENABLED  CREATED_AT
+# admin     true     2026-07-22T...
+
+# 5. 起 serve
+java -jar oryxos-boot/target/oryxos-boot-*.jar serve --port 8080
+
+# 6. 无凭据访问 /admin/ → 401 + WWW-Authenticate（SC-002）
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/admin/
+# 期望: 401
+curl -s -D - http://localhost:8080/admin/ | grep -i www-authenticate
+# 期望: WWW-Authenticate: Basic realm="OryxOS"
+
+# 7. 正确凭据 → 200（SC-002）
+curl -s -o /dev/null -w "%{http_code}\n" -u admin:<密码> http://localhost:8080/admin/
+# 期望: 200
+
+# 8. 错误凭据 → 401
+curl -s -o /dev/null -w "%{http_code}\n" -u admin:wrongpass http://localhost:8080/admin/
+# 期望: 401
+
+# 9. REST 不受影响（SC-003）
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/api/v1/health
+# 期望: 200（无凭据也通）
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/api/v1/profiles
+# 期望: 200（REST 不拦）
+```
+
+## 场景三：禁用账号（US1 场景 6）
+
+```bash
+# 禁用 admin（另开终端或先停 serve）
+java -jar oryxos-boot/target/oryxos-boot-*.jar user disable admin
+java -jar oryxos-boot/target/oryxos-boot-*.jar user list
+# 期望: admin  enabled=false
+
+# 重启 serve，用 admin 登录 → 401（禁用账号登不进）
+java -jar oryxos-boot/target/oryxos-boot-*.jar serve --port 8080
+curl -s -o /dev/null -w "%{http_code}\n" -u admin:<密码> http://localhost:8080/admin/
+# 期望: 401
+# 注意：开 auth 但无 enabled 账号 → serve 启动阻断（SC-006），需先加第二个账号或先 enable admin
+```
+
+## 场景四：改密码（US2 场景 4）
+
+```bash
+java -jar oryxos-boot/target/oryxos-boot-*.jar user passwd admin
+# 输新密码 + 确认
+# 期望: Password updated for 'admin'
+# 旧密码 401，新密码 200
+```
+
+## 单元/切片测试
+
+```bash
+mvn -q test -pl oryxos-storage -Dtest=WebUserServiceTest
+mvn -q test -pl oryxos-web -Dtest=BasicAuthFilterTest
+mvn -q test -pl oryxos-cli -Dtest=UserCommandTest
+```
+
+## 全门禁
+
+```bash
+mvn -q verify
+# Spotless + P3C + Checkstyle + SpotBugs/FSB + OWASP Dep-Check 全绿
+```
+
+## 预期产出
+
+- 场景一：4 个 curl 全 200/302，REST 正常
+- 场景二：无凭据 401 + `WWW-Authenticate`，正确凭据 200，错误 401，REST 不受影响
+- 场景三：禁用账号 401
+- 场景四：改密码后旧 401 新 200
+- `user list` 输出 0% 含密码/hash
+- `web_users` 表 `password_hash` 列 0% 明文

--- a/specs/012-web-auth/research.md
+++ b/specs/012-web-auth/research.md
@@ -1,0 +1,139 @@
+# Research: Web Service 认证机制（最小 Auth）
+
+**Feature**: 012-web-auth | **Date**: 2026-07-22
+
+Phase 0 研究产出。三个探索 agent（storage / web / cli）已返回，所有 NEEDS CLARIFICATION 已解析。
+
+## 1. 表结构与建表方式
+
+**Decision**: `web_users` 表追加进 `oryxos-storage/src/main/resources/schema.sql`，`CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS`，镜像现有 `sessions`/`llm_calls` 块。`ddl-auto: none` + `spring.sql.init.mode: always`（`oryxos-boot/src/main/resources/application.yml:20-25`）保证启动幂等加载。
+
+**Rationale**:
+- 宪法原则 VIII 明确：表结构手工 `schema.sql` 唯一权威，禁 `ddl-auto=update`（SQLite `ALTER TABLE` 弱）。
+- `StorageModule.java` Javadoc 同样警告。
+- 现有 6 表全走 `schema.sql`，无 Flyway/Liquibase（pom 无依赖，无 `db/migration`）。
+
+**Alternatives considered**:
+- Hibernate `ddl-auto=update`：违宪，SQLite ALTER 弱，否。
+- Flyway：引入新依赖 + 迁移文件目录，项目无先例，过度，否。
+- 配置文件存账号（`application.yml` 或 `users.yaml`）：web 探索建议，但 spec FR-003 明确 SQLite 表 + CLI 管理 + 加账号免重启（FR-007）。配置文件改要重启，违 FR-007，否。
+
+## 2. 实体/Repository 约定
+
+**Decision**: `WebUser` 实体镜像 `LlmCall`（auto-increment 模式）：
+- `package io.oryxos.storage;`（flat，无子包）
+- `@Entity @Table(name = "web_users")`
+- `@Id @GeneratedValue(strategy = GenerationType.IDENTITY) private Long id;`（surrogate key，**不**用 username 当主键——username 是 unique 列但非 PK，便于改名/删重建）
+- `@Column(name = "username", nullable = false, unique = true) private String username;`
+- `@Column(name = "password_hash", nullable = false) private String passwordHash;`
+- `@Column(nullable = false) private boolean enabled;`
+- `@Column(name = "created_at", nullable = false) private Instant createdAt;`
+- `@Column(name = "updated_at", nullable = false) private Instant updatedAt;`
+- `@PrePersist void onCreate() { if (createdAt==null) createdAt = Instant.now(); if (updatedAt==null) updatedAt = Instant.now(); }`
+- plain getters/setters，**无 Lombok**（storage 模块全无 Lombok）
+- 单行 Javadoc 注 "表结构以手工 schema.sql 为唯一权威"（镜像 `LlmCall.java:12`）
+- `updatedAt` 在 service 改动时手动 `setUpdatedAt(Instant.now())`（镜像 `JpaScheduledTaskStore`，无 `@UpdateTimestamp` 约定）
+
+**Repository**: `WebUserRepository extends JpaRepository<WebUser, Long>`，加 `Optional<WebUser> findByUsername(String)` + `boolean existsByUsername(String)`。无 `@Repository` 注解（现有 repo 全无）。无 `@Query`（Spring Data 派生方法够用）。
+
+**Rationale**: 6 个现有实体全这模式。不引 Lombok 避免模块风格分裂。surrogate `Long id` 而非 username 当 PK——改名/删重建不丢外键，且 spec FR-003 说 username 是 unique 列。
+
+**Alternatives**:
+- username 当 PK（`String`）：改名要级联，外键风险，否。
+- `AbstractEntity` 基类：项目无先例（grep 零匹配），引新约定过度，否。
+- Lombok：storage 全无，分裂风格，否。
+
+## 3. Service 层
+
+**Decision**: `WebUserService` plain class（非 `@Service` 注解），构造注入 `WebUserRepository` + `PasswordEncoder`。放 `io.oryxos.storage` 包。在 `OryxOsRuntime` 用 `@Bean` 装配（镜像 `JpaSessionManager` 在 `OryxOsRuntime:290`）。
+
+方法：`create(username, rawPassword)`、`delete(username)`、`changePassword(username, rawPassword)`、`disable(username)`、`list()`、`verify(username, rawPassword)→boolean`、`hasEnabledAccount()→boolean`（启动校验用，FR-006）。
+
+**Rationale**: storage 模块现有 `Jpa*Manager`/`Jpa*Auditor`/`Jpa*Store` 全是 plain class + 构造注入 + `@Bean` 外部装配，无 `@Service` 注解。`WebUserService` 遵同模式（命名用 `Service` 因它非 core 接口实现，是独立服务，但风格一致）。
+
+**Alternatives**:
+- `@Service` 注解自动装配：storage 模块无先例（全 plain class），违模块风格，否。但 `io.oryxos` 被 `OryxOsRuntime` 扫，`@Service` 也能工作——**可由实现者定**，plan 不强求 plain class，但推荐 plain + `@Bean` 对齐 storage 风格。
+- filter 直接用 `WebUserRepository`：省一层，但密码哈希/校验逻辑散落 filter，不利测试，否。
+
+## 4. 密码哈希
+
+**Decision**: `org.springframework.security:spring-security-crypto` 单 jar。用 `PasswordEncoderEncoderFactories.createDelegatingPasswordEncoder()` 得 `DelegatingPasswordEncoder`，hash 带 `{bcrypt}` 前缀。`PasswordEncoder` bean 由 `oryxos-web` 的 `PasswordEncoderFactory`（`@Configuration` class，`@Bean` 方法，见 tasks T009）提供，component scan（`OryxOsRuntime` 扫 `io.oryxos`）自动注册，**不**在 `OryxOsRuntime` 显式 `@Bean`。
+
+**Rationale**:
+- spec FR-009 明确要求 `DelegatingPasswordEncoder`（`{bcrypt}` 前缀，将来升 Argon2 无迁移）。
+- `spring-security-crypto` 是单 jar，**非** `spring-boot-starter-security` 全套（无 filter chain / autoconfig / RBAC），不违"自实现核心、不锁框架"宪法精神。
+- 版本由 Spring Boot parent BOM（3.3.5）管，无版本冲突。
+- `DelegatingPasswordEncoder.matches(rawPw, "{bcrypt}...hash")` 自动识别前缀校验；`encode(rawPw)` 产出 `{bcrypt}...`。
+
+**Alternatives considered**:
+- `org.mindrot:jbcrypt`：停更多年，无算法升级机制，观感差，否。
+- PBKDF2 纯 JDK：零依赖最纯，但无 `DelegatingPasswordEncoder` 升级路径，违 FR-009，否。
+- Argon2（`argon2-jvm`）：带 native lib，破单 JAR 部署目标，否。
+- `spring-boot-starter-security` 全套：引 autoconfig + filter chain，违"自实现核心"，否。
+
+**依赖位置**：`PasswordEncoder` bean 由 `oryxos-web` 的 `PasswordEncoderFactory` 提供（`@Configuration` class + `@Bean` 方法，component scan 自动注册），故 `oryxos-web/pom.xml` 需加 `spring-security-crypto` 依赖（声明 bean 的模块需类可见）。`WebUserService`（在 `oryxos-storage`）构造注入 `PasswordEncoder`，故 `oryxos-storage/pom.xml` 也需加（用 encoder 哈希）。`oryxos-cli` 传递依赖 storage 即得类型，不必单独加。**总结**：`oryxos-storage/pom.xml` + `oryxos-web/pom.xml` 两处加 `spring-security-crypto`。
+
+## 5. Filter 注册
+
+**Decision**: `FilterRegistrationBean<BasicAuthFilter>` in `oryxos-web/config/AuthFilterConfig.java`，`addUrlPatterns("/admin/**")`，`setOrder(Ordered.HIGHEST_PRECEDENCE + 10)`。`BasicAuthFilter extends OncePerRequestFilter`。
+
+**Rationale**:
+- web 探索确认：项目无任何 filter/interceptor 先例（grep 零匹配），本 feature 引首个。
+- `/admin/**`（静态 SPA，`ResourceHttpRequestHandler`）与 `/api/v1/**`（REST controller）URL 空间不交叠，`addUrlPatterns("/admin/**")` 精确保证 `/api/v1/**` 不被拦（SC-003）。
+- `/api/v1/health` 天然免认证（不在 `/admin/**`），满足 FR-008。
+- `OncePerRequestFilter` + `FilterRegistrationBean` 是 Spring Boot 惯用法，无需 `@WebFilter`/`@ServletComponentScan`（项目不用）。
+- `WebConfig` 非 `@EnableWebMvc`（不 disable Boot 自动注册），filter 正常生效。
+
+**Alternatives**:
+- `HandlerInterceptor` + `addInterceptors`：对静态资源 handler 也生效但更绕，filter 更底层更可靠，否。
+- `@WebFilter` + `@ServletComponentScan`：项目无先例，引入 servlet 扫描，否。
+- Spring Security 全套 filter chain：违"自实现核心"，否。
+
+## 6. 401 响应写法
+
+**Decision**: filter 内直接写 `ApiResponse.error(401, "Unauthorized")` JSON 到 response（status 401 + `Content-Type: application/json` + `WWW-Authenticate: Basic realm="<配置值>"`），不抛异常。
+
+**Rationale**: web 探索确认 `GlobalExceptionHandler`（`@RestControllerAdvice`）只捕 DispatcherServlet handler 路径内异常，filter 在 DispatcherServlet 之前跑，filter 抛异常不被 advice 捕，会冒到 servlet 容器错误页。直接写 response 最简单且统一信封。
+
+**Alternatives**:
+- 抛 `UnauthorizedException` + 转发 `/error`：复杂，要注册 error handler，否。
+- 依赖 `GlobalExceptionHandler` 加 401 映射：advice 捕不到 filter 异常，无效，否。
+
+## 7. 配置绑定
+
+**Decision**: `WebAuthProperties` `@ConfigurationProperties(prefix = "oryxos.web.auth")` record/class，字段 `boolean enabled`（默认 false）+ `String realm`（默认 "OryxOS"）。加到 `OryxOsRuntime` 的 `@EnableConfigurationProperties({...})` 列表（镜像 `ProvidersProperties` 等四个，对齐项目约定，不用 `@Component`）。
+
+**Rationale**:
+- web 探索确认项目无 `@ConfigurationPropertiesScan`，四个现有 properties 全走 `@EnableConfigurationProperties` 显式注册。对齐此约定。
+- `oryxos.web.*` 子树在所有 yml 中完全未占用（grep 零匹配），无冲突。
+- `oryxos` 前缀已被 `ProvidersProperties`（`oryxos.providers`）占用，但 `oryxos.web.auth` 是不同子树，无碰撞。
+
+**Alternatives**:
+- `@ConfigurationProperties` + `@Component`：组件扫描拾取，更简，但违项目约定（现有四个全 `@EnableConfigurationProperties`），否。
+- 配置文件（非 properties 类）：弱类型，否。
+
+## 8. CLI 命令模式
+
+**Decision**: `UserCommand` parent `@Command(name="user", subcommands={AddCommand.class, ListCommand.class, DeleteCommand.class, PasswdCommand.class, DisableCommand.class})` implements `Runnable`（bare `oryxos user` 打 usage）。5 leaf 全是 static nested class，**全是 heavy command**（仿 `ChatCommand`）：`run()` 内 `new SpringApplicationBuilder(OryxOsRuntime.class).web(WebApplicationType.NONE).bannerMode(Banner.Mode.OFF).run()` try-with-resources，`context.getBean(WebUserService.class)` 干活。
+
+**Rationale**:
+- cli 探索确认：`ProfileCommand` 是 group 命令模板（parent + static nested leaf）；`ChatCommand` 是 heavy command 模板（自启 Spring + getBean）。
+- `user add/passwd` 需 `WebUserService`（BCrypt 哈希），必须 Spring 上下文；`user list/delete/disable` 也走 service（统一入口、复用校验、保持一致）。全 heavy。
+- entity/repo 在 `oryxos-storage`，`OryxOsRuntime` 已 `@EnableJpaRepositories(basePackages="io.oryxos.storage")` + `@EntityScan`，自动发现 `WebUser`/`WebUserRepository`，无需改 scan 注解。
+- `UserCommand.class` 注册进 `OryxOsCli` 的 `subcommands={...}` 数组（line 26-37）。
+
+**密码输入**: `System.console().readPassword("[%s] ", prompt)`（spec FR-004/Edge Cases）。`System.console()` 返 null（piped stdin）时报错拒绝（不 fallback 明文读，避免脚本注入密码泄漏）。两次输入比对不一致拒绝（FR-011）。校验：username 非空/无空格/≤64；密码 ≥8 字符（FR-011）。明文密码 NEVER 打印/日志（宪法 VI）。
+
+**Alternatives**:
+- Light JDBC（仿 `SessionListCommand`）：走不了 `DelegatingPasswordEncoder`（需 Spring bean），且 spec FR-009 要求 encoder，否。
+- leaf 用 `@Autowired` + `@Component`：Picocli 命令非 Spring bean（`OryxOsCli.main` 用 `new CommandLine(new OryxOsCli())`，无 bean factory），`@Autowired` 不生效，否。
+
+## 9. 启动校验（FR-006）
+
+**Decision**: `OryxOsRuntime` 或 `WebAuthProperties` 启动后（`@Bean` 装配 `WebUserService` 后）跑 `WebUserService.hasEnabledAccount()`；若 `auth.enabled=true` 且无 enabled 账号，抛 `IllegalStateException` 阻断启动（清晰 message 提示 `oryxos user add`）。
+
+**Rationale**: spec FR-006 要求开 auth 但无账号时阻断启动，不静默裸奔。固定用 `@Component implements ApplicationRunner`（放 `oryxos-web`，与 filter 同模块便于聚合），`run()` 内判 `auth.enabled==true && !webUserService.hasEnabledAccount()` 时抛 `IllegalStateException` 阻断启动。不选 `@Bean` init 方式（启动顺序耦合 bean 装配链，`ApplicationRunner` 在 context 就绪后跑更可靠）。
+
+## 10. DB 文件路径勘误
+
+**发现**: spec Assumptions 写 DB 在 `.oryxos/oryxos.db`，实际 `oryxos-boot/src/main/resources/application.yml:18-19` 是 `jdbc:sqlite:oryxos.db`（工作目录根）。**plan 按实际路径**。spec 不改（spec 是 WHAT 层，路径是实现细节，plan 对齐即可）。实现时若 maintainer 要 `.oryxos/oryxos.db` 另议，当前按现状 `oryxos.db`。

--- a/specs/012-web-auth/spec.md
+++ b/specs/012-web-auth/spec.md
@@ -1,0 +1,171 @@
+# Feature Specification: Web Service 认证机制（最小 Auth）
+
+**Feature Branch**: `012-web-auth`
+
+**Created**: 2026-07-22
+
+**Status**: Draft
+
+**Input**: User description: "OryxOS 缺用户登录机制。给管理台加最小 Basic Auth，feature flag 默认关，不破'假设内网'宪法前提。REST API 不做 Basic Auth，auth 只管用户访问（管理台）。账号存 SQLite 新表，密码 BCrypt 哈希（用 spring-security-crypto，不引 Spring Security 全套）。CLI 加 `oryxos user` 子命令管账号。"
+
+## 定位与宪法关系
+
+- 核心阶段 Web Service spec（`specs/009-web-service/spec.md`）边界明确："认证鉴权（假设内网，扩展阶段补）"。本 feature **提前实现扩展阶段能力**，但不破坏核心阶段行为。
+- 手段：feature flag `oryxos.web.auth.enabled` 默认 `false`。默认关 = 现状不变 = 不违宪。
+- 不引 Spring Security 全套（尊重"自实现核心、不锁框架"宪法精神）。只引 `spring-security-crypto` 单 jar 做密码哈希，非 filter chain、非 autoconfig、非 RBAC。
+- 不加新 Maven 模块（尊重 9 模块宪法）。塞 `oryxos-storage` + `oryxos-web` + `oryxos-cli`。
+- 凭证不落地：密码哈希存 DB，明文密码 MUST NOT 写入代码、配置、日志、提交历史（宪法原则 VI）。
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 管理员启用认证保护管理台 (Priority: P1)
+
+运维不想让管理台裸奔内网。改配置开 auth，加 admin 账号，重启后访问管理台必须登录。REST API 不受影响（业务系统调 `/api/v1/**` 继续无认证）。
+
+**Why this priority**: 这是本 feature 存在的唯一理由——管理台是给人看的、可直接操作的入口，裸奔风险最高。REST API 后续单独做 API Key。开 auth 后管理台从"任意能访问内网者可操作"变成"需账密才能操作"，是核心价值。
+
+**Independent Test**: 配 `auth.enabled=true` 但无账号 → 启动报清晰错误；跑 `oryxos user add admin` → 输密码 → 表里有 BCrypt hash 非明文；启动 `oryxos serve` → 浏览器访问 `/admin/` 跳 `/admin/login` → 输对进 SPA，输错留登录页；curl `-u admin:pw` 访问 `/admin/` → 200。REST API `/api/v1/health` 不需认证、`/api/v1/profiles` 也不需（确认 REST 不受 auth 影响）。
+
+**Acceptance Scenarios**:
+
+1. **Given** `auth.enabled=false`（默认），**When** 访问 `/admin/`，**Then** 不弹登录、直接进（现状不变，回归零破坏）。
+2. **Given** `auth.enabled=true` 且 `web_users` 无 enabled 账号，**When** 启动服务，**Then** 启动失败并报清晰错误，提示先跑 `oryxos user add`（不静默裸奔）。
+3. **Given** `auth.enabled=true` 且有 enabled 账号 admin，**When** 浏览器访问 `/admin/`，**Then** 跳 `/admin/login`（登录页）。
+4. **Given** 登录页，**When** 输对账密提交，**Then** `POST /api/v1/auth/login` 返 200 + 设 `oryxos_session` cookie，跳 `/admin/` 加载 SPA。
+5. **Given** 登录页，**When** 输错账密，**Then** 返 401，留登录页显示"用户名或密码错误"。
+6. **Given** 账号 `enabled=false`（被禁用），**When** 用该账密登录，**Then** 401（禁用账号登不进）。
+7. **Given** `auth.enabled=true`，**When** 访问 `/api/v1/health`，**Then** 不需认证、正常返回（健康端点免认证）。
+8. **Given** `auth.enabled=true`，**When** 访问 `/api/v1/profiles` 等 REST 端点，**Then** 不需认证、正常返回（REST API 不做认证，后续 API Key 单独 PR）。
+9. **Given** `auth.enabled=true`，**When** curl `-u admin:pw` 访问 `/admin/`，**Then** 200（Basic Auth 路径并存，curl/自动化可用）。
+
+---
+
+### User Story 2 - 管理员通过 CLI 增删账号 (Priority: P1)
+
+管理员通过命令行管理账号，不直接碰数据库，不重启服务即可让新账号生效（每请求查 DB）。
+
+**Why this priority**: 没有账号管理就没法用 US1——启用 auth 必须先有账号。跟 US1 并列 P1，是 US1 的前置依赖。
+
+**Independent Test**: `oryxos user add alice` → 交互输密码（不回显）→ `oryxos user list` 看到 alice（不显密码）→ 开 auth 后 Basic Auth 用 alice 登录成功 → `oryxos user delete alice` → 再登录 401。
+
+**Acceptance Scenarios**:
+
+1. **Given** 服务运行中或已初始化 DB，**When** `oryxos user add alice`，**Then** 提示输密码（不回显）→ 提示确认密码 → 成功提示 → `web_users` 表有 alice 行，`password_hash` 字段是 BCrypt hash（非明文、每次 salt 不同）。
+2. **Given** 已有 alice，**When** `oryxos user add alice`，**Then** 报错"用户已存在"，退出码非 0，不覆盖原密码。
+3. **Given** 有 alice 与 admin，**When** `oryxos user list`，**Then** 列出用户名 + enabled 状态 + 创建时间，**MUST NOT** 显示任何密码字段。
+4. **Given** 有 alice，**When** `oryxos user passwd alice`，**Then** 提示新密码（不回显）+ 确认 → 更新 hash → 旧密码登不进、新密码能进。
+5. **Given** 有 alice，**When** `oryxos user delete alice`，**Then** 表删行 → 开 auth 后 Basic Auth 用 alice 401。
+6. **Given** 无 alice，**When** `oryxos user delete alice` 或 `oryxos user passwd alice`，**Then** 报错"用户不存在"，退出码非 0。
+7. **Given** 有 alice，**When** `oryxos user disable alice`，**Then** `enabled` 置 false → 登录 401。
+8. **Given** 有 alice 且已被禁用（`enabled=false`），**When** `oryxos user enable alice`，**Then** `enabled` 置 true → 登录 200（对称 disable，禁用后可恢复）。
+9. **Given** 无账号时，**When** `oryxos user list`，**Then** 输出空列表提示，退出码 0（不是错误）。
+
+---
+
+### User Story 3 - 管理员用浏览器登录管理台 (Priority: P1)
+
+管理员在浏览器打开管理台，看到同官网风格的登录页，输账密登录后进 SPA 管理台，可登出。curl/自动化仍可用 Basic Auth。
+
+**Why this priority**: Basic Auth 原生弹窗体验差、无登出。登录页是"可对外展示"的管理台入口，跟 US1/US2 并列 P1。
+
+**Independent Test**: 开 auth + 有 admin 账号 → 浏览器访问 `/admin/` → 跳 `/admin/login` → 输对 → 跳 `/admin/` SPA 加载 → 点登出 → 跳回登录页。curl `-u admin:pw` 访问 `/admin/` → 200（Basic 仍可用）。
+
+**Acceptance Scenarios**:
+
+1. **Given** 未登录，**When** 浏览器访问 `/admin/`，**Then** 跳 `/admin/login`（filter 302 或前端路由守卫）。
+2. **Given** 登录页，**When** 输对账密提交，**Then** `POST /api/v1/auth/login` 返 200 + 设 `oryxos_session` cookie，前端跳 `/admin/`，SPA 加载。
+3. **Given** 登录页，**When** 输错账密，**Then** 返 401，留登录页显示"用户名或密码错误"（不区分用户名是否存在，防枚举）。
+4. **Given** 已登录（有有效 session cookie），**When** 访问 `/admin/`，**Then** filter 认 session 通过，直接加载 SPA。
+5. **Given** 已登录，**When** 点登出，**Then** `POST /api/v1/auth/logout` 清 session 行 + 清 cookie，跳 `/admin/login`。
+6. **Given** session 过期（`expires_at < now`），**When** 访问 `/admin/`，**Then** filter 认 session 失效，跳登录页。
+7. **Given** 用 curl `-u admin:pw`，**When** 访问 `/admin/`，**Then** 200（Basic 路径并存）。
+8. **Given** 已登录，**When** `GET /api/v1/auth/me`，**Then** 返当前用户名（验证 session 有效）。
+
+---
+
+### Edge Cases
+
+- **密码不回显**：`user add` / `user passwd` 输密码时终端不显示明文（用 `Console.readPassword`）。
+- **密码长度下限**：空密码或短于 8 字符 MUST 被拒绝（给清晰提示，拒绝建号）。
+- **BCrypt salt**：相同密码每次 hash 不同（不同 salt），校验走 `BCrypt.checkpw` / `DelegatingPasswordEncoder.matches`。
+- **用户名规范**：空用户名、含空格、超 64 字符 MUST 被拒绝。
+- **确认密码不一致**：`user add` / `user passwd` 两次输入不一致 MUST 报错、不落库。
+- **DB 未初始化跑 user 命令**：MUST 提示先 `oryxos init`，或命令自身触发建表，不崩。
+- **公网部署**：Basic Auth / session cookie 须前置 HTTPS（非本 feature 范围，文档说明）。
+- **健康端点免认证**：`/api/v1/health` 即使 `auth.enabled=true` 也 MUST 免认证（k8s/监控探活依赖）。
+- **管理台静态资源**：`/admin/assets/**` 等 SPA 静态资源是否也拦？**决定**：整个 `/admin/**` 前缀都拦（含 assets），否则浏览器加载 SPA 壳时不弹窗、调 API 时才弹，体验割裂。浏览器首次访问 `/admin/` 弹一次后，后续同域资源自动带凭据。
+- **并发改密码**：两个管理员同时改同一账号 → 最后写者胜，DB 事务保证一致性，无额外锁。
+- **session 过期**：`web_sessions` 带 `expires_at`，filter 查到过期 session 当作无 session（浏览器跳 `/admin/login`，curl 401），不自动续期（核心阶段简化；滑动续期留扩展阶段）。过期行由 filter 查到时顺手删（惰性清），登出删当前行，无后台定时清理线程。
+- **session 吊销**：登出 POST `/api/v1/auth/logout` 删当前 session 行；改密码/禁用账号后旧 session 仍有效到过期（核心阶段不级联清，留扩展阶段）。
+- **并发登录**：同一账号多次登录建多个 session（不互踢），核心阶段不做单点登录约束。
+- **CSRF**：登录用 POST + `SameSite=Strict` cookie 防 CSRF；核心阶段不引 CSRF token（SameSite 够）。
+- **登录页放行**：`/admin/login` 路径 filter MUST 放行（未登录也要能访问登录页 + 其静态资源）。
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 系统 MUST 提供 feature flag `oryxos.web.auth.enabled`，默认 `false`。`false` 时管理台与 REST API 全部行为与现状一致（回归零破坏）。
+- **FR-002**: `auth.enabled=true` 时，系统 MUST 仅对 `/admin/**` 路径前缀启用认证（Basic Auth + session 两条路径，见 FR-005）；`/api/v1/**` REST 端点 MUST 维持无认证（现状不变，仅 `/api/v1/auth/*` 子树是认证专用端点）。Basic Auth realm MUST 取配置值 `oryxos.web.auth.realm`（默认 "OryxOS"，curl 401 时 `WWW-Authenticate` 用）。
+- **FR-003**: 系统 MUST 用 `web_users` 表存账号，字段含 `username`（唯一）、`password_hash`（BCrypt）、`enabled`、时间戳。明文密码 MUST NEVER 写入数据库、配置、日志或提交历史（宪法原则 VI）。
+- **FR-004**: 系统 MUST 提供 CLI 命令组 `oryxos user`，含子命令 `add`、`list`、`delete`、`passwd`、`disable`、`enable`，走 Picocli，与现有 CLI 命令同风格。密码输入 MUST 不回显。
+- **FR-005**: 认证校验流程 MUST 支持两条路径，任一通过即放行：(a) Basic Auth——取 `Authorization: Basic` 头 → Base64 解码拆 user/pass → 按 username 查 `web_users` → 用 `DelegatingPasswordEncoder.matches` 比对密码 → 账号 `enabled` 必须 true；(b) Session——取 `oryxos_session` cookie → 按 session id 查 `web_sessions` → session 未过期（`expires_at >= now`）即放行（**不**顺带查 `web_users` 的 enabled——Clarifications Q1 决定：改密/禁用后旧 session 仍有效到过期，不级联查 user 表）。两者都无/都失败：浏览器（`Accept` 头含 `text/html`）→ 302 跳 `/admin/login`；curl/自动化 → 401 + `WWW-Authenticate: Basic realm="<配置值>"`。
+- **FR-006**: `auth.enabled=true` 且 `web_users` 无任何 enabled 账号时，服务启动 MUST 报清晰错误并阻断启动（不静默裸奔），提示运行 `oryxos user add`。
+- **FR-007**: 增 / 删 / 改账号 MUST NOT 重启服务即生效——每次认证请求 MUST 实时查 DB（不进程内缓存账号表）。
+- **FR-008**: `/api/v1/health` 端点 MUST 免认证（即使 `auth.enabled=true`），保障 k8s/监控探活。
+- **FR-009**: 密码哈希 MUST 用 `spring-security-crypto` 的 `DelegatingPasswordEncoder`（hash 带 `{bcrypt}` 前缀），为将来升级 Argon2 等算法预留无迁移切换路径。MUST NOT 引入 Spring Security 全套（无 filter chain、无 autoconfig、无 RBAC）。
+- **FR-010**: 建表 MUST 走手工脚本（`schema.sql` 或等价），MUST NOT 依赖 Hibernate `ddl-auto=update` 自动迁移（宪法原则 VIII，SQLite `ALTER TABLE` 支持弱）。
+- **FR-011**: `oryxos user` 命令 MUST 做输入校验：空用户名、含空格、超 64 字符拒绝；空密码或短于 8 字符拒绝；两次密码输入不一致拒绝。
+- **FR-012**: `oryxos user list` 输出 MUST NEVER 包含密码或哈希字段，仅用户名 / enabled / 创建时间。
+- **FR-013**: 系统 MUST 暴露 `POST /api/v1/auth/login`（接 JSON `{username, password}`，验账密 → 建 `web_sessions` 行 → 设 `oryxos_session` cookie `HttpOnly`+`SameSite=Strict`+`Secure`(HTTPS 时)），失败返 401 统一信封；`POST /api/v1/auth/logout`（清当前 session 行 + 清 cookie）；`GET /api/v1/auth/me`（返当前登录用户名，未登录 401）。
+- **FR-014**: 系统 MUST 用 `web_sessions` 表存 session，字段含 `session_id`（UUID，唯一）、`username`、`expires_at`、`created_at`。session id 由安全随机生成（`UUID.randomUUID` 或等价）。
+- **FR-015**: session 过期时间 `oryxos.web.auth.session-ttl`（默认 12 小时，可配）；filter 查到 `expires_at < now` 的 session 当作无 session（不自动续期）。
+- **FR-016**: 管理台前端 MUST 有 `LoginView.vue`（`/admin/login` 路由，同官网首页设计风格：深色 + 橙、同字体），未登录访问 `/admin/**`（除 `/admin/login` 与静态资源）→ 前端路由跳 `/admin/login`。登录成功跳 `/admin/`。登录失败显示"用户名或密码错误"（不区分用户名存在与否，防枚举），密码框清空、用户名框保留。
+- **FR-017**: `/admin/login` 路径（含其静态资源）filter MUST 放行，让未登录用户能加载登录页。
+- **FR-018**: 登录页 SPA MUST 无独立后端模板，纯 Vue 组件调 `/api/v1/auth/login`，复用 `web_users` 账号体系。
+
+### Key Entities *(include if feature involves data)*
+
+- **WebUser**：管理员账号实体。关键属性：用户名（唯一标识）、密码哈希（BCrypt，非明文）、启用状态、创建时间、更新时间。一个 WebUser 对应一个可登录管理台的管理员。
+- **BasicAuth 凭据**：HTTP `Authorization: Basic <Base64(user:pass)>` 头，由浏览器在弹窗后或 curl 自动携带，服务端拆解校验（curl/自动化路径）。
+- **Session**：`web_sessions` 表一行，含 session id（UUID cookie 值）、username、`expires_at`、`created_at`。浏览器走此路径（登录页建 session → cookie 后续携带）。
+- **`oryxos_session` cookie**：HttpOnly + SameSite=Strict + Secure(HTTPS)，值 = session id（UUID）。
+- **Auth 配置开关**：`oryxos.web.auth.enabled` + `oryxos.web.auth.realm` + `oryxos.web.auth.session-ttl`，控制认证是否启用、realm 文案、session 过期。
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `auth.enabled=false`（默认）时，管理台与 REST API 100% 行为与未加 auth 前一致（前序测试全绿、回归零破坏）。
+- **SC-002**: `auth.enabled=true` 且存在 enabled 账号时，无凭据 curl 访问 `/admin/` 100% 返 401 + `WWW-Authenticate`；正确 Basic 凭据 100% 返 200；浏览器无 session 访问 `/admin/` 跳 `/admin/login`。
+- **SC-003**: `auth.enabled=true` 时，`/api/v1/**` REST 端点 100% 不受 `/admin/**` filter 认证影响（无凭据也正常返回，含 `/api/v1/health`）；`/api/v1/auth/*` 子树是认证专用端点（login/logout/me），靠 controller 自身校验，非 `/admin/**` filter 拦。
+- **SC-004**: 数据库中密码字段 0% 明文、100% BCrypt hash；`oryxos user list` 输出 0% 含密码或哈希字段。
+- **SC-005**: `oryxos user add/list/delete/passwd/disable/enable` 全部子命令可正常运行；加账号后无需重启服务，下一次认证请求即可用新账号登录。
+- **SC-006**: `auth.enabled=true` 且无 enabled 账号时，服务启动 100% 阻断并报清晰错误（不静默放行）。
+- **SC-007**: 管理员完成"开 auth + 建首账号 + 登录"全流程在 3 分钟内（配置改一行 + 一条 CLI 命令 + 浏览器登录页登录）。
+- **SC-008**: 前序全部 spec 测试保持全绿（本 feature 默认关，不改前序契约）。
+- **SC-009**: 浏览器访问 `/admin/`（未登录）→ 跳 `/admin/login` → 输对账密 → 跳 `/admin/` 加载 SPA；输错 → 留登录页显示错误；登出 → 跳回登录页 + 清 cookie。
+- **SC-010**: session 过期后访问 `/admin/` → 跳登录页（filter 认过期 session 失效）。
+- **SC-011**: curl 走 Basic Auth（`-u user:pass`）仍可访问 `/admin/`（两种认证路径并存，curl 200）。
+
+## Assumptions
+
+- `web_users` 表走现有 SQLite + Spring Data JPA，与 sessions / 审计表同数据源（`oryxos.db`，工作目录根，以 `application.yml` 实际配置为准）。
+- 密码哈希用 `org.springframework.security:spring-security-crypto` 单 jar（不引 `spring-boot-starter-security` 全套），其 `DelegatingPasswordEncoder` 提供 `{bcrypt}` 前缀与将来 Argon2 升级路径。
+- Basic Auth 适合内网 + HTTPS 场景；公网部署需前置 HTTPS（非本 feature 范围，文档说明）。
+- `oryxos user` 命令走 Picocli，与现有 12 命令同风格；命令访问 DB 需 Spring 上下文（沿用现有需 Spring 的命令的启动模式）。
+- 管理台前端为 Vue SPA，托管在 `/admin/**`（由 `oryxos-web` 的 `WebConfig` 静态资源映射）。
+- **登录页**：浏览器走 session/cookie（SPA 登录页 `/admin/login`），curl/自动化走 Basic Auth（两者并存，filter 都认）。session 存 SQLite 新表 `web_sessions`（重启不丢、单机够用；多实例共享留扩展阶段 Redis）。cookie `HttpOnly`+`Secure`(HTTPS)+`SameSite=Strict`。
+- REST API 的机器调用认证（API Key）为后续独立 PR，本 feature 不涉及。
+- Session/Cookie 登录、登出、超时在本 feature 做（登录页配套）；JWT、OAuth2/SSO、RBAC、多租户均为扩展阶段，本 feature 不做；`web_users` 表不预留 `roles` 字段（YAGNI，到扩展阶段再加）。
+- 本 feature 提前实现扩展阶段能力（虽默认关），需在上游 PR 描述中说明并征得 maintainer 同意。
+
+## Clarifications
+
+### Session 2026-07-22
+
+- Q: 禁用账号或改密码后，已发放的 session 是否立即失效？ → A: B 不失效，旧 session 有效到过期（12h）。核心阶段不级联清，filter 查 session 不顺带查 user 表（简单，有 12h 安全窗口，内网可控）。改密码/禁用后旧 session 仍到过期，扩展阶段再加级联失效。
+- Q: 浏览器访问 `/admin/`（未登录）时，filter 如何让其跳登录页？ → A: A 分流——filter 检测 Accept 头含 `text/html`（浏览器）→ 302 跳 `/admin/login`；否则（curl/自动化）→ 401 + `WWW-Authenticate: Basic realm="..."`。后端单一真相按客户端分流，前端 SPA 路由守卫兜底（直接访问 `/admin/<sub>` 子路由也守卫跳登录）。
+- Q: 登录失败时，前端 LoginView 错误文案 + 是否清空密码框？ → A: A 文案"用户名或密码错误"（不区分用户名存在与否，防枚举），密码框清空、用户名框保留。标准登录页体验。
+- Q: session 存 SQLite，过期 session 行怎么清？ → A: B 惰性清——登出删当前行 + filter 查到过期行顺手删当前行，无后台定时线程。简单，过期行可能累积到被访问才清（扩展阶段可加定时清）。
+- Q: 登录页视觉风格"同官网首页"，具体复用哪些？ → A: A 复用 `oryxos-web` frontend 现有 design tokens（`src/styles/tokens.css`，深色 + 橙品牌色 + Space Grotesk 字体），LoginView 居中卡片（logo + 用户名/密码输入 + 登录按钮），全用 token 变量。与官网首页/管理台同视觉。

--- a/specs/012-web-auth/tasks.md
+++ b/specs/012-web-auth/tasks.md
@@ -1,0 +1,243 @@
+---
+
+description: "Task list for feature 012-web-auth implementation"
+---
+
+# Tasks: Web Service 认证机制（最小 Auth）
+
+**Input**: Design documents from `/specs/012-web-auth/`
+
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/cli-auth.md ✅, quickstart.md ✅
+
+**Tests**: 含测试任务（项目质量门禁要求 `mvn verify` 全绿，auth 是安全特性必须有测试）。
+
+**Organization**: 按 user story 分组（spec.md 两个 P1 user story）。US1=管理台启用 auth，US2=CLI 增删账号。
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: 可并行（不同文件，无依赖）
+- **[Story]**: 属哪个 user story（US1/US2）
+- 含精确文件路径
+
+## Path Conventions
+
+- Maven 多模块，路径形如 `oryxos-<module>/src/main/java/io/oryxos/<layer>/...`
+- 镜像现有约定（见 plan.md Project Structure）
+
+## Phase 1: Setup（共享基础设施）
+
+**Purpose**: 依赖、配置骨架、新表
+
+- [ ] T001 [P] 在 `oryxos-storage/pom.xml` 与 `oryxos-web/pom.xml` 两处加 `org.springframework.security:spring-security-crypto` 依赖（单 jar，非 starter-security；版本由 Spring Boot parent BOM 管。storage 用 encoder 哈希，web 声明 `PasswordEncoder` bean）
+- [ ] T002 [P] 在 `oryxos-storage/src/main/resources/schema.sql` 追加 `web_users` 建表块 + `idx_web_users_username` 索引（见 data-model.md DDL，镜像现有 `llm_calls` 块风格，`CREATE TABLE IF NOT EXISTS`）
+- [ ] T003 [P] 在 `oryxos-boot/src/main/resources/application.yml` 的 `oryxos:` 子树下加 `web.auth.enabled: false` + `web.auth.realm: OryxOS`（默认关，SC-001）
+- [ ] T004 [P] 在 `config/application.yml.example` 加 `oryxos.web.auth.*` 示例段 + 注释说明（开 auth 前先 `oryxos user add`）
+
+**Checkpoint**: 依赖就位，表结构定义好，配置骨架在。
+
+---
+
+## Phase 2: Foundational（阻塞性前置）
+
+**Purpose**: 实体/Repo/Service/Encoder 配置——所有 user story 依赖
+
+**⚠️ CRITICAL**: US1（filter 校验账号）和 US2（CLI 管账号）都依赖本 phase
+
+- [ ] T005 [P] 在 `oryxos-storage/src/main/java/io/oryxos/storage/WebUser.java` 建 `@Entity @Table(name="web_users")`，字段 `id`(Long,IDENTITY)/`username`(unique)/`passwordHash`/`enabled`/`createdAt`/`updatedAt`(Instant)，`@PrePersist onCreate()`，无 Lombok，单行 Javadoc 注"表结构以手工 schema.sql 为唯一权威"（镜像 `LlmCall.java`）
+- [ ] T006 [P] 在 `oryxos-storage/src/main/java/io/oryxos/storage/WebUserRepository.java` 建 `interface WebUserRepository extends JpaRepository<WebUser, Long>`，加 `Optional<WebUser> findByUsername(String)` + `boolean existsByUsername(String)`，无 `@Repository` 注解
+- [ ] T007 在 `oryxos-storage/src/main/java/io/oryxos/storage/WebUserService.java` 建 plain class（非 `@Service`），构造注入 `WebUserRepository` + `PasswordEncoder`。方法：`create(username,rawPw)`、`delete(username)`、`changePassword(username,rawPw)`、`disable(username)`、`list()`、`verify(username,rawPw)→boolean`、`hasEnabledAccount()→boolean`。每次 mutate 手动 `setUpdatedAt(Instant.now())`（镜像 `JpaScheduledTaskStore`）。校验 username 非空/无空格/≤64，password ≥8
+- [ ] T008 [P] 在 `oryxos-web/src/main/java/io/oryxos/web/config/WebAuthProperties.java` 建 `@ConfigurationProperties(prefix="oryxos.web.auth")`，字段 `boolean enabled`(默认 false) + `String realm`(默认 "OryxOS")
+- [ ] T009 [P] 在 `oryxos-web/src/main/java/io/oryxos/web/security/PasswordEncoderFactory.java` 建 `@Configuration` class，`@Bean PasswordEncoder` 返 `PasswordEncoderEncoderFactories.createDelegatingPasswordEncoder()`（`{bcrypt}` 前缀，FR-009）
+- [ ] T010 改 `oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java`：(a) `@EnableConfigurationProperties({...})` 列表加 `WebAuthProperties.class`；(b) 加 `@Bean WebUserService webUserService(WebUserRepository, PasswordEncoder)` 装配（镜像 `sessionManager` 在 line 290）
+
+**Checkpoint**: Foundation ready——实体/repo/service/encoder/配置全就位，可装 Bean，filter 和 CLI 都能用。
+
+---
+
+## Phase 3: User Story 1 - 启用认证保护管理台 (Priority: P1) 🎯 MVP
+
+**Goal**: `auth.enabled=true` 时 `/admin/**` 弹 Basic Auth，`/api/v1/**` 不受影响，`/api/v1/health` 免认证。默认关回归零破坏。
+
+**Independent Test**: quickstart.md 场景二——无凭据 `/admin/` 返 401 + `WWW-Authenticate`，正确凭据 200，REST 全不受影响。场景一——默认关全 200。
+
+### Tests for User Story 1
+
+> 先写测试，先失败再实现（TDD，auth 安全特性）
+
+- [ ] T011 [P] [US1] 在 `oryxos-web/src/test/java/io/oryxos/web/security/BasicAuthFilterTest.java` 写 `@WebMvcTest` + `MockMvc`：无凭据 `/admin/` 期望 401 + `WWW-Authenticate: Basic realm="OryxOS"`；正确凭据期望 200；错误凭据 401；禁用账号 401；`/api/v1/health` 无凭据 200（免认证）；`/api/v1/profiles` 无凭据 200（REST 不拦）；`auth.enabled=false` 时 `/admin/` 无凭据 200（默认关）
+- [ ] T012 [P] [US1] 在 `oryxos-web/src/test/java/io/oryxos/web/config/WebAuthPropertiesTest.java` 写配置绑定测试：`enabled` 默认 false，`realm` 默认 "OryxOS"，yml 覆盖生效
+
+### Implementation for User Story 1
+
+- [ ] T013 [P] [US1] 在 `oryxos-web/src/main/java/io/oryxos/web/security/BasicAuthFilter.java` 建 `extends OncePerRequestFilter`：注入 `WebUserService` + `WebAuthProperties` + `ObjectMapper`。`auth.enabled=false` 直接放行；`true` 时取 `Authorization: Basic` 头 → Base64 解码拆 user/pass → `WebUserService.verify` → 失败写 401 JSON `ApiResponse.error(401,"Unauthorized")` + `WWW-Authenticate: Basic realm="<配置值>"`；成功 `chain.doFilter`。不抛异常（advice 捕不到 filter 异常）
+- [ ] T014 [US1] 在 `oryxos-web/src/main/java/io/oryxos/web/config/AuthFilterConfig.java` 建 `@Configuration`，`@Bean FilterRegistrationBean<BasicAuthFilter>`：`addUrlPatterns("/admin/**")` + `setOrder(Ordered.HIGHEST_PRECEDENCE + 10)`（仅 `/admin/**`，`/api/v1/**` 不拦，依赖 T013）
+- [ ] T015 [US1] 在 `oryxos-web/src/main/java/io/oryxos/web/security/AuthStartupCheck.java` 建 `@Component implements ApplicationRunner`：注入 `WebAuthProperties` + `WebUserService`，`run()` 内判 `auth.enabled==true && !hasEnabledAccount()` 时抛 `IllegalStateException` 阻断启动，message 提示 `oryxos user add`（FR-006，依赖 T010；放 oryxos-web 与 filter 同模块）
+
+**Checkpoint**: US1 全功能——开 auth 后管理台要登录，REST 不受影响，无账号启动阻断。默认关回归零破坏。
+
+---
+
+## Phase 4: User Story 2 - CLI 增删账号 (Priority: P1)
+
+**Goal**: `oryxos user add/list/delete/passwd/disable/enable` 子命令组，密码不回显，加账号免重启即生效。
+
+**Independent Test**: quickstart.md 场景四 + `user list` 不显密码——`oryxos user add alice` 交互输密码 → `user list` 见 alice 不显 hash → Basic Auth 用 alice 登录成功 → `user delete alice` → 登录 401。
+
+### Tests for User Story 2
+
+- [ ] T016 [P] [US2] 在 `oryxos-storage/src/test/java/io/oryxos/storage/WebUserServiceTest.java` 写 `@DataJpaTest` + `@AutoConfigureTestDatabase(replace=NONE)` + `@DynamicPropertySource`（设 `ddl-auto=none` + SQLiteDialect + `sql.init.mode=always`，镜像 `LlmCallRepositoryTest`）：`create` 存 hash 非明文 + 每次 salt 不同；重名抛错；`verify` 对的真假错；`disable` 后 `verify` 返 false；`hasEnabledAccount` 空=false 有=true；password <8 抛错；username 空格/超长抛错
+- [ ] T017 [P] [US2] 在 `oryxos-cli/src/test/java/io/oryxos/cli/command/UserCommandTest.java` 写 CLI 集成测试：`add`/`list`/`delete`/`passwd`/`disable`/`enable` 各覆盖成功 + 失败路径；`list` 输出 0% 含密码/hash；mock `System.console` 或用 ` ByteArrayInputStream` 测密码读取（验证不回显由 console API 保证，测逻辑即可）
+
+### Implementation for User Story 2
+
+- [ ] T018 [P] [US2] 在 `oryxos-cli/src/main/java/io/oryxos/cli/command/UserCommand.java` 建 parent `@Command(name="user", subcommands={AddCommand.class, ListCommand.class, DeleteCommand.class, PasswdCommand.class, DisableCommand.class, EnableCommand.class})` implements `Runnable`（bare `oryxos user` 打 usage），镜像 `ProfileCommand`
+- [ ] T019 [US2] 在 `UserCommand.java` 加 static nested `AddCommand` `@Command(name="add")`：`@Parameters(index="0") String username`。`run()` 内 `new SpringApplicationBuilder(OryxOsRuntime.class).web(WebApplicationType.NONE).bannerMode(Banner.Mode.OFF).run()` try-with-resources，`context.getBean(WebUserService.class)`。`System.console().readPassword` 读密码（null 报错拒绝）+ 确认，校验后 `create`，stdout `Created user '<name>'`。重名/短密码/不一致/console null → stderr + 退出码 1（依赖 T018，镜像 `ChatCommand` heavy 模式）
+- [ ] T020 [US2] 在 `UserCommand.java` 加 static nested `ListCommand` `@Command(name="list")`：heavy 起 Spring，`context.getBean(WebUserService.class).list()`，输出表格 `USERNAME/ENABLED/CREATED_AT`，**不含密码/hash**。空表提示 `No users found...`，退出码 0（依赖 T018）
+- [ ] T021 [US2] 在 `UserCommand.java` 加 static nested `DeleteCommand` `@Command(name="delete")`：`@Parameters(index="0") String username`，heavy 起 Spring，`delete`，成功 stdout / 不存在 stderr + 退出码 1（依赖 T018）
+- [ ] T022 [US2] 在 `UserCommand.java` 加 static nested `PasswdCommand` `@Command(name="passwd")`：`@Parameters(index="0") String username`，heavy 起 Spring，`readPassword` 读新密码 + 确认，`changePassword`，stdout `Password updated`。用户不存在/短/不一致/console null → stderr + 退出码 1（依赖 T018）
+- [ ] T023 [US2] 在 `UserCommand.java` 加 static nested `DisableCommand` `@Command(name="disable")`：`@Parameters(index="0") String username`，heavy 起 Spring，`disable`，stdout `Disabled user` / 不存在 stderr + 退出码 1（依赖 T018）
+- [ ] T023a [US2] 在 `UserCommand.java` 加 static nested `EnableCommand` `@Command(name="enable")`：`@Parameters(index="0") String username`，heavy 起 Spring，`enable`，stdout `Enabled user` / 不存在 stderr + 退出码 1（对称 disable，禁用后可恢复；依赖 T018）
+- [ ] T024 [US2] 改 `oryxos-cli/src/main/java/io/oryxos/cli/OryxOsCli.java`：`subcommands={...}` 数组加 `UserCommand.class`（line 26-37）
+
+**Checkpoint**: US2 全功能——五子命令跑通，账号管理可用，`user list` 不泄密码。
+
+---
+
+## Phase 4b: User Story 3 - 浏览器登录管理台 (Priority: P1)
+
+**Goal**: 浏览器走 session/cookie + 登录页，curl 走 Basic Auth，两者并存。
+
+**Independent Test**: quickstart 场景五——浏览器访问 `/admin/` → 跳 `/admin/login` → 输对 → 跳 `/admin/` SPA 加载 → 点登出 → 跳回登录页；curl `-u admin:pw` `/admin/` → 200。
+
+### Tests for User Story 3
+
+- [ ] T031 [P] [US3] 在 `oryxos-storage/src/test/java/io/oryxos/storage/WebSessionServiceTest.java` 写 `@DataJpaTest` + `@DynamicPropertySource`（镜像 WebUserServiceTest）：`createSession` 存 session_id(UUID)+expires_at+username；`findBySessionId` 命中/未命中；`isExpired` 过期判定；`deleteSession` 删行；过期行 filter 顺手删（惰性清）
+- [ ] T032 [P] [US3] 在 `oryxos-web/src/test/java/io/oryxos/web/controller/AuthApiControllerTest.java` 写 `@WebMvcTest` + MockMvc：`POST /login` 对返 200+Set-Cookie（HttpOnly+SameSite=Strict+Path=/）/错返 401（"Invalid username or password"，不区分原因）；`POST /logout` 清 cookie + 删 session；`GET /me` 已登录返用户名/未登录 401
+
+### Implementation for User Story 3
+
+- [ ] T033 [P] [US3] 在 `oryxos-storage/src/main/java/io/oryxos/storage/WebSession.java` 建 `@Entity @Table(name="web_sessions")`，字段 `id`(Long,IDENTITY)/`sessionId`(String,unique)/`username`/`expiresAt`(Instant)/`createdAt`(Instant)，`@PrePersist`，无 Lombok（镜像 WebUser）
+- [ ] T034 [P] [US3] 在 `oryxos-storage/src/main/java/io/oryxos/storage/WebSessionRepository.java` 建 `interface WebSessionRepository extends JpaRepository<WebSession,Long>`，加 `Optional<WebSession> findBySessionId(String)` + `void deleteBySessionId(String)`
+- [ ] T035 [US3] 在 `oryxos-storage/src/main/java/io/oryxos/storage/WebSessionService.java` 建 plain class（构造注入 `WebSessionRepository` + `WebAuthProperties`），方法 `create(username)→WebSession`（UUID.randomUUID + `expires_at=now+sessionTtl`）、`findValid(sessionId)→Optional<WebSession>`（查到且未过期返，过期顺手 `delete` 惰性清）、`delete(sessionId)`、`isExpired(WebSession)`
+- [ ] T036 [P] [US3] 在 `oryxos-storage/src/main/resources/schema.sql` 追加 `web_sessions` 建表块 + `idx_web_sessions_session` 索引（见 data-model.md DDL）
+- [ ] T037 [US3] 在 `oryxos-web/src/main/java/io/oryxos/web/config/WebAuthProperties.java` 加 `Duration sessionTtl` 字段（默认 12h，`@DurationUnit(ChronoUnit.HOURS)` 或 yml `12h`）
+- [ ] T038 [US3] 在 `oryxos-web/src/main/java/io/oryxos/web/controller/AuthApiController.java` 建 `@RestController @RequestMapping("/api/v1/auth")`：`POST /login`（接 `{username,password}` JSON → `WebUserService.verify` → 对则 `WebSessionService.create` + `Set-Cookie: oryxos_session=<id>; Path=/; HttpOnly; SameSite=Strict`(+Secure 若 HTTPS) → 返 `ApiResponse.ok({username})`；错则 401 `ApiResponse.error(401,"Invalid username or password")`）；`POST /logout`（从 cookie 取 session id → `delete` + 清 cookie → 200）；`GET /me`（从 cookie 取 session → `findValid` → 200 返 username / 401）
+- [ ] T039 [US3] 改 `oryxos-web/src/main/java/io/oryxos/web/security/BasicAuthFilter.java`（**保留类名**，不改名——保 T011 测试引用 + SpotBugs 注解），扩两条路径：(1) 查 `oryxos_session` cookie → `WebSessionService.findValid`（未过期即放行，不查 user enabled——Clarifications Q1 B）→ 放行；(2) 无 session 则查 `Authorization: Basic` 头 → `WebUserService.verify`（原逻辑）→ 放行；(3) 都无——`Accept` 头含 `text/html` → 302 跳 `/admin/login`；否则 401 + `WWW-Authenticate`。`/admin/login` 路径（`requestURI.startsWith("/admin/login")`）内部放行（含其静态资源）
+- [ ] T040 [US3] 改 `oryxos-web/src/main/java/io/oryxos/web/config/AuthFilterConfig.java`：filter 注册 URL 模式仍 `/admin/*`，`/admin/login` 放行在 filter 内部判路径（T039 实现），此 config 不改 URL 模式
+- [ ] T041 [US3] 改 `oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java`：`@Bean` 装配 `WebSessionRepository`（JPA 自动扫）+ `WebSessionService`（构造注入 repo + `WebAuthProperties`）
+- [ ] T042 [P] [US3] 在 `oryxos-web/src/main/frontend/src/views/LoginView.vue` 建登录页：居中卡片（logo + username 输入 + password 输入 + 登录按钮），复用 `src/styles/tokens.css`（深色 + 橙 + Space Grotesk）。提交调 `POST /api/v1/auth/login` → 200 跳 `/admin/`；401 显示"用户名或密码错误"（密码框清空、用户名保留）
+- [ ] T043 [US3] 改 `oryxos-web/src/main/frontend/src/router.js`（或 App.vue 路由）：加 `/admin/login` 路由 → LoginView；全局前置守卫（`beforeEach`）：未登录访问 `/admin/**`（除 login）→ 跳 `/admin/login`；已登录访问 `/admin/login` → 跳 `/admin/`
+- [ ] T044 [US3] 改 `oryxos-web/src/main/frontend/src/App.vue`（或 Layout）：加"登出"按钮（调 `POST /api/v1/auth/logout` → 跳 `/admin/login`）
+
+**Checkpoint**: US3 全功能——浏览器登录页登录/登出，curl Basic 并存，session 过期跳登录。
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: 文档、门禁、端到端验证
+
+- [ ] T025 [P] 在 `website/docs/auth.md` 补登录页/session/登出说明（开 auth 步骤、浏览器登录页、curl Basic、REST 不受影响、HTTPS 前置提醒）
+- [ ] T026 [P] 在 `website/zh/docs/auth.md` 补中文（同上）
+- [ ] T027 [P] 在 `website/docs/cli.md` 与 `website/zh/docs/cli.md` 补 `oryxos user` 命令组说明（已含 add/list/delete/passwd/disable/enable，确认）
+- [ ] T028 跑 `mvn -q verify` 过全门禁（Spotless + P3C + Checkstyle + SpotBugs/FSB + OWASP Dep-Check）
+- [ ] T029 跑 quickstart.md 全场景验证（场景一~五），含免重启验证：serve 运行中 `oryxos user add bob`，不重启用 bob curl `/admin/` 期望 200（FR-007）
+- [ ] T030 安全复查：`web_users.password_hash` + `web_sessions` DB 中 0% 明文密码；`oryxos user list` 0% 含密码；日志 0% 明文密码；明文未入 git/配置
+- [ ] T045 [P] 在 `specs/012-web-auth/quickstart.md` 加场景五（浏览器登录页 + 登出 + session 过期 + curl Basic 并存）
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: 无依赖，立即开始。T001 先（后续编译需依赖）
+- **Foundational (Phase 2)**: 依赖 Phase 1。**阻塞**所有 user story
+- **US1 (Phase 3)**: 依赖 Phase 2（需 `WebUserService`/`WebAuthProperties`/`PasswordEncoder`）。US1 的 filter 实现会被 US3（Phase 4b）扩——US1 先做 Basic 版，US3 再扩 session 路径
+- **US2 (Phase 4)**: 依赖 Phase 2（需 `WebUserService`）。与 US1 可并行
+- **US3 (Phase 4b)**: 依赖 Phase 2 + US1（扩 `BasicAuthFilter` 为 `AuthFilter`，加 session 路径 + AuthApiController + LoginView）。在 US1 之后
+- **Polish (Phase 5)**: 依赖 US1+US2+US3 完成
+
+### User Story Dependencies
+
+- **US1 (P1)**: Phase 2 完成后开始。独立可测（filter Basic 版 + 配置）
+- **US2 (P1)**: Phase 2 完成后开始。独立可测（CLI + service）
+- **US3 (P1)**: Phase 2 + US1 完成后开始。扩 filter + 加 session/controller/LoginView
+- **US1 ⫻ US2**: 互不依赖，可并行
+- **US3 ⫻ US2**: 互不依赖（US3 改 web，US2 改 cli，不冲突），但 US3 依赖 US1 的 filter 已存在
+
+### Within Each User Story
+
+- 测试先写先失败（TDD）
+- 实体 → service → filter/command
+- service 前于 endpoint/command
+- 每 task 后 commit
+
+### Parallel Opportunities
+
+- Phase 1: T002/T003/T004 并行（不同文件）
+- Phase 2: T005/T006/T008/T009 并行（实体/repo/配置/encoder 互不依赖）；T007 依赖 T005+T006；T010 依赖 T007+T008+T009
+- Phase 3 (US1): T011/T012 测试并行；T013 依赖 T011；T014 依赖 T013；T015 依赖 T010
+- Phase 4 (US2): T016/T017 测试并行；T018 先（parent）；T019-T023a 串行（同文件 `UserCommand.java` static class，物理不可并行，按序加）；T024 独立改 `OryxOsCli`
+- Phase 4b (US3): T031/T032 测试并行；T033/T034/T036/T037 并行（实体/repo/schema/配置）；T035 依赖 T033+T034+T037；T038 依赖 T035；T039 依赖 T035+T013（扩 filter）；T040/T041/T042/T043/T044 后续
+- US2 与 US3 跨 story 可并行（不同模块：cli vs web），但 US3 依赖 US1 filter 已存在
+
+---
+
+## Parallel Example: Phase 2 Foundational
+
+```bash
+# 四个独立件并行（不同文件）：
+Task: "WebUser 实体 in oryxos-storage/.../WebUser.java"
+Task: "WebUserRepository in oryxos-storage/.../WebUserRepository.java"
+Task: "WebAuthProperties in oryxos-web/.../config/WebAuthProperties.java"
+Task: "PasswordEncoder bean in oryxos-web/.../security/PasswordEncoderFactory.java"
+# 然后（依赖上面）：
+Task: "WebUserService in oryxos-storage/.../WebUserService.java"  # 依赖 WebUser + WebUserRepository + PasswordEncoder
+Task: "OryxOsRuntime 装配 in oryxos-cli/.../OryxOsRuntime.java"   # 依赖 WebUserService + WebAuthProperties
+```
+
+## Parallel Example: US1 vs US2
+
+```bash
+# Phase 2 完成后，两个 P1 story 并行（不同模块）：
+Developer A (oryxos-web):  BasicAuthFilter + AuthFilterConfig + 启动校验 + filter 测试
+Developer B (oryxos-cli):  UserCommand 五 leaf + OryxOsCli 注册 + CLI 测试
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Phase 1: Setup
+2. Phase 2: Foundational（CRITICAL，阻塞）
+3. Phase 3: US1
+4. **STOP VALIDATE**: quickstart 场景一 + 场景二（用配置文件或测试预置账号验证 filter）
+5. Deploy/demo
+
+### Incremental Delivery
+
+1. Setup + Foundational → 基础就位
+2. + US1 → 独立测（filter 生效）→ MVP
+3. + US2 → 独立测（CLI 管账号）→ 完整功能
+4. + Polish → 文档/门禁/端到端
+5. 每 story 加值不破前序
+
+### Parallel Team Strategy
+
+- Phase 2 完后：Dev A=US1(web)，Dev B=US2(cli) 并行
+- US1/US2 独立模块无冲突
+- 端到端验证需两者都完
+
+---
+
+## Notes
+
+- [P] = 不同文件无依赖可并行
+- `UserCommand.java` 内 6 个 leaf 是同文件 static class——T019-T023a 已去 `[P]` 标记，按序串行实现（物理同文件不可并行）
+- 宪法合规：原则 VI（凭证不落地）+ VIII（手工 schema.sql）已内建；原则 VII（同步）filter 同步阻塞
+- 质量门禁：实现时每 task 跑 `mvn -q verify` 子集，T028 全量
+- commit 每 task 或逻辑组
+- 敏感：明文密码不入 git/配置/日志（T030 复查）

--- a/website/docs/auth.md
+++ b/website/docs/auth.md
@@ -1,0 +1,86 @@
+# Authentication
+
+OryxOS ships with an **opt-in** HTTP Basic Auth for the management console (`/admin/**`). It is disabled by default — the core phase assumes a trusted internal network. When enabled, access to the admin console requires an account; the REST API (`/api/v1/**`) is **not** affected.
+
+> Basic Auth is suited to internal networks fronted by HTTPS. For internet-facing deployments, terminate TLS at a reverse proxy and restrict network exposure; this minimal auth is a first line, not a perimeter.
+
+## How it works
+
+- **Scope**: only `/admin/**` is protected. `/api/v1/**` (REST endpoints, including `/api/v1/health`) stays open — machine-to-machine API auth (API Key) is a separate, future feature.
+- **Accounts**: stored in the `web_users` SQLite table. Passwords are BCrypt-hashed (with a `{bcrypt}` prefix via Spring's `DelegatingPasswordEncoder`) — **never stored in plaintext**, never written to config, logs, or git history.
+- **Realtime**: account changes take effect immediately. Each request re-reads the database — no in-process cache, no server restart needed for a new account to work.
+- **Startup guard**: if you enable auth but no enabled account exists, startup is blocked with a clear error pointing at `oryxos user add`.
+
+## Configuration
+
+Auth is controlled under `oryxos.web.auth` in `application.yml` (the in-jar defaults, overridable via `config/application.yml`):
+
+```yaml
+oryxos:
+  web:
+    auth:
+      enabled: false        # default off — trusted internal network
+      realm: "OryxOS"        # Basic Auth realm string in the WWW-Authenticate header
+```
+
+| Property | Default | Description |
+| --- | --- | --- |
+| `oryxos.web.auth.enabled` | `false` | Master switch. `false` = no auth (current behavior). `true` = `/admin/**` requires Basic Auth. |
+| `oryxos.web.auth.realm` | `OryxOS` | Realm value sent back in the `WWW-Authenticate: Basic realm="..."` challenge. |
+
+There is no `exclude-paths` setting — the filter is scoped to `/admin/**` only, so `/api/v1/**` (and `/api/v1/health`) is naturally exempt.
+
+## Quick start
+
+1. **Enable auth** in `config/application.yml`:
+
+   ```yaml
+   oryxos:
+     web:
+       auth:
+         enabled: true
+   ```
+
+2. **Create the first admin account** (startup is blocked until at least one enabled account exists):
+
+   ```bash
+   oryxos user add admin
+   # Password (>= 8 chars): ********
+   # Confirm: ********
+   # Created user 'admin'
+   ```
+
+3. **Start the server**:
+
+   ```bash
+   oryxos serve
+   ```
+
+4. **Open the console** at `http://localhost:8080/admin/` — the browser prompts for credentials. Enter the account you just created.
+
+## Verifying it works
+
+```bash
+# No credentials → 401 + WWW-Authenticate challenge
+curl -i http://localhost:8080/admin/
+
+# Correct credentials → 200
+curl -u admin:<password> http://localhost:8080/admin/
+
+# REST API stays open (not protected by Basic Auth)
+curl http://localhost:8080/api/v1/health
+```
+
+## Account management
+
+See the [`oryxos user` CLI reference](./cli.md#user-management) for `add`, `list`, `passwd`, `disable`, and `delete`.
+
+- `list` **never prints passwords or hashes**.
+- `disable` keeps the row but blocks login (returns 401). `delete` removes it permanently.
+- Passwords must be ≥ 8 characters; usernames must be ≤ 64 characters with no whitespace.
+
+## Design notes
+
+- **No Spring Security full stack**: only `spring-security-crypto` (the password-hashing jar) is used — no filter chain, no autoconfig, no RBAC. The `BasicAuthFilter` is a plain `OncePerRequestFilter` registered via a `FilterRegistrationBean` scoped to `/admin/**`.
+- **What this is not**: this is not SSO, RBAC, multi-tenancy, or session-based login with logout. Those are extension-phase capabilities. Password hashing with a delegating encoder leaves an upgrade path to Argon2 without migration.
+- **HTTP Basic has no logout** — clearing credentials is browser-controlled. For richer session semantics, a future feature can add a login page backed by the same `web_users` table.

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -249,3 +249,72 @@ oryxos session list
 cli:user-001:ops-agent                   ops-agent        active    2025-06-01 10:05
 cli:user-002:default                      default          active    2025-06-01 09:30
 ```
+
+---
+
+## User management
+
+Manage admin accounts for the management console (`/admin/**`) Basic Auth. Accounts are stored in the `web_users` SQLite table; passwords are BCrypt-hashed and never stored in plaintext. Changes take effect immediately — no server restart is required for new accounts to work.
+
+> Basic Auth is opt-in. It is disabled by default (`oryxos.web.auth.enabled=false`, assuming a trusted internal network). Enable it in `config/application.yml`, then create at least one account before starting `serve` — otherwise startup is blocked with a clear error.
+
+### user add
+
+Create an account. Prompts for a password twice (input is not echoed); the password must be at least 8 characters and the two entries must match.
+
+```bash
+oryxos user add <username>
+```
+
+```bash
+oryxos user add admin
+# Password (>= 8 chars): ********
+# Confirm: ********
+# Created user 'admin'
+```
+
+### user list
+
+List all accounts. **Never prints passwords or hashes.**
+
+```bash
+oryxos user list
+```
+
+```text
+USERNAME                ENABLED  CREATED_AT
+admin                   true     2026-07-22T10:30:00Z
+alice                   true     2026-07-22T11:00:00Z
+```
+
+### user passwd
+
+Change an account's password. Prompts for the new password twice (not echoed).
+
+```bash
+oryxos user passwd <username>
+```
+
+### user disable
+
+Disable an account without deleting it. A disabled account cannot log in (Basic Auth returns 401).
+
+```bash
+oryxos user disable <username>
+```
+
+### user enable
+
+Re-enable a previously disabled account (symmetric to `disable`).
+
+```bash
+oryxos user enable <username>
+```
+
+### user delete
+
+Delete an account permanently.
+
+```bash
+oryxos user delete <username>
+```

--- a/website/zh/docs/auth.md
+++ b/website/zh/docs/auth.md
@@ -1,0 +1,86 @@
+# 认证
+
+OryxOS 内置**可选**的管理台 HTTP Basic Auth（`/admin/**`）。默认关闭——核心阶段假设受信内网。开启后访问管理台需账密;REST API（`/api/v1/**`）**不受**影响。
+
+> Basic Auth 适合前置 HTTPS 的内网。公网部署须在反向代理终止 TLS 并限制网络暴露——这套最小 auth 是第一道防线,不是边界。
+
+## 工作机制
+
+- **范围**:仅 `/admin/**` 受保护。`/api/v1/**`（REST 端点,含 `/api/v1/health`）保持开放——机器到机器的 API 认证（API Key）是后续独立 feature。
+- **账号**:存 `web_users` SQLite 表。密码 BCrypt 哈希（经 Spring `DelegatingPasswordEncoder` 带 `{bcrypt}` 前缀）——**绝不存明文**,不落配置/日志/git 历史。
+- **实时**:账号变更即时生效。每请求重读 DB——无进程内缓存,新账号无需重启即可用。
+- **启动校验**:开启 auth 但无 enabled 账号时,启动被阻断,清晰报错指向 `oryxos user add`。
+
+## 配置
+
+auth 由 `application.yml` 的 `oryxos.web.auth` 控制（jar 内默认值,可用 `config/application.yml` 覆盖）:
+
+```yaml
+oryxos:
+  web:
+    auth:
+      enabled: false        # 默认关——受信内网
+      realm: "OryxOS"        # WWW-Authenticate 头里的 realm 文案
+```
+
+| 属性 | 默认 | 说明 |
+| --- | --- | --- |
+| `oryxos.web.auth.enabled` | `false` | 总开关。`false` = 无认证（现状）。`true` = `/admin/**` 启用 Basic Auth。 |
+| `oryxos.web.auth.realm` | `OryxOS` | `WWW-Authenticate: Basic realm="..."` 挑战头里的 realm 值。 |
+
+无 `exclude-paths` 配置——filter 只挂在 `/admin/**`,`/api/v1/**`（含 `/api/v1/health`）天然豁免。
+
+## 快速开始
+
+1. **开 auth**（`config/application.yml`）:
+
+   ```yaml
+   oryxos:
+     web:
+       auth:
+         enabled: true
+   ```
+
+2. **建第一个管理员账号**（无 enabled 账号时启动被阻断）:
+
+   ```bash
+   oryxos user add admin
+   # Password (>= 8 chars): ********
+   # Confirm: ********
+   # Created user 'admin'
+   ```
+
+3. **启动服务**:
+
+   ```bash
+   oryxos serve
+   ```
+
+4. **打开管理台** `http://localhost:8080/admin/`——浏览器弹认证。输入刚建的账号。
+
+## 验证
+
+```bash
+# 无凭据 → 401 + WWW-Authenticate 挑战
+curl -i http://localhost:8080/admin/
+
+# 正确凭据 → 200
+curl -u admin:<密码> http://localhost:8080/admin/
+
+# REST API 保持开放（不受 Basic Auth 影响）
+curl http://localhost:8080/api/v1/health
+```
+
+## 账号管理
+
+见 [`oryxos user` CLI 参考](./cli.md#用户管理):`add`、`list`、`passwd`、`disable`、`delete`。
+
+- `list` **绝不打印密码或哈希**。
+- `disable` 保留行但禁止登录（返 401）。`delete` 永久删除。
+- 密码须 ≥8 字符;用户名须 ≤64 字符且无空格。
+
+## 设计说明
+
+- **不引 Spring Security 全套**:只用 `spring-security-crypto`（密码哈希单 jar）——无 filter chain、无 autoconfig、无 RBAC。`BasicAuthFilter` 是普通 `OncePerRequestFilter`,经 `FilterRegistrationBean` 挂在 `/admin/**`。
+- **这不是**:非 SSO、非 RBAC、非多租户、非带登出的 session 登录。这些是扩展阶段能力。密码哈希用 delegating encoder 留了将来升 Argon2 无迁移的路径。
+- **HTTP Basic 无登出**——清凭据由浏览器控制。要更丰富的 session 语义,后续 feature 可加登录页,复用同一张 `web_users` 表。

--- a/website/zh/docs/cli.md
+++ b/website/zh/docs/cli.md
@@ -205,3 +205,72 @@ oryxos tool list
 ```bash
 oryxos session list
 ```
+
+---
+
+## 用户管理
+
+管理管理台（`/admin/**`）Basic Auth 的管理员账号。账号存于 `web_users` SQLite 表，密码 BCrypt 哈希、绝不存明文。变更即时生效——新增账号无需重启服务即可登录。
+
+> Basic Auth 默认关（`oryxos.web.auth.enabled=false`，假设受信内网）。在 `config/application.yml` 中开启后，启动 `serve` 前必须先用 `oryxos user add` 建至少一个账号，否则启动会被阻断并报清晰错误。
+
+### oryxos user add
+
+创建账号。两次提示输入密码（不回显），密码须 ≥8 字符且两次一致。
+
+```bash
+oryxos user add <用户名>
+```
+
+```bash
+oryxos user add admin
+# Password (>= 8 chars): ********
+# Confirm: ********
+# Created user 'admin'
+```
+
+### oryxos user list
+
+列出全部账号。**绝不打印密码或哈希。**
+
+```bash
+oryxos user list
+```
+
+```text
+USERNAME                ENABLED  CREATED_AT
+admin                   true     2026-07-22T10:30:00Z
+alice                   true     2026-07-22T11:00:00Z
+```
+
+### oryxos user passwd
+
+修改账号密码。两次提示输入新密码（不回显）。
+
+```bash
+oryxos user passwd <用户名>
+```
+
+### oryxos user disable
+
+禁用账号（不删除）。禁用账号无法登录（Basic Auth 返回 401）。
+
+```bash
+oryxos user disable <用户名>
+```
+
+### oryxos user enable
+
+重新启用已禁用的账号（对称 `disable`）。
+
+```bash
+oryxos user enable <用户名>
+```
+
+### oryxos user delete
+
+永久删除账号。
+
+```bash
+oryxos user delete <用户名>
+```


### PR DESCRIPTION
- Restore the management console login functionality that was accidentally removed.
- Keep authentication scoped to `/admin/**`; regular `/api/v1/**` endpoints remain unauthenticated.
- Preserve the HTTPS `Secure` cookie fix and ensure the login page is bypassed when authentication is disabled.