### PR TITLE
fix(config): update author model example from deprecated deepseek-chat

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -75,4 +75,4 @@ oryxos:
   # 「一句话生成 Agent 草稿」调 LLM 用的作者模型；provider 缺省取 providers 第一个
   author:
     provider: deepseek
-    model: deepseek-chat
+    model: deepseek-v4-flash     # deepseek-chat 已废弃；可选 deepseek-v4-flash（快/省）| deepseek-v4-pro（强）


### PR DESCRIPTION
- deepseek-chat is deprecated per DeepSeek's docs (https://api-docs.deepseek.com/), so the example config would ship a dead default.
- Switch the author model in config/application.yml.example to deepseek-v4-flash.
- Add an inline comment noting the alternatives: deepseek-v4-flash (fast/cheap) or deepseek-v4-pro (stronger).