### PR TITLE
chore: add bug_report & feature_request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug 报告
+about: 报告 OryxOS 的缺陷行为
+title: "[bug] "
+labels: ["bug", "needs-triage"]
+assignees: ""
+---
+
+## 现象
+<!-- 一句话：发生了什么 -->
+
+## 复现步骤
+1.
+2.
+3.
+
+## 期望行为
+<!-- 应该是什么样 -->
+
+## 实际行为
+<!-- 实际是什么样，贴关键报错/堆栈（用 ``` 代码块）-->
+
+## 环境
+- OryxOS 版本 / commit：
+- Java：
+- OS / 架构：
+- Provider（如 deepseek / qwen / mock）：
+- 是否本地部署：
+- 触发方式：`oryxos chat` / `oryxos serve` / REST `/api/v1/...` / 管理台 `/admin/`：
+
+## 相关日志 / 审计
+<!-- logs/oryxos.log 尾部、或 tool_invocations / llm_calls 审计记录的脱敏片段 -->
+
+## 补充
+<!-- 截图、最小可复现工程、Agent 的 AGENT.md 片段等 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: 特性建议
+about: 提出新能力或改进建议
+title: "[feature] "
+labels: ["enhancement", "needs-triage"]
+assignees: ""
+---
+
+## 想要解决什么问题 / 痛点
+<!-- 你在什么场景下遇到困难 -->
+
+## 期望的能力
+<!-- 你希望 OryxOS 能做什么 -->
+
+## 你考虑过的替代方案
+<!-- 已经能用什么凑合、为什么不满意 -->
+
+## 与五大核心能力 / 设计原则 的关系
+<!-- 动到哪块：Provider / ReActLoop / Memory / Tool / Web？是否涉及 docs/TechnicalSolution.md 某节 -->
+
+## 补充
+<!-- 草图、参考实现、其它项目里的对应做法 -->


### PR DESCRIPTION
## Summary
- 为仓库补齐缺失的 GitHub Issue 模板(此前 `.github/` 下只有 `workflows/`,无 `ISSUE_TEMPLATE/`)
- 新增两个经典 Markdown 模板:`bug_report.md`、`feature_request.md`
- 零代码改动,只动 `.github/ISSUE_TEMPLATE/` 两个新文件
## 模板内容
- **Bug 报告**(`labels: bug, needs-triage`):现象 / 复现步骤 / 期望 vs 实际 / **OryxOS 专用环境字段**(版本·commit、Java、OS、Provider、是否本地部署、触发方式 chat/serve/REST/admin)/ 日志与审计片段
- **特性建议**(`labels: enhancement, needs-triage`):痛点 / 期望能力 / 替代方案 / 与五大核心能力 + `docs/TechnicalSolution.md` 的关系 / 草图参考
环境字段贴合 OryxOS 实际排障需要——很多问题排查依赖 Provider 选型、触发渠道、是否走审计表,模板里直接引导用户填。
## 未做的事(范围约束)
- 未加 PR 模板、question 模板、YAML 表单格式(只做 Bug+Feature 经典 md)
- 未加 `config.yml`:GitHub 在无此文件时**默认允许空白 issue**,等价 `blank_issues_enabled: true`,符合项目早期宽松收 issue 的诉求,且避免讨论链接指向 fork 未开启的 Discussions
## 验证
- 两个模板 YAML frontmatter 合法(`name`/`labels` 已校验)
- `git diff --stat origin/main...HEAD` 仅两个新文件,无其它路径
- Push 后在仓库 "New issue" 页应出现「Bug 报告 / 特性建议」两个模板 + 一个「Open a blank issue」入口