### PR TITLE
fix(bin): start.sh 静默退出——find 代替 ls|head,无 jar 时正常报错

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -8,7 +8,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT" # 工作区（.oryxos/、oryxos.db、config/）都相对 CWD，必须在项目根跑
 
 PORT="${1:-8080}"
-JAR="$(ls "$ROOT"/oryxos-boot/target/oryxos-boot-*.jar 2>/dev/null | head -1)"
+JAR="$(find "$ROOT/oryxos-boot/target" -maxdepth 1 -name 'oryxos-boot-*.jar' 2>/dev/null | head -1)"
 CONFIG="$ROOT/config/application.yml"
 PIDFILE="$ROOT/bin/oryxos.pid"
 LOG="$ROOT/logs/oryxos.log"


### PR DESCRIPTION
start.sh 在 fat JAR 未构建时,因 set -euo pipefail + ls 无匹配退出码非零, 命令替换让脚本在第 11 行静默终止,走不到第 19 行本该打印的 [ERROR]。
改用 find -maxdepth 1: find 无匹配不报错,管道退出 0,脚本能正常走到 JAR 判空分支打 [ERROR]。