### PR TITLE
fix(bin): start.sh 在 jar 未构建时静默退出，不再吞掉找不到 jar 的报错

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -8,7 +8,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT" # 工作区（.oryxos/、oryxos.db、config/）都相对 CWD，必须在项目根跑
 
 PORT="${1:-8080}"
-JAR="$(find "$ROOT/oryxos-boot/target" -maxdepth 1 -name 'oryxos-boot-*.jar' 2>/dev/null | head -1)"
+JAR="$(find "$ROOT/oryxos-boot/target" -maxdepth 1 -name 'oryxos-boot-*.jar' 2>/dev/null | head -1 || true)"
 CONFIG="$ROOT/config/application.yml"
 PIDFILE="$ROOT/bin/oryxos.pid"
 LOG="$ROOT/logs/oryxos.log"


### PR DESCRIPTION
## 为什么改

全新 clone、未执行 `mvn package` 时,`oryxos-boot/target/` 目录不存在,
`bin/start.sh` 第 11 行的 `find` 返回非零退出码;在 `set -euo pipefail` 下,
pipefail 让整条管道取 find 的非零码,`set -e` 使脚本在第 11 行静默终止——
永远走不到第 17-20 行本该打印 `[ERROR] 找不到可执行 jar` 的分支。

## 怎么改

第 11 行管道末尾追加 `|| true`,让"没找到 jar"不触发 `set -e`,
由后面的 `[ -z "$JAR" ]` 分支正常打印错误提示并以退出码 1 退出。

## 怎么验证的

在 `oryxos-boot/target/` 不存在的环境下运行 `bash bin/start.sh`:

- 修改前:零输出,退出码 1(静默退出,bug 复现)
- 修改后:打印 `[ERROR] 找不到可执行 jar，先构建：mvn -pl oryxos-boot -am package -DskipTests`,退出码 1

Closes #31