### PR TITLE
feat(web): support choose model and edit details in web

### DIFF
--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -503,6 +503,7 @@ public class OryxOsRuntime {
   }
 
   /** 32 节：异步触发的后台执行器——虚拟线程（宪法 VII：虚拟线程处理并发，非 Reactor/WebFlux）。 */
+  @SuppressWarnings("PMD.ThreadPoolCreationRule")
   @Bean(destroyMethod = "shutdown")
   ExecutorService agentExecutionExecutor() {
     return Executors.newVirtualThreadPerTaskExecutor();

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentExecutionService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentExecutionService.java
@@ -12,6 +12,9 @@ import org.slf4j.LoggerFactory;
  * <p>异步触发（{@link #triggerAsync}）先落一条"运行中"记录、立即返回 id（HTTP 请求不再干等整轮 ReAct，杜绝浏览器 Failed to fetch），真正的
  * ReAct 在虚拟线程后台跑，结束回填状态——符合宪法 VII（虚拟线程处理并发，非 Reactor/WebFlux）。成功失败都留痕（宪法 V）。
  */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "CRLF_INJECTION_LOGS",
+    justification = "日志消息中唯一动态部分是 agentName，已通过 sanitize() 去除 CRLF——不存在注入风险。")
 public class AgentExecutionService {
 
   private static final Logger LOG = LoggerFactory.getLogger(AgentExecutionService.class);
@@ -41,7 +44,7 @@ public class AgentExecutionService {
             ok = true;
           } catch (RuntimeException e) {
             error = e.getMessage();
-            LOG.error("Agent {} 后台执行失败", sanitize(agentName), e);
+            LOG.error("Agent " + sanitize(agentName) + " 后台执行失败", e);
           } finally {
             safeFinish(id, sessionId, ok, error);
           }

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
@@ -21,6 +21,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.DumperOptions.FlowStyle;
+import org.yaml.snakeyaml.Yaml;
 
 /**
  * Agent 生命周期编排（第 30 节）：三条录入（API create / WorkspaceWatcher 事件 / 启动扫描）都汇到同一段 {@link
@@ -45,7 +48,7 @@ public class AgentLifecycleService {
         prompt: 你是一个乐于助人的助手。
       provider:
         name: {provider}
-        model: 请在此填写模型名
+        model: {model}
       tools:
         - read_file
         - shell
@@ -105,7 +108,7 @@ public class AgentLifecycleService {
       硬性规则：
       1. AGENT.md 以 YAML frontmatter 开头结尾（--- 与 ---），frontmatter 必须含 name、description、identity(agent_name/prompt)、\
       provider(name/model)、tools、settings(max_iterations/max_history_turns)；有定时需求再加 schedules。
-      2. name 必须是「{name}」；provider.name 必须是「{provider}」；model 填该 provider 下合理的模型名。
+      2. name 必须是「{name}」；provider.name 必须是「{provider}」；model 必须是「{model}」（若该 provider 下没有这个 exact 模型名，就填该 provider 下合理的默认模型名）。
       3. tools 只能从下面【可用工具】里按需挑选，**绝不允许编造清单以外的工具名**。常见映射：查网页/接口数据用 http_get / http_post；\
       抓网页正文用 fetch_webpage；读写文件用 read_file / write_file；跑脚本用 shell。
       4. schedules 每条的字段只有：id（任务标识）、cron（Spring 6 段 cron，如 "0 0 9 * * *" 表示每天 9 点）、zone（时区，如 Asia/Shanghai）、\
@@ -166,6 +169,14 @@ public class AgentLifecycleService {
 
   /** Markdown 代码围栏标记（模型偶尔会用 ``` 包住输出，剥掉它）。 */
   private static final String CODE_FENCE = "```";
+
+  /** YAML frontmatter 围栏（与 AgentMarkdown 一致）。 */
+  private static final String YAML_FENCE = "---";
+
+  /** YAML 层级的缩进字面量。 */
+  private static final String INDENT_SPACE = " ";
+
+  private static final String INDENT_TAB = "\t";
 
   private final AgentLoader agentLoader;
   private final ProfileRegistry profileRegistry;
@@ -269,10 +280,24 @@ public class AgentLifecycleService {
    * 冲突第一步就拒；中途失败回滚已写目录，不留半个 Agent。
    */
   public Profile create(String name, String description) {
+    return create(name, description, null, null);
+  }
+
+  /**
+   * 创建：name + description + 可选 provider/model；provider/model 写进 AGENT.md 的 frontmatter，新建时即可选模型。
+   * provider/model 为空则回退默认 provider（oryxos.agent.default-provider）与占位模型名。
+   */
+  public Profile create(String name, String description, String provider, String model) {
     if (profileRegistry.exists(name)) {
       throw new IllegalArgumentException("Agent 已存在: " + name);
     }
-    Path agentDir = agentStore.writeAll(name, scaffold(name, description));
+    String resolvedProvider =
+        (provider == null || provider.isBlank())
+            ? (defaultProvider == null || defaultProvider.isBlank() ? "deepseek" : defaultProvider)
+            : provider;
+    String resolvedModel = (model == null || model.isBlank()) ? "请在此填写模型名" : model;
+    Path agentDir =
+        agentStore.writeAll(name, scaffold(name, description, resolvedProvider, resolvedModel));
     try {
       return register(agentDir);
     } catch (RuntimeException e) {
@@ -281,17 +306,17 @@ public class AgentLifecycleService {
     }
   }
 
-  private Map<String, String> scaffold(String name, String description) {
+  private Map<String, String> scaffold(
+      String name, String description, String provider, String model) {
     String desc = description == null || description.isBlank() ? "描述这个 Agent 做什么" : description;
-    String provider =
-        defaultProvider == null || defaultProvider.isBlank() ? "deepseek" : defaultProvider;
     Map<String, String> files = new LinkedHashMap<>();
     files.put(
         "AGENT.md",
         AGENT_MD_TEMPLATE
             .replace("{name}", name)
             .replace("{description}", desc)
-            .replace("{provider}", provider));
+            .replace("{provider}", provider)
+            .replace("{model}", model));
     files.put("scripts/example.py", SCRIPT_TEMPLATE);
     files.put("skills/example.md", SKILL_TEMPLATE);
     files.put("REFERENCE.md", REFERENCE_TEMPLATE);
@@ -343,6 +368,63 @@ public class AgentLifecycleService {
   }
 
   /**
+   * 编辑基本信息：只改 AGENT.md frontmatter 里的若干 key（description / provider.name / provider.model /
+   * skills），正文与未提及的 frontmatter 字段原样保留（不丢指令、不丢定时/工具等配置）。 传 null 的字段保持原值；description 清空→置空；
+   * provider.model 为空则沿用原值（model 为必填，不允许清空）。 先合成新 markdown 并用 {@link AgentLoader#parse} 预校验（非法→抛
+   * ProfileValidationException，且不落盘、不破坏原文件），通过再走 {@link #update} 重写+重注册。
+   */
+  public Profile updateBasicInfo(
+      String name, String description, String provider, String model, List<String> skills) {
+    String raw = agentStore.read(name);
+    AgentMarkdown.Parsed parsed = AgentMarkdown.split(raw);
+    // frontmatter 来自 snakeyaml 解析，本身是 LinkedHashMap（保序）；复制进可变 Map 再改，避免改动原始不可变 Map
+    Map<String, Object> fm = new LinkedHashMap<>(parsed.frontmatter());
+    if (description != null) {
+      String d = description.strip();
+      if (d.isEmpty()) {
+        fm.remove("description");
+      } else {
+        fm.put("description", d);
+      }
+    }
+    if (provider != null && !provider.isBlank()) {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> pm =
+          fm.get("provider") instanceof Map
+              ? new LinkedHashMap<>((Map<String, Object>) fm.get("provider"))
+              : new LinkedHashMap<>();
+      pm.put("name", provider.strip());
+      if (model != null && !model.isBlank()) {
+        pm.put("model", model.strip());
+      }
+      fm.put("provider", pm);
+    } else if (model != null && !model.isBlank()) {
+      // 只改 model、provider 不变：直接在原 provider 段更新 model
+      @SuppressWarnings("unchecked")
+      Map<String, Object> pm =
+          fm.get("provider") instanceof Map
+              ? new LinkedHashMap<>((Map<String, Object>) fm.get("provider"))
+              : new LinkedHashMap<>();
+      pm.put("model", model.strip());
+      fm.put("provider", pm);
+    }
+    if (skills != null) {
+      fm.put("skills", new ArrayList<>(skills));
+    }
+    String newMarkdown = assembleMarkdown(fm, parsed.body());
+    agentLoader.parse(newMarkdown, name); // 预校验：非法定义直接抛，不破坏原文件
+    return update(name, newMarkdown);
+  }
+
+  /** 把改好的 frontmatter Map + 正文重新拼成 AGENT.md（与 {@link AgentMarkdown#split} 的围栏约定一致）。 */
+  private static String assembleMarkdown(Map<String, Object> frontmatter, String body) {
+    DumperOptions opts = new DumperOptions();
+    opts.setDefaultFlowStyle(FlowStyle.BLOCK);
+    String yaml = new Yaml(opts).dump(frontmatter);
+    return "---\n" + yaml + "---\n\n" + body + "\n";
+  }
+
+  /**
    * 用大模型按一句话需求生成一份 AGENT.md 草稿（30 节「生成/编辑 Agent」）：一次 LLM 调用（走既有 {@link ProviderService}，落 llm_calls
    * 审计）产出文本 → 校验能否解析成合法定义（非法抛 {@code ProfileValidationException} → 400）→ 原样返回 {relativePath:
    * content} 给前端预览可改；**不落盘、不注册**（保存另走 {@link #saveFiles}）。生成用的 provider/model 取 oryxos.author.*
@@ -358,6 +440,20 @@ public class AgentLifecycleService {
    */
   public Map<String, String> generateFiles(
       String name, String description, String notifyChannel, List<String> requiredSkills) {
+    return generateFiles(name, description, notifyChannel, requiredSkills, null, null);
+  }
+
+  /**
+   * 同上，但允许用户在前端**显式选好 provider/model**：生成时直接把它们写进输出 AGENT.md 的 frontmatter（覆盖默认/沿用逻辑），
+   * 让「用大模型生成」也尊重用户在新建页挑的模型。provider/model 为空则沿用原有逻辑（已存在 Agent 用其 provider，否则用作者 provider）。
+   */
+  public Map<String, String> generateFiles(
+      String name,
+      String description,
+      String notifyChannel,
+      List<String> requiredSkills,
+      String provider,
+      String model) {
     String genProvider =
         authorProvider == null || authorProvider.isBlank()
             ? (defaultProvider == null || defaultProvider.isBlank() ? "deepseek" : defaultProvider)
@@ -378,8 +474,12 @@ public class AgentLifecycleService {
         throw new IllegalArgumentException("Skill 不存在: " + s);
       }
     }
+    // provider/model：用户在前端挑了就用挑的；否则沿用已有 Agent 的 provider，再否则用作者 provider
     String outputProvider =
-        profileRegistry.get(name).map(p -> p.provider().name()).orElse(genProvider);
+        (provider != null && !provider.isBlank())
+            ? provider
+            : profileRegistry.get(name).map(p -> p.provider().name()).orElse(genProvider);
+    String modelHint = (model != null && !model.isBlank()) ? model : "该 provider 下合理的模型名";
     Profile genProfile =
         new Profile(
             "agent-author",
@@ -397,6 +497,7 @@ public class AgentLifecycleService {
         AGENT_AUTHOR_PROMPT
                 .replace("{name}", name)
                 .replace("{provider}", outputProvider)
+                .replace("{model}", modelHint)
                 .replace("{tools}", describeTools())
                 .replace("{mcp_servers}", describeMcpServers())
                 .replace("{skills}", describeSkills())
@@ -444,12 +545,12 @@ public class AgentLifecycleService {
     // 定位 frontmatter 围栏（合法定义必有；找不到则不动，交由后续校验报错）
     String normalized = agentMarkdown.replace("\r\n", "\n").replace('\r', '\n');
     String[] lines = normalized.split("\n", -1);
-    if (lines.length == 0 || !"---".equals(lines[0].strip())) {
+    if (lines.length == 0 || !YAML_FENCE.equals(lines[0].strip())) {
       return agentMarkdown;
     }
     int close = -1;
     for (int i = 1; i < lines.length; i++) {
-      if ("---".equals(lines[i].strip())) {
+      if (YAML_FENCE.equals(lines[i].strip())) {
         close = i;
         break;
       }
@@ -467,7 +568,9 @@ public class AgentLifecycleService {
               && line.strip().matches("skills\\s*:.*");
       if (topLevelSkills) {
         i++;
-        while (i < close && (lines[i].startsWith(" ") || lines[i].startsWith("\t"))) { // 跳过其列表项/缩进块
+        while (i < close
+            && (lines[i].startsWith(INDENT_SPACE)
+                || lines[i].startsWith(INDENT_TAB))) { // 跳过其列表项/缩进块
           i++;
         }
         i--; // 抵消 for 的 i++
@@ -475,7 +578,7 @@ public class AgentLifecycleService {
       }
       kept.add(line);
     }
-    StringBuilder out = new StringBuilder("---\n");
+    StringBuilder out = new StringBuilder(YAML_FENCE + "\n");
     for (String line : kept) {
       out.append(line).append('\n');
     }
@@ -483,7 +586,7 @@ public class AgentLifecycleService {
     for (String s : merged) {
       out.append("  - ").append(s).append('\n');
     }
-    out.append("---\n");
+    out.append(YAML_FENCE).append("\n");
     for (int i = close + 1; i < lines.length; i++) {
       out.append(lines[i]);
       if (i < lines.length - 1) {

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentMaxIterationsExceededException.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentMaxIterationsExceededException.java
@@ -1,0 +1,13 @@
+package io.oryxos.core.agent;
+
+/**
+ * ReAct 循环达到 {@code max_iterations} 上限时抛——通常是反复调用工具失败（权限不足、模型幻觉等）耗尽全部轮数。
+ *
+ * <p>这是一个可恢复错误：session 中的对话与工具调用记录保留在现场，供排查迭代不收敛的原因； Agent 状态不受影响。
+ */
+public class AgentMaxIterationsExceededException extends RuntimeException {
+
+  public AgentMaxIterationsExceededException(String message) {
+    super(message);
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentService.java
@@ -46,8 +46,14 @@ public class AgentService {
     ProfileContext.set(profile); // 工具执行时靠它知道"当前是哪个 Agent"
     try {
       String reply = reActLoop.run(session, userMessage, profile);
-      sessionManager.save(session); // 把累积完的历史持久化（仅正常路径）
-      recordTrigger(profile.name(), userMessage, reply); // 每次触发留一条归档记忆（运行足迹）
+      // 达到最大迭代上限时 ReAct 返回占位文本（不抛异常），这里检测并转为异常，
+      // 让 triggerAsync 把执行记成失败状态（否则前端显示"执行成功"——错误引导用户）
+      boolean exhausted = ReActLoop.MAX_ITERATIONS_REPLY.equals(reply);
+      sessionManager.save(session); // 无论是正常结束还是迭代耗尽，保存现场供审计/排查
+      if (exhausted) {
+        throw new AgentMaxIterationsExceededException(reply);
+      }
+      recordTrigger(profile.name(), userMessage, reply); // 正常完成才记运行足迹
       return reply;
     } finally {
       ProfileContext.clear(); // 虚拟线程每请求独立，用完必须清

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentStore.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentStore.java
@@ -28,6 +28,22 @@ public class AgentStore {
     this.archiveDir = oryxosRoot.resolve("archive");
   }
 
+  /**
+   * 读 .oryxos/agents/&lt;name&gt;/AGENT.md 的原始文本；缺文件抛 {@link IllegalStateException}（调用方应先确认 Agent
+   * 存在）。
+   */
+  public String read(String name) {
+    Path file = agentsDir.resolve(safe(name)).resolve(AGENT_FILE);
+    if (!Files.isRegularFile(file)) {
+      throw new IllegalStateException("Agent 目录缺少 AGENT.md: " + name);
+    }
+    try {
+      return Files.readString(file);
+    } catch (IOException e) {
+      throw new UncheckedIOException("读取 Agent 目录失败: " + name, e);
+    }
+  }
+
   /** 写 .oryxos/agents/&lt;name&gt;/AGENT.md，返回该 Agent 目录。 */
   public Path write(String name, String agentMarkdown) {
     Path dir = agentsDir.resolve(safe(name));

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/PromptBuilder.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/PromptBuilder.java
@@ -21,6 +21,9 @@ import java.util.Map;
  * 消息及其后全部消息）④可用工具——不进文本， 经 {@link ProviderRequest#availableTools()} 传递，schema 挂载由 16 节
  * ToolSchemaAdapter 单点负责。
  */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "contextLoader 是 Spring 注入的共享单例，构造注入共享同一引用正是意图。")
 public class PromptBuilder {
 
   private static final DateTimeFormatter DATE_TIME =

--- a/oryxos-core/src/main/java/io/oryxos/core/context/ContextLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/context/ContextLoader.java
@@ -22,6 +22,9 @@ import org.slf4j.LoggerFactory;
  * SkillRegistry} 解析，把 Skill 正文注入 system prompt——这样 Skill 才能"强约束"Agent 产出（而非靠模型自觉 read_file）。引用了不存在的
  * Skill 记 WARN 跳过，同 Bootstrap 缺失的处理。
  */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "skillRegistry 是 Spring 注入的共享单例，构造注入共享同一引用正是意图。")
 public class ContextLoader {
 
   private static final Logger LOG = LoggerFactory.getLogger(ContextLoader.class);

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillService.java
@@ -13,6 +13,9 @@ import java.util.Optional;
  * 层解耦：{@link #get} 返回 {@link Optional}，404 由 web 决定；非法入参抛 {@link IllegalArgumentException}（web 映射
  * 400）。
  */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "registry / store 均为 Spring 注入的共享单例，构造注入共享同一引用正是意图（全局 Skill 库必须是同一份）。")
 public class SkillService {
 
   /** 内置 Skill 名（供测试与外部引用）。 */

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleServiceTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 /** 课件《第30节》验收 harness：AgentLifecycleServiceTest——编排顺序 + 失败回滚 + 删除时序。 */
@@ -187,5 +188,30 @@ class AgentLifecycleServiceTest {
         noSkills,
         AgentLifecycleService.ensureRequiredSkills(noSkills, List.of()),
         "未勾选任何 Skill → 原样不动");
+  }
+
+  @Test
+  @DisplayName("updateBasicInfo 改 description/provider/model/skills，正文与其它字段保留")
+  void updateBasicInfo_editsFrontmatterPreservesBodyAndOtherKeys() throws Exception {
+    when(agentStore.read("demo")).thenReturn(MD);
+    Path dir = Path.of("agents", "demo");
+    when(agentStore.write(eq("demo"), any())).thenReturn(dir);
+    Profile updated = profile("demo");
+    doReturn(updated).when(agentLoader).parse(any(), eq("demo"));
+    doReturn(updated).when(agentLoader).deriveProfile(dir);
+
+    service.updateBasicInfo("demo", "新描述", "openai", "gpt-4o", List.of("s1", "s2"));
+
+    ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+    verify(agentStore).write(eq("demo"), markdownCaptor.capture());
+    String written = markdownCaptor.getValue();
+    assertTrue(written.contains("description: 新描述"), "description 被更新");
+    assertTrue(written.contains("name: openai"), "provider.name 被更新");
+    assertTrue(written.contains("model: gpt-4o"), "provider.model 被更新");
+    assertTrue(written.contains("skills:"), "skills 块被写入");
+    assertTrue(written.contains("- s1"), "skills 包含 s1");
+    assertTrue(written.contains("- s2"), "skills 包含 s2");
+    assertTrue(written.contains("name: demo"), "name 保留");
+    assertTrue(written.contains("正文"), "正文保留");
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentServiceTest.java
@@ -120,4 +120,18 @@ class AgentServiceTest {
 
     assertTrue(ex.getMessage().contains("no-such-agent"), "报错必须点名缺失的 Profile");
   }
+
+  @Test
+  @DisplayName("达到最大迭代上限时抛 AgentMaxIterationsExceededException，且 Session 已保存（对话保留供排查）")
+  void maxIterationsExceeded_throwsExceptionAndSavesSession() {
+    when(reActLoop.run(any(), any(), any())).thenReturn(ReActLoop.MAX_ITERATIONS_REPLY);
+
+    AgentMaxIterationsExceededException ex =
+        assertThrows(
+            AgentMaxIterationsExceededException.class, () -> agentService.process(session, "hi"));
+
+    assertEquals(ReActLoop.MAX_ITERATIONS_REPLY, ex.getMessage());
+    verify(sessionManager).save(session); // 对话现场保留，供排查为什么不收敛
+    assertNull(ProfileContext.current());
+  }
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -35,6 +35,12 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   /** 域名白名单里的通配前缀；命中后转成"以 . 之后部分结尾"的点号边界匹配。 */
   private static final String WILDCARD_PREFIX = "*.";
 
+  /** SSRF 防护：已知内部主机名。 */
+  private static final String LOCALHOST = "localhost";
+
+  private static final String METADATA_GOOGLE_INTERNAL = "metadata.google.internal";
+  private static final String INTERNAL_SUFFIX = ".internal";
+
   // 具体类型 CopyOnWriteArrayList（而非 List 接口）：需要 addIfAbsent 的原子"不存在才加"语义
   private final CopyOnWriteArrayList<Path> allowedRoots = new CopyOnWriteArrayList<>();
   private final Set<String> allowedCommands = ConcurrentHashMap.newKeySet();
@@ -172,9 +178,12 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   }
 
   /** SSRF 兜底：拒绝主机解析到回环/任意本地/链路本地(含云元数据 169.254.169.254)/站点内网/组播/CGNAT，及 localhost、*.internal。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification = "toLowerCase(Locale.ROOT) 已是稳定的大小写转换；主机名不含特殊 Unicode 字符，误报。")
   private static void assertNotInternalHost(String host) {
     String h = host.toLowerCase(Locale.ROOT);
-    if (h.equals("localhost") || h.equals("metadata.google.internal") || h.endsWith(".internal")) {
+    if (LOCALHOST.equals(h) || METADATA_GOOGLE_INTERNAL.equals(h) || h.endsWith(INTERNAL_SUFFIX)) {
       throw new SandboxViolationException("拒绝访问内网 / 元数据主机（SSRF 防护）: " + host + "。这是安全策略，请勿重试。");
     }
     // IPv6 字面量 getHost() 带方括号（如 [fd00::1]），解析前剥掉，ULA/回环等判断才生效

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -313,13 +313,39 @@ async function loadAgents() {
 
 // 新建 Agent：独立成页（不再是弹框），把「大模型生成」折叠进来。
 // 只填 name + description 可直接按模板脚手架；也可先「用大模型生成」各文件、编辑后再创建。
-const agentCreate = reactive({ open: false, name: '', description: '', notifyChannel: '', skills: [], files: null, busy: false, error: '' })
+const agentCreate = reactive({ open: false, name: '', description: '', provider: '', model: '', notifyChannel: '', skills: [], files: null, busy: false, error: '' })
+
+// 新建页用的 provider / model 下拉数据源：provider 来自 GET /providers；model 来自 GET /providers/{name}/models（服务端代理）
+const createProviders = ref({ loading: false, error: null, data: [] })
+const createModels = ref({ loading: false, error: null, data: [] })
+async function loadCreateProviders() {
+  createProviders.value = { loading: true, error: null, data: [] }
+  try {
+    const res = await fetch('/api/v1/providers')
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '加载失败')
+    createProviders.value = { loading: false, error: null, data: body.data || [] }
+  } catch (e) { createProviders.value = { loading: false, error: e.message, data: [] } }
+}
+async function loadCreateModels(name) {
+  if (!name) { createModels.value = { loading: false, error: null, data: [] }; return }
+  createModels.value = { loading: true, error: null, data: [] }
+  try {
+    const res = await fetch(`/api/v1/providers/${encodeURIComponent(name)}/models`)
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '加载失败')
+    createModels.value = { loading: false, error: null, data: body.data || [] }
+  } catch (e) { createModels.value = { loading: false, error: e.message, data: [] } }
+}
+function onProviderChange() { agentCreate.model = ''; loadCreateModels(agentCreate.provider) }
 
 // 打开新建页：重置字段 + 拉通知渠道下拉数据
 function openCreate() {
   agentCreate.open = true
   agentCreate.name = ''
   agentCreate.description = ''
+  agentCreate.provider = ''
+  agentCreate.model = ''
   agentCreate.notifyChannel = ''
   agentCreate.skills = []
   agentCreate.files = null
@@ -327,6 +353,7 @@ function openCreate() {
   agentCreate.error = ''
   loadNotifyChannels()
   loadSkills() // Skill 选择器的数据源（可手动指定必启用的 Skill；不选则由作者模型自动选）
+  loadCreateProviders() // provider 下拉数据源
 }
 
 function cancelCreate() { agentCreate.open = false }
@@ -338,7 +365,7 @@ async function generateFiles() {
   try {
     const res = await fetch(`/api/v1/agents/${encodeURIComponent(agentCreate.name)}/generate-files`, {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ description: agentCreate.description, notifyChannel: agentCreate.notifyChannel, skills: agentCreate.skills }),
+      body: JSON.stringify({ description: agentCreate.description, notifyChannel: agentCreate.notifyChannel, skills: agentCreate.skills, provider: agentCreate.provider || undefined, model: agentCreate.model || undefined }),
     })
     const body = await res.json()
     if (body.code !== 0) throw new Error(body.message || '生成失败')
@@ -356,9 +383,9 @@ async function submitCreate() {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ files: agentCreate.files }),
         })
-      : await fetch('/api/v1/agents', {
+        : await fetch('/api/v1/agents', {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: agentCreate.name, description: agentCreate.description }),
+          body: JSON.stringify({ name: agentCreate.name, description: agentCreate.description, provider: agentCreate.provider || undefined, model: agentCreate.model || undefined }),
         })
     const body = await res.json()
     if (body.code !== 0) throw new Error(body.message || '创建失败')
@@ -706,8 +733,13 @@ async function deleteWhitelist(category, value) {
 }
 
 // —— Agent 详情：Tab 切换（基本信息 / 文件 / 会话 / 记忆）——
-const agentDetail = ref(null) // { name, agent, tab, loading, error, node }
+const agentDetail = ref(null) // { name, agent, tab, loading, error, node, editing }
 const fileView = ref(null) // { path, loading, error, content, saving, saved }
+// 详情页「编辑基本信息」表单态 + 编辑态的 model 下拉数据源（与新建页的 createModels 分开，避免串台）
+const editBasic = reactive({ description: '', provider: '', model: '', skills: [] })
+const editModels = ref({ loading: false, error: null, data: [] })
+const editSaving = ref(false)
+const editError = ref(null)
 // .md 文件视图切换：'preview'（渲染，默认）/ 'source'（原文，可编辑）。共享一个 ref——
 // 工作区/输出两个浏览器同时只显示一个，且都复用同一个 fileView。
 const mdView = ref('preview')
@@ -750,7 +782,7 @@ function toggleTurn(i) {
 const agentMemory = reactive({ text: '', loading: false, error: null })
 
 async function openAgent(agent) {
-  agentDetail.value = { name: agent.name, agent, tab: 'info', loading: true, error: null, node: null }
+  agentDetail.value = { name: agent.name, agent, tab: 'info', loading: true, error: null, node: null, editing: false }
   fileView.value = null
   resetChat()
   resetAgentMemory()
@@ -807,6 +839,55 @@ function detailTab(tab) {
   } else if (tab === 'executions') {
     loadExecutions()
   }
+}
+
+// —— 详情页「编辑基本信息」：结构化改 description / provider / model / skills（只动 AGENT.md frontmatter，正文与其它配置不动）——
+function startEditBasic() {
+  const a = agentDetail.value?.agent || {}
+  editBasic.description = a.description || ''
+  editBasic.provider = a.provider || ''
+  editBasic.model = a.model || ''
+  editBasic.skills = (a.skills || []).slice()
+  editError.value = null
+  agentDetail.value = { ...agentDetail.value, editing: true }
+  loadCreateProviders() // provider 下拉数据源（与新建页共用）
+  loadSkills() // Skill 选择器数据源
+  loadEditModels(editBasic.provider) // 拉当前 provider 的模型列表
+}
+function cancelEditBasic() {
+  agentDetail.value = { ...agentDetail.value, editing: false }
+  editError.value = null
+}
+async function loadEditModels(name) {
+  if (!name) { editModels.value = { loading: false, error: null, data: [] }; return }
+  editModels.value = { loading: true, error: null, data: [] }
+  try {
+    const res = await fetch(`/api/v1/providers/${encodeURIComponent(name)}/models`)
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '加载失败')
+    editModels.value = { loading: false, error: null, data: body.data || [] }
+  } catch (e) { editModels.value = { loading: false, error: e.message, data: [] } }
+}
+function onEditProviderChange() { editBasic.model = ''; loadEditModels(editBasic.provider) }
+async function saveEditBasic() {
+  if (!editBasic.provider || !editBasic.model) { editError.value = 'provider 与 model 必填'; return }
+  editSaving.value = true; editError.value = null
+  const name = agentDetail.value.name
+  try {
+    const res = await fetch(`/api/v1/agents/${encodeURIComponent(name)}/basic`, {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        description: editBasic.description,
+        provider: editBasic.provider,
+        model: editBasic.model,
+        skills: editBasic.skills,
+      }),
+    })
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '保存失败')
+    agentDetail.value = { ...agentDetail.value, editing: false }
+    await reloadAgent() // 刷新 agent 元数据（provider/model/skills 即时反映）
+  } catch (e) { editError.value = e.message } finally { editSaving.value = false }
 }
 
 // —— 执行历史 tab：该 Agent 每次触发的起止时间 / 状态 / 时长（手动 + 定时）——
@@ -1234,6 +1315,20 @@ const outputRows = computed(() =>
                 <input v-model="agentCreate.name" class="gen-input" placeholder="例如 pr-digest" />
                 <label class="empty" style="display:block;margin:6px 0 2px">描述这个 Agent 要做什么</label>
                 <textarea v-model="agentCreate.description" class="gen-draft" rows="4" placeholder="例如：每天早上抓取团队仓库的 PR，汇总成一份摘要推送到群里"></textarea>
+                <label class="empty" style="display:block;margin:6px 0 2px">Provider（模型供应商，从已配置的 Provider 里选；不选=默认 provider）</label>
+                <select v-model="agentCreate.provider" class="gen-input" @change="onProviderChange">
+                  <option value="">默认 provider</option>
+                  <option v-for="p in (createProviders.data || [])" :key="p.name" :value="p.name">{{ p.name }}</option>
+                </select>
+                <label class="empty" style="display:block;margin:6px 0 2px">Model（选好 Provider 后从它的模型列表里挑；不选=生成时再填）</label>
+                <select v-model="agentCreate.model" class="gen-input" :disabled="!agentCreate.provider">
+                  <option value="">— 请先选 Provider —</option>
+                  <option v-for="m in (createModels.data || [])" :key="m" :value="m">{{ m }}</option>
+                </select>
+                <p v-if="createProviders.loading" class="empty">加载 Provider 列表…</p>
+                <p v-else-if="createProviders.error" class="error">Provider 列表加载失败：{{ createProviders.error }}</p>
+                <p v-else-if="agentCreate.provider && createModels.loading" class="empty">加载模型列表…</p>
+                <p v-else-if="agentCreate.provider && createModels.error" class="error">模型列表加载失败：{{ createModels.error }}</p>
                 <label class="empty" style="display:block;margin:6px 0 2px">通知渠道（投递目标，由你手动选；不选=本 Agent 不发通知）</label>
                 <select v-model="agentCreate.notifyChannel" class="gen-input">
                   <option value="">不通知</option>
@@ -1278,13 +1373,56 @@ const outputRows = computed(() =>
 
               <!-- Tab 1：基本信息 -->
               <div v-if="agentDetail.tab === 'info'" class="info-grid">
-                <div class="info-row"><span class="k">name</span><span class="mono">{{ agentDetail.agent.name }}</span></div>
-                <div class="info-row"><span class="k">description</span><span>{{ agentDetail.agent.description || '—' }}</span></div>
-                <div class="info-row"><span class="k">provider</span><span>{{ agentDetail.agent.provider || '—' }}</span></div>
-                <div class="info-row"><span class="k">model</span><span>{{ agentDetail.agent.model || '—' }}</span></div>
-                <div class="info-row"><span class="k">tools</span><span>{{ (agentDetail.agent.tools || []).join(', ') || '—' }}</span></div>
-                <div class="info-row"><span class="k">skills</span><span>{{ (agentDetail.agent.skills || []).join(', ') || '—' }}</span></div>
-                <div class="info-row"><span class="k">定时</span><span class="mono">{{ (agentDetail.agent.schedules || []).map((s) => s.cron + ' (' + s.zone + ')').join('；') || '—' }}</span></div>
+                <div class="info-actions" v-if="!agentDetail.editing">
+                  <button class="btn" @click="startEditBasic">编辑基本信息</button>
+                </div>
+                <template v-if="agentDetail.editing">
+                  <div class="info-row edit">
+                    <label class="k">description</label>
+                    <textarea v-model="editBasic.description" class="gen-input" rows="3" placeholder="这个 Agent 做什么"></textarea>
+                  </div>
+                  <div class="info-row edit">
+                    <label class="k">provider</label>
+                    <select v-model="editBasic.provider" class="gen-input" @change="onEditProviderChange">
+                      <option value="">— 请选择 Provider —</option>
+                      <option v-for="p in (createProviders.data || [])" :key="p.name" :value="p.name">{{ p.name }}</option>
+                    </select>
+                  </div>
+                  <div class="info-row edit">
+                    <label class="k">model</label>
+                    <select v-model="editBasic.model" class="gen-input" :disabled="!editBasic.provider">
+                      <option value="">— 请先选 Provider —</option>
+                      <option v-for="m in (editModels.data || [])" :key="m" :value="m">{{ m }}</option>
+                    </select>
+                    <p v-if="editModels.loading" class="empty">加载模型列表…</p>
+                    <p v-else-if="editModels.error" class="error">模型列表加载失败：{{ editModels.error }}</p>
+                  </div>
+                  <div class="info-row edit">
+                    <label class="k">skills</label>
+                    <div class="skill-picker">
+                      <label v-for="s in (skills.data || [])" :key="s.name" class="skill-opt">
+                        <input type="checkbox" :value="s.name" v-model="editBasic.skills" /> {{ s.name }}
+                      </label>
+                      <span v-if="!(skills.data || []).length" class="empty">（暂无 Skill）</span>
+                    </div>
+                  </div>
+                  <div class="info-actions">
+                    <button class="btn btn-primary" :disabled="editSaving" @click="saveEditBasic">保存</button>
+                    <button class="btn" :disabled="editSaving" @click="cancelEditBasic">取消</button>
+                    <span v-if="editSaving" class="empty">保存中…</span>
+                    <span v-if="editError" class="error">{{ editError }}</span>
+                  </div>
+                  <p class="empty">name 为 Agent 标识，不可改；正文/工具/定时等配置不受影响。</p>
+                </template>
+                <template v-else>
+                  <div class="info-row"><span class="k">name</span><span class="mono">{{ agentDetail.agent.name }}</span></div>
+                  <div class="info-row"><span class="k">description</span><span>{{ agentDetail.agent.description || '—' }}</span></div>
+                  <div class="info-row"><span class="k">provider</span><span>{{ agentDetail.agent.provider || '—' }}</span></div>
+                  <div class="info-row"><span class="k">model</span><span>{{ agentDetail.agent.model || '—' }}</span></div>
+                  <div class="info-row"><span class="k">tools</span><span>{{ (agentDetail.agent.tools || []).join(', ') || '—' }}</span></div>
+                  <div class="info-row"><span class="k">skills</span><span>{{ (agentDetail.agent.skills || []).join(', ') || '—' }}</span></div>
+                  <div class="info-row"><span class="k">定时</span><span class="mono">{{ (agentDetail.agent.schedules || []).map((s) => s.cron + ' (' + s.zone + ')').join('；') || '—' }}</span></div>
+                </template>
               </div>
 
               <!-- Tab 3：文件浏览器（可编辑） -->
@@ -1471,13 +1609,14 @@ const outputRows = computed(() =>
               <p v-if="agents.loading" class="empty">加载中…</p>
               <p v-else-if="agents.error" class="error">出错：{{ agents.error }}</p>
               <table v-else>
-                <thead><tr><th>name</th><th>description</th><th>provider</th><th>tools</th><th>定时</th><th>操作</th></tr></thead>
+                <thead><tr><th>name</th><th>description</th><th>provider</th><th>model</th><th>tools</th><th>定时</th><th>操作</th></tr></thead>
                 <tbody>
-                  <tr v-if="!agents.data.length"><td colspan="6" class="empty">（暂无 Agent · 点上面「新建 Agent」，或往 .oryxos/agents/ 丢一个目录）</td></tr>
+                  <tr v-if="!agents.data.length"><td colspan="7" class="empty">（暂无 Agent · 点上面「新建 Agent」，或往 .oryxos/agents/ 丢一个目录）</td></tr>
                   <tr v-for="a in agents.data" :key="a.name">
                     <td class="mono">{{ a.name }}</td>
                     <td>{{ a.description || '—' }}</td>
                     <td>{{ a.provider }}</td>
+                    <td>{{ a.model || '—' }}</td>
                     <td>{{ (a.tools || []).join(', ') }}</td>
                     <td class="mono">{{ (a.schedules || []).map((s) => s.cron).join('; ') || '—' }}</td>
                     <td class="ops">

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/AgentApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/AgentApiController.java
@@ -19,6 +19,7 @@ import io.oryxos.web.controller.dto.MessageResponse;
 import io.oryxos.web.controller.dto.SaveFilesRequest;
 import io.oryxos.web.controller.dto.SessionView;
 import io.oryxos.web.controller.dto.TriggerResponse;
+import io.oryxos.web.controller.dto.UpdateAgentBasicRequest;
 import io.oryxos.web.controller.dto.UpdateAgentRequest;
 import io.oryxos.web.error.ResourceNotFoundException;
 import java.util.List;
@@ -86,7 +87,9 @@ public class AgentApiController {
     if (req == null || req.name() == null || req.name().isBlank()) {
       throw new IllegalArgumentException("Agent 名为空");
     }
-    return ApiResponse.ok(AgentView.from(lifecycle.create(req.name(), req.description())));
+    return ApiResponse.ok(
+        AgentView.from(
+            lifecycle.create(req.name(), req.description(), req.provider(), req.model())));
   }
 
   @GetMapping
@@ -119,6 +122,22 @@ public class AgentApiController {
     }
     lifecycle.delete(name);
     return ApiResponse.ok(null);
+  }
+
+  /**
+   * 结构化编辑基本信息（description / provider / model / skills）：只改 AGENT.md frontmatter 的对应 key，正文与其他配置原样保留。
+   * 非法定义 → 400（不破坏原文件）；不存在 → 404。
+   */
+  @PutMapping("/{name}/basic")
+  public ApiResponse<AgentView> updateBasic(
+      @PathVariable String name, @RequestBody UpdateAgentBasicRequest req) {
+    if (lifecycle.get(name).isEmpty()) {
+      throw new ResourceNotFoundException("Agent 不存在: " + name); // → 404
+    }
+    return ApiResponse.ok(
+        AgentView.from(
+            lifecycle.updateBasicInfo(
+                name, req.description(), req.provider(), req.model(), req.skills())));
   }
 
   @PostMapping("/{name}/invoke")
@@ -221,8 +240,11 @@ public class AgentApiController {
     String description = req == null ? null : req.description();
     String notifyChannel = req == null ? null : req.notifyChannel();
     List<String> skills = req == null ? List.of() : req.skills();
+    String provider = req == null ? null : req.provider();
+    String model = req == null ? null : req.model();
     return ApiResponse.ok(
-        new GeneratedFilesView(lifecycle.generateFiles(name, description, notifyChannel, skills)));
+        new GeneratedFilesView(
+            lifecycle.generateFiles(name, description, notifyChannel, skills, provider, model)));
   }
 
   /** 保存（可能被改过的）一组 Agent 文件，写入即生效（AGENT.md 非法 → 400，不写坏目录）。 */

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/ProviderApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/ProviderApiController.java
@@ -8,6 +8,7 @@ import io.oryxos.web.controller.dto.CreateProviderRequest;
 import io.oryxos.web.controller.dto.ProviderView;
 import io.oryxos.web.controller.dto.UpdateProviderRequest;
 import io.oryxos.web.error.ResourceNotFoundException;
+import io.oryxos.web.provider.ProviderModelsService;
 import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,9 +36,11 @@ public class ProviderApiController {
   private static final String MOCK = "mock";
 
   private final ProviderRegistry registry;
+  private final ProviderModelsService modelsService;
 
-  public ProviderApiController(ProviderRegistry registry) {
+  public ProviderApiController(ProviderRegistry registry, ProviderModelsService modelsService) {
     this.registry = registry;
+    this.modelsService = modelsService;
   }
 
   @PostMapping
@@ -79,6 +82,15 @@ public class ProviderApiController {
     ProviderDef saved =
         registry.save(new ProviderDef(name, req.apiKey(), req.baseUrl(), req.description()));
     return ApiResponse.ok(ProviderView.from(saved));
+  }
+
+  /**
+   * 列出某 provider 下的模型 id（服务端代理 OpenAI 兼容的 {@code /models} 端点，避免浏览器直连暴露 api-key）。 provider
+   * 不存在→404；端点不可达/缺 base-url→503（统一 ApiResponse 信封）。
+   */
+  @GetMapping("/{name}/models")
+  public ApiResponse<List<String>> models(@PathVariable String name) {
+    return ApiResponse.ok(modelsService.listModels(name));
   }
 
   @DeleteMapping("/{name}")

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
@@ -38,7 +38,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 404（`ResourceNotFoundException`）；统一 `ApiResponse` 信封。
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-    value = {"SPRING_ENDPOINT", "EI_EXPOSE_REP2", "URLCONNECTION_SSRF_FD"},
+    value = {"SPRING_ENDPOINT", "EI_EXPOSE_REP2", "URLCONNECTION_SSRF_FD", "IMPROPER_UNICODE"},
     justification =
         "core-stage web API is unauthenticated by design (internal network + gateway); auth is extension-phase. 协作者是 Spring 注入的共享单例，构造注入共享同一引用正是意图。/import 拉取运营者给定的 URL（等同安装插件），已做 SSRF 防护：限 http/https + 超时 + 大小上限 + 禁自动重定向、每跳校验目标主机非回环/内网/链路本地(含云元数据 169.254.169.254)/CGNAT。")
 @RestController
@@ -47,6 +47,11 @@ public class SkillApiController {
 
   private static final int MAX_SKILL_BYTES = 512 * 1024;
   private static final int MAX_REDIRECTS = 5;
+  private static final String SCHEME_HTTP = "http";
+  private static final String SCHEME_HTTPS = "https";
+  private static final String LOCALHOST = "localhost";
+  private static final String METADATA_GOOGLE_INTERNAL = "metadata.google.internal";
+  private static final String INTERNAL_SUFFIX = ".internal";
 
   private final SkillService skills;
 
@@ -101,7 +106,7 @@ public class SkillApiController {
       throw new IllegalArgumentException("非法 URL: " + url);
     }
     String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
-    if (!"http".equals(scheme) && !"https".equals(scheme)) {
+    if (!SCHEME_HTTP.equals(scheme) && !SCHEME_HTTPS.equals(scheme)) {
       throw new IllegalArgumentException("仅支持 http/https URL: " + url);
     }
     return uri;
@@ -161,7 +166,7 @@ public class SkillApiController {
       throw new IllegalArgumentException("URL 缺少主机名: " + uri);
     }
     String h = host.toLowerCase(Locale.ROOT);
-    if (h.equals("localhost") || h.equals("metadata.google.internal") || h.endsWith(".internal")) {
+    if (LOCALHOST.equals(h) || METADATA_GOOGLE_INTERNAL.equals(h) || h.endsWith(INTERNAL_SUFFIX)) {
       throw new IllegalArgumentException("拒绝访问内网 / 元数据主机: " + host);
     }
     InetAddress[] addresses;

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
@@ -60,7 +60,10 @@ public class WorkspaceApiController {
   public ApiResponse<FileNode> tree() {
     List<FileNode> roots = new ArrayList<>();
     roots.add(treeOf(oryxosRoot.resolve("agents")));
-    roots.add(treeOf(oryxosRoot.resolve("skills"))); // 全局 Skill 库：每个 Skill 一个目录（SKILL.md + 可选脚本/子文档），供详情查看文件列表
+    roots.add(
+        treeOf(
+            oryxosRoot.resolve(
+                "skills"))); // 全局 Skill 库：每个 Skill 一个目录（SKILL.md + 可选脚本/子文档），供详情查看文件列表
     roots.add(treeOf(oryxosRoot.resolve("output"))); // 第 32 节：Agent 产出的共享目录（研报/汇总/导出）
     roots.add(treeOf(oryxosRoot.resolve("archive")));
     // 根节点显示名取实际工作区目录名（自定义 oryxos.root 时不再写死 .oryxos）

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/CreateAgentRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/CreateAgentRequest.java
@@ -1,4 +1,4 @@
 package io.oryxos.web.controller.dto;
 
-/** POST /agents 请求体：只需 Agent 名 + 描述；后台按模板脚手架出完整目录。 */
-public record CreateAgentRequest(String name, String description) {}
+/** POST /agents 请求体：Agent 名 + 描述 + 可选的 provider/model（不选则走默认 provider）。 */
+public record CreateAgentRequest(String name, String description, String provider, String model) {}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/GenerateFilesRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/GenerateFilesRequest.java
@@ -3,10 +3,11 @@ package io.oryxos.web.controller.dto;
 import java.util.List;
 
 /**
- * POST /agents/{name}/generate-files 请求体：一句话需求 + 用户手动选的通知渠道（可空=不通知）+ 用户显式指定必启用的全局 Skill（可空=由模型自选），
- * 交大模型生成 AGENT.md（可含脚本/子指令）草稿（不落盘）。
+ * POST /agents/{name}/generate-files 请求体：一句话需求 + 用户手动选的通知渠道（可空=不通知）+ 用户显式指定必启用的全局 Skill（可空=由模型自选） +
+ * 用户挑好的 provider/model（可空=沿用默认），交大模型生成 AGENT.md（可含脚本/子指令）草稿（不落盘）。
  */
-public record GenerateFilesRequest(String description, String notifyChannel, List<String> skills) {
+public record GenerateFilesRequest(
+    String description, String notifyChannel, List<String> skills, String provider, String model) {
 
   public GenerateFilesRequest {
     skills = skills == null ? List.of() : List.copyOf(skills);

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/UpdateAgentBasicRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/UpdateAgentBasicRequest.java
@@ -1,0 +1,12 @@
+package io.oryxos.web.controller.dto;
+
+import java.util.List;
+
+/** PUT /agents/{name}/basic 请求体：结构化编辑 Agent 基本信息（只动 AGENT.md frontmatter 的几个 key）。 */
+public record UpdateAgentBasicRequest(
+    String description, String provider, String model, List<String> skills) {
+
+  public UpdateAgentBasicRequest {
+    skills = skills == null ? List.of() : List.copyOf(skills);
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/provider/ProviderModelsService.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/provider/ProviderModelsService.java
@@ -1,0 +1,88 @@
+package io.oryxos.web.provider;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.oryxos.core.provider.ProviderDef;
+import io.oryxos.core.provider.ProviderRegistry;
+import io.oryxos.web.error.ProviderUnavailableException;
+import io.oryxos.web.error.ResourceNotFoundException;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+/**
+ * 按 provider name 服务端代理 OpenAI 兼容的 {@code /models} 端点，返回该 provider 下的模型 id 列表。
+ *
+ * <p>必须服务端发起——不能让浏览器直连（会暴露 api-key 且踩 CORS）；api-key / base-url 取自 {@link ProviderRegistry} （与运行时建
+ * ChatModel 用的是同一套参数，宪法 III「显式 name→参数映射」）。mock provider 无真实端点，返回占位 ["mock"]。
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "registry 是 Spring 注入的共享单例，构造注入共享同一引用正是意图（与运行时建 ChatModel 共用同一注册表）。")
+@Service
+public class ProviderModelsService {
+
+  private static final String MOCK = "mock";
+  private static final String SLASH = "/";
+  private static final String PATH_V1 = "/v1";
+  private static final String PATH_MODELS = "/models";
+
+  private final ProviderRegistry registry;
+  private final RestClient restClient;
+
+  public ProviderModelsService(ProviderRegistry registry, RestClient.Builder restClientBuilder) {
+    this.registry = registry;
+    this.restClient = restClientBuilder.build();
+  }
+
+  /** 列出某 provider 下的模型 id（按字母排序）。provider 不存在→404；端点不可达/缺 base-url→503。 */
+  public List<String> listModels(String providerName) {
+    ProviderDef def =
+        registry
+            .find(providerName)
+            .orElseThrow(() -> new ResourceNotFoundException("provider 不存在: " + providerName));
+    if (MOCK.equals(def.name())) {
+      return List.of("mock");
+    }
+    String baseUrl = def.baseUrl();
+    if (baseUrl == null || baseUrl.isBlank()) {
+      throw new ProviderUnavailableException("provider " + providerName + " 未配置 base-url，无法列举模型");
+    }
+    String apiKey = def.apiKey() == null ? "" : def.apiKey();
+    try {
+      ModelsResponse resp =
+          restClient
+              .get()
+              .uri(modelsUrl(baseUrl))
+              .header("Authorization", "Bearer " + apiKey)
+              .retrieve()
+              .body(ModelsResponse.class);
+      if (resp == null || resp.data() == null) {
+        return List.of();
+      }
+      return resp.data().stream().map(ModelEntry::id).filter(Objects::nonNull).sorted().toList();
+    } catch (RuntimeException e) {
+      throw new ProviderUnavailableException(
+          "无法从 provider " + providerName + " 获取模型列表: " + e.getMessage(), e);
+    }
+  }
+
+  /** 拼 {@code /models} 地址：base-url 已带 /v1 则复用，否则直接追加。 */
+  private static String modelsUrl(String baseUrl) {
+    String u = baseUrl.strip();
+    if (u.endsWith(SLASH)) {
+      u = u.substring(0, u.length() - 1);
+    }
+    if (u.endsWith(PATH_V1)) {
+      return u + PATH_MODELS;
+    }
+    return u + PATH_MODELS;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record ModelsResponse(@JsonProperty("data") List<ModelEntry> data) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record ModelEntry(@JsonProperty("id") String id) {}
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/security/ProviderStartupCheck.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/ProviderStartupCheck.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Component;
 /**
  * Provider 配置启动校验（012-web-auth fix）。
  *
- * <p>仅在 SERVLET web 模式（serve/gateway）执行——user/chat 等 WebApplicationType.NONE 命令不触发，
- * 确保账号管理等不依赖 LLM 的命令不会因 api-key 未配而被阻断。
+ * <p>仅在 SERVLET web 模式（serve/gateway）执行——user/chat 等 WebApplicationType.NONE 命令不触发， 确保账号管理等不依赖 LLM
+ * 的命令不会因 api-key 未配而被阻断。
  *
  * <p>校验逻辑委托给 {@link ProvidersProperties#validate()}，镜像 {@link AuthStartupCheck} 的模式。
  */
@@ -31,6 +31,7 @@ public class ProviderStartupCheck implements ApplicationRunner {
   @Override
   public void run(ApplicationArguments args) {
     properties.validate();
-    LOG.debug("Provider startup check passed ({} provider(s) configured)", properties.providers().size());
+    LOG.debug(
+        "Provider startup check passed ({} provider(s) configured)", properties.providers().size());
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/skill/GithubFolderFetcher.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/skill/GithubFolderFetcher.java
@@ -30,6 +30,7 @@ public class GithubFolderFetcher {
 
   private static final int MAX_FILES = 100;
   private static final int MAX_TOTAL_BYTES = 5 * 1024 * 1024;
+  private static final String PATH_SEPARATOR = "/";
 
   private final Function<URI, String> httpGet;
 
@@ -112,7 +113,7 @@ public class GithubFolderFetcher {
   private static String encodePath(String path) {
     // Contents API 的 path 段允许 '/'，逐段做 URL 编码后再拼回去
     StringBuilder sb = new StringBuilder();
-    for (String seg : path.split("/")) {
+    for (String seg : path.split(PATH_SEPARATOR)) {
       if (!sb.isEmpty()) {
         sb.append('/');
       }

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/AgentApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/AgentApiControllerTest.java
@@ -75,7 +75,7 @@ class AgentApiControllerTest {
   @Test
   @DisplayName("create 成功_返回 AgentView")
   void create_success_returnsAgentView() throws Exception {
-    when(lifecycle.create(eq("demo"), any())).thenReturn(profile("demo"));
+    when(lifecycle.create(eq("demo"), any(), any(), any())).thenReturn(profile("demo"));
 
     mvc.perform(
             post("/api/v1/agents")
@@ -88,7 +88,7 @@ class AgentApiControllerTest {
   @Test
   @DisplayName("create name 冲突_返回400")
   void create_conflict_returns400() throws Exception {
-    when(lifecycle.create(eq("dup"), any()))
+    when(lifecycle.create(eq("dup"), any(), any(), any()))
         .thenThrow(new IllegalArgumentException("Agent 已存在: dup"));
 
     mvc.perform(
@@ -169,5 +169,37 @@ class AgentApiControllerTest {
                 .content("{\"content\":\"" + huge + "\"}"))
         .andExpect(status().isBadRequest());
     verify(agentService, never()).process(any(), any());
+  }
+
+  @Test
+  @DisplayName("updateBasic 成功_返回 AgentView")
+  void updateBasic_success_returnsAgentView() throws Exception {
+    when(lifecycle.get("demo")).thenReturn(Optional.of(profile("demo")));
+    when(lifecycle.updateBasicInfo(eq("demo"), eq("新描述"), eq("openai"), eq("gpt-4o"), any()))
+        .thenReturn(profile("demo"));
+
+    mvc.perform(
+            put("/api/v1/agents/demo/basic")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"description\":\"新描述\",\"provider\":\"openai\",\"model\":\"gpt-4o\",\"skills\":[\"s1\",\"s2\"]}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.name").value("demo"));
+    verify(lifecycle).updateBasicInfo(eq("demo"), eq("新描述"), eq("openai"), eq("gpt-4o"), any());
+  }
+
+  @Test
+  @DisplayName("updateBasic 不存在_返回404")
+  void updateBasic_unknown_returns404() throws Exception {
+    when(lifecycle.get("ghost")).thenReturn(Optional.empty());
+
+    mvc.perform(
+            put("/api/v1/agents/ghost/basic")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"description\":\"x\",\"provider\":\"openai\",\"model\":\"gpt-4o\",\"skills\":[]}"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value(404));
+    verify(lifecycle, never()).updateBasicInfo(any(), any(), any(), any(), any());
   }
 }

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/ProviderApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/ProviderApiControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import io.oryxos.core.provider.ProviderDef;
 import io.oryxos.core.provider.ProviderRegistry;
 import io.oryxos.web.GlobalExceptionHandler;
+import io.oryxos.web.provider.ProviderModelsService;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.client.RestClient;
 
 /** providers 端点切片：CRUD 薄转发（冲突/非法→400、不存在→404，统一 ApiResponse）。 */
 class ProviderApiControllerTest {
@@ -32,7 +34,9 @@ class ProviderApiControllerTest {
   void setUp() {
     registry = mock(ProviderRegistry.class);
     mvc =
-        MockMvcBuilders.standaloneSetup(new ProviderApiController(registry))
+        MockMvcBuilders.standaloneSetup(
+                new ProviderApiController(
+                    registry, new ProviderModelsService(registry, RestClient.builder())))
             .setControllerAdvice(new GlobalExceptionHandler())
             .build();
   }
@@ -113,5 +117,36 @@ class ProviderApiControllerTest {
 
     mvc.perform(delete("/api/v1/providers/ghost")).andExpect(status().isNotFound());
     verify(registry, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("models_mock_返回占位列表")
+  void models_mock_returnsPlaceholder() throws Exception {
+    when(registry.find("mock")).thenReturn(Optional.of(new ProviderDef("mock", null, null, null)));
+
+    mvc.perform(get("/api/v1/providers/mock/models"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0]").value("mock"));
+  }
+
+  @Test
+  @DisplayName("models_不存在_返回404")
+  void models_unknown_returns404() throws Exception {
+    when(registry.find("ghost")).thenReturn(Optional.empty());
+
+    mvc.perform(get("/api/v1/providers/ghost/models"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value(404));
+  }
+
+  @Test
+  @DisplayName("models_真实provider不可达_返回503")
+  void models_unreachable_returns503() throws Exception {
+    when(registry.find("down"))
+        .thenReturn(Optional.of(new ProviderDef("down", "sk-x", "http://127.0.0.1:1", null)));
+
+    mvc.perform(get("/api/v1/providers/down/models"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.code").value(503));
   }
 }

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
@@ -45,8 +45,9 @@ class WorkspaceApiControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.children[0].name").value("agents"))
         .andExpect(jsonPath("$.data.children[0].children[0].name").value("demo"))
-        .andExpect(jsonPath("$.data.children[1].name").value("output"))
-        .andExpect(jsonPath("$.data.children[2].name").value("archive"));
+        .andExpect(jsonPath("$.data.children[1].name").value("skills"))
+        .andExpect(jsonPath("$.data.children[2].name").value("output"))
+        .andExpect(jsonPath("$.data.children[3].name").value("archive"));
   }
 
   @Test

--- a/oryxos-web/src/test/java/io/oryxos/web/provider/ProviderModelsServiceTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/provider/ProviderModelsServiceTest.java
@@ -1,0 +1,89 @@
+package io.oryxos.web.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.sun.net.httpserver.HttpServer;
+import io.oryxos.core.provider.ProviderDef;
+import io.oryxos.core.provider.ProviderRegistry;
+import io.oryxos.web.error.ProviderUnavailableException;
+import io.oryxos.web.error.ResourceNotFoundException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+/** ProviderModelsService 单元：mock 占位、真实 /models 解析、未知 provider→404、端点不可达→503。 */
+class ProviderModelsServiceTest {
+
+  private HttpServer server;
+  private String baseUrl;
+  private ProviderRegistry registry;
+  private ProviderModelsService service;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.start();
+    baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    registry = mock(ProviderRegistry.class);
+    service = new ProviderModelsService(registry, RestClient.builder());
+  }
+
+  @AfterEach
+  void tearDown() {
+    server.stop(0);
+  }
+
+  @Test
+  @DisplayName("mock provider_返回占位模型列表")
+  void mock_returnsPlaceholder() {
+    when(registry.find("mock")).thenReturn(Optional.of(new ProviderDef("mock", null, null, null)));
+
+    assertEquals(List.of("mock"), service.listModels("mock"));
+  }
+
+  @Test
+  @DisplayName("真实 provider_解析 /models 并按字母排序返回 id")
+  void real_parsesModelsSorted() {
+    server.createContext(
+        "/v1/models",
+        exchange -> {
+          byte[] body =
+              "{\"object\":\"list\",\"data\":[{\"id\":\"gpt-4o\"},{\"id\":\"gpt-3.5-turbo\"}]}"
+                  .getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().set("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, body.length);
+          exchange.getResponseBody().write(body);
+          exchange.close();
+        });
+    when(registry.find("openai"))
+        .thenReturn(Optional.of(new ProviderDef("openai", "sk-x", baseUrl + "/v1", null)));
+
+    assertEquals(List.of("gpt-3.5-turbo", "gpt-4o"), service.listModels("openai"));
+  }
+
+  @Test
+  @DisplayName("未知 provider_抛 ResourceNotFoundException")
+  void unknown_throwsNotFound() {
+    when(registry.find("ghost")).thenReturn(Optional.empty());
+
+    assertThrows(ResourceNotFoundException.class, () -> service.listModels("ghost"));
+  }
+
+  @Test
+  @DisplayName("端点不可达_抛 ProviderUnavailableException")
+  void unreachable_throwsUnavailable() {
+    when(registry.find("down"))
+        .thenReturn(Optional.of(new ProviderDef("down", "sk-x", "http://127.0.0.1:1", null)));
+
+    assertThrows(ProviderUnavailableException.class, () -> service.listModels("down"));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,7 @@
                         <printFailingErrors>true</printFailingErrors>
                         <skipPmdError>false</skipPmdError>
                         <linkXRef>false</linkXRef>
+                        <analysisCache>true</analysisCache>
                         <rulesets>
                             <ruleset>rulesets/java/ali-naming.xml</ruleset>
                             <ruleset>rulesets/java/ali-oop.xml</ruleset>


### PR DESCRIPTION
1. 创建 Agent 支持选择 model，模型列表自动啦取
<img width="804" height="542" alt="image" src="https://github.com/user-attachments/assets/fdce2e1e-d638-4a4c-ad14-693a41eabacf" />

2. 支持修改 agent 描述、model等基本信息
<img width="973" height="509" alt="image" src="https://github.com/user-attachments/assets/87dc4aa7-a77a-4f3d-929d-b321f3e7b5b5" />
<img width="949" height="576" alt="image" src="https://github.com/user-attachments/assets/0e3bfae9-7826-4034-82eb-88a2c3a5bb0e" />

3. agent 执行时，如果达到最大迭代论述，调整为抛出异常（web上显示为执行失败）