### PR TITLE
feat: add progressive Agent Skill loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ logs/
 
 # 运行时工作区：Profile / MEMORY.md / SQLite / 会话 / 日志都在这里，随环境生成，不入库
 .oryxos/
+
+# Codex isolated worktrees
+.worktrees/

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/012-agent-send-shortcut"
+  "feature_directory": "specs/012-agent-skill-links"
 }

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,27 +1,37 @@
 <!--
 Sync Impact Report
-- Version change: 1.0.0 → 1.1.0
-- Bump rationale: MINOR — 技术栈与架构约束新增「模块结构可按需演进」条款（用户在第17节
-  tasks 停点批准）：模块划分跟随 Agent 能力域，不锁死 9 模块，可新建（如 oryxos-sandbox）
-  或调整模块；新建/改名须在对应特性 plan 中声明并同步 CLAUDE.md 与 TechnicalSolution §10。
-- Previous version change: (none) → 1.0.0  (initial ratification)
-- Bump rationale (1.0.0): First formal adoption of the OryxOS constitution. MAJOR baseline.
+- Version change: 1.1.0 → 2.0.0
+- Bump rationale: MAJOR — 原则 IV 从「禁止跨 Agent 共享 Skill」重定义为「公共 Skill 实体库 +
+  Agent 本地相对软连接绑定 + 分层渐进式披露」，并移除 AGENT.md frontmatter skills 引用这一
+  旧绑定方式；原则 VI 同步新增软连接真实路径安全门禁。
 - Principles defined (8):
     I.   自实现 ReAct 循环 (NON-NEGOTIABLE)
     II.  Spring AI 仅做协议转换与 Schema 生成 (NON-NEGOTIABLE)
     III. Provider 显式映射
-    IV.  一个目录 = 一个 Agent；AGENT.md 由 ContextLoader 加载，不作为 Tool
+    IV.  一个目录 = 一个 Agent；Skill 以本地软连接绑定并渐进披露
     V.   审计 Day One 落库 (NON-NEGOTIABLE)
-    VI.  安全是地基：强制沙箱白名单，不用 SecurityManager (NON-NEGOTIABLE)
+    VI.  安全是地基：强制沙箱与真实路径校验，不用 SecurityManager (NON-NEGOTIABLE)
     VII. 同步执行 + 虚拟线程，不引入异步编程模型
-    VIII.配置即 Agent，实例无状态、状态外置
-- Added sections: 技术栈与架构约束; 开发流程与质量门禁; Governance
-- Removed sections: none (initial)
+    VIII.目录配置即 Agent，实例无状态、状态外置
+- Modified principles:
+    IV.  禁止共享 Skill → 公共实体库 + Agent 本地软连接绑定 + 元数据常驻/正文按需
+    VI.  路径白名单 → 软连接感知的真实路径白名单
+    VIII.YAML Profile 定义 Agent → Agent 目录（frontmatter + 本地 Skill 绑定）定义 Agent
+- Added sections: none
+- Removed sections: none
 - Templates checked:
-    ✅ .specify/templates/plan-template.md   (Constitution Check gate is dynamic; no edit needed)
-    ✅ .specify/templates/spec-template.md    (no constitution-specific tokens)
-    ✅ .specify/templates/tasks-template.md   (no constitution-specific tokens)
-- Follow-up TODOs: none
+    ✅ .specify/templates/plan-template.md (Constitution Check gate is dynamic; no edit needed)
+    ✅ .specify/templates/spec-template.md (现有安全/边界 Edge Cases 可承载软连接约束)
+    ✅ .specify/templates/tasks-template.md (已有 Tests + Security hardening 阶段，无需改模板)
+    ✅ .specify/templates/constitution-template.md (通用模板，无项目语义)
+    ✅ .specify/templates/commands/ (目录不存在，无命令模板待同步)
+- Runtime guidance requiring sync in this amendment:
+    ✅ CLAUDE.md
+    ✅ README.md
+    ✅ docs/DemandAnalysis.md
+    ✅ docs/TechnicalSolution.md
+    ⚠ AGENTS.md（未纳入当前 Git worktree；外部工作区指南需由维护者同步）
+- Follow-up items: none（本特性的 spec/plan/tasks、实现与端到端验收已同步完成）。
 -->
 
 # OryxOS Constitution
@@ -57,19 +67,31 @@ Spring 容器中的 `ChatModel` Bean 类型来区分 Provider（类型相同会�
 
 **Rationale**: 显式映射是多模型可预测路由的唯一可靠方式。
 
-### IV. 一个目录 = 一个 Agent；AGENT.md 由 ContextLoader 加载，不作为 Tool
+### IV. 一个目录 = 一个 Agent；Skill 以本地软连接绑定并渐进披露
 
-一个 Agent MUST 是 `.oryxos/agents/<name>/` 一个目录（借 Anthropic Agent Skills 的目录形态，
-但定义的是 Agent）：`AGENT.md` = frontmatter（这个 Agent 自己的 profile）+ 正文（任务指令），
-外加可选 `skills/*.md` 子指令、`scripts/` 脚本、`REFERENCE.md`。`AgentLoader.deriveProfile`
-MUST 把 frontmatter 派生成 `Profile` 复用底座。`AGENT.md` **正文** MUST 由 `oryxos-core` 的
-`ContextLoader` 注入 system prompt，与 Bootstrap 文件（`AGENTS.md`、`SOUL.md`、`USER.md`）同类；
-目录里的子指令 / 脚本经底座既有 `read_file`/`shell` 按需取用。MUST NOT 建跨 Agent 的共享能力库、
-`use_skill` 工具或全局能力索引；一个 Agent 目录 MUST NOT 注册进 `ToolRegistry` 或放入 `oryxos-tool`
-模块。内置 Tool 与 MCP Client MUST 合并在单一 `oryxos-tool` 模块，不拆分。
+一个 Agent MUST 是 `.oryxos/agents/<name>/` 一个目录：`AGENT.md` 的 frontmatter 定义运行配置，
+正文定义任务指令；可选 `scripts/`、`REFERENCE.md` 与 `skills/` 构成该 Agent 的本地资源视图。
+`AgentLoader.deriveProfile` MUST 从 frontmatter 派生 `Profile`，`ContextLoader` MUST 每次现读
+`AGENT.md` 正文并注入 system prompt，不得缓存。
 
-**Rationale**: Agent 目录是上下文来源而非可执行工具；每个 Agent 自足独立，只调用底座系统基础能力，
-混淆两者会在执行期报错、并让模块依赖混乱。
+公共 Skill 实体 MUST 存在 `.oryxos/skills/<name>/`，至少包含带 `name`、`description`
+frontmatter 的 `SKILL.md`。Agent 可见的 Skill MUST 且只能由
+`.oryxos/agents/<agent>/skills/<name>` 下指向公共实体的受控相对软连接表达；这组本地软连接是
+绑定关系的唯一真相源，MUST NOT 再用 `AGENT.md` frontmatter `skills:` 或其它并行索引表达同一关系。
+
+`ContextLoader` MUST 在每次 prompt 组装时重新扫描当前 Agent 的 `skills/`，稳定排序并验证软连接，
+只注入每个有效绑定的 `name`、`description` 与 Agent 本地绝对读取路径。MUST NOT 预载
+`SKILL.md` 正文、references、模板或脚本；模型需要某项能力时，MUST 复用底座既有 `read_file` /
+`shell` 按需读取或运行，使内容仅以工具结果进入后续 ReAct 上下文。MUST NOT 新增 `use_skill`
+工具；Skill 是上下文资源，不是可执行 Tool，不得进入 `ToolRegistry`。
+
+Skill create/import/update/delete、Agent bind/unbind/archive/delete 与启动恢复 MUST 执行一致性检查，
+识别 dangling、escaped、invalid-target、name-mismatch 与 stale-reference。删除仍被 Agent 引用的
+公共 Skill MUST 默认拒绝并返回引用 Agent 列表，不得制造悬空软连接。Skill 加载、绑定与协调实现
+归 `oryxos-core`，内置 Tool 与 MCP Client 仍合并在单一 `oryxos-tool` 模块。
+
+**Rationale**: 公共实体消除 Skill 内容复制，Agent 本地软连接明确能力边界；元数据常驻、正文按需
+兼顾发现能力与上下文成本。唯一绑定真相源与强制一致性检查避免 frontmatter/目录漂移和悬空引用。
 
 ### V. 审计 Day One 落库 (NON-NEGOTIABLE)
 
@@ -78,14 +100,20 @@ MUST 把 frontmatter 派生成 `Profile` 复用底座。`AGENT.md` **正文** MU
 
 **Rationale**: 可审计是 OryxOS 的核心差异化能力；事后从日志反解析代价高且不可靠。
 
-### VI. 安全是地基：强制沙箱白名单，不用 SecurityManager (NON-NEGOTIABLE)
+### VI. 安全是地基：强制沙箱与真实路径校验，不用 SecurityManager (NON-NEGOTIABLE)
 
 工具调用 MUST 经 `SandboxChecker` 白名单校验：文件走路径白名单、Shell 走命令首 token 白名单、
 HTTP 走域名通配白名单。MUST NOT 使用 `SecurityManager`（JDK 21 已不可用）。凭证 MUST 走
 环境变量 / 企业密钥体系，MUST NOT 明文写入代码、配置、日志或提交历史。最小权限、来源受控、
 全链路可审计从第一天就在架构里，不是补丁。
 
-**Rationale**: 企业私有部署对安全零容忍；安全若非地基，后期无法补齐。
+任何允许软连接的文件访问 MUST 校验真实路径：已存在目标经 `toRealPath()` 解析后仍须位于允许根；
+创建新路径时须解析最近已存在父目录的真实路径后再校验。Agent Skill 绑定 MUST 拒绝绝对软连接、
+链式越界以及指向 `.oryxos/skills/` 之外的目标。字符串形式的 `normalize()+startsWith()` 不足以
+作为软连接场景的安全判定。
+
+**Rationale**: 企业私有部署对安全零容忍；软连接可绕过纯字符串路径白名单，若不校验真实路径，
+公共 Skill 绑定会成为读取工作区外文件的通道。
 
 ### VII. 同步执行 + 虚拟线程，不引入异步编程模型
 
@@ -94,13 +122,15 @@ HTTP 走域名通配白名单。MUST NOT 使用 `SecurityManager`（JDK 21 已�
 
 **Rationale**: 虚拟线程已让同步代码扛住高并发；异步会让复杂度激增、调试困难。
 
-### VIII. 配置即 Agent，实例无状态、状态外置
+### VIII. 目录配置即 Agent，实例无状态、状态外置
 
-一个 Agent MUST 完全由一份 YAML Profile 定义，不需要写代码。运行实例 MUST 无状态，会话与
-记忆等状态 MUST 外置（SQLite / 文件），为走向分布式预留路径。表结构变更 MUST NOT 依赖
+一个 Agent MUST 完全由一个目录定义：`AGENT.md` frontmatter/正文给出配置与任务，本地 `skills/`
+软连接给出可见 Skill，附属脚本/参考按需存在；定义 Agent 不需要写 Java 代码。运行实例 MUST 无状态，
+会话与记忆等状态 MUST 外置（SQLite / 文件），为走向分布式预留路径。表结构变更 MUST NOT 依赖
 Hibernate 自动迁移（SQLite `ALTER TABLE` 支持弱），需手工建表脚本或 Flyway。
 
-**Rationale**: 「配置即 Agent」降低接入门槛；「状态外置」是未来分布式化不大改设计的前提。
+**Rationale**: 「目录配置即 Agent」降低接入门槛并容纳渐进式资源；「状态外置」是未来分布式化
+不大改设计的前提。
 
 ## 技术栈与架构约束
 
@@ -114,6 +144,8 @@ Hibernate 自动迁移（SQLite `ALTER TABLE` 支持弱），需手工建表脚�
 - HTTP：Spring MVC + 虚拟线程；持久化：SQLite + Spring Data JPA；日志：Logback + SLF4J
   （生产 JSON 结构化，禁用 `System.out`）。
 - 开放标准优先：工具用 MCP、Agent 协作用 A2A、Agent 目录借 Anthropic Agent Skills 的形态，不另立协议。
+- Skill 绑定：公共实体在 `.oryxos/skills/`，Agent 以本地相对软连接选择可见集合；元数据每轮注入，
+  正文与附属资源按需读取，禁止复制内容或维护第二份绑定索引。
 - 模块解耦：新增 Channel 或 Tool 只加新模块，不改 `oryxos-core`。
 - 底座优先于 Agent：最重要的交付是让任意 Agent 可靠运行的环境，而非某个强大的 Agent。
 
@@ -139,4 +171,4 @@ Hibernate 自动迁移（SQLite `ALTER TABLE` 支持弱），需手工建表脚�
   优先选择更简单、更符合原则的方案。
 - 运行时开发指南以 `CLAUDE.md` 为准，其内容 MUST 与本宪法保持一致。
 
-**Version**: 1.1.0 | **Ratified**: 2026-07-01 | **Last Amended**: 2026-07-10
+**Version**: 2.0.0 | **Ratified**: 2026-07-01 | **Last Amended**: 2026-07-26

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,24 +90,26 @@ Map<String, ChatModel> providerMap = Map.of(
 );
 ```
 
-### 原则四：一个目录 = 一个 Agent；`AGENT.md` 归 `ContextLoader`，不是 Tool
+### 原则四：一个目录 = 一个 Agent；Skill 以本地软连接绑定并渐进披露
 
-**一个目录 = 一个 Agent**（借 Anthropic Agent Skills 的**目录形态**，但定义的是 Agent）：`.oryxos/agents/<name>/` 里 `AGENT.md` = frontmatter（这个 Agent 自己的 profile：name/description/provider/model/tools/notify_channels/schedules）+ 正文（任务指令）；外加可选 `skills/*.md`（子指令）、`scripts/`（脚本）、`REFERENCE.md`（参考）。`AgentLoader.deriveProfile(agentDir)` 把 frontmatter 派生成底座认识的 `Profile`——`.oryxos/profiles/` 取消，profile 就是 frontmatter。
+**一个目录 = 一个 Agent**：`.oryxos/agents/<name>/` 里 `AGENT.md` = frontmatter（运行配置）+ 正文（任务指令），外加可选 `skills/`（Skill 绑定视图）、`scripts/`、`REFERENCE.md`。`AgentLoader.deriveProfile(agentDir)` 把 frontmatter 派生成底座认识的 `Profile`；`.oryxos/profiles/` 取消。
 
-加载走**一个 Agent 内部的渐进式披露**：`AGENT.md` **正文**由 `ContextLoader`/`PromptBuilder` 注入 system prompt（跟 Bootstrap 文件 `AGENTS.md`/`SOUL.md`/`USER.md` 同一层，因为它就是这个 Agent）；目录里的**参考**用底座既有 `read_file` 按需读、**脚本**用 `shell` 按需跑。**一个 Agent 目录永远不是一个可执行 Tool**，不进 `ToolRegistry`、不放在 `oryxos-tool` 模块里（详见 `docs/TechnicalSolution.md` §11）。
+公共 Skill 实体统一存放在 `.oryxos/skills/<name>/`。Agent 可见的 Skill 只由 `.oryxos/agents/<agent>/skills/<name>` 下指向公共实体的**相对软连接**表达；软连接集合是唯一绑定真相源，`AGENT.md` frontmatter 不再声明 `skills:`。
 
-> **修订（v1.2.0，第 32 节）：Skill 升级为全局共享能力库。** 原条款"没有跨 Agent 的能力库 / 没有 `use_skill` / 没有全局能力索引"**已废止**。现在 Skill 是**全局的**：存 `.oryxos/skills/<name>/SKILL.md`（frontmatter `name`/`description` + 正文=约束指令），由 `SkillService`/`SkillStore`/`SkillRegistry`（`oryxos-core`，与 Agent 那套同构）做 CRUD，`/api/v1/skills` 暴露。Agent 在 `AGENT.md` frontmatter 用 `skills: [名]` **按名引用**全局 Skill，`ContextLoader` 组装 system prompt 时把引用到的 Skill 正文**注入**（强约束产出，不靠模型自觉 `read_file`）；引用不存在的 Skill 记 WARN 跳过。生成 Agent 时作者模型会拿到 Skill 目录（名+描述）自动按需选，用户也可在前端显式勾选必启用的 Skill。**不变的边界**：Skill 仍不是可执行 Tool、不进 `ToolRegistry`；Skill 的加载/注入仍归 `oryxos-core` 的 `ContextLoader`（不进 `oryxos-tool`）。每个 Agent 目录里的 `skills/` 子目录不再是脚手架默认项——约束产出的规范优先用全局 Skill 库。
+加载走三层渐进式披露：每轮 prompt 只注入当前 Agent 已绑定 Skill 的 `name + description + 本地绝对读取路径`；模型命中后用 `read_file` 读取 `SKILL.md` 正文；Skill 附属参考/脚本继续按需读取或运行。不得预载正文、不得新增 `use_skill`、Skill 不进 `ToolRegistry`。CRUD 与启动恢复必须检测 dangling/escaped/invalid-target/name-mismatch/stale-reference；公共 Skill 被引用时默认拒绝删除并返回引用 Agent。
 
 ### 原则五：审计表 Day One 写入
 
 `tool_invocations` 和 `llm_calls` 两张审计表**核心阶段就必须写入**（不需要查询接口，但写入不能省）。不得以"日志够了"为由跳过落库，可审计是 OryxOS 的核心差异化能力。
 
-### 原则六：不使用 Java SecurityManager
+### 原则六：不使用 Java SecurityManager；软连接必须校验真实路径
 
 `SecurityManager` 在 JDK 17 起废弃、JDK 21 已不可用。Sandbox 通过 `SandboxChecker` 的 Path / Pattern 白名单实现：
 - 文件操作：路径白名单（`file.allowed_paths`）
 - Shell：命令首 token 白名单（`shell.allowed_commands`）
 - HTTP：域名通配符白名单（`http.allowed_domains`）
+
+文件目标存在时必须用 `toRealPath()` 校验真实路径仍位于白名单根；新建路径校验最近存在父目录的真实路径。Agent Skill 绑定只允许指向 `.oryxos/skills/` 的相对软连接，拒绝绝对链接和越界链接。
 
 ### 原则七：同步执行模型
 
@@ -125,8 +127,8 @@ OryxOS 启动后在当前目录创建 `.oryxos/` 工作区：
 
 ```
 .oryxos/
-├── agents/             # 每个子目录 = 一个 Agent（AGENT.md + 可选 scripts/ REFERENCE.md）
-├── skills/             # 全局 Skill 库：每个子目录 = 一个 Skill（SKILL.md），Agent 按名引用来约束产出（第 32 节）
+├── agents/             # 每个子目录 = 一个 Agent（AGENT.md + skills/软连接 + scripts/ REFERENCE.md）
+├── skills/             # 公共 Skill 实体库：每个子目录 = 一个 Skill（SKILL.md + 可选附属资源）
 ├── memory/
 │   └── MEMORY.md       # 长期记忆（Agent 通过 save_memory 写入，不得手动修改）
 ├── sessions/           # 会话数据（已迁入 SQLite，此目录备用）
@@ -148,7 +150,7 @@ OryxOS 启动后在当前目录创建 `.oryxos/` 工作区：
 
 ### AGENT.md（`.oryxos/agents/<name>/AGENT.md`）
 
-一个 Agent 目录里 `AGENT.md` = frontmatter（这个 Agent 自己的 profile）+ 正文（任务指令）。`AgentLoader.deriveProfile(agentDir)` 把 frontmatter 派生成底座认识的 `Profile`。子指令 / 脚本放同目录的 `skills/`、`scripts/`，由正文指引用 `read_file`/`shell` 按需取用（不在 frontmatter 里声明）。
+一个 Agent 目录里 `AGENT.md` = frontmatter（这个 Agent 自己的 profile）+ 正文（任务指令）。`AgentLoader.deriveProfile(agentDir)` 把 frontmatter 派生成底座认识的 `Profile`。该 Agent 的 `skills/` 只放指向公共 Skill 实体的相对软连接；`ContextLoader` 每轮注入绑定 Skill 的名称、描述和读取路径，正文与附属资源经 `read_file`/`shell` 按需取用。
 
 ```markdown
 ---
@@ -238,7 +240,7 @@ settings:
 用户消息
   → 追加到 Session 对话历史
   → PromptBuilder 组装 Prompt：
-      [1] system prompt（AGENT.md 正文 + Bootstrap；子指令/脚本经 read_file/shell 按需取）← ContextLoader
+      [1] system prompt（AGENT.md 正文 + Skill 元数据 + Bootstrap；正文/脚本按需取）← ContextLoader
       [2] 长期记忆（MEMORY.md 全文，超 4000 字自动截断）         ← MemoryService
       [3] 对话历史（最近 max_history_turns 轮）                  ← SessionManager
       [4] 可用 Tool 列表（Function Calling 格式）                ← ToolRegistry
@@ -396,7 +398,7 @@ provider:
 
 - **底座优先于 Agent**：最重要的交付不是某个强大的 Agent，而是让任意 Agent 可靠运行的环境
 - **自实现核心，复用管道**：ReAct 循环手写；LLM 协议适配委托给 Spring AI Alibaba
-- **一个目录 = 一个 Agent**：一个业务 Agent 由一个目录定义——`AGENT.md`（frontmatter 配置：谁/何时/怎么跑 + 正文指令），可选 `skills/` 子指令、`scripts/` 脚本；子资源经底座 `read_file`/`shell` 按需取用，不需要写 Java 代码
+- **一个目录 = 一个 Agent**：一个业务 Agent 由一个目录定义——`AGENT.md`（frontmatter 配置 + 正文指令）、可选 `skills/` 公共 Skill 软连接与 `scripts/`；Skill 元数据每轮注入，正文/附属资源经 `read_file`/`shell` 按需取用
 - **对接开放标准**：工具用 MCP，Agent 间协作用 A2A，Agent 目录借 Anthropic Agent Skills 的形态（目录 + 渐进式披露）
 - **无状态实例，状态外置**：这是未来走向分布式架构而不需要大改设计的前提
 - **安全是地基，不是补丁**：工具来源管控、最小权限、强制沙箱白名单、凭证走环境变量、完整审计记录从第一天就写入 SQLite

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ OryxOS is the third column — and it ships the second one for every agent it ru
 ## Features
 
 **🤖 One Directory = One Agent**
-An Agent is a directory: `.oryxos/agents/<name>/AGENT.md` — YAML frontmatter (the Agent's profile: model, tools, channels, schedules) plus a body of task instructions. Optional `skills/`, `scripts/`, and `REFERENCE.md` are loaded on demand. Multiple agents co-exist on one instance.
+An Agent is a directory: `.oryxos/agents/<name>/AGENT.md` — YAML frontmatter plus task instructions. Its optional `skills/` directory contains relative symlinks to shared Skill entities. Every prompt receives only each bound Skill's name, description, and local path; bodies and resources load on demand. Multiple agents co-exist on one instance.
 
 **⚡ Dynamic Agent Management**
 Create an agent via REST, generate a draft `AGENT.md` from one sentence with an LLM, or just drop a directory into the workspace — a `WorkspaceWatcher` picks it up and the agent goes live with no restart.
@@ -203,7 +203,7 @@ The dev server runs on port **5173** with base `/admin/` and proxies `/api` → 
 
 ## Agent Definition
 
-**One directory = one Agent.** Each agent lives in `.oryxos/agents/<name>/` with an `AGENT.md` — YAML frontmatter (its profile) plus a body of task instructions injected into the system prompt. Optional `skills/*.md`, `scripts/`, and `REFERENCE.md` in the same directory are loaded on demand via `read_file` / `shell`. There is no `.oryxos/profiles/` directory.
+**One directory = one Agent.** Each agent lives in `.oryxos/agents/<name>/` with an `AGENT.md`, optional scripts/references, and a `skills/` binding view. Shared Skill entities live under `.oryxos/skills/<name>/`; an Agent binds one through a relative symlink at `agents/<agent>/skills/<name>`. Each prompt receives only bound Skill names, descriptions, and local paths. Bodies and resources load on demand through `read_file` / `shell`; there is no `use_skill` tool or `.oryxos/profiles/` directory.
 
 ```markdown
 ---
@@ -261,7 +261,7 @@ All endpoints are prefixed with `/api/v1` and every response is wrapped in a uni
 
 - **Platform before Agent** — the most important deliverable is not a powerful Agent, but the environment that lets any Agent run reliably
 - **Self-implement the core** — reasoning loop is self-implemented; protocol adapters reuse mature libraries; no reinventing the wheel
-- **One directory = one Agent** — an Agent is a directory (`AGENT.md` + optional skills/scripts), not code
+- **One directory = one Agent** — `AGENT.md` + Agent-local Skill symlinks + optional scripts, not code
 - **Open standards** — MCP for tools, A2A for collaboration, open formats for skills
 - **Stateless instances** — state externalized from the start; the prerequisite for scaling to distributed
 - **Security as foundation** — controlled tool sources, least privilege, mandatory sandbox, credentials never persisted, full audit trail from day one

--- a/docs/DemandAnalysis.md
+++ b/docs/DemandAnalysis.md
@@ -141,8 +141,8 @@ API 覆盖六类操作：
 
 | 术语 | 定义 |
 |------|------|
-| **Agent（智能体）** | 一个具象的业务智能体，定义本体是一个目录 `.oryxos/agents/<name>/`：`AGENT.md`（frontmatter 是这个 Agent 自己的 profile——用哪个模型、能用哪些工具、绑定哪个渠道、要不要定时；正文是任务指令——做什么、什么时候该做）加可选 `skills/*.md` 子指令、`scripts/` 脚本、`REFERENCE.md` 参考。一个目录就是一个完整可用的业务 Agent，不是写代码写出来的 |
-| **Profile（配置）** | 底座内部的运行时宿主配置对象，决定一个 Agent"怎么跑"：绑定的 LLM Provider、可用 Tool 列表、绑定 Channel、Tool Policy、引用的 Skill、定时规则。它不再是一份单独手写的 YAML——`AgentLoader.deriveProfile()` 把 `AGENT.md` 的 frontmatter 派生成 `Profile`，让 Agent 目录零改动复用整台底座 |
+| **Agent（智能体）** | 一个具象的业务智能体，定义本体是一个目录 `.oryxos/agents/<name>/`：`AGENT.md`（frontmatter 是运行配置、正文是任务指令）加可选 `skills/` 公共 Skill 软连接、`scripts/` 脚本、`REFERENCE.md` 参考。一个目录就是一个完整可用的业务 Agent，不是写代码写出来的 |
+| **Profile（配置）** | 底座内部的运行时宿主配置对象，决定一个 Agent"怎么跑"：绑定的 LLM Provider、可用 Tool 列表、Channel、Tool Policy 和定时规则。它不再是一份单独手写的 YAML——`AgentLoader.deriveProfile()` 把 `AGENT.md` 的 frontmatter 派生成 `Profile`；Skill 绑定由 Agent 本地 `skills/` 软连接集合独立表达 |
 | **Provider（供应商）** | LLM API 服务的抽象，实现统一接口让 Agent 不感知具体调的是哪家模型 |
 | **ReAct 循环** | Agent 的核心工作机制，Reason + Act。LLM 思考是否调用工具，调用后看结果，再决定下一步，直到给出最终响应 |
 | **Tool（工具）** | Agent 可以调用的外部能力。内置 Tool 是 OryxOS 自带的（文件、Shell、HTTP、通知推送）；Plugin Tool 是业务方自己写的 |
@@ -152,7 +152,7 @@ API 覆盖六类操作：
 | **Session（会话）** | 用户和 Agent 一次对话的上下文容器，包含对话历史、当前上下文、临时变量 |
 | **Sandbox（沙箱）** | 工具执行的隔离环境。核心阶段是应用层白名单校验，扩展阶段补容器级隔离 |
 | **Tool Policy（工具策略）** | 控制 Agent 可用工具的允许或拒绝规则，在 Profile 级别配置 |
-| **Skill（技能）** | 全局共享的能力库，存 `.oryxos/skills/<name>/SKILL.md`（frontmatter 加约束指令正文）。Agent 在 `AGENT.md` frontmatter 用 `skills: [名]` 按名引用，`ContextLoader` 组装 system prompt 时把引用到的 Skill 正文注入，用来强约束产出。Skill 不是可执行 Tool，不进 `ToolRegistry` |
+| **Skill（技能）** | 公共实体存 `.oryxos/skills/<name>/`，Agent 通过自身 `skills/<name>` 相对软连接选择可见集合。`ContextLoader` 每轮只注入已绑定 Skill 的 name、description 和本地读取路径；正文与附属资源经 `read_file`/`shell` 按需进入上下文。Skill 不是 Tool，不进 `ToolRegistry` |
 | **Bootstrap（引导文件）** | 加载到系统提示词中的上下文文件：AGENTS.md（项目级 agent 行为说明）、SOUL.md（agent 人格定义）、USER.md（用户偏好） |
 | **Workspace（工作区）** | OryxOS 实例的工作目录，默认是 `.oryxos/`，包含 Agent 目录、全局 Skill 库、Bootstrap 文件、记忆、会话、产出物、日志的子目录 |
 
@@ -211,8 +211,8 @@ oryxos init   # 在当前目录下创建 .oryxos/ 工作区
 
 ```
 .oryxos/
-├── agents/            # 每个子目录 = 一个 Agent（AGENT.md + 可选 skills/ scripts/ REFERENCE.md）
-├── skills/            # 全局 Skill 库（每个子目录一个 SKILL.md），Agent 按名引用
+├── agents/            # 每个子目录 = 一个 Agent（AGENT.md + skills/软连接 + scripts/ REFERENCE.md）
+├── skills/            # 公共 Skill 实体库（每个子目录一个 SKILL.md + 可选附属资源）
 ├── output/            # Agent 产出物
 ├── memory/
 │   └── MEMORY.md      # 长期记忆文件
@@ -230,7 +230,7 @@ oryxos init   # 在当前目录下创建 .oryxos/ 工作区
 
 ### 5.2 定义一个 Agent：AGENT.md
 
-一个目录 = 一个 Agent。`.oryxos/agents/<name>/AGENT.md` 由两部分组成：**frontmatter** 是这个 Agent 自己的 profile（用哪个 Provider/模型、能用哪些 Tool、引用哪些全局 Skill、绑定哪个 Channel、要不要定时），**正文**是任务指令（"这个 Agent 具体做什么"）。`AgentLoader.deriveProfile()` 把 frontmatter 派生成底座认识的 `Profile`，所以不需要另写一份 Profile YAML。
+一个目录 = 一个 Agent。`.oryxos/agents/<name>/AGENT.md` 由两部分组成：**frontmatter** 是这个 Agent 自己的 profile（用哪个 Provider/模型、能用哪些 Tool、绑定哪个 Channel、要不要定时），**正文**是任务指令。`AgentLoader.deriveProfile()` 把 frontmatter 派生成底座认识的 `Profile`。Agent 的 Skill 绑定不写进 frontmatter，而由同目录 `skills/` 下的相对软连接表达。
 
 **AGENT.md frontmatter 结构：**
 
@@ -249,9 +249,6 @@ provider:
 
 tools:
   - string                      # 可用 Tool 名称列表
-
-skills:
-  - string                      # 按名引用全局 Skill 库（.oryxos/skills/<名>/），正文注入 system prompt
 
 mcp_servers:
   - string                      # 引用的 MCP Server 列表
@@ -377,7 +374,7 @@ Tool 是 Agent 可以调用的外部能力。Agent 通过 LLM Function Calling �
 **零代码示例**：想做"每天早上推送昨日 GitHub PR 评审进度到 Slack"，只需：
 1. 建 `.oryxos/agents/daily-pr-digest/`，写一份 `AGENT.md`：frontmatter 声明 provider、`mcp_servers`、`schedules`，正文写任务指令
 2. 复用社区现成的 `github-mcp` 和 `slack-mcp`，配置在 `mcp_servers.yaml`
-3. 需要固定产出格式就在 frontmatter 用 `skills: [名]` 引用全局 Skill 库里的规范
+3. 需要固定产出格式就在 Agent 的 `skills/` 下绑定对应公共 Skill；下一轮 prompt 自动出现其名称和描述，正文按需读取
 
 整个过程不写一行代码。
 
@@ -516,7 +513,7 @@ OryxOS 作为开源项目，需要一个独立的主页作为对外门面，讲�
 - **Memory 语义检索**：集成向量数据库（Milvus、Qdrant、Weaviate、PostgreSQL pgvector），按语义相似度匹配
 - **情景记忆**：补齐 Memory 第三层，记录任务过程中修改的文件、决策、成果
 - **Memory Wiki**：结构化 claim/evidence、矛盾检测、新鲜度管理
-- **Skill 库增强**：全局 Skill 库（`.oryxos/skills/<name>/SKILL.md`，按名引用、正文注入）在核心阶段已落地；扩展阶段补语义检索选 Skill、版本管理、以及从 agentskills.io 等开放格式导入时的企业审查流程
+- **Skill 库增强**：公共 Skill 实体 + Agent 本地软连接绑定 + 元数据发现/正文按需加载在核心阶段落地；扩展阶段补语义推荐、版本管理和企业审查流程
 
 ### 6.3 工具和安全层
 
@@ -826,7 +823,7 @@ OryxOS 核心功能的实施按 **4 周节奏**组织，每周 3 小时，合计
 | Demo | 验证能力 | 场景描述 | 验收标准 |
 |------|---------|---------|---------|
 | **Demo 一：每日天气** | 能力一+二（LLM + ReAct）、能力四（内置 HTTP Tool）、定时任务（`AgentScheduler`） | 每天早上到点自动查天气、生成穿搭建议，推送到企业 IM 群 | 不需要人工触发，到点自动跑完整 ReAct 循环；查天气和推送各一次 HTTP 调用，都过 Sandbox 域名白名单且都写入 `tool_invocations`；`GET /api/v1/sessions/{id}` 能查到这次自动触发的完整对话记录 |
-| **Demo 二：每日科技日报** | 能力四（Plugin Tool 方式一 Agent 目录零代码 + 方式二 MCP）、能力三（Memory）、定时任务（`AgentScheduler`） | 每天到点自动汇总当日科技新闻并推送，且日报内容会体现用户之前说过的关注方向（比如"更关注 AI 和芯片"） | 业务方全程不写 Java 代码，只写 `AGENT.md`（含 `schedules` 字段）+ 目录内 `skills/` 子指令 + `mcp_servers.yaml`；LLM 自己决定调新闻 MCP 工具、自己组织日报、自己调推送 MCP 工具，OryxOS 不解析任务步骤；日报内容能体现 `MEMORY.md` 里记住的偏好 |
+| **Demo 二：每日科技日报** | 能力四（Plugin Tool 方式一 Agent 目录零代码 + 方式二 MCP）、能力三（Memory）、定时任务（`AgentScheduler`） | 每天到点自动汇总当日科技新闻并推送，且日报内容会体现用户之前说过的关注方向（比如"更关注 AI 和芯片"） | 业务方全程不写 Java 代码，只写 `AGENT.md`（含 `schedules` 字段）并在 Agent `skills/` 绑定公共 Skill，再配置 `mcp_servers.yaml`；prompt 只出现 Skill 元数据，模型按需读取正文并完成日报 |
 
 两个 Demo 都是"钟推"（`AgentScheduler` 到点自动触发），但都要能同时支持"人推"手动补跑一次做验证（`oryxos chat` 或 `POST /agents/{name}/invoke`），验证同一个 Agent 不管从哪个入口触发，走的都是同一条 `AgentService` 链路。
 

--- a/docs/TechnicalSolution.md
+++ b/docs/TechnicalSolution.md
@@ -256,7 +256,7 @@ Tool 是 Agent 可以调用的外部能力。OryxOS 的 Tool 分两类：**内�
 
 > **模块调整说明：** 核心阶段 Tool 相关合并为一个 `oryxos-tool` 模块（内置 Tool、MCP Client、`ToolRegistry`、Sandbox 都在里面），不拆成 builtin/skill/mcp 三个模块。原因是它们共享同一个 `OryxTool` 抽象和 `ToolRegistry`，耦合度高，核心阶段没必要拆细。
 >
-> 另外，一个 Agent 目录（`AGENT.md` 及其 `skills/` 子指令）严格说不是一种 Tool，而是上下文来源（正文注入 system prompt、子指令经 `read_file` 按需读，见 11.1），因此 `AgentLoader`/`ContextLoader` 不放在 Tool 体系里，归到上下文加载那一层（见 8.3）。这样概念更齐整。
+> 另外，一个 Agent 目录（`AGENT.md` 及其 `skills/` 绑定视图）不是 Tool，而是上下文来源：正文和已绑定 Skill 元数据进入 system prompt，Skill 正文经 `read_file` 按需读取。因此 `AgentLoader`/`ContextLoader` 归上下文层，不放进 Tool 体系。
 
 ### 6.1 OryxTool 抽象
 
@@ -291,9 +291,9 @@ OryxOS 内部统一的 Tool 抽象接口。内置 Tool、`@Tool` 注解的 Plugi
 
 OryxOS **主推**的接入方式。业务方不写代码，只写一个 Agent 目录描述要做的事，LLM 自己理解任务、自己组合调用 MCP 工具。
 
-定义一个 Agent = 写一个目录 `.oryxos/agents/<name>/`（借 Anthropic Agent Skills 的目录形态，详见第 11 章）：`AGENT.md` = frontmatter（这个 Agent 自己的 profile）加任务说明正文，外加可选的 `skills/*.md`（子指令）、`scripts/*.py`、`REFERENCE.md` 等资源。一个目录就是一个自足的 Agent，只调用底座的系统基础能力。
+定义一个 Agent = 写一个目录 `.oryxos/agents/<name>/`：`AGENT.md` = frontmatter（运行配置）加任务说明正文，外加可选的 `skills/` 公共 Skill 软连接、`scripts/*.py`、`REFERENCE.md`。一个目录就是一个自足的 Agent。
 
-加载走**一个 Agent 内部的渐进式披露**：`AGENT.md` 正文进 system prompt，正文里指向的子指令 / 脚本 / 参考经底座 `read_file`/`shell` 按需读跑。LLM 读到后自己理解任务、自己决定调哪个 MCP 工具、自己组合完成——OryxOS 不解析任务步骤、不做工作流引擎，所有逻辑交给 LLM。
+加载走三层渐进式披露：`AGENT.md` 正文常驻；当前 Agent 绑定 Skill 的 name/description/本地路径每轮注入；Skill 正文、参考与脚本经底座 `read_file`/`shell` 按需读取或运行。OryxOS 不解析任务步骤、不做工作流引擎。
 
 > 注意 `AGENT.md` 的解析由 `AgentLoader` / `ContextLoader`（8.3）负责，不在 Tool 模块里——它是 prompt 的输入源、不是可执行 Tool（见宪法原则四与 11.1）。
 
@@ -471,7 +471,8 @@ Web Service 是 OryxOS 的对外完整门面，业务系统通过 REST API 接�
 
 ```
 .oryxos/
-├── agents/            # 每个子目录 = 一个 Agent（AGENT.md + 可选 skills/ scripts/ REFERENCE.md）
+├── agents/            # 每个子目录 = 一个 Agent（AGENT.md + skills/软连接 + scripts/ REFERENCE.md）
+├── skills/            # 公共 Skill 实体库（SKILL.md + 可选附属资源）
 ├── memory/
 │   └── MEMORY.md      # 长期记忆
 ├── mcp_servers.yaml   # MCP 配置
@@ -493,9 +494,9 @@ Web Service 是 OryxOS 的对外完整门面，业务系统通过 REST API 接�
 
 ### 8.3 上下文加载（Bootstrap + AGENT.md 正文）
 
-> **调整说明：** Bootstrap 文件与 `AGENT.md` 正文都由 `ContextLoader` 全量注入 system prompt；Agent 目录里的子指令 / 脚本 / 参考不预载，由正文指引经底座 `read_file`/`shell` 按需取（一个 Agent 内部的渐进式披露，详见 11.1）。
+> **调整说明：** Bootstrap 与 `AGENT.md` 正文全量注入；Agent `skills/` 绑定的公共 Skill 每轮只注入 name/description/本地路径，正文与附属资源不预载，经 `read_file`/`shell` 按需取。
 
-**`ContextLoader` 模块。** 按 Profile 的 `bootstrap` 字段从 `.oryxos/` 读取 `AGENTS.md`、`SOUL.md`、`USER.md`（Bootstrap，全量注入）；同时把这个 Agent 自己 `AGENT.md` 的**正文**（任务指令）一并交给 `PromptBuilder`。每次组装 prompt 时重新加载不缓存，用户修改后立即生效。目录里的子指令 / 脚本 / 参考不在这里注入，由模型经 `read_file`/`shell` 在需要时现取——把 `AGENT.md` 归到上下文这一层而不是 Tool 模块，是因为它是 prompt 的输入、不是可执行的 Tool。
+**`ContextLoader` 模块。** 按 Profile 的 `bootstrap` 字段读取 Bootstrap，同时现读 Agent 自己 `AGENT.md` 正文；每次组装 prompt 时重新扫描 Agent `skills/` 的相对软连接，验证真实目标位于公共 Skill 根，只注入 Skill frontmatter 的 name/description 与 Agent 本地绝对读取路径。Skill 正文、脚本和参考不在这里预载，由模型经 `read_file`/`shell` 现取。全部无缓存，修改或重新绑定后下一轮立即生效。
 
 ### 8.4 Channel 接入
 
@@ -680,15 +681,15 @@ mvn clean package
 **底座 / Agent 两层，分清楚。** 这是这一章最关键的一条：
 
 - **底座 = 系统基础能力**：Provider、ReAct、内置 Tool（`read_file`/`shell`/`http_get`/`notify`/`save_memory`…）、Memory、Sandbox、定时、Web（第 1~10 章）。所有 Agent 共享。
-- **Agent = 一个目录** `.oryxos/agents/<name>/`：`AGENT.md`（frontmatter = 这个 Agent 自己的 profile：`name`/`description`/`provider`/`model`/`tools`/`notify_channels`/`schedules`；正文 = 任务指令）+ 可选 `skills/*.md`（子指令）、`scripts/`（脚本）、`REFERENCE.md`（参考）。一个自足的业务 Agent，**自带一切、不再另写 Profile YAML**（`.oryxos/profiles/` 取消）。
+- **Agent = 一个目录** `.oryxos/agents/<name>/`：`AGENT.md`（frontmatter = profile；正文 = 任务指令）+ 可选 `skills/` 公共 Skill 软连接、`scripts/`、`REFERENCE.md`。Agent 目录决定全部运行配置和可见资源。
 
 **借 Anthropic Agent Skills 的形态、但定义的是 Agent。** Anthropic 把这种目录叫一个 Skill（Claude 这个大 Agent 的一项可加载能力）；我们借的是目录的**形态**，不是命名——在 OryxOS，**一个目录 = 一个 Agent**。每个 Agent 独立自足，只调用底座的系统基础能力。
 
-> **修订（v1.2.0，第 32 节）：Skill 升级为全局共享能力库。** 上一段"skill 只是 Agent 目录里的子指令、不做跨 Agent 的共享能力库、没有 `use_skill`、没有全局索引"**已废止**。现在 Skill 是全局的：存 `.oryxos/skills/<name>/SKILL.md`，由 `SkillService`/`SkillStore`/`SkillRegistry`（`oryxos-core`，与 Agent 那套同构）做 CRUD，`/api/v1/skills` 暴露。Agent 在 `AGENT.md` frontmatter 用 `skills: [名]` 按名引用，`ContextLoader` 组装 system prompt 时把引用到的 Skill 正文**注入**来强约束产出。边界不变：Skill 不是可执行 Tool、不进 `ToolRegistry`，加载/注入归 `oryxos-core` 的 `ContextLoader`。详见 `CLAUDE.md` 原则四修订。
+> **宪章 v2.0.0 修订：公共实体与 Agent 绑定分离。** Skill 内容存 `.oryxos/skills/<name>/`；Agent 通过自身 `skills/<name>` 下的受控相对软连接选择可见集合。软连接集合是唯一绑定真相源，不再使用 frontmatter `skills:`。公共 CRUD 保留，但删除被引用 Skill 默认拒绝并返回引用 Agent。
 
 **派生 Profile**：底座（第 1~10 章的一切）都吃 `Profile`，所以 `AgentLoader.deriveProfile(agentDir)` 把 `AGENT.md` 的 frontmatter 映射成一个 `Profile`，让 Agent 目录**零改动复用整台底座**。
 
-**渐进式披露（收进一个 Agent 内部）**：Agent 的**正文**在被触发时进 system prompt（它就是这个 Agent 的"人格 + 干什么"）；目录里的**子指令 / 参考 / 脚本不预载**，按正文指引**用底座既有能力按需取**——读子指令 / 参考用 `read_file`，跑脚本用 `shell`/`python`（脚本产出进上下文、代码不进）。没有新工具、没有能力库、没有全局索引。
+**渐进式披露**：L1 每轮注入当前 Agent 已绑定 Skill 的 name、description 和本地绝对路径；L2 模型命中后 `read_file` 读取 `SKILL.md` 正文；L3 再按正文引用读取 references/模板或运行脚本。未绑定 Skill 不进入 Agent prompt；不新增 `use_skill`，Skill 不进 `ToolRegistry`。
 
 > **底线不变（宪法原则四）**：`AGENT.md` 正文由 `ContextLoader` 注入 system prompt（与 Bootstrap 文件同层）；**一个 Agent 目录不是一个可执行 Tool**——它的子资源经底座既有的 `read_file`/`shell` 取用，不新造机制。
 
@@ -696,9 +697,9 @@ mvn clean package
 
 核心阶段走文件系统，一步到位：
 
-1. 在 `.oryxos/agents/<name>/` 放一个目录：至少一份 `AGENT.md`，需要子指令 / 脚本就加 `skills/*.md`、`scripts/`。
+1. 在 `.oryxos/agents/<name>/` 放一个目录：至少一份 `AGENT.md`；需要 Skill 就在 `skills/` 创建指向公共实体的相对软连接，需要脚本则放 `scripts/`。
 2. 启动时 `AgentLoader` 扫 `.oryxos/agents/`，对每个目录 `deriveProfile` → `ProfileRegistry.register`；有 `schedules` 的交 `AgentScheduler`。
-3. 运行时：Agent 到点被触发，正文进 system prompt，子指令 / 参考 / 脚本按需经 `read_file`/`shell` 取用；`ContextLoader` / `read_file` 每次现取、不缓存，改正文即时生效。
+3. 运行时：正文与已绑定 Skill 元数据进 system prompt，Skill 正文/参考/脚本按需经 `read_file`/`shell` 取用；`ContextLoader` 每次现扫、不缓存。
 
 配合运行时注册（11.3 的改造点在核心阶段就立好），新增 Agent 无需重启。
 
@@ -725,7 +726,7 @@ mvn clean package
 
 ### 11.5 三个例子
 
-下一章（12.1~12.3）的三个 Demo——每日天气、每日科技日报、每日 GitHub 日报——各演一种 **Agent 目录丰富度**：**天气 Agent 是光杆 `AGENT.md`**（正文写指令，用内置 HTTP Tool + `schedules`）；**科技日报 Agent 是 `AGENT.md` + `skills/` 子指令**（组稿规范单独一份，Agent 用 `read_file` 按需读，配 MCP / Memory）；**GitHub 日报 Agent 是 `AGENT.md` + `scripts/` 脚本**（含 `scripts/github_trending.py`，Agent 用 `shell` 跑脚本拿确定性数据）。核心阶段先靠 11.2 的手动路径跑通，扩展阶段升级到 11.3 的统一 API 后，不用重启进程就能上新 Agent。
+下一章（12.1~12.3）的三个 Demo 各演一种 Agent 目录丰富度：天气 Agent 是光杆 `AGENT.md`；科技日报 Agent 绑定公共组稿 Skill，prompt 只注入元数据、正文按需读取；GitHub 日报 Agent 带 `scripts/` 脚本。
 
 ---
 
@@ -733,7 +734,7 @@ mvn clean package
 
 ## 12. 关键流程
 
-早期按"一个 Demo 验证一个能力"拆过五个流程，但真实场景里能力从来不是分开跑的。改成三个**每日自动运行**的端到端流程，横向串起全部五大核心能力加定时任务这个第三触发源——而且它们正好是第 11 章"一个目录 = 一个 Agent"的具体产出，把一个 Agent 目录的三种丰富度各演到一个：天气 = 光杆 `AGENT.md`、科技日报 = `AGENT.md` + `skills/` 子指令、GitHub 日报 = `AGENT.md` + `scripts/` 脚本。底座和"定义 Agent"两部分在这里合到一起跑通。
+早期按"一个 Demo 验证一个能力"拆过五个流程，现改成三个每日自动运行的端到端流程：天气 = 光杆 `AGENT.md`、科技日报 = `AGENT.md` + 公共 Skill 软连接、GitHub 日报 = `AGENT.md` + `scripts/`。
 
 ### 12.1 Demo 一：每日天气（光杆 AGENT.md）
 
@@ -751,18 +752,18 @@ mvn clean package
 
 涉及能力一（Provider）+ 能力二（ReAct）+ 能力四（内置 HTTP Tool + `NotifyTools` + Sandbox）+ 定时任务（`AgentScheduler`）+ 能力五（Session 查询兜底）。
 
-### 12.2 Demo 二：每日科技日报（AGENT.md + skills/ 子指令）
+### 12.2 Demo 二：每日科技日报（AGENT.md + 公共 Skill 绑定）
 
 **场景：** 每天早上 9 点，Agent 自动汇总当日科技新闻并推送，日报内容会体现用户之前提过的关注方向。业务方全程不写 Java 代码。
 
-1. 业务方**写一个 Agent 目录** `.oryxos/agents/daily-tech-digest/`：`AGENT.md`（frontmatter：`identity` + `tools`（含 `http_get`、`read_file`、`notify`）+ 每天 09:00 的 `schedules` + `notify_channels`；正文写"编日报、组稿规范去读 `skills/digest-format.md`"）+ `skills/digest-format.md`（较长的组稿排版规范）；需要新闻聚合 MCP 就在 `mcp_servers.yaml` 配一条
+1. 业务方创建 `.oryxos/agents/daily-tech-digest/AGENT.md`，并把 `skills/digest-format` 绑定为指向 `.oryxos/skills/digest-format/` 的相对软连接；需要新闻聚合 MCP 就在 `mcp_servers.yaml` 配一条
 2. 用户此前说过"更关注 AI 和芯片方向"，DeepSeek 调 `save_memory` 写入 `MEMORY.md` 归档区
-3. 到点，`AgentScheduler` 触发 `AgentService.process`，`PromptBuilder` 往 system prompt 注入 `AGENT.md` 正文 + `MEMORY.md`——组稿规范那段较长的子指令**不预载**
-4. LLM 按正文指引，调 **`read_file("skills/digest-format.md")`** 取回组稿规范作为工具结果进上下文——子指令只在此刻才占上下文（一个 Agent 内部的渐进式披露，用底座既有 `read_file`）
+3. 到点后 system prompt 注入 `AGENT.md` 正文、记忆，以及 digest-format 的 name/description/本地绝对路径；组稿规范正文不预载
+4. LLM 根据描述命中该 Skill，调用 `read_file("<agent绝对路径>/skills/digest-format/SKILL.md")`，正文此时才作为工具结果进入上下文
 5. LLM 按规范调新闻工具（`http_get` 或新闻 MCP，`McpToolAdapter` 转发）拉当日科技新闻；因为看到记忆里的偏好，组稿时自然侧重 AI 和芯片方向——OryxOS 不解析任务步骤
 6. LLM 调内置 `notify(content="...")` 推送，`ToolExecutor` 写 `tool_invocations`
 
-**验收要点：** 业务方只写一个 Agent 目录（两份 markdown），零 Java；`tool_invocations` 里有 `read_file("skills/digest-format.md")`（子指令按需加载生效）；`GET /api/v1/agents` 查得到 `daily-tech-digest`；日报体现记忆偏好；同一个 Agent 可被人工触发验证。
+**验收要点：** prompt 只有 Skill 元数据、没有正文；`tool_invocations` 有对 Agent 本地软连接路径的 `read_file`；未绑定 Skill 不可见；日报体现记忆偏好。
 
 涉及 Agent 目录子指令（`read_file` 按需读）+ 能力四方式二（MCP）+ 内置 `NotifyTools` + 能力三（Memory）+ 定时任务。
 

--- a/oryxos-boot/src/test/java/io/oryxos/boot/MockProviderFlowTest.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/MockProviderFlowTest.java
@@ -94,7 +94,10 @@ class MockProviderFlowTest {
 
     PromptBuilder promptBuilder =
         new PromptBuilder(
-            new ContextLoader(root, new io.oryxos.core.skill.SkillRegistry()),
+            new ContextLoader(
+                root,
+                new io.oryxos.core.skill.AgentSkillBindingService(
+                    root, new io.oryxos.core.skill.SkillLoader(root.resolve("skills")))),
             tools,
             memory,
             Clock.systemDefaultZone());

--- a/oryxos-cli/pom.xml
+++ b/oryxos-cli/pom.xml
@@ -60,6 +60,11 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -26,6 +26,11 @@ import io.oryxos.core.provider.ProviderService;
 import io.oryxos.core.sandbox.SandboxWhitelist.Category;
 import io.oryxos.core.sandbox.SandboxWhitelistStore;
 import io.oryxos.core.session.SessionManager;
+import io.oryxos.core.skill.AgentSkillBindingService;
+import io.oryxos.core.skill.AgentSkillMigrationService;
+import io.oryxos.core.skill.AgentSkillStartupReport;
+import io.oryxos.core.skill.InstalledSkillCatalog;
+import io.oryxos.core.skill.SkillCatalog;
 import io.oryxos.core.skill.SkillLoader;
 import io.oryxos.core.skill.SkillRegistry;
 import io.oryxos.core.skill.SkillService;
@@ -190,7 +195,8 @@ public class OryxOsRuntime {
   }
 
   @Bean
-  ProfileRegistry profileRegistry(AgentLoader agentLoader) {
+  ProfileRegistry profileRegistry(
+      AgentLoader agentLoader, AgentSkillStartupReport ignoredSkillStartupReport) {
     // 启动全量扫；30 节 WorkspaceWatcher 负责启动后的实时变更（同一段 register）
     return agentLoader.loadAll();
   }
@@ -213,6 +219,8 @@ public class OryxOsRuntime {
       NotifyChannelRegistry notifyChannelRegistry,
       io.oryxos.core.mcp.McpServerAdmin mcpServerAdmin,
       SkillRegistry skillRegistry,
+      AgentSkillBindingService skillBindings,
+      SkillCatalog skillCatalog,
       @Value("${oryxos.author.provider:}") String authorProvider,
       @Value("${oryxos.author.model:}") String authorModel) {
     String defaultProvider =
@@ -234,7 +242,9 @@ public class OryxOsRuntime {
         tools,
         notifyChannelRegistry,
         mcpServerAdmin,
-        skillRegistry);
+        skillRegistry,
+        skillBindings,
+        skillCatalog);
   }
 
   /** 30 节 WorkspaceWatcher 专用守护线程执行器（跟 25 节调度线程池同类，不手工 new Thread）。 */
@@ -258,9 +268,8 @@ public class OryxOsRuntime {
   }
 
   @Bean
-  ContextLoader contextLoader(SkillRegistry skillRegistry) {
-    // 32 节：Agent 引用的全局 Skill 由 ContextLoader 按名从注册表解析并注入 system prompt（约束产出）
-    return new ContextLoader(oryxosRoot(), skillRegistry);
+  ContextLoader contextLoader(AgentSkillBindingService skillBindings) {
+    return new ContextLoader(oryxosRoot(), skillBindings);
   }
 
   @Bean
@@ -279,13 +288,32 @@ public class OryxOsRuntime {
     return skillLoader.loadAll();
   }
 
+  @Bean
+  AgentSkillBindingService agentSkillBindingService(SkillLoader skillLoader) {
+    return new AgentSkillBindingService(oryxosRoot(), skillLoader);
+  }
+
+  @Bean
+  SkillCatalog skillCatalog(SkillRegistry skillRegistry) {
+    return new InstalledSkillCatalog(skillRegistry);
+  }
+
   /** 32 节：全局 Skill 库 CRUD；启动播种内置 Skill（report-format，幂等——用户改过不覆盖）。 */
   @Bean
   SkillService skillService(
-      SkillStore skillStore, SkillRegistry skillRegistry, SkillLoader skillLoader) {
-    SkillService service = new SkillService(skillStore, skillRegistry, skillLoader);
+      SkillStore skillStore,
+      SkillRegistry skillRegistry,
+      SkillLoader skillLoader,
+      AgentSkillBindingService skillBindings) {
+    SkillService service = new SkillService(skillStore, skillRegistry, skillLoader, skillBindings);
     service.seedBuiltins();
     return service;
+  }
+
+  @Bean
+  AgentSkillStartupReport agentSkillStartupReport(
+      SkillService ignoredSeededSkills, AgentSkillBindingService skillBindings) {
+    return new AgentSkillMigrationService(oryxosRoot(), skillBindings).migrateAll();
   }
 
   /** 31 节：Sandbox 白名单持久化（SQLite）。运行时增删写穿落库、重启保留。 */
@@ -503,8 +531,8 @@ public class OryxOsRuntime {
   }
 
   /** 32 节：异步触发的后台执行器——虚拟线程（宪法 VII：虚拟线程处理并发，非 Reactor/WebFlux）。 */
-  @SuppressWarnings("PMD.ThreadPoolCreationRule")
   @Bean(destroyMethod = "shutdown")
+  @SuppressWarnings("PMD.ThreadPoolCreationRule") // Spring 管理完整生命周期；Java 21 虚拟线程无池参数可配置。
   ExecutorService agentExecutionExecutor() {
     return Executors.newVirtualThreadPerTaskExecutor();
   }

--- a/oryxos-cli/src/test/java/io/oryxos/cli/AgentSkillStartupOrderTest.java
+++ b/oryxos-cli/src/test/java/io/oryxos/cli/AgentSkillStartupOrderTest.java
@@ -1,0 +1,59 @@
+package io.oryxos.cli;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.oryxos.core.agent.AgentLoader;
+import io.oryxos.core.profile.ProfileRegistry;
+import io.oryxos.core.skill.AgentSkillBindingService;
+import io.oryxos.core.skill.AgentSkillStartupReport;
+import io.oryxos.core.skill.SkillLoader;
+import io.oryxos.core.skill.SkillRegistry;
+import io.oryxos.core.skill.SkillService;
+import io.oryxos.core.skill.SkillStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class AgentSkillStartupOrderTest {
+
+  @TempDir Path root;
+
+  @Test
+  void builtinsSeedBeforeMigrationAndMigrationFinishesBeforeProfiles() throws Exception {
+    legacyAgent("good", "report-format");
+    legacyAgent("bad", "missing");
+    OryxOsRuntime runtime = new OryxOsRuntime();
+    ReflectionTestUtils.setField(runtime, "oryxosRootProp", root.toString());
+
+    SkillStore store = runtime.skillStore();
+    SkillLoader skillLoader = runtime.skillLoader();
+    SkillRegistry skillRegistry = runtime.skillRegistry(skillLoader);
+    AgentSkillBindingService bindings = runtime.agentSkillBindingService(skillLoader);
+    SkillService seeded = runtime.skillService(store, skillRegistry, skillLoader, bindings);
+    AgentSkillStartupReport report = runtime.agentSkillStartupReport(seeded, bindings);
+    AgentLoader agents = new AgentLoader(root.resolve("agents"), Set.of("mock"));
+    ProfileRegistry profiles = runtime.profileRegistry(agents, report);
+
+    assertTrue(Files.isRegularFile(root.resolve("skills/report-format/SKILL.md")));
+    assertTrue(Files.isSymbolicLink(root.resolve("agents/good/skills/report-format")));
+    assertFalse(Files.readString(root.resolve("agents/good/AGENT.md")).contains("skills:"));
+    assertTrue(Files.readString(root.resolve("agents/bad/AGENT.md")).contains("skills:"));
+    assertTrue(profiles.exists("good"));
+    assertTrue(profiles.exists("bad"), "单 Agent 迁移失败不阻断其它 Profile 启动");
+  }
+
+  private void legacyAgent(String name, String skill) throws Exception {
+    Path directory = Files.createDirectories(root.resolve("agents").resolve(name));
+    Files.writeString(
+        directory.resolve("AGENT.md"),
+        "---\nname: "
+            + name
+            + "\nprovider:\n  name: mock\n  model: mock\nskills:\n  - "
+            + skill
+            + "\n---\nbody");
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
@@ -8,18 +8,22 @@ import io.oryxos.core.profile.Profile;
 import io.oryxos.core.profile.ProfileRegistry;
 import io.oryxos.core.provider.ProviderRequest;
 import io.oryxos.core.provider.ProviderService;
-import io.oryxos.core.skill.Skill;
+import io.oryxos.core.skill.AgentSkillBindingService;
+import io.oryxos.core.skill.BoundSkillDescriptor;
+import io.oryxos.core.skill.InstalledSkillCatalog;
+import io.oryxos.core.skill.SkillCatalog;
+import io.oryxos.core.skill.SkillCatalogEntry;
 import io.oryxos.core.skill.SkillRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.DumperOptions.FlowStyle;
@@ -29,14 +33,16 @@ import org.yaml.snakeyaml.Yaml;
  * Agent 生命周期编排（第 30 节）：三条录入（API create / WorkspaceWatcher 事件 / 启动扫描）都汇到同一段 {@link
  * #register(Path)}；创建脚手架、创建回滚、删除时序（注销定时 → 移索引 → 归档）都在这里串起来。
  *
- * <p>创建只需 name + description，后台按模板脚手架出**完整目录**（AGENT.md + scripts/ + skills/ +
- * REFERENCE.md，内容为模板），再注册。本类不产生 HTTP 语义：{@link #get} 返回 {@link Optional}，404 由 web 层决定（core 不反向依赖
- * web）；定义非法统一抛 {@code ProfileValidationException}（web 映射 400）。
+ * <p>创建只需 name + description，后台按模板脚手架出 Agent 自有文件；共享 Skill 仅通过 {@code skills/<name>} 软连接绑定。本类不产生
+ * HTTP 语义：{@link #get} 返回 {@link Optional}，404 由 web 层决定（core 不反向依赖 web）；定义非法统一抛 {@code
+ * ProfileValidationException}（web 映射 400）。
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",
     justification = "协作者均为 Spring 注入的共享单例，构造注入共享同一引用正是意图（无法也不应防御性拷贝）。")
 public class AgentLifecycleService {
+
+  private static final String PARENT_PATH_SEGMENT = "..";
 
   private static final String AGENT_MD_TEMPLATE =
       """
@@ -61,7 +67,7 @@ public class AgentLifecycleService {
       ---
 
       在这里写这个 Agent 的任务指令（正文）。被触发时它会照做。
-      - 较长的规范 / 清单放 skills/，正文指到时用 read_file 按需读；
+      - 已绑定 Skill 的 name、description 与本地 SKILL.md 入口会自动列入提示；需要时再用 read_file 按需读正文；
       - 参考资料放 REFERENCE.md，拿不准时用 read_file 读；
       - 脚本放 scripts/，正文让 shell/python 跑，产出进上下文、代码不进；
       - 任务产出的文件（研报 / 汇总 / 导出）用 write_file 写到本 Agent 的 output/ 目录，便于在管理台查看与下载。
@@ -75,12 +81,6 @@ public class AgentLifecycleService {
       import sys
 
       json.dump({"hello": "world"}, sys.stdout, ensure_ascii=False)
-      """;
-
-  private static final String SKILL_TEMPLATE =
-      """
-      # 示例子指令
-      把较长的规范 / 清单 / 格式要求放这里。Agent 正文指到时，用底座的 read_file 把它读进上下文——平时不占常驻 prompt。
       """;
 
   private static final String REFERENCE_TEMPLATE =
@@ -117,11 +117,11 @@ public class AgentLifecycleService {
       6. MCP：如果任务需要用到下面【可用 MCP Server】里"已连接"的某个 server 提供的能力，把该 server 名加进 frontmatter 的 \
       mcp_servers 列表，**并且**把它提供的具体工具名也加进 tools 列表（两者都要写，只写一个不生效）；未连接 / 清单外的 server \
       不要选、不要编造。没有需要就不加 mcp_servers 字段。
-      7. Skill（用全局能力库约束产出）：下面【可用 Skill】里每个 Skill 是一段约束产出质量/格式的规范。若需求命中某个 Skill 覆盖的场景\
-      （如"产出报告/研报/日报"就用 report-format），把该 Skill 名加进 frontmatter 的 skills 列表（可多个）——这些 Skill 正文会在\
-      运行时注入 system prompt 来强约束 Agent 的产出。没有合适的就不加 skills 字段；**绝不编造清单以外的 Skill 名**。{required_skills}
-      8. 你可以按需**额外产出文件**——脚本放 scripts/<名>、参考资料放 REFERENCE.md。要不要、要几个由你按需求决定；\
-      例如需要抓 GitHub 榜单，就写一个 scripts/xxx.py 并在 AGENT.md 正文里用 shell 调它。（约束产出的规范优先用全局 Skill，不必再写 skills/ 子文件。）
+      7. Skill（用共享能力库约束产出）：下面【可用 Skill】只提供候选元数据。若需求命中某个 Skill 覆盖的场景，允许在本次生成的\
+      AGENT.md frontmatter 暂时输出 skills 列表作为**生成建议 sidecar**；后端会立即移除该字段，最终 AGENT.md 绝不保存 skills。\
+      Skill 正文不会预载，运行时只展示绑定 Skill 的元数据和本地入口，再由 Agent 用 read_file 按需读取。**绝不编造清单外名称**。{required_skills}
+      8. 你可以按需**额外产出 Agent 自有文件**——脚本放 scripts/<名>、参考资料放 REFERENCE.md。绝不产出 skills/**；\
+      例如需要抓 GitHub 榜单，就写一个 scripts/xxx.py 并在 AGENT.md 正文里用 shell 调它。
       9. 输出格式：多个文件时，每个文件前**单独一行**写分隔符 `===FILE: <相对路径>===`（第一个必须是 AGENT.md）；\
       若只需要 AGENT.md 可不用分隔符直接输出它。不要用 Markdown 代码围栏（```）包整个输出，也不要任何额外解释。
 
@@ -131,7 +131,7 @@ public class AgentLifecycleService {
       【可用 MCP Server】（mcp_servers 只能从这里选"已连接"的，禁止编造）
       {mcp_servers}
 
-      【可用 Skill】（skills 只能从这里选，禁止编造）
+      【可用 Skill】（仅用于生成建议 sidecar，禁止编造）
       {skills}
 
       【正确示例（仅示范字段与工具用法，name/provider 以上面规则为准）】
@@ -191,8 +191,10 @@ public class AgentLifecycleService {
   private final NotifyChannelRegistry notifyChannels;
   // 31 节：生成时把已连接 MCP server 目录喂给作者模型，让它自己判断要不要挂、挂哪个（可空——旧调用方不带这个能力）
   private final McpServerAdmin mcpServerAdmin;
-  // 32 节：生成时把全局 Skill 库目录喂给作者模型，让它按需把 Skill 加进 frontmatter 的 skills（可空——旧调用方不带）
+  // 32 节：生成时把 catalog 元数据喂给作者模型，模型的临时 skills 建议会转成 sidecar 后从 AGENT.md 删除。
   private final SkillRegistry skillRegistry;
+  private final AgentSkillBindingService skillBindings;
+  private final SkillCatalog skillCatalog;
 
   public AgentLifecycleService(
       AgentLoader agentLoader,
@@ -261,6 +263,38 @@ public class AgentLifecycleService {
       NotifyChannelRegistry notifyChannels,
       McpServerAdmin mcpServerAdmin,
       SkillRegistry skillRegistry) {
+    this(
+        agentLoader,
+        profileRegistry,
+        agentScheduler,
+        agentStore,
+        providerService,
+        defaultProvider,
+        authorProvider,
+        authorModel,
+        tools,
+        notifyChannels,
+        mcpServerAdmin,
+        skillRegistry,
+        null,
+        skillRegistry == null ? null : new InstalledSkillCatalog(skillRegistry));
+  }
+
+  public AgentLifecycleService(
+      AgentLoader agentLoader,
+      ProfileRegistry profileRegistry,
+      AgentScheduler agentScheduler,
+      AgentStore agentStore,
+      ProviderService providerService,
+      String defaultProvider,
+      String authorProvider,
+      String authorModel,
+      Map<String, OryxTool> tools,
+      NotifyChannelRegistry notifyChannels,
+      McpServerAdmin mcpServerAdmin,
+      SkillRegistry skillRegistry,
+      AgentSkillBindingService skillBindings,
+      SkillCatalog skillCatalog) {
     this.agentLoader = agentLoader;
     this.profileRegistry = profileRegistry;
     this.agentScheduler = agentScheduler;
@@ -273,14 +307,15 @@ public class AgentLifecycleService {
     this.notifyChannels = notifyChannels;
     this.mcpServerAdmin = mcpServerAdmin;
     this.skillRegistry = skillRegistry;
+    this.skillBindings = skillBindings;
+    this.skillCatalog = skillCatalog;
   }
 
   /**
-   * 创建：只需 name + description，后台按模板脚手架出完整目录（AGENT.md + scripts/ + skills/ + REFERENCE.md）→ 派生注册。name
-   * 冲突第一步就拒；中途失败回滚已写目录，不留半个 Agent。
+   * 创建：只需 name + description，后台按模板脚手架出 Agent 自有文件并单独提交 Skill 绑定。name 冲突第一步就拒；中途失败回滚已写目录，不留半个 Agent。
    */
   public Profile create(String name, String description) {
-    return create(name, description, null, null);
+    return create(name, description, null, null, List.of());
   }
 
   /**
@@ -288,6 +323,20 @@ public class AgentLifecycleService {
    * provider/model 为空则回退默认 provider（oryxos.agent.default-provider）与占位模型名。
    */
   public Profile create(String name, String description, String provider, String model) {
+    return create(name, description, provider, model, List.of());
+  }
+
+  public Profile create(String name, String description, List<String> initialSkills) {
+    return create(name, description, null, null, initialSkills);
+  }
+
+  /** 创建 Agent 并原子写入其初始 Skill 绑定。 */
+  public Profile create(
+      String name,
+      String description,
+      String provider,
+      String model,
+      List<String> initialSkills) {
     if (profileRegistry.exists(name)) {
       throw new IllegalArgumentException("Agent 已存在: " + name);
     }
@@ -298,9 +347,20 @@ public class AgentLifecycleService {
     String resolvedModel = (model == null || model.isBlank()) ? "请在此填写模型名" : model;
     Path agentDir =
         agentStore.writeAll(name, scaffold(name, description, resolvedProvider, resolvedModel));
+    Profile profile = null;
     try {
-      return register(agentDir);
+      profile = register(agentDir);
+      if (skillBindings != null) {
+        skillBindings.replaceBindings(name, validateBindable(initialSkills));
+      } else if (initialSkills != null && !initialSkills.isEmpty()) {
+        throw new IllegalStateException("Agent Skill 绑定服务未装配");
+      }
+      return profile;
     } catch (RuntimeException e) {
+      if (profile != null) {
+        agentScheduler.unregisterProfile(profile);
+      }
+      profileRegistry.remove(name);
       agentStore.delete(agentDir); // 回滚：把已写的目录删回去
       throw e;
     }
@@ -318,7 +378,6 @@ public class AgentLifecycleService {
             .replace("{provider}", provider)
             .replace("{model}", model));
     files.put("scripts/example.py", SCRIPT_TEMPLATE);
-    files.put("skills/example.md", SKILL_TEMPLATE);
     files.put("REFERENCE.md", REFERENCE_TEMPLATE);
     files.put("output/README.md", OUTPUT_README_TEMPLATE); // 建出产出目录（writeAll 建不了空目录，用占位说明落地）
     return files;
@@ -336,6 +395,9 @@ public class AgentLifecycleService {
     if (!profile.schedules().isEmpty()) {
       agentScheduler.registerProfile(profile);
     }
+    if (skillBindings != null) {
+      skillBindings.logCurrentIssues();
+    }
     return profile;
   }
 
@@ -349,32 +411,17 @@ public class AgentLifecycleService {
 
   /** 更新：覆写 AGENT.md；先注销旧定时、再注册新的（旧 cron 不会跟新 cron 一起跑）。 */
   public Profile update(String name, String agentMarkdown) {
-    Profile old = profileRegistry.get(name).orElse(null);
-    Path agentDir = agentStore.write(name, agentMarkdown);
-    Profile updated;
-    try {
-      updated = agentLoader.deriveProfile(agentDir);
-    } catch (IOException e) {
-      throw new UncheckedIOException("读取 Agent 目录失败: " + agentDir.getFileName(), e);
-    }
-    if (old != null) {
-      agentScheduler.unregisterProfile(old);
-    }
-    profileRegistry.register(updated);
-    if (!updated.schedules().isEmpty()) {
-      agentScheduler.registerProfile(updated);
-    }
-    return updated;
+    return saveFiles(name, Map.of("AGENT.md", agentMarkdown), null);
   }
 
   /**
-   * 编辑基本信息：只改 AGENT.md frontmatter 里的若干 key（description / provider.name / provider.model /
-   * skills），正文与未提及的 frontmatter 字段原样保留（不丢指令、不丢定时/工具等配置）。 传 null 的字段保持原值；description 清空→置空；
+   * 编辑基本信息：只改 AGENT.md frontmatter 里的若干 key（description / provider.name / provider.model），正文与未提及的
+   * frontmatter 字段原样保留（不丢指令、不丢定时/工具等配置）。 Skill 绑定另由 {@link AgentSkillBindingService} 管理，绝不写回 AGENT.md。
+   * 传 null 的字段保持原值；description 清空→置空；
    * provider.model 为空则沿用原值（model 为必填，不允许清空）。 先合成新 markdown 并用 {@link AgentLoader#parse} 预校验（非法→抛
    * ProfileValidationException，且不落盘、不破坏原文件），通过再走 {@link #update} 重写+重注册。
    */
-  public Profile updateBasicInfo(
-      String name, String description, String provider, String model, List<String> skills) {
+  public Profile updateBasicInfo(String name, String description, String provider, String model) {
     String raw = agentStore.read(name);
     AgentMarkdown.Parsed parsed = AgentMarkdown.split(raw);
     // frontmatter 来自 snakeyaml 解析，本身是 LinkedHashMap（保序）；复制进可变 Map 再改，避免改动原始不可变 Map
@@ -408,9 +455,6 @@ public class AgentLifecycleService {
       pm.put("model", model.strip());
       fm.put("provider", pm);
     }
-    if (skills != null) {
-      fm.put("skills", new ArrayList<>(skills));
-    }
     String newMarkdown = assembleMarkdown(fm, parsed.body());
     agentLoader.parse(newMarkdown, name); // 预校验：非法定义直接抛，不破坏原文件
     return update(name, newMarkdown);
@@ -435,12 +479,12 @@ public class AgentLifecycleService {
   }
 
   /**
-   * 同上，但允许用户在前端**显式指定必须启用的 Skill**（{@code requiredSkills}）：这些 Skill 会作为硬指令写进作者提示词，让生成的 AGENT.md 的
-   * skills 列表务必包含它们。传空列表则完全由作者模型按需自选。指定了不存在的 Skill → 400。
+   * 同上，但允许用户显式指定必须启用的 Skill。作者建议与必选项只存在于返回 sidecar，最终 AGENT.md 不保留旧版顶层 {@code
+   * skills}。传空列表则完全由作者模型按需建议。指定了不可绑定 Skill → 400。
    */
   public Map<String, String> generateFiles(
       String name, String description, String notifyChannel, List<String> requiredSkills) {
-    return generateFiles(name, description, notifyChannel, requiredSkills, null, null);
+    return generateDraft(name, description, notifyChannel, requiredSkills).files();
   }
 
   /**
@@ -448,6 +492,22 @@ public class AgentLifecycleService {
    * 让「用大模型生成」也尊重用户在新建页挑的模型。provider/model 为空则沿用原有逻辑（已存在 Agent 用其 provider，否则用作者 provider）。
    */
   public Map<String, String> generateFiles(
+      String name,
+      String description,
+      String notifyChannel,
+      List<String> requiredSkills,
+      String provider,
+      String model) {
+    return generateDraft(name, description, notifyChannel, requiredSkills, provider, model).files();
+  }
+
+  public GeneratedAgentDraft generateDraft(
+      String name, String description, String notifyChannel, List<String> requiredSkills) {
+    return generateDraft(name, description, notifyChannel, requiredSkills, null, null);
+  }
+
+  /** 生成草稿，并在指定时保留用户明确选择的 provider/model。 */
+  public GeneratedAgentDraft generateDraft(
       String name,
       String description,
       String notifyChannel,
@@ -468,10 +528,13 @@ public class AgentLifecycleService {
       throw new IllegalArgumentException("通知渠道不存在: " + channel);
     }
     // 用户显式指定的 Skill（"启用哪个 Skill"也是人的决定）：校验确实存在于全局库
-    List<String> required = requiredSkills == null ? List.of() : requiredSkills;
-    for (String s : required) {
-      if (skillRegistry == null || !skillRegistry.exists(s)) {
-        throw new IllegalArgumentException("Skill 不存在: " + s);
+    List<SkillCatalogEntry> candidates = availableCatalogCandidates();
+    Set<String> candidateNames =
+        candidates.stream().map(SkillCatalogEntry::name).collect(Collectors.toSet());
+    List<String> required = normalizedSkills(requiredSkills);
+    for (String skill : required) {
+      if (!candidateNames.contains(skill)) {
+        throw new IllegalArgumentException("Skill 不在可访问且已安装的 catalog 中: " + skill);
       }
     }
     // provider/model：用户在前端挑了就用挑的；否则沿用已有 Agent 的 provider，再否则用作者 provider
@@ -500,7 +563,7 @@ public class AgentLifecycleService {
                 .replace("{model}", modelHint)
                 .replace("{tools}", describeTools())
                 .replace("{mcp_servers}", describeMcpServers())
-                .replace("{skills}", describeSkills())
+                .replace("{skills}", describeSkills(candidates))
                 .replace("{required_skills}", requiredSkillsDirective(required))
                 .replace("{notify}", notifyDirective(channel))
                 .replace("{example}", AUTHOR_EXAMPLE)
@@ -512,102 +575,35 @@ public class AgentLifecycleService {
     }
     // 多文件解析（模型自己决定要不要脚本/子指令）：按 ===FILE: path=== 切分；无分隔符则整段当 AGENT.md
     Map<String, String> files = parseGeneratedFiles(text);
+    for (String path : files.keySet()) {
+      Path relative = Path.of(path).normalize();
+      if (isIllegalGeneratedPath(relative)) {
+        throw new IllegalArgumentException("作者模型产出了非法或保留路径: " + path);
+      }
+    }
     String agentMarkdown = files.get("AGENT.md");
     if (agentMarkdown == null || agentMarkdown.isBlank()) {
       throw new IllegalArgumentException("生成结果缺少 AGENT.md");
     }
-    // 确定性兜底：用户勾选的 Skill 必须出现在 frontmatter 的 skills 里——模型漏写就在这里补齐（不靠模型自觉）
-    agentMarkdown = ensureRequiredSkills(agentMarkdown, required);
+    List<String> suggested = AgentMarkdown.legacySkills(agentMarkdown).stream().distinct().toList();
+    for (String skill : suggested) {
+      if (!candidateNames.contains(skill)) {
+        throw new IllegalArgumentException("作者模型建议了列表外或未安装 Skill: " + skill);
+      }
+    }
+    agentMarkdown = AgentMarkdown.removeLegacySkills(agentMarkdown);
     files.put("AGENT.md", agentMarkdown);
     agentLoader.parse(agentMarkdown, name); // 校验：解析不成合法定义就抛 ProfileValidationException（→400）
-    return files;
+    Set<String> bindingSet = new java.util.TreeSet<>(required);
+    bindingSet.addAll(suggested);
+    return new GeneratedAgentDraft(files, required, suggested, List.copyOf(bindingSet));
   }
 
-  /**
-   * 把 {@code required} 里用户勾选的 Skill 并进 AGENT.md frontmatter 的 {@code skills}
-   * 列表：模型已写的保留，缺的补上（去重、模型选的排前）。 只重写 skills 一个块，其余 frontmatter 原样保留。required 为空或全已在则原样返回。
-   */
-  static String ensureRequiredSkills(String agentMarkdown, List<String> required) {
-    if (required == null || required.isEmpty()) {
-      return agentMarkdown;
+  private static boolean isIllegalGeneratedPath(Path relative) {
+    if (relative.isAbsolute() || relative.startsWith(PARENT_PATH_SEGMENT)) {
+      return true;
     }
-    AgentMarkdown.Parsed parsed = AgentMarkdown.split(agentMarkdown);
-    List<String> existing = skillsFromFrontmatter(parsed.frontmatter());
-    if (existing.containsAll(required)) {
-      return agentMarkdown; // 模型已把勾选的都写进去了，无需改动
-    }
-    List<String> merged = new ArrayList<>(existing);
-    for (String s : required) {
-      if (!merged.contains(s)) {
-        merged.add(s);
-      }
-    }
-    // 定位 frontmatter 围栏（合法定义必有；找不到则不动，交由后续校验报错）
-    String normalized = agentMarkdown.replace("\r\n", "\n").replace('\r', '\n');
-    String[] lines = normalized.split("\n", -1);
-    if (lines.length == 0 || !YAML_FENCE.equals(lines[0].strip())) {
-      return agentMarkdown;
-    }
-    int close = -1;
-    for (int i = 1; i < lines.length; i++) {
-      if (YAML_FENCE.equals(lines[i].strip())) {
-        close = i;
-        break;
-      }
-    }
-    if (close < 0) {
-      return agentMarkdown;
-    }
-    // 保留 frontmatter 里除 skills 块以外的行（skills: 顶层键及其后续缩进的列表项一并剔除）
-    List<String> kept = new ArrayList<>();
-    for (int i = 1; i < close; i++) {
-      String line = lines[i];
-      boolean topLevelSkills =
-          !line.isEmpty()
-              && !Character.isWhitespace(line.charAt(0))
-              && line.strip().matches("skills\\s*:.*");
-      if (topLevelSkills) {
-        i++;
-        while (i < close
-            && (lines[i].startsWith(INDENT_SPACE)
-                || lines[i].startsWith(INDENT_TAB))) { // 跳过其列表项/缩进块
-          i++;
-        }
-        i--; // 抵消 for 的 i++
-        continue;
-      }
-      kept.add(line);
-    }
-    StringBuilder out = new StringBuilder(YAML_FENCE + "\n");
-    for (String line : kept) {
-      out.append(line).append('\n');
-    }
-    out.append("skills:\n");
-    for (String s : merged) {
-      out.append("  - ").append(s).append('\n');
-    }
-    out.append(YAML_FENCE).append("\n");
-    for (int i = close + 1; i < lines.length; i++) {
-      out.append(lines[i]);
-      if (i < lines.length - 1) {
-        out.append('\n');
-      }
-    }
-    return out.toString();
-  }
-
-  private static List<String> skillsFromFrontmatter(Map<String, Object> frontmatter) {
-    Object value = frontmatter.get("skills");
-    if (!(value instanceof List<?> list)) {
-      return List.of();
-    }
-    List<String> out = new ArrayList<>();
-    for (Object item : list) {
-      if (item != null) {
-        out.add(String.valueOf(item));
-      }
-    }
-    return out;
+    return relative.getNameCount() > 0 && "skills".equals(relative.getName(0).toString());
   }
 
   /**
@@ -615,27 +611,93 @@ public class AgentLifecycleService {
    * 变更先注销旧句柄再注册新的，同 {@link #update}）。用于「生成/编辑 Agent」的保存与文件浏览器的多文件保存。
    */
   public Profile saveFiles(String name, Map<String, String> files) {
+    return saveFiles(name, files, null);
+  }
+
+  public Profile saveFiles(String name, Map<String, String> files, List<String> bindingSkills) {
     String agentMarkdown = files == null ? null : files.get("AGENT.md");
     if (agentMarkdown == null || agentMarkdown.isBlank()) {
       throw new IllegalArgumentException("缺少 AGENT.md 内容");
     }
+    rejectLegacySkills(agentMarkdown);
     agentLoader.parse(agentMarkdown, name); // 先校验再落盘：非法定义不写进目录
+    List<String> validated = bindingSkills == null ? null : validateBindable(bindingSkills);
     Profile old = profileRegistry.get(name).orElse(null);
-    Path agentDir = agentStore.writeAll(name, files);
-    Profile updated;
+    if (validated != null && skillBindings == null) {
+      throw new IllegalStateException("Agent Skill 绑定服务未装配");
+    }
+    List<String> previousBindings =
+        validated == null || old == null
+            ? List.of()
+            : skillBindings.inspect(name).bindings().stream()
+                .map(BoundSkillDescriptor::name)
+                .toList();
+    AgentStore.FileSnapshot snapshot =
+        old == null ? null : agentStore.snapshot(name, files.keySet());
+    Path agentDir = null;
+    Profile updated = null;
     try {
+      agentDir = agentStore.writeAll(name, files);
       updated = agentLoader.deriveProfile(agentDir);
+      if (validated != null) {
+        skillBindings.replaceBindings(name, validated);
+      }
+      if (old != null) {
+        agentScheduler.unregisterProfile(old);
+      }
+      profileRegistry.register(updated);
+      if (!updated.schedules().isEmpty()) {
+        agentScheduler.registerProfile(updated);
+      }
     } catch (IOException e) {
-      throw new UncheckedIOException("读取 Agent 目录失败: " + agentDir.getFileName(), e);
+      rollbackSave(name, agentDir, old, null, snapshot, validated, previousBindings);
+      throw new UncheckedIOException("读取 Agent 目录失败: " + name, e);
+    } catch (RuntimeException e) {
+      rollbackSave(name, agentDir, old, updated, snapshot, validated, previousBindings);
+      throw e;
     }
-    if (old != null) {
-      agentScheduler.unregisterProfile(old);
-    }
-    profileRegistry.register(updated);
-    if (!updated.schedules().isEmpty()) {
-      agentScheduler.registerProfile(updated);
+    if (skillBindings != null) {
+      skillBindings.logCurrentIssues();
     }
     return updated;
+  }
+
+  private void rollbackSave(
+      String name,
+      Path agentDir,
+      Profile old,
+      Profile updated,
+      AgentStore.FileSnapshot snapshot,
+      List<String> validated,
+      List<String> previousBindings) {
+    if (validated != null && skillBindings != null) {
+      try {
+        skillBindings.replaceBindings(name, previousBindings);
+      } catch (RuntimeException ignored) {
+        // 原始异常优先；reconcile 会报告任何回滚残留。
+      }
+    }
+    if (updated != null) {
+      try {
+        agentScheduler.unregisterProfile(updated);
+      } catch (RuntimeException ignored) {
+        // 继续恢复文件与旧 Profile。
+      }
+    }
+    if (old == null) {
+      profileRegistry.remove(name);
+      if (agentDir != null) {
+        agentStore.delete(agentDir);
+      }
+      return;
+    }
+    if (snapshot != null) {
+      agentStore.restore(snapshot);
+    }
+    profileRegistry.register(old);
+    if (!old.schedules().isEmpty()) {
+      agentScheduler.registerProfile(old);
+    }
   }
 
   /** 去掉模型可能多吐的 Markdown 代码围栏（```lang ... ```），只留里面的 AGENT.md 文本。 */
@@ -682,23 +744,81 @@ public class AgentLifecycleService {
         .collect(Collectors.joining("\n"));
   }
 
-  /** 把全局 Skill 库（名+描述）铺给作者模型；模型据此按需把 Skill 加进 frontmatter 的 skills，禁止编造清单外的名字。 */
-  private String describeSkills() {
-    if (skillRegistry == null || skillRegistry.all().isEmpty()) {
+  /** 把已过滤 catalog（名+描述）铺给作者模型；模型据此生成瞬时建议，禁止编造清单外名字。 */
+  private String describeSkills(List<SkillCatalogEntry> candidates) {
+    if (candidates == null || candidates.isEmpty()) {
       return "（当前无可用 Skill）";
     }
-    return skillRegistry.all().stream()
-        .sorted(Comparator.comparing(Skill::name))
-        .map(s -> "- " + s.name() + "：" + oneLine(s.description()))
+    return candidates.stream()
+        .sorted(Comparator.comparing(SkillCatalogEntry::name))
+        .map(
+            skill ->
+                "- "
+                    + skill.name()
+                    + " ["
+                    + skill.visibility()
+                    + "/"
+                    + skill.source()
+                    + "]："
+                    + oneLine(skill.description()))
         .collect(Collectors.joining("\n"));
   }
 
-  /** 用户显式指定必启用的 Skill：作为硬指令追加到 skills 规则末尾；没指定则为空。目标由人定，不让模型漏。 */
+  private List<SkillCatalogEntry> availableCatalogCandidates() {
+    if (skillCatalog == null || skillRegistry == null) {
+      return List.of();
+    }
+    List<SkillCatalogEntry> entries = skillCatalog.query("", null);
+    Map<String, SkillCatalogEntry> unique = new LinkedHashMap<>();
+    for (SkillCatalogEntry entry : entries) {
+      if (unique.putIfAbsent(entry.name(), entry) != null) {
+        throw new IllegalStateException("Skill catalog 存在同名公共/私有冲突: " + entry.name());
+      }
+    }
+    return unique.values().stream()
+        .filter(entry -> entry.installed() && skillRegistry.exists(entry.name()))
+        .sorted(Comparator.comparing(SkillCatalogEntry::name))
+        .toList();
+  }
+
+  private List<String> validateBindable(List<String> names) {
+    List<String> normalized = normalizedSkills(names);
+    Set<String> available =
+        availableCatalogCandidates().stream()
+            .map(SkillCatalogEntry::name)
+            .collect(Collectors.toSet());
+    for (String name : normalized) {
+      if (!available.contains(name)) {
+        throw new IllegalArgumentException("Skill 不在可访问且已安装的 catalog 中: " + name);
+      }
+    }
+    return normalized;
+  }
+
+  private static List<String> normalizedSkills(List<String> names) {
+    if (names == null) {
+      return List.of();
+    }
+    return names.stream()
+        .map(String::strip)
+        .filter(name -> !name.isEmpty())
+        .distinct()
+        .sorted()
+        .toList();
+  }
+
+  private static void rejectLegacySkills(String markdown) {
+    if (AgentMarkdown.hasLegacySkills(markdown)) {
+      throw new IllegalArgumentException("运行期禁止写入旧版顶层 skills；请使用 Agent Skill 绑定 API");
+    }
+  }
+
+  /** 用户显式指定必启用的 Skill：作为 sidecar 硬约束；没指定则为空。目标由人定，不让模型漏。 */
   private static String requiredSkillsDirective(List<String> required) {
     if (required == null || required.isEmpty()) {
       return "";
     }
-    return "【用户已指定：frontmatter 的 skills 列表必须包含这些 Skill】" + String.join("、", required);
+    return "【用户已指定：生成建议必须包含这些 Skill；后端会把它们写入 sidecar，不写入最终 AGENT.md】" + String.join("、", required);
   }
 
   /** 通知指令：用户选了渠道就固定投递到它（唯一目标）；没选就明确禁止 notify。目标由人定，不让模型猜。 */
@@ -766,6 +886,9 @@ public class AgentLifecycleService {
     agentScheduler.unregisterProfile(profile);
     profileRegistry.remove(name);
     agentStore.archive(name);
+    if (skillBindings != null) {
+      skillBindings.logCurrentIssues();
+    }
   }
 
   /** WorkspaceWatcher 收到删除事件用：目录已被手工删，只注销 + 移索引，不归档。 */

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
@@ -332,11 +332,7 @@ public class AgentLifecycleService {
 
   /** 创建 Agent 并原子写入其初始 Skill 绑定。 */
   public Profile create(
-      String name,
-      String description,
-      String provider,
-      String model,
-      List<String> initialSkills) {
+      String name, String description, String provider, String model, List<String> initialSkills) {
     if (profileRegistry.exists(name)) {
       throw new IllegalArgumentException("Agent 已存在: " + name);
     }
@@ -416,10 +412,10 @@ public class AgentLifecycleService {
 
   /**
    * 编辑基本信息：只改 AGENT.md frontmatter 里的若干 key（description / provider.name / provider.model），正文与未提及的
-   * frontmatter 字段原样保留（不丢指令、不丢定时/工具等配置）。 Skill 绑定另由 {@link AgentSkillBindingService} 管理，绝不写回 AGENT.md。
-   * 传 null 的字段保持原值；description 清空→置空；
-   * provider.model 为空则沿用原值（model 为必填，不允许清空）。 先合成新 markdown 并用 {@link AgentLoader#parse} 预校验（非法→抛
-   * ProfileValidationException，且不落盘、不破坏原文件），通过再走 {@link #update} 重写+重注册。
+   * frontmatter 字段原样保留（不丢指令、不丢定时/工具等配置）。 Skill 绑定另由 {@link AgentSkillBindingService} 管理，绝不写回
+   * AGENT.md。 传 null 的字段保持原值；description 清空→置空； provider.model 为空则沿用原值（model 为必填，不允许清空）。 先合成新
+   * markdown 并用 {@link AgentLoader#parse} 预校验（非法→抛 ProfileValidationException，且不落盘、不破坏原文件），通过再走
+   * {@link #update} 重写+重注册。
    */
   public Profile updateBasicInfo(String name, String description, String provider, String model) {
     String raw = agentStore.read(name);
@@ -573,6 +569,11 @@ public class AgentLifecycleService {
     if (text == null || text.isBlank()) {
       throw new IllegalStateException("模型未返回内容"); // → 503
     }
+    return parseGeneratedDraft(text, name, required, candidateNames);
+  }
+
+  private GeneratedAgentDraft parseGeneratedDraft(
+      String text, String name, List<String> required, Set<String> candidateNames) {
     // 多文件解析（模型自己决定要不要脚本/子指令）：按 ===FILE: path=== 切分；无分隔符则整段当 AGENT.md
     Map<String, String> files = parseGeneratedFiles(text);
     for (String path : files.keySet()) {
@@ -592,6 +593,9 @@ public class AgentLifecycleService {
       }
     }
     agentMarkdown = AgentMarkdown.removeLegacySkills(agentMarkdown);
+    if (AgentMarkdown.hasLegacySkills(agentMarkdown)) {
+      throw new IllegalArgumentException("生成结果中的顶层 skills 未能安全移除");
+    }
     files.put("AGENT.md", agentMarkdown);
     agentLoader.parse(agentMarkdown, name); // 校验：解析不成合法定义就抛 ProfileValidationException（→400）
     Set<String> bindingSet = new java.util.TreeSet<>(required);

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentMarkdown.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentMarkdown.java
@@ -1,6 +1,8 @@
 package io.oryxos.core.agent;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.yaml.snakeyaml.Yaml;
 
@@ -48,6 +50,84 @@ public final class AgentMarkdown {
     String frontmatterText = String.join("\n", Arrays.copyOfRange(lines, 1, close));
     String body = String.join("\n", Arrays.copyOfRange(lines, close + 1, lines.length)).strip();
     return new Parsed(parseYaml(frontmatterText), body);
+  }
+
+  /** Returns the legacy top-level skills list, rejecting non-list or non-string values. */
+  public static List<String> legacySkills(String content) {
+    Object value = split(content).frontmatter().get("skills");
+    if (value == null) {
+      return List.of();
+    }
+    if (!(value instanceof List<?> list)) {
+      throw new IllegalArgumentException("旧版顶层 skills 必须是字符串列表");
+    }
+    List<String> names = new ArrayList<>();
+    for (Object item : list) {
+      if (!(item instanceof String name) || name.isBlank()) {
+        throw new IllegalArgumentException("旧版顶层 skills 必须是非空字符串列表");
+      }
+      names.add(name);
+    }
+    return List.copyOf(names);
+  }
+
+  /** Removes only the top-level skills YAML block while preserving all other lines and endings. */
+  public static String removeLegacySkills(String content) {
+    if (content == null || content.isEmpty()) {
+      return content;
+    }
+    String newline = content.contains("\r\n") ? "\r\n" : "\n";
+    String normalized = content.replace("\r\n", "\n").replace('\r', '\n');
+    String[] lines = normalized.split("\n", -1);
+    if (lines.length == 0 || !FENCE.equals(lines[0].strip())) {
+      return content;
+    }
+    int close = -1;
+    for (int i = 1; i < lines.length; i++) {
+      if (FENCE.equals(lines[i].strip())) {
+        close = i;
+        break;
+      }
+    }
+    if (close < 0) {
+      return content;
+    }
+    List<String> kept = new ArrayList<>();
+    kept.add(lines[0]);
+    boolean removed = false;
+    for (int i = 1; i < close; i++) {
+      String line = lines[i];
+      if (isTopLevelKey(line, "skills")) {
+        removed = true;
+        while (i + 1 < close && isIndented(lines[i + 1])) {
+          i++;
+        }
+        continue;
+      }
+      kept.add(line);
+    }
+    if (!removed) {
+      return content;
+    }
+    for (int i = close; i < lines.length; i++) {
+      kept.add(lines[i]);
+    }
+    return String.join(newline, kept);
+  }
+
+  public static boolean hasLegacySkills(String content) {
+    return split(content).frontmatter().containsKey("skills");
+  }
+
+  private static boolean isTopLevelKey(String line, String key) {
+    return line != null
+        && !line.isEmpty()
+        && !Character.isWhitespace(line.charAt(0))
+        && line.matches(java.util.regex.Pattern.quote(key) + "\\s*:.*");
+  }
+
+  private static boolean isIndented(String line) {
+    return !line.isEmpty() && Character.isWhitespace(line.charAt(0));
   }
 
   private static Map<String, Object> parseYaml(String text) {

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentMarkdown.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentMarkdown.java
@@ -16,6 +16,9 @@ import org.yaml.snakeyaml.Yaml;
 public final class AgentMarkdown {
 
   private static final String FENCE = "---";
+  private static final int QUOTED_KEY_MIN_LENGTH = 2;
+  private static final char SINGLE_QUOTE = '\'';
+  private static final char DOUBLE_QUOTE = '"';
 
   private AgentMarkdown() {}
 
@@ -99,7 +102,7 @@ public final class AgentMarkdown {
       String line = lines[i];
       if (isTopLevelKey(line, "skills")) {
         removed = true;
-        while (i + 1 < close && isIndented(lines[i + 1])) {
+        while (i + 1 < close && isLegacyValueLine(lines[i + 1])) {
           i++;
         }
         continue;
@@ -119,15 +122,78 @@ public final class AgentMarkdown {
     return split(content).frontmatter().containsKey("skills");
   }
 
+  /** Replaces all matching top-level scalars, or inserts one when absent. */
+  public static String replaceTopLevelScalar(String content, String key, String value) {
+    if (content == null || content.isEmpty()) {
+      throw new IllegalArgumentException("Markdown 内容为空");
+    }
+    String newline = content.contains("\r\n") ? "\r\n" : "\n";
+    String normalized = content.replace("\r\n", "\n").replace('\r', '\n');
+    String[] lines = normalized.split("\n", -1);
+    if (lines.length == 0 || !FENCE.equals(lines[0].strip())) {
+      throw new IllegalArgumentException("Markdown 缺少 frontmatter");
+    }
+    int close = -1;
+    boolean replaced = false;
+    for (int i = 1; i < lines.length; i++) {
+      if (FENCE.equals(lines[i].strip())) {
+        close = i;
+        break;
+      }
+      if (isTopLevelKey(lines[i], key)) {
+        lines[i] = key + ": " + value;
+        replaced = true;
+      }
+    }
+    if (close < 0) {
+      throw new IllegalArgumentException("Markdown frontmatter 未闭合");
+    }
+    if (replaced) {
+      return String.join(newline, lines);
+    }
+    List<String> inserted = new ArrayList<>(Arrays.asList(lines));
+    inserted.add(1, key + ": " + value);
+    return String.join(newline, inserted);
+  }
+
   private static boolean isTopLevelKey(String line, String key) {
-    return line != null
-        && !line.isEmpty()
-        && !Character.isWhitespace(line.charAt(0))
-        && line.matches(java.util.regex.Pattern.quote(key) + "\\s*:.*");
+    if (line == null || line.isEmpty() || Character.isWhitespace(line.charAt(0))) {
+      return false;
+    }
+    int colon = line.indexOf(':');
+    if (colon < 0) {
+      return false;
+    }
+    String candidate = line.substring(0, colon).strip();
+    if (candidate.length() >= QUOTED_KEY_MIN_LENGTH) {
+      char first = candidate.charAt(0);
+      char last = candidate.charAt(candidate.length() - 1);
+      if (hasMatchingQuotes(first, last)) {
+        candidate = candidate.substring(1, candidate.length() - 1);
+      }
+    }
+    return key.equals(candidate);
+  }
+
+  private static boolean hasMatchingQuotes(char first, char last) {
+    if (first == SINGLE_QUOTE) {
+      return last == SINGLE_QUOTE;
+    }
+    if (first == DOUBLE_QUOTE) {
+      return last == DOUBLE_QUOTE;
+    }
+    return false;
   }
 
   private static boolean isIndented(String line) {
     return !line.isEmpty() && Character.isWhitespace(line.charAt(0));
+  }
+
+  private static boolean isLegacyValueLine(String line) {
+    return isIndented(line)
+        || (!line.isEmpty()
+            && line.charAt(0) == '-'
+            && (line.length() == 1 || Character.isWhitespace(line.charAt(1))));
   }
 
   private static Map<String, Object> parseYaml(String text) {

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentStore.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentStore.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -34,11 +35,17 @@ public class AgentStore {
 
   private final Path agentsDir;
   private final Path archiveDir;
+  private final Clock clock;
 
   public AgentStore(Path oryxosRoot) {
+    this(oryxosRoot, Clock.systemUTC());
+  }
+
+  AgentStore(Path oryxosRoot, Clock clock) {
     Path root = oryxosRoot.toAbsolutePath().normalize();
     this.agentsDir = root.resolve("agents");
     this.archiveDir = root.resolve("archive");
+    this.clock = clock;
   }
 
   /**
@@ -174,20 +181,31 @@ public class AgentStore {
   }
 
   /** 整个 Agent 目录移入 .oryxos/archive/（不物理删）；目标已存在则加时间戳后缀避免覆盖。 */
-  public void archive(String name) {
+  public synchronized void archive(String name) {
     Path src = agentsDir.resolve(safe(name));
     requireSafe(src);
     try {
       Files.createDirectories(archiveDir);
-      Path dst = archiveDir.resolve(name);
-      if (SKILLS_NAMESPACE.equals(name) || Files.exists(dst, LinkOption.NOFOLLOW_LINKS)) {
-        dst = archiveDir.resolve(name + "-" + System.currentTimeMillis());
-      }
+      Path dst = uniqueArchivePath(name);
       RealPathBoundary.requireWithin(archiveDir, dst);
       Files.move(src, dst);
     } catch (IOException e) {
       throw new UncheckedIOException("归档 Agent 目录失败: " + name, e);
     }
+  }
+
+  private Path uniqueArchivePath(String name) {
+    Path direct = archiveDir.resolve(name);
+    if (!SKILLS_NAMESPACE.equals(name) && !Files.exists(direct, LinkOption.NOFOLLOW_LINKS)) {
+      return direct;
+    }
+    String base = name + "-" + clock.millis();
+    Path candidate = archiveDir.resolve(base);
+    int suffix = 2;
+    while (Files.exists(candidate, LinkOption.NOFOLLOW_LINKS)) {
+      candidate = archiveDir.resolve(base + "-" + suffix++);
+    }
+    return candidate;
   }
 
   private static void deleteOne(Path path) {

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentStore.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentStore.java
@@ -1,11 +1,21 @@
 package io.oryxos.core.agent;
 
+import io.oryxos.core.fs.RealPathBoundary;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -17,6 +27,8 @@ import java.util.stream.Stream;
  */
 public class AgentStore {
 
+  private static final String SKILLS_NAMESPACE = "skills";
+
   private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9_-]+");
   private static final String AGENT_FILE = "AGENT.md";
 
@@ -24,8 +36,9 @@ public class AgentStore {
   private final Path archiveDir;
 
   public AgentStore(Path oryxosRoot) {
-    this.agentsDir = oryxosRoot.resolve("agents");
-    this.archiveDir = oryxosRoot.resolve("archive");
+    Path root = oryxosRoot.toAbsolutePath().normalize();
+    this.agentsDir = root.resolve("agents");
+    this.archiveDir = root.resolve("archive");
   }
 
   /**
@@ -46,44 +59,111 @@ public class AgentStore {
 
   /** 写 .oryxos/agents/&lt;name&gt;/AGENT.md，返回该 Agent 目录。 */
   public Path write(String name, String agentMarkdown) {
-    Path dir = agentsDir.resolve(safe(name));
-    try {
-      Files.createDirectories(dir);
-      Files.writeString(dir.resolve(AGENT_FILE), agentMarkdown);
-    } catch (IOException e) {
-      throw new UncheckedIOException("写入 Agent 目录失败: " + name, e);
-    }
-    return dir;
+    return writeAll(name, Map.of(AGENT_FILE, agentMarkdown));
   }
 
   /**
    * 脚手架式写入整个 Agent 目录：{@code files} 的键是相对 Agent 目录的路径（如 {@code AGENT.md}、{@code
    * scripts/example.py}），值是文件内容。每个路径 normalize 后必须落在该 Agent 目录内（防穿越）。返回该 Agent 目录。
    */
-  public Path writeAll(String name, Map<String, String> files) {
+  public synchronized Path writeAll(String name, Map<String, String> files) {
     Path dir = agentsDir.resolve(safe(name)).normalize();
+    requireSafe(dir);
+    boolean existed = Files.exists(dir, LinkOption.NOFOLLOW_LINKS);
+    List<StagedWrite> staged = new ArrayList<>();
     try {
       Files.createDirectories(dir);
+      Set<Path> uniqueTargets = new HashSet<>();
       for (Map.Entry<String, String> entry : files.entrySet()) {
-        Path target = dir.resolve(entry.getKey()).normalize();
-        if (!target.startsWith(dir)) {
-          throw new IllegalArgumentException("非法文件路径: " + entry.getKey());
+        Path target = writableTarget(dir, entry.getKey());
+        if (!uniqueTargets.add(target)) {
+          throw new IllegalArgumentException("重复文件路径: " + entry.getKey());
         }
         Path parent = target.getParent();
         if (parent != null) {
           Files.createDirectories(parent);
         }
-        Files.writeString(target, entry.getValue());
+        Path temporary =
+            target.resolveSibling("." + target.getFileName() + ".write-" + UUID.randomUUID());
+        Files.writeString(temporary, entry.getValue());
+        Path backup =
+            target.resolveSibling("." + target.getFileName() + ".backup-" + UUID.randomUUID());
+        staged.add(new StagedWrite(target, temporary, backup));
+      }
+      for (StagedWrite write : staged) {
+        if (Files.exists(write.target, LinkOption.NOFOLLOW_LINKS)) {
+          moveAtomic(write.target, write.backup);
+          write.originalMoved = true;
+        }
+        moveAtomic(write.temporary, write.target);
+        write.committed = true;
+      }
+      for (StagedWrite write : staged) {
+        try {
+          Files.deleteIfExists(write.backup);
+        } catch (IOException ignored) {
+          // 提交已经完成；遗留隐藏备份比回滚已成功提交的用户文件更安全。
+        }
       }
     } catch (IOException e) {
+      rollback(staged);
+      if (!existed) {
+        delete(dir);
+      }
       throw new UncheckedIOException("写入 Agent 目录失败: " + name, e);
+    } catch (RuntimeException e) {
+      rollback(staged);
+      if (!existed) {
+        delete(dir);
+      }
+      throw e;
     }
     return dir;
   }
 
+  FileSnapshot snapshot(String name, Set<String> relativePaths) {
+    Path dir = agentsDir.resolve(safe(name)).normalize();
+    Map<String, byte[]> existing = new LinkedHashMap<>();
+    Set<String> absent = new HashSet<>();
+    try {
+      for (String relativePath : relativePaths) {
+        Path target = writableTarget(dir, relativePath);
+        if (Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS)) {
+          existing.put(relativePath, Files.readAllBytes(target));
+        } else {
+          absent.add(relativePath);
+        }
+      }
+      return new FileSnapshot(name, existing, absent);
+    } catch (IOException e) {
+      throw new UncheckedIOException("读取 Agent 文件快照失败: " + name, e);
+    }
+  }
+
+  void restore(FileSnapshot snapshot) {
+    Path dir = agentsDir.resolve(safe(snapshot.agentName)).normalize();
+    try {
+      for (String relativePath : snapshot.absent) {
+        Files.deleteIfExists(writableTarget(dir, relativePath));
+      }
+      for (Map.Entry<String, byte[]> entry : snapshot.existing.entrySet()) {
+        Path target = writableTarget(dir, entry.getKey());
+        Path parent = target.getParent();
+        if (parent == null) {
+          throw new IllegalArgumentException("Agent 文件缺少父目录: " + entry.getKey());
+        }
+        Files.createDirectories(parent);
+        Files.write(target, entry.getValue());
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("恢复 Agent 文件快照失败: " + snapshot.agentName, e);
+    }
+  }
+
   /** 递归删除一个 Agent 目录（create 中途失败回滚用）。 */
   public void delete(Path agentDir) {
-    if (!Files.exists(agentDir)) {
+    requireSafe(agentDir);
+    if (!Files.exists(agentDir, LinkOption.NOFOLLOW_LINKS)) {
       return;
     }
     try (Stream<Path> walk = Files.walk(agentDir)) {
@@ -96,12 +176,14 @@ public class AgentStore {
   /** 整个 Agent 目录移入 .oryxos/archive/（不物理删）；目标已存在则加时间戳后缀避免覆盖。 */
   public void archive(String name) {
     Path src = agentsDir.resolve(safe(name));
+    requireSafe(src);
     try {
       Files.createDirectories(archiveDir);
       Path dst = archiveDir.resolve(name);
-      if (Files.exists(dst)) {
+      if (SKILLS_NAMESPACE.equals(name) || Files.exists(dst, LinkOption.NOFOLLOW_LINKS)) {
         dst = archiveDir.resolve(name + "-" + System.currentTimeMillis());
       }
+      RealPathBoundary.requireWithin(archiveDir, dst);
       Files.move(src, dst);
     } catch (IOException e) {
       throw new UncheckedIOException("归档 Agent 目录失败: " + name, e);
@@ -116,10 +198,89 @@ public class AgentStore {
     }
   }
 
+  private Path writableTarget(Path dir, String relativePath) {
+    Path target = dir.resolve(relativePath).normalize();
+    if (!target.startsWith(dir)) {
+      throw new IllegalArgumentException("非法文件路径: " + relativePath);
+    }
+    Path relative = dir.relativize(target);
+    if (relative.getNameCount() > 0 && SKILLS_NAMESPACE.equals(relative.getName(0).toString())) {
+      throw new IllegalArgumentException("skills/ 是 Agent Skill 绑定保留目录，禁止写普通文件");
+    }
+    requireSafe(target);
+    if (isNonRegularTarget(target)) {
+      throw new IllegalArgumentException("Agent 文件目标不是普通文件: " + relativePath);
+    }
+    return target;
+  }
+
+  private static boolean isNonRegularTarget(Path target) {
+    if (Files.isSymbolicLink(target)) {
+      return true;
+    }
+    return Files.exists(target, LinkOption.NOFOLLOW_LINKS)
+        && !Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS);
+  }
+
+  private static void moveAtomic(Path source, Path target) throws IOException {
+    try {
+      Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+    } catch (AtomicMoveNotSupportedException e) {
+      throw new IOException("文件系统不支持原子移动: " + source, e);
+    }
+  }
+
+  private static void rollback(List<StagedWrite> staged) {
+    for (int i = staged.size() - 1; i >= 0; i--) {
+      StagedWrite write = staged.get(i);
+      try {
+        if (write.committed) {
+          Files.deleteIfExists(write.target);
+        }
+        if (write.originalMoved && Files.exists(write.backup, LinkOption.NOFOLLOW_LINKS)) {
+          moveAtomic(write.backup, write.target);
+        }
+        Files.deleteIfExists(write.temporary);
+      } catch (IOException ignored) {
+        // 原始异常优先；一致性检查和隐藏备份保留恢复线索。
+      }
+    }
+  }
+
+  static final class FileSnapshot {
+    private final String agentName;
+    private final Map<String, byte[]> existing;
+    private final Set<String> absent;
+
+    private FileSnapshot(String agentName, Map<String, byte[]> existing, Set<String> absent) {
+      this.agentName = agentName;
+      this.existing = Map.copyOf(existing);
+      this.absent = Set.copyOf(absent);
+    }
+  }
+
+  private static final class StagedWrite {
+    private final Path target;
+    private final Path temporary;
+    private final Path backup;
+    private boolean originalMoved;
+    private boolean committed;
+
+    private StagedWrite(Path target, Path temporary, Path backup) {
+      this.target = target;
+      this.temporary = temporary;
+      this.backup = backup;
+    }
+  }
+
   private static String safe(String name) {
     if (name == null || !SAFE_NAME.matcher(name).matches()) {
       throw new IllegalArgumentException("非法 Agent 名（只允许字母/数字/下划线/连字符）: " + name);
     }
     return name;
+  }
+
+  private void requireSafe(Path path) {
+    RealPathBoundary.requireWithin(agentsDir, path);
   }
 }

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/GeneratedAgentDraft.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/GeneratedAgentDraft.java
@@ -1,0 +1,18 @@
+package io.oryxos.core.agent;
+
+import java.util.List;
+import java.util.Map;
+
+/** Transient authoring sidecar; the binding lists are never persisted in Agent files. */
+public record GeneratedAgentDraft(
+    Map<String, String> files,
+    List<String> requiredSkills,
+    List<String> suggestedSkills,
+    List<String> bindingSkills) {
+  public GeneratedAgentDraft {
+    files = files == null ? Map.of() : Map.copyOf(files);
+    requiredSkills = requiredSkills == null ? List.of() : List.copyOf(requiredSkills);
+    suggestedSkills = suggestedSkills == null ? List.of() : List.copyOf(suggestedSkills);
+    bindingSkills = bindingSkills == null ? List.of() : List.copyOf(bindingSkills);
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/context/ContextLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/context/ContextLoader.java
@@ -2,8 +2,10 @@ package io.oryxos.core.context;
 
 import io.oryxos.core.agent.AgentMarkdown;
 import io.oryxos.core.profile.Profile;
-import io.oryxos.core.skill.Skill;
-import io.oryxos.core.skill.SkillRegistry;
+import io.oryxos.core.skill.AgentSkillBindingReader;
+import io.oryxos.core.skill.BindingInspection;
+import io.oryxos.core.skill.BoundSkillDescriptor;
+import io.oryxos.core.skill.SkillBindingIssue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -12,15 +14,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * system prompt 上下文供给者：把 identity.prompt、这个 Agent 自己 {@code AGENT.md} 的正文、 Agent 引用的全局 Skill 正文、与
- * Profile 的 bootstrap 文件按序拼接（宪法 IV 修订：Agent 目录是 prompt 输入；Skill 是 Agent 按名引用的全局能力库）。
+ * system prompt 上下文供给者：把 identity.prompt、这个 Agent 自己 {@code AGENT.md} 的正文、当前 Agent 绑定的 Skill 元数据目录与
+ * Profile 的 bootstrap 文件按序拼接。
  *
  * <p>一个目录 = 一个 Agent（第 29 节）：正文现读自 {@code .oryxos/agents/<name>/AGENT.md}，去掉 frontmatter 后注入。
  * 两条铁律（TechSol §8.3）：每次调用重新读文件、无任何缓存（用户改完正文下一次触发立即生效）； Bootstrap 缺失 WARN——静默跳过会造成"人格悄悄丢了"这类最难查的软故障。
  *
- * <p>Skill 注入（第 32 节）：{@code AGENT.md} frontmatter 声明的 {@code skills:[名]} 按名从全局 {@link
- * SkillRegistry} 解析，把 Skill 正文注入 system prompt——这样 Skill 才能"强约束"Agent 产出（而非靠模型自觉 read_file）。引用了不存在的
- * Skill 记 WARN 跳过，同 Bootstrap 缺失的处理。
+ * <p>Skill 渐进披露：每次只扫描 {@code agents/<name>/skills/} 的有效相对软连接，注入 name、description 和 Agent 本地
+ * SKILL.md 绝对路径；正文/脚本/参考绝不预载，由模型用既有 read_file/shell 按需加载并进入工具审计。
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",
@@ -38,11 +39,11 @@ public class ContextLoader {
       Set.of("write_file", "append_file", "edit_file", "make_dir", "download_file");
 
   private final Path oryxosRoot;
-  private final SkillRegistry skillRegistry;
+  private final AgentSkillBindingReader skillBindings;
 
-  public ContextLoader(Path oryxosRoot, SkillRegistry skillRegistry) {
+  public ContextLoader(Path oryxosRoot, AgentSkillBindingReader skillBindings) {
     this.oryxosRoot = oryxosRoot;
-    this.skillRegistry = skillRegistry;
+    this.skillBindings = skillBindings;
   }
 
   public String load(Profile profile) {
@@ -58,7 +59,7 @@ public class ContextLoader {
         context.append(body).append('\n');
       }
     }
-    // 引用的全局 Skill：按名解析并注入正文（约束产出）；库里没有的记 WARN 跳过，不阻断
+    // 当前 Agent 的有效 Skill：只注入目录元数据与读取路径，正文由 read_file 按需加载
     appendSkills(context, profile);
     // 告知会写盘的 Agent 它的绝对产出目录（已在文件白名单内），落盘文件有确定去处，避免它猜 ./output 撞沙箱
     appendOutputDir(context, profile);
@@ -73,20 +74,38 @@ public class ContextLoader {
     return context.toString();
   }
 
-  /** 把 Profile 引用的全局 Skill 正文按序注入；skillRegistry 未装配或引用不存在均安全跳过。 */
+  /** 每轮重扫 Agent 本地绑定；问题项记录 WARN 并跳过，合法项只注入元数据。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "CRLF_INJECTION_LOGS",
+      justification = "Every untrusted issue string is passed through sanitize before logging.")
   private void appendSkills(StringBuilder context, Profile profile) {
-    if (skillRegistry == null) {
+    if (skillBindings == null) {
       return;
     }
-    for (String name : profile.skills()) {
-      Skill skill = skillRegistry.get(name).orElse(null);
-      if (skill == null) {
-        LOG.warn("Agent 引用了不存在的 Skill，跳过: {}", sanitize(name));
-        continue;
-      }
-      if (!skill.body().isBlank()) {
-        context.append(skill.body()).append('\n');
-      }
+    BindingInspection inspection = skillBindings.inspect(profile.name());
+    for (SkillBindingIssue issue : inspection.issues()) {
+      LOG.warn(
+          "Agent Skill 绑定异常 [{}]，跳过 {}/{}: {}",
+          issue.type(),
+          sanitize(issue.agentName()),
+          sanitize(issue.entryName()),
+          sanitize(issue.message()));
+    }
+    if (inspection.bindings().isEmpty()) {
+      return;
+    }
+    context.append(
+        "你可以按需使用以下 Skill。仅在当前任务需要时，用 read_file 读取给出的 SKILL.md；"
+            + "其中的相对资源路径以该 SKILL.md 所在目录为基准并转换成绝对路径，不要猜测未读取的内容：\n");
+    for (BoundSkillDescriptor binding : inspection.bindings()) {
+      context
+          .append("- ")
+          .append(binding.name())
+          .append("：")
+          .append(binding.description())
+          .append("\n  SKILL.md：")
+          .append(binding.skillFile())
+          .append('\n');
     }
   }
 

--- a/oryxos-core/src/main/java/io/oryxos/core/fs/RealPathBoundary.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/fs/RealPathBoundary.java
@@ -1,0 +1,71 @@
+package io.oryxos.core.fs;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/** Symlink-aware path projection used by every workspace file boundary. */
+public final class RealPathBoundary {
+
+  private RealPathBoundary() {}
+
+  /**
+   * Resolves the nearest existing ancestor to its real path and appends any not-yet-existing
+   * suffix. Dangling links, link cycles and unresolvable ancestors fail closed.
+   */
+  public static Projection project(Path input) {
+    if (input == null) {
+      throw new IllegalArgumentException("路径不能为空");
+    }
+    Path absolute = input.toAbsolutePath().normalize();
+    Path cursor = absolute;
+    Deque<Path> suffix = new ArrayDeque<>();
+    while (cursor != null && !Files.exists(cursor, LinkOption.NOFOLLOW_LINKS)) {
+      Path name = cursor.getFileName();
+      if (name != null) {
+        suffix.addFirst(name);
+      }
+      cursor = cursor.getParent();
+    }
+    if (cursor == null) {
+      throw new IllegalArgumentException("路径没有可解析的已存在祖先: " + absolute);
+    }
+    Path ancestorReal;
+    try {
+      ancestorReal = cursor.toRealPath();
+    } catch (IOException e) {
+      throw new UncheckedIOException("真实路径解析失败: " + cursor, e);
+    }
+    Path projected = ancestorReal;
+    for (Path segment : suffix) {
+      projected = projected.resolve(segment.toString());
+    }
+    return new Projection(absolute, ancestorReal, projected.normalize());
+  }
+
+  /** Returns the projected real path when it is inside the projected root, otherwise rejects it. */
+  public static Path requireWithin(Path root, Path target) {
+    Path rootReal = project(root).projectedReal();
+    Path targetReal = project(target).projectedReal();
+    if (!targetReal.startsWith(rootReal)) {
+      throw new IllegalArgumentException("真实路径越界，拒绝访问: " + target);
+    }
+    return targetReal;
+  }
+
+  public static boolean isWithin(Path root, Path target) {
+    try {
+      requireWithin(root, target);
+      return true;
+    } catch (IllegalArgumentException | UncheckedIOException e) {
+      return false;
+    }
+  }
+
+  public record Projection(
+      Path absoluteNormalized, Path existingAncestorReal, Path projectedReal) {}
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/profile/Profile.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/Profile.java
@@ -19,7 +19,6 @@ public record Profile(
     List<NotifyChannel> notifyChannels,
     List<ScheduleConfig> schedules,
     List<String> bootstrap,
-    List<String> skills,
     Settings settings) {
 
   public Profile {
@@ -29,14 +28,10 @@ public record Profile(
     notifyChannels = notifyChannels == null ? List.of() : List.copyOf(notifyChannels);
     schedules = schedules == null ? List.of() : List.copyOf(schedules);
     bootstrap = bootstrap == null ? List.of() : List.copyOf(bootstrap);
-    skills = skills == null ? List.of() : List.copyOf(skills);
     settings = settings == null ? Settings.defaults() : settings;
   }
 
-  /**
-   * 兼容旧 11 参构造（第 32 节前无 skills 字段）：现有调用点无需改动，skills 缺省为空——引用全局 Skill 库是可选能力。 新代码请用规范 12 参构造显式传
-   * skills。
-   */
+  /** 源码兼容旧 12 参调用点。{@code ignoredSkills} 不再进入 Profile，也不参与绑定；Agent Skill 的唯一真相源是目录软连接。 */
   public Profile(
       String name,
       String description,
@@ -48,6 +43,7 @@ public record Profile(
       List<NotifyChannel> notifyChannels,
       List<ScheduleConfig> schedules,
       List<String> bootstrap,
+      List<String> ignoredSkills,
       Settings settings) {
     this(
         name,
@@ -60,7 +56,6 @@ public record Profile(
         notifyChannels,
         schedules,
         bootstrap,
-        List.of(),
         settings);
   }
 

--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -122,7 +122,6 @@ public class ProfileLoader {
         toNotifyChannels(asList(map.get("notify_channels"))),
         toSchedules(asList(map.get("schedules"))),
         asStringList(map.get("bootstrap")),
-        asStringList(map.get("skills")),
         toSettings(asMap(map.get("settings"))));
   }
 

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBinding.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBinding.java
@@ -1,0 +1,7 @@
+package io.oryxos.core.skill;
+
+import java.nio.file.Path;
+
+/** Agent 本地 Skill 软连接解析出的有效绑定；正文不在该模型中，避免被误入常驻 prompt。 */
+public record AgentSkillBinding(
+    String agentName, String skillName, String description, Path linkPath, Path skillFile) {}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBindingReader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBindingReader.java
@@ -1,0 +1,7 @@
+package io.oryxos.core.skill;
+
+/** Read-only boundary used by prompt assembly; implementations must return a fresh scan. */
+@FunctionalInterface
+public interface AgentSkillBindingReader {
+  BindingInspection inspect(String agentName);
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBindingService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBindingService.java
@@ -164,6 +164,17 @@ public class AgentSkillBindingService implements AgentSkillBindingReader {
     }
   }
 
+  /**
+   * Returns whether a concrete installed directory exists. Symlink directories are intentionally
+   * excluded, matching {@link SkillLoader#loadAll()}; malformed installed metadata remains a 400.
+   */
+  public boolean skillExists(String skillName) {
+    String skill = safe(skillName, "Skill");
+    Path directory = skillsDir.resolve(skill);
+    return Files.isDirectory(directory, LinkOption.NOFOLLOW_LINKS)
+        && RealPathBoundary.isWithin(skillsDir, directory);
+  }
+
   public List<AgentSkillBinding> validBindings(String agentName) {
     String agent = safe(agentName, "Agent");
     return inspect(agent).bindings().stream().map(binding -> legacy(binding, agent)).toList();

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBindingService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBindingService.java
@@ -1,0 +1,693 @@
+package io.oryxos.core.skill;
+
+import io.oryxos.core.agent.AgentMarkdown;
+import io.oryxos.core.fs.RealPathBoundary;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Filesystem coordinator for the single-source-of-truth Agent-to-Skill symlink bindings. */
+public class AgentSkillBindingService implements AgentSkillBindingReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AgentSkillBindingService.class);
+  private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9_-]+");
+  private static final String AGENT_FILE = "AGENT.md";
+  private static final String SKILL_FILE = "SKILL.md";
+  private static final String LEGACY_SKILLS_FIELD = "skills";
+
+  private final Path root;
+  private final Path agentsDir;
+  private final Path archiveDir;
+  private final Path skillsDir;
+  private final SkillMetadataReader metadataReader;
+
+  public AgentSkillBindingService(Path oryxosRoot, SkillLoader ignoredLoader) {
+    this(oryxosRoot, new SkillMetadataReader());
+  }
+
+  public AgentSkillBindingService(Path oryxosRoot, SkillMetadataReader metadataReader) {
+    this.root = oryxosRoot.toAbsolutePath().normalize();
+    this.agentsDir = root.resolve("agents");
+    this.archiveDir = root.resolve("archive");
+    this.skillsDir = root.resolve("skills");
+    this.metadataReader = metadataReader;
+  }
+
+  /** Creates the fixed relative link; rebinding the same valid Skill is idempotent. */
+  public synchronized AgentSkillBinding bind(String agentName, String skillName) {
+    String agent = safe(agentName, "Agent");
+    String skill = safe(skillName, "Skill");
+    Path agentDir = requireAgent(agent);
+    requireSkill(skill);
+    Path linksDir = agentDir.resolve("skills");
+    Path link = linksDir.resolve(skill);
+    if (Files.exists(link, LinkOption.NOFOLLOW_LINKS)) {
+      BoundSkillDescriptor existing =
+          inspect(agent).bindings().stream()
+              .filter(binding -> binding.name().equals(skill))
+              .findFirst()
+              .orElseThrow(() -> new IllegalArgumentException("Agent Skill 绑定位置已被无效条目占用: " + link));
+      return legacy(existing, agent);
+    }
+    try {
+      Files.createDirectories(linksDir);
+      Files.createSymbolicLink(link, expectedTarget(skill));
+    } catch (IOException e) {
+      throw new UncheckedIOException("创建 Agent Skill 绑定失败: " + agent + "/" + skill, e);
+    }
+    BoundSkillDescriptor created =
+        inspect(agent).bindings().stream()
+            .filter(binding -> binding.name().equals(skill))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("刚创建的 Skill 绑定未通过一致性校验: " + skill));
+    return legacy(created, agent);
+  }
+
+  /** Deletes only a controlled fixed-target symlink; an absent binding is idempotent. */
+  public synchronized void unbind(String agentName, String skillName) {
+    String agent = safe(agentName, "Agent");
+    String skill = safe(skillName, "Skill");
+    Path link = requireAgent(agent).resolve("skills").resolve(skill);
+    if (!Files.exists(link, LinkOption.NOFOLLOW_LINKS)) {
+      return;
+    }
+    requireControlledLink(link, skill);
+    try {
+      Files.delete(link);
+    } catch (IOException e) {
+      throw new UncheckedIOException("解绑 Agent Skill 失败: " + agent + "/" + skill, e);
+    }
+  }
+
+  /**
+   * Atomically replaces an Agent's binding set from the caller's perspective, rolling back on I/O
+   * failure.
+   */
+  public synchronized BindingInspection replaceBindings(
+      String agentName, List<String> desiredSkills) {
+    String agent = safe(agentName, "Agent");
+    Path agentDir = requireAgent(agent);
+    List<String> desired = normalizedNames(desiredSkills);
+    desired.forEach(this::requireSkill);
+    BindingInspection before = inspect(agent);
+    if (before.issues().stream()
+        .anyMatch(issue -> issue.type() != SkillBindingIssue.Type.STALE_REFERENCE)) {
+      throw new IllegalArgumentException("Agent 存在损坏绑定，修复后才能整体替换: " + agent);
+    }
+    Set<String> current = new LinkedHashSet<>();
+    before.bindings().forEach(binding -> current.add(binding.name()));
+    if (current.equals(new LinkedHashSet<>(desired))) {
+      return before;
+    }
+    Path linksDir = agentDir.resolve("skills");
+    List<Path> created = new ArrayList<>();
+    List<Move> removed = new ArrayList<>();
+    try {
+      Files.createDirectories(linksDir);
+      for (String skill : desired) {
+        if (!current.contains(skill)) {
+          Path finalLink = linksDir.resolve(skill);
+          Path temporary = linksDir.resolve("." + skill + ".tmp-" + UUID.randomUUID());
+          Files.createSymbolicLink(temporary, expectedTarget(skill));
+          moveAtomic(temporary, finalLink);
+          created.add(finalLink);
+        }
+      }
+      for (String skill : current) {
+        if (!desired.contains(skill)) {
+          Path link = linksDir.resolve(skill);
+          requireControlledLink(link, skill);
+          // Keep rollback artifacts outside skills/: that directory is the complete binding truth,
+          // so a transaction-internal link must never be observable as a malformed binding.
+          Path backup =
+              agentDir.resolve(".skill-binding-remove-" + skill + "-" + UUID.randomUUID());
+          moveAtomic(link, backup);
+          removed.add(new Move(link, backup));
+        }
+      }
+      BindingInspection after = inspect(agent);
+      List<String> actual = after.bindings().stream().map(BoundSkillDescriptor::name).toList();
+      boolean hasBindingIssue =
+          after.issues().stream()
+              .anyMatch(issue -> issue.type() != SkillBindingIssue.Type.STALE_REFERENCE);
+      if (hasBindingIssue || !actual.equals(desired)) {
+        throw new IllegalStateException("替换后的 Agent Skill 绑定未通过一致性校验: " + agent);
+      }
+      for (Move move : removed) {
+        try {
+          Files.deleteIfExists(move.temporary());
+        } catch (IOException cleanupFailure) {
+          LOG.warn("清理 Agent Skill 绑定备份失败: {}", sanitize(move.temporary().toString()));
+        }
+      }
+      return after;
+    } catch (IOException e) {
+      rollbackReplace(created, removed);
+      throw new UncheckedIOException("原子替换 Agent Skill 绑定失败: " + agent, e);
+    } catch (RuntimeException e) {
+      rollbackReplace(created, removed);
+      throw e;
+    }
+  }
+
+  public List<AgentSkillBinding> validBindings(String agentName) {
+    String agent = safe(agentName, "Agent");
+    return inspect(agent).bindings().stream().map(binding -> legacy(binding, agent)).toList();
+  }
+
+  /** Returns a new stable snapshot every time; no Registry or cache participates. */
+  @Override
+  public BindingInspection inspect(String agentName) {
+    String agent = safe(agentName, "Agent");
+    Path agentDir = agentsDir.resolve(agent);
+    if (!Files.isDirectory(agentDir, LinkOption.NOFOLLOW_LINKS)) {
+      return new BindingInspection(List.of(), List.of());
+    }
+    SkillBindingIssue.AgentState state =
+        Files.isRegularFile(agentDir.resolve(AGENT_FILE))
+            ? SkillBindingIssue.AgentState.ACTIVE
+            : SkillBindingIssue.AgentState.INVALID;
+    return inspectDirectory(agent, agentDir, state);
+  }
+
+  /** Finds every active and archived reference, including a controlled dangling link by name. */
+  public synchronized List<SkillReference> references(String skillName) {
+    String skill = safe(skillName, "Skill");
+    List<SkillReference> references = new ArrayList<>();
+    collectReferences(agentsDir, SkillReference.AgentState.ACTIVE, skill, references, false);
+    collectReferences(archiveDir, SkillReference.AgentState.ARCHIVED, skill, references, true);
+    return references.stream()
+        .sorted(
+            Comparator.comparing(SkillReference::agentName)
+                .thenComparing(reference -> reference.state().name())
+                .thenComparing(SkillReference::directoryName))
+        .toList();
+  }
+
+  public synchronized <T> T archiveIfUnreferenced(
+      String skillName, java.util.function.Supplier<T> archiveAction) {
+    List<SkillReference> refs = references(skillName);
+    if (!refs.isEmpty()) {
+      throw new SkillReferencedException(skillName, refs);
+    }
+    return archiveAction.get();
+  }
+
+  /**
+   * Runs a compound workspace mutation under the same reentrant lock as bind/archive operations.
+   */
+  public synchronized <T> T coordinate(java.util.function.Supplier<T> action) {
+    return action.get();
+  }
+
+  /** Compatibility hook for older callers that have no result value. */
+  public synchronized void deleteIfUnreferenced(String skillName, Runnable action) {
+    archiveIfUnreferenced(
+        skillName,
+        () -> {
+          action.run();
+          return null;
+        });
+  }
+
+  /** Scans active Agents, archived Agents and legacy frontmatter, excluding archive/skills. */
+  public synchronized List<SkillBindingIssue> reconcile() {
+    List<SkillBindingIssue> issues = new ArrayList<>();
+    scanContainer(agentsDir, SkillBindingIssue.AgentState.ACTIVE, false, issues);
+    scanContainer(archiveDir, SkillBindingIssue.AgentState.ARCHIVED, true, issues);
+    return issues.stream()
+        .sorted(
+            Comparator.comparing(SkillBindingIssue::agentName)
+                .thenComparing(issue -> issue.agentState().name())
+                .thenComparing(SkillBindingIssue::entryName)
+                .thenComparing(issue -> issue.type().name()))
+        .toList();
+  }
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "CRLF_INJECTION_LOGS",
+      justification = "Every untrusted issue string is passed through sanitize before logging.")
+  public void logCurrentIssues() {
+    for (SkillBindingIssue issue : reconcile()) {
+      LOG.warn(
+          "Agent Skill 绑定异常 [{}] {}/{}: {}",
+          issue.type(),
+          sanitize(issue.agentName()),
+          sanitize(issue.entryName()),
+          sanitize(issue.message()));
+    }
+  }
+
+  private BindingInspection inspectDirectory(
+      String agent, Path agentDir, SkillBindingIssue.AgentState state) {
+    List<BoundSkillDescriptor> valid = new ArrayList<>();
+    List<SkillBindingIssue> issues = new ArrayList<>();
+    if (state == SkillBindingIssue.AgentState.INVALID) {
+      Path linksDir = agentDir.resolve("skills");
+      if (Files.isDirectory(linksDir, LinkOption.NOFOLLOW_LINKS)) {
+        issues.add(
+            issue(
+                agent,
+                state,
+                "skills",
+                linksDir,
+                SkillBindingIssue.Type.STALE_REFERENCE,
+                "Agent 目录缺少有效 AGENT.md"));
+      }
+      return new BindingInspection(valid, issues);
+    }
+    addLegacyIssue(agent, agentDir, state, issues);
+    Path linksDir = agentDir.resolve("skills");
+    if (!Files.isDirectory(linksDir, LinkOption.NOFOLLOW_LINKS)) {
+      return new BindingInspection(valid, issues);
+    }
+    try (Stream<Path> entries = Files.list(linksDir)) {
+      entries.sorted().forEach(entry -> inspectEntry(agent, state, entry, valid, issues));
+    } catch (IOException e) {
+      issues.add(
+          issue(
+              agent,
+              state,
+              "skills",
+              linksDir,
+              SkillBindingIssue.Type.INVALID_TARGET,
+              "无法读取 Agent skills 目录: " + e.getMessage()));
+    }
+    return new BindingInspection(
+        valid.stream().sorted(Comparator.comparing(BoundSkillDescriptor::name)).toList(), issues);
+  }
+
+  private void inspectEntry(
+      String agent,
+      SkillBindingIssue.AgentState state,
+      Path entry,
+      List<BoundSkillDescriptor> valid,
+      List<SkillBindingIssue> issues) {
+    String entryName = String.valueOf(entry.getFileName());
+    if (!SAFE_NAME.matcher(entryName).matches() || !Files.isSymbolicLink(entry)) {
+      issues.add(
+          issue(
+              agent,
+              state,
+              entryName,
+              entry,
+              SkillBindingIssue.Type.INVALID_TARGET,
+              "绑定项必须是安全命名的相对软连接"));
+      return;
+    }
+    Path rawTarget = readLinkTarget(agent, state, entryName, entry, issues);
+    if (rawTarget == null
+        || !validateLexicalTarget(agent, state, entryName, entry, rawTarget, issues)) {
+      return;
+    }
+    Path targetReal = resolveRealTarget(agent, state, entryName, entry, issues);
+    if (targetReal == null
+        || !validateTargetLayout(agent, state, entryName, entry, targetReal, issues)) {
+      return;
+    }
+    inspectMetadata(agent, state, entryName, entry, targetReal, valid, issues);
+  }
+
+  private Path readLinkTarget(
+      String agent,
+      SkillBindingIssue.AgentState state,
+      String entryName,
+      Path entry,
+      List<SkillBindingIssue> issues) {
+    try {
+      return Files.readSymbolicLink(entry);
+    } catch (IOException e) {
+      issues.add(
+          issue(
+              agent,
+              state,
+              entryName,
+              entry,
+              SkillBindingIssue.Type.INVALID_TARGET,
+              "无法读取软连接: " + e.getMessage()));
+      return null;
+    }
+  }
+
+  private boolean validateLexicalTarget(
+      String agent,
+      SkillBindingIssue.AgentState state,
+      String entryName,
+      Path entry,
+      Path rawTarget,
+      List<SkillBindingIssue> issues) {
+    if (rawTarget.isAbsolute()) {
+      issues.add(
+          issue(agent, state, entryName, entry, SkillBindingIssue.Type.ESCAPED, "绑定必须使用相对软连接"));
+      return false;
+    }
+    Path parent = entry.getParent();
+    if (parent == null) {
+      issues.add(
+          issue(agent, state, entryName, entry, SkillBindingIssue.Type.INVALID_TARGET, "绑定项缺少父目录"));
+      return false;
+    }
+    Path lexicalTarget = parent.resolve(rawTarget).toAbsolutePath().normalize();
+    if (!lexicalTarget.startsWith(skillsDir) || !rawTarget.equals(expectedTarget(entryName))) {
+      SkillBindingIssue.Type type;
+      if (!lexicalTarget.startsWith(skillsDir)) {
+        type = SkillBindingIssue.Type.ESCAPED;
+      } else if (!entryName.equals(String.valueOf(rawTarget.getFileName()))) {
+        type = SkillBindingIssue.Type.NAME_MISMATCH;
+      } else {
+        type = SkillBindingIssue.Type.INVALID_TARGET;
+      }
+      issues.add(
+          issue(agent, state, entryName, entry, type, "绑定目标不是固定相对路径 ../../../skills/" + entryName));
+      return false;
+    }
+    if (!Files.exists(entry)) {
+      issues.add(issue(agent, state, entryName, entry, SkillBindingIssue.Type.DANGLING, "绑定目标不存在"));
+      return false;
+    }
+    return true;
+  }
+
+  private Path resolveRealTarget(
+      String agent,
+      SkillBindingIssue.AgentState state,
+      String entryName,
+      Path entry,
+      List<SkillBindingIssue> issues) {
+    try {
+      Path targetReal = entry.toRealPath();
+      RealPathBoundary.requireWithin(skillsDir, targetReal);
+      return targetReal;
+    } catch (RuntimeException | IOException e) {
+      issues.add(
+          issue(
+              agent,
+              state,
+              entryName,
+              entry,
+              SkillBindingIssue.Type.ESCAPED,
+              "绑定真实目标越过公共 Skill 根或无法解析"));
+      return null;
+    }
+  }
+
+  private boolean validateTargetLayout(
+      String agent,
+      SkillBindingIssue.AgentState state,
+      String entryName,
+      Path entry,
+      Path targetReal,
+      List<SkillBindingIssue> issues) {
+    if (!Files.isDirectory(targetReal) || !Files.isRegularFile(targetReal.resolve(SKILL_FILE))) {
+      issues.add(
+          issue(
+              agent,
+              state,
+              entryName,
+              entry,
+              SkillBindingIssue.Type.INVALID_TARGET,
+              "绑定目标不是含 SKILL.md 的目录"));
+      return false;
+    }
+    if (!entryName.equals(String.valueOf(targetReal.getFileName()))) {
+      issues.add(
+          issue(
+              agent,
+              state,
+              entryName,
+              entry,
+              SkillBindingIssue.Type.NAME_MISMATCH,
+              "链接名与公共 Skill 目录名不一致"));
+      return false;
+    }
+    return true;
+  }
+
+  private void inspectMetadata(
+      String agent,
+      SkillBindingIssue.AgentState state,
+      String entryName,
+      Path entry,
+      Path targetReal,
+      List<BoundSkillDescriptor> valid,
+      List<SkillBindingIssue> issues) {
+    try {
+      SkillMetadataReader.Metadata metadata = metadataReader.read(targetReal);
+      if (!entryName.equals(metadata.name())) {
+        issues.add(
+            issue(
+                agent,
+                state,
+                entryName,
+                entry,
+                SkillBindingIssue.Type.NAME_MISMATCH,
+                "链接名与 SKILL.md name 不一致"));
+        return;
+      }
+      Path link = entry.toAbsolutePath().normalize();
+      valid.add(
+          new BoundSkillDescriptor(
+              metadata.name(), metadata.description(), link, link.resolve(SKILL_FILE)));
+    } catch (RuntimeException e) {
+      SkillBindingIssue.Type type =
+          e.getMessage() != null && e.getMessage().contains("name")
+              ? SkillBindingIssue.Type.NAME_MISMATCH
+              : SkillBindingIssue.Type.INVALID_TARGET;
+      issues.add(issue(agent, state, entryName, entry, type, e.getMessage()));
+    }
+  }
+
+  private void addLegacyIssue(
+      String agent,
+      Path agentDir,
+      SkillBindingIssue.AgentState state,
+      List<SkillBindingIssue> issues) {
+    Path markdown = agentDir.resolve(AGENT_FILE);
+    if (!Files.isRegularFile(markdown)) {
+      return;
+    }
+    try {
+      if (AgentMarkdown.split(Files.readString(markdown))
+          .frontmatter()
+          .containsKey(LEGACY_SKILLS_FIELD)) {
+        issues.add(
+            issue(
+                agent,
+                state,
+                "skills",
+                markdown,
+                SkillBindingIssue.Type.STALE_REFERENCE,
+                "AGENT.md 仍含旧版顶层 skills 字段"));
+      }
+    } catch (IOException | RuntimeException e) {
+      issues.add(
+          issue(
+              agent,
+              state,
+              AGENT_FILE,
+              markdown,
+              SkillBindingIssue.Type.INVALID_TARGET,
+              "无法读取 Agent 定义"));
+    }
+  }
+
+  private void scanContainer(
+      Path container,
+      SkillBindingIssue.AgentState expectedState,
+      boolean skipSkillArchive,
+      List<SkillBindingIssue> issues) {
+    if (!Files.isDirectory(container, LinkOption.NOFOLLOW_LINKS)) {
+      return;
+    }
+    try (Stream<Path> dirs = Files.list(container)) {
+      dirs.filter(path -> Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS))
+          .filter(path -> !skipSkillArchive || !"skills".equals(String.valueOf(path.getFileName())))
+          .sorted()
+          .forEach(
+              dir -> {
+                String name = String.valueOf(dir.getFileName());
+                SkillBindingIssue.AgentState state =
+                    Files.isRegularFile(dir.resolve(AGENT_FILE))
+                        ? expectedState
+                        : SkillBindingIssue.AgentState.INVALID;
+                issues.addAll(inspectDirectory(name, dir, state).issues());
+              });
+    } catch (IOException e) {
+      throw new UncheckedIOException("扫描 Agent Skill 绑定失败: " + container, e);
+    }
+  }
+
+  private void collectReferences(
+      Path container,
+      SkillReference.AgentState state,
+      String skill,
+      List<SkillReference> output,
+      boolean skipSkillArchive) {
+    if (!Files.isDirectory(container, LinkOption.NOFOLLOW_LINKS)) {
+      return;
+    }
+    try (Stream<Path> dirs = Files.list(container)) {
+      dirs.filter(path -> Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS))
+          .filter(path -> !skipSkillArchive || !"skills".equals(String.valueOf(path.getFileName())))
+          .sorted()
+          .forEach(
+              dir -> {
+                Path link = dir.resolve("skills").resolve(skill);
+                if (!Files.isSymbolicLink(link)) {
+                  return;
+                }
+                try {
+                  if (!Files.readSymbolicLink(link).equals(expectedTarget(skill))) {
+                    return;
+                  }
+                } catch (IOException e) {
+                  return;
+                }
+                String directoryName = String.valueOf(dir.getFileName());
+                output.add(
+                    new SkillReference(
+                        agentName(dir, directoryName),
+                        state,
+                        directoryName,
+                        link.toAbsolutePath().normalize()));
+              });
+    } catch (IOException e) {
+      throw new UncheckedIOException("扫描 Skill 引用失败: " + container, e);
+    }
+  }
+
+  private static String agentName(Path directory, String fallback) {
+    Path file = directory.resolve(AGENT_FILE);
+    if (!Files.isRegularFile(file)) {
+      return fallback;
+    }
+    try {
+      Object name = AgentMarkdown.split(Files.readString(file)).frontmatter().get("name");
+      return name == null || String.valueOf(name).isBlank() ? fallback : String.valueOf(name);
+    } catch (IOException | RuntimeException e) {
+      return fallback;
+    }
+  }
+
+  private Path requireAgent(String agent) {
+    Path dir = agentsDir.resolve(agent);
+    if (!Files.isDirectory(dir, LinkOption.NOFOLLOW_LINKS)
+        || !Files.isRegularFile(dir.resolve(AGENT_FILE))) {
+      throw new IllegalArgumentException("Agent 不存在或定义无效: " + agent);
+    }
+    RealPathBoundary.requireWithin(agentsDir, dir);
+    return dir;
+  }
+
+  private Path requireSkill(String skill) {
+    Path dir = skillsDir.resolve(skill);
+    if (!Files.isDirectory(dir, LinkOption.NOFOLLOW_LINKS)) {
+      throw new IllegalArgumentException("Skill 不存在: " + skill);
+    }
+    RealPathBoundary.requireWithin(skillsDir, dir);
+    SkillMetadataReader.Metadata metadata = metadataReader.read(dir);
+    if (!skill.equals(metadata.name())) {
+      throw new IllegalArgumentException("Skill 名与目录不一致: " + skill);
+    }
+    return dir.toAbsolutePath().normalize();
+  }
+
+  private static List<String> normalizedNames(List<String> names) {
+    if (names == null) {
+      return List.of();
+    }
+    return names.stream().map(name -> safe(name, "Skill")).distinct().sorted().toList();
+  }
+
+  private static void requireControlledLink(Path link, String skill) {
+    if (!Files.isSymbolicLink(link)) {
+      throw new IllegalArgumentException("绑定位置不是软连接，拒绝删除: " + link);
+    }
+    try {
+      if (!Files.readSymbolicLink(link).equals(expectedTarget(skill))) {
+        throw new IllegalArgumentException("绑定不是受控固定链接，拒绝删除: " + link);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("读取绑定失败: " + link, e);
+    }
+  }
+
+  private static Path expectedTarget(String skill) {
+    return Path.of("..", "..", "..", "skills", skill);
+  }
+
+  private static void moveAtomic(Path source, Path target) throws IOException {
+    try {
+      Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+    } catch (AtomicMoveNotSupportedException e) {
+      throw new IOException("文件系统不支持原子移动: " + source, e);
+    }
+  }
+
+  private static void rollbackReplace(List<Path> created, List<Move> removed) {
+    for (Path path : created) {
+      try {
+        Files.deleteIfExists(path);
+      } catch (IOException ignored) {
+        // Keep the original failure; reconciliation will report any residue.
+      }
+    }
+    for (int i = removed.size() - 1; i >= 0; i--) {
+      Move move = removed.get(i);
+      try {
+        if (Files.exists(move.temporary(), LinkOption.NOFOLLOW_LINKS)) {
+          moveAtomic(move.temporary(), move.original());
+        }
+      } catch (IOException ignored) {
+        // Keep the original failure; reconciliation will report any residue.
+      }
+    }
+  }
+
+  private static AgentSkillBinding legacy(BoundSkillDescriptor descriptor, String agent) {
+    return new AgentSkillBinding(
+        agent,
+        descriptor.name(),
+        descriptor.description(),
+        descriptor.linkPath(),
+        descriptor.skillFile());
+  }
+
+  private static SkillBindingIssue issue(
+      String agent,
+      SkillBindingIssue.AgentState state,
+      String entry,
+      Path path,
+      SkillBindingIssue.Type type,
+      String message) {
+    return new SkillBindingIssue(
+        agent, state, entry, path.toAbsolutePath().normalize(), type, sanitize(message));
+  }
+
+  private static String safe(String name, String kind) {
+    if (name == null || !SAFE_NAME.matcher(name).matches()) {
+      throw new IllegalArgumentException("非法 " + kind + " 名（只允许字母/数字/下划线/连字符）: " + name);
+    }
+    return name;
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+
+  private record Move(Path original, Path temporary) {}
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillMigrationService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillMigrationService.java
@@ -1,0 +1,126 @@
+package io.oryxos.core.skill;
+
+import io.oryxos.core.agent.AgentMarkdown;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+/**
+ * One-time, per-Agent atomic migration from legacy frontmatter skills to local symlink bindings.
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification =
+        "Binding service is an injected workspace coordinator, intentionally shared by reference.")
+public final class AgentSkillMigrationService {
+
+  private final Path agentsDir;
+  private final AgentSkillBindingService bindings;
+
+  public AgentSkillMigrationService(Path oryxosRoot, AgentSkillBindingService bindings) {
+    this.agentsDir = oryxosRoot.toAbsolutePath().normalize().resolve("agents");
+    this.bindings = bindings;
+  }
+
+  public AgentSkillStartupReport migrateAll() {
+    if (!Files.isDirectory(agentsDir, LinkOption.NOFOLLOW_LINKS)) {
+      return new AgentSkillStartupReport(List.of(), bindings.reconcile());
+    }
+    List<MigrationResult> results = new ArrayList<>();
+    try (Stream<Path> dirs = Files.list(agentsDir)) {
+      dirs.filter(path -> Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS))
+          .sorted()
+          .forEach(path -> results.add(migrate(path)));
+    } catch (IOException e) {
+      throw new UncheckedIOException("扫描旧 Agent Skill 配置失败", e);
+    }
+    return new AgentSkillStartupReport(results, bindings.reconcile());
+  }
+
+  public MigrationResult migrate(Path agentDirectory) {
+    return bindings.coordinate(() -> migrateLocked(agentDirectory));
+  }
+
+  private MigrationResult migrateLocked(Path agentDirectory) {
+    String agent = String.valueOf(agentDirectory.getFileName());
+    Path markdown = agentDirectory.resolve("AGENT.md");
+    if (!Files.isRegularFile(markdown)) {
+      return new MigrationResult(agent, Status.NOT_NEEDED, "缺少 AGENT.md");
+    }
+    byte[] original;
+    String text;
+    try {
+      original = Files.readAllBytes(markdown);
+      text = new String(original, java.nio.charset.StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      return new MigrationResult(agent, Status.FAILED, "读取 AGENT.md 失败");
+    }
+    if (!AgentMarkdown.hasLegacySkills(text)) {
+      return new MigrationResult(agent, Status.NOT_NEEDED, "无需迁移");
+    }
+    List<String> legacy;
+    try {
+      legacy = AgentMarkdown.legacySkills(text);
+    } catch (RuntimeException e) {
+      return new MigrationResult(agent, Status.FAILED, sanitize(e.getMessage()));
+    }
+    List<String> before =
+        bindings.inspect(agent).bindings().stream().map(BoundSkillDescriptor::name).toList();
+    Set<String> desired = new LinkedHashSet<>(before);
+    desired.addAll(legacy);
+    Path temporary = markdown.resolveSibling(".AGENT.md.migrate-" + UUID.randomUUID());
+    try {
+      String migrated = AgentMarkdown.removeLegacySkills(text);
+      Files.writeString(temporary, migrated);
+      bindings.replaceBindings(agent, List.copyOf(desired));
+      moveAtomic(temporary, markdown);
+      return new MigrationResult(agent, Status.MIGRATED, "已迁移 " + legacy.size() + " 个 Skill");
+    } catch (IOException | RuntimeException e) {
+      try {
+        bindings.replaceBindings(agent, before);
+      } catch (RuntimeException ignored) {
+        // Reconciliation exposes rollback residue while the original error remains primary.
+      }
+      try {
+        Files.deleteIfExists(temporary);
+        if (!java.util.Arrays.equals(original, Files.readAllBytes(markdown))) {
+          Files.write(markdown, original);
+        }
+      } catch (IOException ignored) {
+        // The failure is reported; startup continues with other Agents.
+      }
+      return new MigrationResult(agent, Status.FAILED, sanitize(e.getMessage()));
+    }
+  }
+
+  private static void moveAtomic(Path source, Path target) throws IOException {
+    try {
+      Files.move(
+          source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    } catch (AtomicMoveNotSupportedException e) {
+      throw new IOException("文件系统不支持 AGENT.md 原子迁移", e);
+    }
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "迁移失败" : value.replace('\r', '_').replace('\n', '_');
+  }
+
+  public enum Status {
+    NOT_NEEDED,
+    MIGRATED,
+    FAILED
+  }
+
+  public record MigrationResult(String agentName, Status status, String message) {}
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillMigrationService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillMigrationService.java
@@ -81,6 +81,9 @@ public final class AgentSkillMigrationService {
     Path temporary = markdown.resolveSibling(".AGENT.md.migrate-" + UUID.randomUUID());
     try {
       String migrated = AgentMarkdown.removeLegacySkills(text);
+      if (AgentMarkdown.hasLegacySkills(migrated)) {
+        throw new IllegalArgumentException("旧版顶层 skills 未能安全移除");
+      }
       Files.writeString(temporary, migrated);
       bindings.replaceBindings(agent, List.copyOf(desired));
       moveAtomic(temporary, markdown);

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillStartupReport.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillStartupReport.java
@@ -1,0 +1,12 @@
+package io.oryxos.core.skill;
+
+import java.util.List;
+
+/** Explicit startup dependency result: migration finishes before profile scanning and watchers. */
+public record AgentSkillStartupReport(
+    List<AgentSkillMigrationService.MigrationResult> migrations, List<SkillBindingIssue> issues) {
+  public AgentSkillStartupReport {
+    migrations = migrations == null ? List.of() : List.copyOf(migrations);
+    issues = issues == null ? List.of() : List.copyOf(issues);
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/BindingInspection.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/BindingInspection.java
@@ -1,0 +1,12 @@
+package io.oryxos.core.skill;
+
+import java.util.List;
+
+/** Immutable result of one live scan of an Agent's local Skill links. */
+public record BindingInspection(
+    List<BoundSkillDescriptor> bindings, List<SkillBindingIssue> issues) {
+  public BindingInspection {
+    bindings = bindings == null ? List.of() : List.copyOf(bindings);
+    issues = issues == null ? List.of() : List.copyOf(issues);
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/BoundSkillDescriptor.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/BoundSkillDescriptor.java
@@ -1,0 +1,10 @@
+package io.oryxos.core.skill;
+
+import java.nio.file.Path;
+
+/** Level-1 Skill metadata exposed to an Agent; it deliberately has no body/resources field. */
+public record BoundSkillDescriptor(String name, String description, Path linkPath, Path skillFile) {
+  public String skillName() {
+    return name;
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/InstalledSkillCatalog.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/InstalledSkillCatalog.java
@@ -1,0 +1,43 @@
+package io.oryxos.core.skill;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+/** Default catalog adapter exposing validated local installations as PUBLIC/local candidates. */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification =
+        "SkillRegistry is the injected live installation index and must be observed by reference.")
+public final class InstalledSkillCatalog implements SkillCatalog {
+
+  private final SkillRegistry registry;
+
+  public InstalledSkillCatalog(SkillRegistry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  public List<SkillCatalogEntry> query(String query, SkillCatalogEntry.Visibility visibility) {
+    String needle = query == null ? "" : query.strip().toLowerCase(Locale.ROOT);
+    if (visibility == SkillCatalogEntry.Visibility.PRIVATE) {
+      return List.of();
+    }
+    return registry.all().stream()
+        .filter(
+            skill ->
+                needle.isEmpty()
+                    || skill.name().toLowerCase(Locale.ROOT).contains(needle)
+                    || skill.description().toLowerCase(Locale.ROOT).contains(needle))
+        .sorted(Comparator.comparing(Skill::name))
+        .map(
+            skill ->
+                new SkillCatalogEntry(
+                    skill.name(),
+                    skill.description(),
+                    SkillCatalogEntry.Visibility.PUBLIC,
+                    "local-installed",
+                    true))
+        .toList();
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/Skill.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/Skill.java
@@ -5,8 +5,7 @@ package io.oryxos.core.skill;
  *
  * <p>存储形态 {@code .oryxos/skills/<name>/SKILL.md}：frontmatter（name/description）+ 正文（约束指令）。 与"一个目录 =
  * 一个 Agent"的 {@code AGENT.md} 同构，但 Skill 不是 Agent、不进 {@code ProfileRegistry}：它是 Agent
- * 按名引用的**共享能力库**条目，由 {@code ContextLoader} 在组装 system prompt 时把正文注入（宪法 IV 修订：Skill 从"每-Agent
- * 子指令"升级为"全局能力库"）。
+ * 通过本地软连接绑定的共享能力条目。{@code ContextLoader} 只披露元数据与 Agent 本地入口，正文由 {@code read_file} 按需读取。
  */
 public record Skill(String name, String description, String body) {
 

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillArchive.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillArchive.java
@@ -1,0 +1,7 @@
+package io.oryxos.core.skill;
+
+import java.nio.file.Path;
+import java.time.Instant;
+
+/** Result of moving one complete installed Skill directory into the archive. */
+public record SkillArchive(String name, Path archivedPath, Instant archivedAt) {}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillBindingIssue.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillBindingIssue.java
@@ -1,0 +1,27 @@
+package io.oryxos.core.skill;
+
+import java.nio.file.Path;
+
+/** Agent Skill 绑定的一致性问题。无效项只报告并跳过，不自动修改用户文件。 */
+public record SkillBindingIssue(
+    String agentName,
+    AgentState agentState,
+    String entryName,
+    Path path,
+    Type type,
+    String message) {
+
+  public enum AgentState {
+    ACTIVE,
+    ARCHIVED,
+    INVALID
+  }
+
+  public enum Type {
+    DANGLING,
+    ESCAPED,
+    INVALID_TARGET,
+    NAME_MISMATCH,
+    STALE_REFERENCE
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillCatalog.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillCatalog.java
@@ -1,0 +1,9 @@
+package io.oryxos.core.skill;
+
+import java.util.List;
+
+/** Port for a caller-filtered external public/private Skill catalog. */
+@FunctionalInterface
+public interface SkillCatalog {
+  List<SkillCatalogEntry> query(String query, SkillCatalogEntry.Visibility visibility);
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillCatalogEntry.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillCatalogEntry.java
@@ -1,0 +1,10 @@
+package io.oryxos.core.skill;
+
+/** Caller-filtered external Skill candidate metadata; visibility is a label, not an ACL. */
+public record SkillCatalogEntry(
+    String name, String description, Visibility visibility, String source, boolean installed) {
+  public enum Visibility {
+    PUBLIC,
+    PRIVATE
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillLoader.java
@@ -1,6 +1,7 @@
 package io.oryxos.core.skill;
 
 import io.oryxos.core.agent.AgentMarkdown;
+import io.oryxos.core.fs.RealPathBoundary;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -15,7 +16,7 @@ import org.slf4j.LoggerFactory;
  * 启动时扫描 {@code .oryxos/skills/} 下每个子目录的 {@code SKILL.md}，派生成 {@link Skill} 建立索引（第 32 节）。
  *
  * <p>与 {@code AgentLoader} 同构：单个坏目录记 ERROR 跳过、不阻断其余加载。frontmatter 用 {@link AgentMarkdown#split}
- * 拆分（复用 同一套 frontmatter/正文解析），name 缺省取目录名。
+ * 拆分（复用同一套 frontmatter/正文解析）。name 与 description 都是渐进式目录所需元数据，必须显式非空； 从目录加载时 name 还必须等于目录名。
  */
 public class SkillLoader {
 
@@ -36,7 +37,7 @@ public class SkillLoader {
       return new SkillRegistry(loaded);
     }
     try (Stream<Path> dirs = Files.list(skillsDir)) {
-      dirs.filter(Files::isDirectory)
+      dirs.filter(path -> Files.isDirectory(path, java.nio.file.LinkOption.NOFOLLOW_LINKS))
           .sorted()
           .forEach(
               dir -> {
@@ -56,26 +57,39 @@ public class SkillLoader {
     return new SkillRegistry(loaded);
   }
 
-  /** 读 {@code <dir>/SKILL.md} 派生 Skill；缺文件抛异常。name 取 frontmatter，缺省用目录名。 */
+  /** 读 {@code <dir>/SKILL.md} 派生 Skill；缺文件、元数据不完整或 name 与目录不一致均抛异常。 */
   public Skill deriveSkill(Path skillDir) {
+    if (!RealPathBoundary.isWithin(skillsDir, skillDir)) {
+      throw new IllegalArgumentException("Skill 目录真实路径越界: " + skillDir.getFileName());
+    }
     Path skillMd = skillDir.resolve(SKILL_FILE);
     if (!Files.isRegularFile(skillMd)) {
       throw new IllegalArgumentException("Skill 目录缺少 SKILL.md: " + skillDir.getFileName());
     }
     String dirName = String.valueOf(skillDir.getFileName());
-    return parse(read(skillMd), dirName);
+    Skill skill = parse(read(skillMd), dirName);
+    if (!dirName.equals(skill.name())) {
+      throw new IllegalArgumentException("Skill name 与目录名不一致: " + skill.name() + " != " + dirName);
+    }
+    return skill;
   }
 
-  /** 把一份 SKILL.md 文本解析成 Skill（name 缺省用 fallbackName）。 */
+  /** 把一份 SKILL.md 文本解析成 Skill；fallbackName 仅用于报错定位，不再替代必填 name。 */
   public Skill parse(String markdown, String fallbackName) {
     AgentMarkdown.Parsed parsed = AgentMarkdown.split(markdown);
     Object nameVal = parsed.frontmatter().get("name");
-    String name =
-        nameVal == null || String.valueOf(nameVal).isBlank()
-            ? fallbackName
-            : String.valueOf(nameVal);
+    String name = nameVal == null ? null : String.valueOf(nameVal).strip();
+    if (name == null || name.isBlank()) {
+      throw new IllegalArgumentException("SKILL.md 缺少 name: " + fallbackName);
+    }
     Object descVal = parsed.frontmatter().get("description");
-    String description = descVal == null ? "" : String.valueOf(descVal);
+    String description = descVal == null ? null : String.valueOf(descVal).strip();
+    if (description == null || description.isBlank()) {
+      throw new IllegalArgumentException("SKILL.md 缺少 description: " + fallbackName);
+    }
+    if (parsed.body().isBlank()) {
+      throw new IllegalArgumentException("SKILL.md 正文为空: " + fallbackName);
+    }
     return new Skill(name, description, parsed.body());
   }
 

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillMetadataReader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillMetadataReader.java
@@ -1,0 +1,79 @@
+package io.oryxos.core.skill;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.yaml.snakeyaml.Yaml;
+
+/** Reads only SKILL.md frontmatter while verifying that a non-empty body boundary exists. */
+public final class SkillMetadataReader {
+
+  private static final String FENCE = "---";
+
+  public Metadata read(Path skillDirectory) {
+    Path file = skillDirectory.resolve("SKILL.md");
+    if (!Files.isRegularFile(file)) {
+      throw new IllegalArgumentException("Skill 目录缺少可读 SKILL.md: " + skillDirectory.getFileName());
+    }
+    try (BufferedReader reader = Files.newBufferedReader(file)) {
+      if (!FENCE.equals(reader.readLine())) {
+        throw new IllegalArgumentException(
+            "SKILL.md 缺少 frontmatter: " + skillDirectory.getFileName());
+      }
+      StringBuilder yaml = new StringBuilder();
+      String line;
+      boolean closed = false;
+      while ((line = reader.readLine()) != null) {
+        if (FENCE.equals(line.strip())) {
+          closed = true;
+          break;
+        }
+        yaml.append(line).append('\n');
+      }
+      if (!closed) {
+        throw new IllegalArgumentException(
+            "SKILL.md frontmatter 未闭合: " + skillDirectory.getFileName());
+      }
+      boolean hasBody = false;
+      while ((line = reader.readLine()) != null) {
+        if (!line.isBlank()) {
+          hasBody = true;
+          break;
+        }
+      }
+      if (!hasBody) {
+        throw new IllegalArgumentException("SKILL.md 正文为空: " + skillDirectory.getFileName());
+      }
+      Object loaded = new Yaml().load(yaml.toString());
+      if (!(loaded instanceof Map<?, ?> map)) {
+        throw new IllegalArgumentException(
+            "SKILL.md frontmatter 不是对象: " + skillDirectory.getFileName());
+      }
+      String name = value(map.get("name"));
+      String description = value(map.get("description"));
+      if (name.isBlank()) {
+        throw new IllegalArgumentException("SKILL.md 缺少 name: " + skillDirectory.getFileName());
+      }
+      if (description.isBlank()) {
+        throw new IllegalArgumentException(
+            "SKILL.md 缺少 description: " + skillDirectory.getFileName());
+      }
+      String directoryName = String.valueOf(skillDirectory.getFileName());
+      if (!directoryName.equals(name)) {
+        throw new IllegalArgumentException("Skill name 与目录名不一致: " + name + " != " + directoryName);
+      }
+      return new Metadata(name, description);
+    } catch (IOException e) {
+      throw new UncheckedIOException("读取 SKILL.md 元数据失败: " + file, e);
+    }
+  }
+
+  private static String value(Object value) {
+    return value == null ? "" : String.valueOf(value).strip();
+  }
+
+  public record Metadata(String name, String description) {}
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillReference.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillReference.java
@@ -1,0 +1,12 @@
+package io.oryxos.core.skill;
+
+import java.nio.file.Path;
+
+/** Active or archived Agent reference that blocks Skill archival. */
+public record SkillReference(
+    String agentName, AgentState state, String directoryName, Path linkPath) {
+  public enum AgentState {
+    ACTIVE,
+    ARCHIVED
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillReferencedException.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillReferencedException.java
@@ -1,0 +1,28 @@
+package io.oryxos.core.skill;
+
+import java.util.List;
+
+/** Raised when an installed Skill cannot be archived because Agent links still reference it. */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "SE_BAD_FIELD",
+    justification =
+        "This in-process HTTP mapping exception is never Java-serialized; references are immutable response data.")
+public final class SkillReferencedException extends IllegalStateException {
+
+  private final String skillName;
+  private final List<SkillReference> references;
+
+  public SkillReferencedException(String skillName, List<SkillReference> references) {
+    super("Skill 仍被 Agent 引用: " + skillName);
+    this.skillName = skillName;
+    this.references = List.copyOf(references);
+  }
+
+  public String skillName() {
+    return skillName;
+  }
+
+  public List<SkillReference> references() {
+    return references;
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillService.java
@@ -1,5 +1,6 @@
 package io.oryxos.core.skill;
 
+import io.oryxos.core.agent.AgentMarkdown;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -128,7 +129,7 @@ public class SkillService {
     if (name == null || name.isBlank()) {
       throw new IllegalArgumentException("Skill name 为空");
     }
-    if (registry.exists(name) || store.exists(name)) {
+    if (registry.exists(name) || store.entryExists(name)) {
       throw new IllegalArgumentException("Skill 已存在: " + name);
     }
     return writeAndRegister(name, description, body);
@@ -169,7 +170,7 @@ public class SkillService {
   /** 播种内置的一批 Skill：逐个"库里没有才写"（幂等，用户改过/删过的名不重复播种）。启动时调一次。 */
   public void seedBuiltins() {
     for (Builtin b : BUILTINS) {
-      if (!store.exists(b.name()) && !registry.exists(b.name())) {
+      if (!store.entryExists(b.name()) && !registry.exists(b.name())) {
         writeAndRegister(b.name(), b.description(), b.body());
       }
     }
@@ -189,7 +190,7 @@ public class SkillService {
     if (name == null || name.isBlank()) {
       throw new IllegalArgumentException("无法确定 Skill 名（SKILL.md 无 name 字段，也未指定 name）");
     }
-    if (registry.exists(name) || store.exists(name)) {
+    if (registry.exists(name) || store.entryExists(name)) {
       throw new IllegalArgumentException("Skill 已存在: " + name);
     }
     return writeAndRegister(name, parsed.description(), parsed.body());
@@ -218,20 +219,34 @@ public class SkillService {
     if (name == null || name.isBlank()) {
       throw new IllegalArgumentException("无法确定 Skill 名（SKILL.md 无 name 字段，也未指定 name）");
     }
-    if (registry.exists(name) || store.exists(name)) {
+    if (registry.exists(name) || store.entryExists(name)) {
       throw new IllegalArgumentException("Skill 已存在: " + name);
     }
     Map<String, String> normalizedFiles = new LinkedHashMap<>(files);
     if (!name.equals(parsed.name())) {
       normalizedFiles.put(SKILL_FILE, replaceFrontmatterName(skillMd, name));
     }
-    store.writeAll(name, normalizedFiles); // name 非法在此抛（SkillStore.safe）
-    Skill skill = loader.deriveSkill(store.directory(name));
-    registry.register(skill);
-    if (bindings != null) {
-      bindings.logCurrentIssues();
+    boolean registered = false;
+    try {
+      store.writeAll(name, normalizedFiles); // name 非法在此抛（SkillStore.safe）
+      Skill skill = loader.deriveSkill(store.directory(name));
+      registry.register(skill);
+      registered = true;
+      if (bindings != null) {
+        bindings.logCurrentIssues();
+      }
+      return skill;
+    } catch (RuntimeException e) {
+      if (registered) {
+        registry.remove(name);
+      }
+      try {
+        store.rollbackCreate(name);
+      } catch (RuntimeException rollbackFailure) {
+        e.addSuppressed(rollbackFailure);
+      }
+      throw e;
     }
-    return skill;
   }
 
   private Skill writeAndRegister(String name, String description, String body) {
@@ -252,8 +267,7 @@ public class SkillService {
   }
 
   private static String replaceFrontmatterName(String markdown, String name) {
-    String normalized = markdown.replace("\r\n", "\n").replace('\r', '\n');
-    return normalized.replaceFirst("(?m)^name\\s*:.*$", "name: " + name);
+    return AgentMarkdown.replaceTopLevelScalar(markdown, "name", name);
   }
 
   /**

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillService.java
@@ -1,6 +1,7 @@
 package io.oryxos.core.skill;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -9,13 +10,13 @@ import java.util.Optional;
  * 全局 Skill 库的生命周期编排（第 32 节）：CRUD + 内置 Skill 播种。
  *
  * <p>与 {@code AgentLifecycleService} 同构但更薄：Skill 是纯共享资产（无 provider/调度/沙箱）。写盘走 {@link
- * SkillStore}、内存索引走 {@link SkillRegistry}，两者在每次增删改后同步（{@code ContextLoader} 按名解析时即时可见）。校验与 web
- * 层解耦：{@link #get} 返回 {@link Optional}，404 由 web 决定；非法入参抛 {@link IllegalArgumentException}（web 映射
- * 400）。
+ * SkillStore}、内存索引走 {@link SkillRegistry}，两者在每次增删改后同步；运行时绑定元数据直接现读文件系统。校验与 web 层解耦：{@link #get} 返回
+ * {@link Optional}，404 由 web 决定；非法入参抛 {@link IllegalArgumentException}（web 映射 400）。
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",
-    justification = "registry / store 均为 Spring 注入的共享单例，构造注入共享同一引用正是意图（全局 Skill 库必须是同一份）。")
+    justification =
+        "Store, registry and binding service are injected live coordinators intentionally shared by reference.")
 public class SkillService {
 
   /** 内置 Skill 名（供测试与外部引用）。 */
@@ -105,11 +106,21 @@ public class SkillService {
   private final SkillStore store;
   private final SkillRegistry registry;
   private final SkillLoader loader;
+  private final AgentSkillBindingService bindings;
 
   public SkillService(SkillStore store, SkillRegistry registry, SkillLoader loader) {
+    this(store, registry, loader, null);
+  }
+
+  public SkillService(
+      SkillStore store,
+      SkillRegistry registry,
+      SkillLoader loader,
+      AgentSkillBindingService bindings) {
     this.store = store;
     this.registry = registry;
     this.loader = loader;
+    this.bindings = bindings;
   }
 
   /** 新建 Skill：name 冲突第一步就拒；写盘 → 解析 → 登记内存索引。 */
@@ -131,10 +142,20 @@ public class SkillService {
     return writeAndRegister(name, description, body);
   }
 
-  /** 删除 Skill：物理删目录 + 移出内存索引。 */
-  public void delete(String name) {
-    store.delete(name);
+  /** 删除即归档：有活跃或归档引用时拒绝；否则移动完整目录并更新安装索引。 */
+  public synchronized SkillArchive delete(String name) {
+    if (bindings != null) {
+      return bindings.archiveIfUnreferenced(
+          name,
+          () -> {
+            SkillArchive archive = store.archive(name);
+            registry.remove(name);
+            return archive;
+          });
+    }
+    SkillArchive archive = store.archive(name);
     registry.remove(name);
+    return archive;
   }
 
   public Optional<Skill> get(String name) {
@@ -200,20 +221,39 @@ public class SkillService {
     if (registry.exists(name) || store.exists(name)) {
       throw new IllegalArgumentException("Skill 已存在: " + name);
     }
-    store.writeAll(name, files); // name 非法在此抛（SkillStore.safe）
-    // 不能再用 loader.parse(skillMd, name) 重新派生——SKILL.md 里若有 name 字段，parse 会优先用它，
-    // 那样 nameOverride 就白传了；这里直接拿 name（已按 override 优先解析过）+ 已解析出的 description/body。
-    Skill skill = new Skill(name, parsed.description(), parsed.body());
+    Map<String, String> normalizedFiles = new LinkedHashMap<>(files);
+    if (!name.equals(parsed.name())) {
+      normalizedFiles.put(SKILL_FILE, replaceFrontmatterName(skillMd, name));
+    }
+    store.writeAll(name, normalizedFiles); // name 非法在此抛（SkillStore.safe）
+    Skill skill = loader.deriveSkill(store.directory(name));
     registry.register(skill);
+    if (bindings != null) {
+      bindings.logCurrentIssues();
+    }
     return skill;
   }
 
   private Skill writeAndRegister(String name, String description, String body) {
+    if (description == null || description.isBlank()) {
+      throw new IllegalArgumentException("Skill description 为空: " + name);
+    }
+    if (body == null || body.isBlank()) {
+      throw new IllegalArgumentException("Skill body 为空: " + name);
+    }
     String markdown = toSkillMarkdown(name, description, body);
     store.write(name, markdown); // name 非法在此抛（SkillStore.safe）
     Skill skill = loader.parse(markdown, name);
     registry.register(skill);
+    if (bindings != null) {
+      bindings.logCurrentIssues();
+    }
     return skill;
+  }
+
+  private static String replaceFrontmatterName(String markdown, String name) {
+    String normalized = markdown.replace("\r\n", "\n").replace('\r', '\n');
+    return normalized.replaceFirst("(?m)^name\\s*:.*$", "name: " + name);
   }
 
   /**

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillStore.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillStore.java
@@ -1,34 +1,53 @@
 package io.oryxos.core.skill;
 
+import io.oryxos.core.fs.RealPathBoundary;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.util.Comparator;
+import java.nio.file.StandardCopyOption;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 /**
  * 全局 Skill 库的文件读写，限定在 {@code .oryxos/skills/} 内（第 32 节）。
  *
- * <p>write：把一段 {@code SKILL.md} 写进 {@code .oryxos/skills/<name>/}；delete：递归删整个 Skill 目录。 name
- * 必须是安全目录段（只允许字母/数字/下划线/连字符，防路径穿越）。与 {@code AgentStore} 同构，但 Skill 是纯共享资产、删除即物理删（无 archive）。
+ * <p>write：把一段 {@code SKILL.md} 写进 {@code .oryxos/skills/<name>/}；archive：把完整目录移动到 {@code
+ * .oryxos/archive/skills/}。name 必须是安全目录段（只允许字母/数字/下划线/连字符，防路径穿越）。
  */
 public class SkillStore {
 
   private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9_-]+");
   private static final String SKILL_FILE = "SKILL.md";
 
+  private static final DateTimeFormatter ARCHIVE_TIME =
+      DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
+
+  private final Path root;
   private final Path skillsDir;
+  private final Path archiveDir;
+  private final Clock clock;
 
   public SkillStore(Path oryxosRoot) {
-    this.skillsDir = oryxosRoot.resolve("skills");
+    this(oryxosRoot, Clock.systemUTC());
+  }
+
+  SkillStore(Path oryxosRoot, Clock clock) {
+    this.root = oryxosRoot.toAbsolutePath().normalize();
+    this.skillsDir = root.resolve("skills");
+    this.archiveDir = root.resolve("archive");
+    this.clock = clock;
   }
 
   /** 写 {@code .oryxos/skills/<name>/SKILL.md}，返回该 Skill 目录。 */
   public Path write(String name, String skillMarkdown) {
     Path dir = skillsDir.resolve(safe(name));
+    requireSafe(dir.resolve(SKILL_FILE));
     try {
       Files.createDirectories(dir);
       Files.writeString(dir.resolve(SKILL_FILE), skillMarkdown);
@@ -44,6 +63,7 @@ public class SkillStore {
    */
   public Path writeAll(String name, Map<String, String> files) {
     Path dir = skillsDir.resolve(safe(name)).normalize();
+    requireSafe(dir);
     try {
       Files.createDirectories(dir);
       for (Map.Entry<String, String> entry : files.entrySet()) {
@@ -51,6 +71,7 @@ public class SkillStore {
         if (!target.startsWith(dir)) {
           throw new IllegalArgumentException("非法文件路径: " + entry.getKey());
         }
+        requireSafe(target);
         Path parent = target.getParent();
         if (parent != null) {
           Files.createDirectories(parent);
@@ -63,29 +84,64 @@ public class SkillStore {
     return dir;
   }
 
-  /** 递归删除一个 Skill 目录。 */
-  public void delete(String name) {
-    Path dir = skillsDir.resolve(safe(name));
-    if (!Files.exists(dir)) {
-      return;
-    }
-    try (Stream<Path> walk = Files.walk(dir)) {
-      walk.sorted(Comparator.reverseOrder()).forEach(SkillStore::deleteOne);
-    } catch (IOException e) {
-      throw new UncheckedIOException("删除 Skill 目录失败: " + name, e);
-    }
-  }
-
   public boolean exists(String name) {
-    return Files.isRegularFile(skillsDir.resolve(safe(name)).resolve(SKILL_FILE));
+    Path file = skillsDir.resolve(safe(name)).resolve(SKILL_FILE);
+    return RealPathBoundary.isWithin(skillsDir, file) && Files.isRegularFile(file);
   }
 
-  private static void deleteOne(Path path) {
-    try {
-      Files.delete(path);
-    } catch (IOException e) {
-      throw new UncheckedIOException("删除失败: " + path.getFileName(), e);
+  /**
+   * Moves the complete installed Skill directory into archive/skills without overwriting history.
+   */
+  public SkillArchive archive(String name) {
+    String safeName = safe(name);
+    Path source = skillsDir.resolve(safeName);
+    requireSafe(source);
+    if (!Files.isDirectory(source, LinkOption.NOFOLLOW_LINKS)) {
+      throw new IllegalArgumentException("Skill 不存在: " + safeName);
     }
+    Instant archivedAt = clock.instant();
+    try {
+      prepareSkillArchiveNamespace();
+      Path target = uniqueArchivePath(safeName, archivedAt);
+      RealPathBoundary.requireWithin(root, target);
+      Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+      return new SkillArchive(safeName, root.relativize(target), archivedAt);
+    } catch (IOException e) {
+      throw new UncheckedIOException("归档 Skill 目录失败: " + safeName, e);
+    }
+  }
+
+  /** 返回受安全 name 约束的公共 Skill 目录，供加载器在整目录导入后做一致性复验。 */
+  Path directory(String name) {
+    return skillsDir.resolve(safe(name));
+  }
+
+  private void prepareSkillArchiveNamespace() throws IOException {
+    Path skillArchives = archiveDir.resolve("skills");
+    if (Files.isDirectory(skillArchives, LinkOption.NOFOLLOW_LINKS)
+        && Files.isRegularFile(skillArchives.resolve("AGENT.md"))) {
+      Path migrated = archiveDir.resolve("skills-" + System.currentTimeMillis());
+      while (Files.exists(migrated, LinkOption.NOFOLLOW_LINKS)) {
+        migrated = archiveDir.resolve("skills-" + System.nanoTime());
+      }
+      Files.move(skillArchives, migrated, StandardCopyOption.ATOMIC_MOVE);
+    }
+    Files.createDirectories(skillArchives);
+  }
+
+  private Path uniqueArchivePath(String name, Instant instant) {
+    Path skillArchives = archiveDir.resolve("skills");
+    String base = name + "-" + ARCHIVE_TIME.format(instant);
+    Path candidate = skillArchives.resolve(base);
+    int suffix = 2;
+    while (Files.exists(candidate, LinkOption.NOFOLLOW_LINKS)) {
+      candidate = skillArchives.resolve(base + "-" + suffix++);
+    }
+    return candidate;
+  }
+
+  private void requireSafe(Path path) {
+    RealPathBoundary.requireWithin(skillsDir, path);
   }
 
   private static String safe(String name) {

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillStore.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillStore.java
@@ -11,8 +11,10 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
  * 全局 Skill 库的文件读写，限定在 {@code .oryxos/skills/} 内（第 32 节）。
@@ -89,6 +91,12 @@ public class SkillStore {
     return RealPathBoundary.isWithin(skillsDir, file) && Files.isRegularFile(file);
   }
 
+  /** Returns whether any filesystem entry already occupies this Skill name, including residue. */
+  boolean entryExists(String name) {
+    Path directory = skillsDir.resolve(safe(name));
+    return Files.exists(directory, LinkOption.NOFOLLOW_LINKS);
+  }
+
   /**
    * Moves the complete installed Skill directory into archive/skills without overwriting history.
    */
@@ -114,6 +122,20 @@ public class SkillStore {
   /** 返回受安全 name 约束的公共 Skill 目录，供加载器在整目录导入后做一致性复验。 */
   Path directory(String name) {
     return skillsDir.resolve(safe(name));
+  }
+
+  /** Removes a just-created import directory after validation or registration failed. */
+  void rollbackCreate(String name) {
+    Path directory = skillsDir.resolve(safe(name));
+    requireSafe(directory);
+    if (!Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
+      return;
+    }
+    try (Stream<Path> paths = Files.walk(directory)) {
+      paths.sorted(Comparator.reverseOrder()).forEach(SkillStore::deleteRollbackPath);
+    } catch (IOException e) {
+      throw new UncheckedIOException("回滚 Skill 导入目录失败: " + name, e);
+    }
   }
 
   private void prepareSkillArchiveNamespace() throws IOException {
@@ -142,6 +164,14 @@ public class SkillStore {
 
   private void requireSafe(Path path) {
     RealPathBoundary.requireWithin(skillsDir, path);
+  }
+
+  private static void deleteRollbackPath(Path path) {
+    try {
+      Files.deleteIfExists(path);
+    } catch (IOException e) {
+      throw new UncheckedIOException("删除 Skill 导入残留失败: " + path.getFileName(), e);
+    }
   }
 
   private static String safe(String name) {

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleServiceTest.java
@@ -1,8 +1,8 @@
 package io.oryxos.core.agent;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -182,7 +182,8 @@ class AgentLifecycleServiceTest {
     service.updateBasicInfo("demo", "新描述", "openai", "gpt-4o");
 
     @SuppressWarnings("unchecked")
-    ArgumentCaptor<java.util.Map<String, String>> filesCaptor = ArgumentCaptor.forClass(java.util.Map.class);
+    ArgumentCaptor<java.util.Map<String, String>> filesCaptor =
+        ArgumentCaptor.forClass(java.util.Map.class);
     verify(agentStore).writeAll(eq("demo"), filesCaptor.capture());
     String written = filesCaptor.getValue().get("AGENT.md");
     assertTrue(written.contains("description: 新描述"), "description 被更新");

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleServiceTest.java
@@ -1,9 +1,8 @@
 package io.oryxos.core.agent;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -151,7 +150,7 @@ class AgentLifecycleServiceTest {
     Profile updated = profile("w", new ScheduleConfig("m", "0 0 10 * * *", "Asia/Shanghai", "新"));
     when(profileRegistry.get("w")).thenReturn(Optional.of(old));
     Path dir = Path.of("agents", "w");
-    when(agentStore.write(eq("w"), any())).thenReturn(dir);
+    when(agentStore.writeAll(eq("w"), any())).thenReturn(dir);
     doReturn(updated).when(agentLoader).deriveProfile(dir);
 
     service.update("w", MD);
@@ -162,55 +161,34 @@ class AgentLifecycleServiceTest {
   }
 
   @Test
-  @DisplayName("ensureRequiredSkills：模型漏写也补齐勾选的 Skill；模型选的保留去重；已全含或空则不动")
-  void ensureRequiredSkills_mergesReliably() {
-    String noSkills = "---\nname: a\nprovider:\n  name: deepseek\n  model: m\n---\n正文内容";
-    String out = AgentLifecycleService.ensureRequiredSkills(noSkills, List.of("report-format"));
-    assertTrue(out.contains("skills:"), "无 skills 块时补出一个");
-    assertTrue(out.contains("- report-format"));
-    assertTrue(out.contains("name: a"), "其余 frontmatter 保留");
-    assertTrue(out.contains("正文内容"), "正文保留");
+  @DisplayName("运行期更新拒绝 legacy skills，迁移职责不会泄漏到普通 CRUD")
+  void update_rejectsLegacySkills() {
+    String legacy = MD.replace("---\n正文", "skills:\n  - report-format\n---\n正文");
 
-    String withSkills =
-        "---\nname: a\nprovider:\n  name: deepseek\n  model: m\nskills:\n  - web-research\n---\n正文";
-    String out2 = AgentLifecycleService.ensureRequiredSkills(withSkills, List.of("report-format"));
-    Object parsed = AgentMarkdown.split(out2).frontmatter().get("skills");
-    assertTrue(parsed instanceof List, "skills 仍是合法列表");
-    assertTrue(
-        ((List<?>) parsed).containsAll(List.of("web-research", "report-format")), "模型选的保留 + 勾选的补上");
-    assertEquals(out2.indexOf("web-research"), out2.lastIndexOf("web-research"), "不重复写入已有项");
-
-    assertEquals(
-        withSkills,
-        AgentLifecycleService.ensureRequiredSkills(withSkills, List.of("web-research")),
-        "勾选的已全部在场 → 原样不动");
-    assertEquals(
-        noSkills,
-        AgentLifecycleService.ensureRequiredSkills(noSkills, List.of()),
-        "未勾选任何 Skill → 原样不动");
+    assertThrows(IllegalArgumentException.class, () -> service.update("w", legacy));
+    verify(agentStore, never()).writeAll(any(), any());
   }
 
   @Test
-  @DisplayName("updateBasicInfo 改 description/provider/model/skills，正文与其它字段保留")
+  @DisplayName("updateBasicInfo 改 description/provider/model，正文与其它字段保留")
   void updateBasicInfo_editsFrontmatterPreservesBodyAndOtherKeys() throws Exception {
     when(agentStore.read("demo")).thenReturn(MD);
     Path dir = Path.of("agents", "demo");
-    when(agentStore.write(eq("demo"), any())).thenReturn(dir);
+    when(agentStore.writeAll(eq("demo"), any())).thenReturn(dir);
     Profile updated = profile("demo");
     doReturn(updated).when(agentLoader).parse(any(), eq("demo"));
     doReturn(updated).when(agentLoader).deriveProfile(dir);
 
-    service.updateBasicInfo("demo", "新描述", "openai", "gpt-4o", List.of("s1", "s2"));
+    service.updateBasicInfo("demo", "新描述", "openai", "gpt-4o");
 
-    ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
-    verify(agentStore).write(eq("demo"), markdownCaptor.capture());
-    String written = markdownCaptor.getValue();
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<java.util.Map<String, String>> filesCaptor = ArgumentCaptor.forClass(java.util.Map.class);
+    verify(agentStore).writeAll(eq("demo"), filesCaptor.capture());
+    String written = filesCaptor.getValue().get("AGENT.md");
     assertTrue(written.contains("description: 新描述"), "description 被更新");
     assertTrue(written.contains("name: openai"), "provider.name 被更新");
     assertTrue(written.contains("model: gpt-4o"), "provider.model 被更新");
-    assertTrue(written.contains("skills:"), "skills 块被写入");
-    assertTrue(written.contains("- s1"), "skills 包含 s1");
-    assertTrue(written.contains("- s2"), "skills 包含 s2");
+    assertTrue(!written.contains("skills:"), "Skill 绑定不写回 AGENT.md");
     assertTrue(written.contains("name: demo"), "name 保留");
     assertTrue(written.contains("正文"), "正文保留");
   }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleSkillBindingTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleSkillBindingTest.java
@@ -1,0 +1,197 @@
+package io.oryxos.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import io.oryxos.core.notify.NotifyChannelRegistry;
+import io.oryxos.core.profile.ProfileRegistry;
+import io.oryxos.core.provider.ProviderResponse;
+import io.oryxos.core.provider.ProviderService;
+import io.oryxos.core.skill.AgentSkillBindingService;
+import io.oryxos.core.skill.InstalledSkillCatalog;
+import io.oryxos.core.skill.SkillCatalog;
+import io.oryxos.core.skill.SkillLoader;
+import io.oryxos.core.skill.SkillRegistry;
+import io.oryxos.core.skill.SkillStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AgentLifecycleSkillBindingTest {
+
+  @TempDir Path root;
+
+  private ProfileRegistry profiles;
+  private SkillRegistry skillRegistry;
+  private AgentSkillBindingService bindings;
+  private ProviderService provider;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    Files.createDirectories(root.resolve("agents"));
+    SkillStore skillStore = new SkillStore(root);
+    SkillLoader skillLoader = new SkillLoader(root.resolve("skills"));
+    skillRegistry = new SkillRegistry();
+    io.oryxos.core.skill.SkillService skillService =
+        new io.oryxos.core.skill.SkillService(skillStore, skillRegistry, skillLoader);
+    skillService.create("required", "必选", "required body");
+    skillService.create("suggested", "建议", "suggested body");
+    profiles = new ProfileRegistry();
+    bindings = new AgentSkillBindingService(root, skillLoader);
+    provider = mock(ProviderService.class);
+  }
+
+  @Test
+  void directCreateAndGeneratedSidecarNeverPersistLegacySkills() throws Exception {
+    AgentLifecycleService service = service(bindings, new InstalledSkillCatalog(skillRegistry));
+    service.create("direct", "直接创建", List.of("required"));
+    assertTrue(Files.isSymbolicLink(root.resolve("agents/direct/skills/required")));
+    assertFalse(Files.readString(root.resolve("agents/direct/AGENT.md")).contains("skills:"));
+
+    when(provider.chat(eq("agent-author-draft"), any(), any()))
+        .thenReturn(
+            new ProviderResponse(
+                """
+                ---
+                name: draft
+                description: 草稿
+                identity:
+                  agent_name: 草稿
+                  prompt: 按职责执行
+                provider:
+                  name: mock
+                  model: mock
+                tools: []
+                settings:
+                  max_iterations: 10
+                  max_history_turns: 20
+                skills:
+                  - suggested
+                ---
+                生成报告
+                """,
+                List.of(),
+                null));
+
+    GeneratedAgentDraft draft = service.generateDraft("draft", "生成报告", null, List.of("required"));
+
+    assertEquals(List.of("required"), draft.requiredSkills());
+    assertEquals(List.of("suggested"), draft.suggestedSkills());
+    assertEquals(List.of("required", "suggested"), draft.bindingSkills());
+    assertFalse(draft.files().get("AGENT.md").contains("skills:"));
+    assertFalse(Files.exists(root.resolve("agents/draft")), "草稿 sidecar 不落盘");
+  }
+
+  @Test
+  void catalogRejectsUninstalledAndCreateRollsBackBindingFailure() {
+    SkillCatalog uninstalled =
+        (q, visibility) ->
+            List.of(
+                new io.oryxos.core.skill.SkillCatalogEntry(
+                    "required",
+                    "必选",
+                    io.oryxos.core.skill.SkillCatalogEntry.Visibility.PUBLIC,
+                    "external",
+                    false));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service(bindings, uninstalled).create("blocked", "x", List.of("required")));
+    assertFalse(Files.exists(root.resolve("agents/blocked")));
+
+    AgentSkillBindingService failing = mock(AgentSkillBindingService.class);
+    when(failing.replaceBindings(eq("rollback"), any()))
+        .thenThrow(new IllegalStateException("link failed"));
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            service(failing, new InstalledSkillCatalog(skillRegistry))
+                .create("rollback", "x", List.of("required")));
+    assertFalse(Files.exists(root.resolve("agents/rollback")));
+    assertFalse(profiles.exists("rollback"));
+  }
+
+  @Test
+  void generatedUnknownSuggestionAndReservedSkillFilesAreRejected() {
+    AgentLifecycleService service = service(bindings, new InstalledSkillCatalog(skillRegistry));
+    when(provider.chat(eq("agent-author-bad"), any(), any()))
+        .thenReturn(
+            new ProviderResponse(
+                "---\nname: bad\nprovider:\n  name: mock\n  model: mock\nskills:\n  - unknown\n---\nbody",
+                List.of(),
+                null));
+    assertThrows(
+        IllegalArgumentException.class, () -> service.generateDraft("bad", "x", null, List.of()));
+
+    when(provider.chat(eq("agent-author-files"), any(), any()))
+        .thenReturn(
+            new ProviderResponse(
+                "===FILE: AGENT.md===\n---\nname: files\nprovider:\n  name: mock\n  model: mock\n---\nbody\n"
+                    + "===FILE: skills/copy.md===\ncopy",
+                List.of(),
+                null));
+    assertThrows(
+        IllegalArgumentException.class, () -> service.generateDraft("files", "x", null, List.of()));
+  }
+
+  @Test
+  void existingSaveRestoresFilesAndBindingsWhenBindingCommitFails() throws Exception {
+    AgentLifecycleService initial = service(bindings, new InstalledSkillCatalog(skillRegistry));
+    initial.create("existing", "旧描述", List.of("required"));
+    Path markdown = root.resolve("agents/existing/AGENT.md");
+    String before = Files.readString(markdown);
+    AgentSkillBindingService failing = spy(bindings);
+    doThrow(new IllegalStateException("binding commit failed"))
+        .when(failing)
+        .replaceBindings("existing", List.of("suggested"));
+    String replacement = before.replace("description: 旧描述", "description: 新描述");
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            service(failing, new InstalledSkillCatalog(skillRegistry))
+                .saveFiles(
+                    "existing",
+                    Map.of("AGENT.md", replacement, "scripts/new.py", "new"),
+                    List.of("suggested")));
+
+    assertEquals(before, Files.readString(markdown));
+    assertFalse(Files.exists(root.resolve("agents/existing/scripts/new.py")));
+    assertEquals(
+        List.of("required"),
+        bindings.inspect("existing").bindings().stream()
+            .map(io.oryxos.core.skill.BoundSkillDescriptor::name)
+            .toList());
+  }
+
+  private AgentLifecycleService service(
+      AgentSkillBindingService bindingService, SkillCatalog catalog) {
+    AgentLoader loader = new AgentLoader(root.resolve("agents"), java.util.Set.of("mock"));
+    return new AgentLifecycleService(
+        loader,
+        profiles,
+        mock(AgentScheduler.class),
+        new AgentStore(root),
+        provider,
+        "mock",
+        "mock",
+        "mock",
+        Map.of(),
+        mock(NotifyChannelRegistry.class),
+        null,
+        skillRegistry,
+        bindingService,
+        catalog);
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentMarkdownTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentMarkdownTest.java
@@ -3,6 +3,7 @@ package io.oryxos.core.agent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -45,5 +46,20 @@ class AgentMarkdownTest {
     AgentMarkdown.Parsed parsed = AgentMarkdown.split(content);
     assertEquals("ops", parsed.frontmatter().get("name"));
     assertTrue(parsed.body().contains("正文里的分隔线"), "首个闭合围栏之后的 --- 属于正文");
+  }
+
+  @Test
+  @DisplayName("legacy 迁移只移除顶层 skills 块并保留 CRLF、其它字段和正文")
+  void removeLegacySkillsPreservesEverythingElse() {
+    String input =
+        "---\r\nname: ops\r\nsettings:\r\n  skills: nested-kept\r\nskills:\r\n  - report\r\n  - web\r\nprovider: mock\r\n---\r\n正文 skills: 不动\r\n";
+
+    String output = AgentMarkdown.removeLegacySkills(input);
+
+    assertEquals(
+        "---\r\nname: ops\r\nsettings:\r\n  skills: nested-kept\r\nprovider: mock\r\n---\r\n正文 skills: 不动\r\n",
+        output);
+    assertEquals(List.of("report", "web"), AgentMarkdown.legacySkills(input));
+    assertTrue(AgentMarkdown.hasLegacySkills(input));
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentMarkdownTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentMarkdownTest.java
@@ -62,4 +62,30 @@ class AgentMarkdownTest {
     assertEquals(List.of("report", "web"), AgentMarkdown.legacySkills(input));
     assertTrue(AgentMarkdown.hasLegacySkills(input));
   }
+
+  @Test
+  @DisplayName("legacy 迁移识别并移除带引号的顶层 skills 键")
+  void removeLegacySkillsAcceptsQuotedKey() {
+    String input = "---\nname: ops\n\"skills\":\n- report\n---\nbody";
+
+    String output = AgentMarkdown.removeLegacySkills(input);
+
+    assertEquals("---\nname: ops\n---\nbody", output);
+    assertTrue(AgentMarkdown.hasLegacySkills(input));
+    assertEquals(
+        "---\nname: renamed\n---\nbody",
+        AgentMarkdown.replaceTopLevelScalar("---\n\"name\": old\n---\nbody", "name", "renamed"));
+  }
+
+  @Test
+  @DisplayName("标量替换会更新重复键并在缺失时插入")
+  void replaceTopLevelScalarUpdatesDuplicatesAndInsertsMissingKey() {
+    assertEquals(
+        "---\nname: next\nname: next\n---\nbody",
+        AgentMarkdown.replaceTopLevelScalar(
+            "---\nname: first\n\"name\": second\n---\nbody", "name", "next"));
+    assertEquals(
+        "---\nname: next\ndescription: d\n---\nbody",
+        AgentMarkdown.replaceTopLevelScalar("---\ndescription: d\n---\nbody", "name", "next"));
+  }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentStoreTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentStoreTest.java
@@ -8,6 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,6 +58,21 @@ class AgentStoreTest {
 
     assertFalse(Files.exists(oryxosRoot.resolve("agents").resolve("demo")), "原目录已移走");
     assertTrue(Files.exists(oryxosRoot.resolve("archive").resolve("demo")), "归档区保留，可追溯");
+  }
+
+  @Test
+  @DisplayName("archive 时间戳目标已存在时追加序号且不覆盖")
+  void archive_collisionUsesUniqueSuffix() throws IOException {
+    long millis = 1_700_000_000_000L;
+    AgentStore fixed =
+        new AgentStore(oryxosRoot, Clock.fixed(Instant.ofEpochMilli(millis), ZoneOffset.UTC));
+    Files.createDirectories(oryxosRoot.resolve("archive/demo"));
+    Files.createDirectories(oryxosRoot.resolve("archive/demo-" + millis));
+    fixed.write("demo", "x");
+
+    fixed.archive("demo");
+
+    assertTrue(Files.exists(oryxosRoot.resolve("archive/demo-" + millis + "-2/AGENT.md")));
   }
 
   @Test

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentStoreTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentStoreTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -59,5 +61,43 @@ class AgentStoreTest {
   @DisplayName("非法 name 拒绝（防路径穿越）")
   void write_unsafeName_rejected() {
     assertThrows(IllegalArgumentException.class, () -> store.write("../evil", "x"));
+  }
+
+  @Test
+  @DisplayName("write/writeAll 拒绝经父链接逃逸及占用 skills 保留命名空间")
+  void writesRejectSymlinkEscapeAndReservedSkills() throws IOException {
+    Path outside = Files.createDirectories(oryxosRoot.resolveSibling("agent-store-outside"));
+    Path agent = Files.createDirectories(oryxosRoot.resolve("agents/demo"));
+    Files.createSymbolicLink(agent.resolve("escape"), outside);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store.writeAll("demo", Map.of("escape/pwned.txt", "bad")));
+    assertFalse(Files.exists(outside.resolve("pwned.txt")));
+    Path outsideFile = Files.writeString(outside.resolve("keep.txt"), "keep");
+    Files.createSymbolicLink(agent.resolve("final.txt"), outsideFile);
+    assertThrows(
+        IllegalArgumentException.class, () -> store.writeAll("demo", Map.of("final.txt", "bad")));
+    assertEquals("keep", Files.readString(outsideFile));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store.writeAll("demo", Map.of("skills/report/SKILL.md", "copy")));
+    store.writeAll("demo", Map.of("scripts/ok.py", "ok"));
+    assertEquals("ok", Files.readString(agent.resolve("scripts/ok.py")));
+  }
+
+  @Test
+  @DisplayName("writeAll 全量预校验失败时已存在文件保持原样")
+  void writeAllValidationFailureIsAtomic() throws IOException {
+    Path agent = store.write("demo", "old");
+    Files.createDirectories(agent.resolve("collision"));
+    Map<String, String> files = new LinkedHashMap<>();
+    files.put("AGENT.md", "new");
+    files.put("collision", "not-a-file");
+
+    assertThrows(IllegalArgumentException.class, () -> store.writeAll("demo", files));
+
+    assertEquals("old", Files.readString(agent.resolve("AGENT.md")));
+    assertTrue(Files.isDirectory(agent.resolve("collision")));
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/ReActLoopSkillDisclosureTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/ReActLoopSkillDisclosureTest.java
@@ -1,0 +1,131 @@
+package io.oryxos.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.OryxTool;
+import io.oryxos.core.ToolResult;
+import io.oryxos.core.context.ContextLoader;
+import io.oryxos.core.profile.Profile;
+import io.oryxos.core.provider.ProviderRequest;
+import io.oryxos.core.provider.ProviderResponse;
+import io.oryxos.core.provider.ProviderService;
+import io.oryxos.core.provider.ToolCallRequest;
+import io.oryxos.core.session.Session;
+import io.oryxos.core.skill.AgentSkillBindingService;
+import io.oryxos.core.skill.SkillMetadataReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ReActLoopSkillDisclosureTest {
+
+  @TempDir Path root;
+
+  @Test
+  void readFileIsAuditedAndNextRoundRebuildsMetadataWithoutPreloadingBody() throws IOException {
+    Path agent = Files.createDirectories(root.resolve("agents/reporter"));
+    Files.writeString(agent.resolve("AGENT.md"), "---\nname: reporter\n---\n按职责执行");
+    Path skill = Files.createDirectories(root.resolve("skills/report-format"));
+    Path skillFile = skill.resolve("SKILL.md");
+    Files.writeString(skillFile, "---\nname: report-format\ndescription: 旧描述\n---\n只在读取后出现的正文");
+    Path links = Files.createDirectories(agent.resolve("skills"));
+    Files.createSymbolicLink(
+        links.resolve("report-format"), Path.of("../../../skills/report-format"));
+
+    OryxTool readFile =
+        new OryxTool() {
+          @Override
+          public String getName() {
+            return "read_file";
+          }
+
+          @Override
+          public String getDescription() {
+            return "读取文件";
+          }
+
+          @Override
+          public String getInputSchema() {
+            return "{}";
+          }
+
+          @Override
+          public ToolResult execute(JsonNode input) {
+            try {
+              return ToolResult.ok(Files.readString(Path.of(input.path("path").asText())));
+            } catch (IOException e) {
+              return ToolResult.error(e.getMessage(), false);
+            }
+          }
+        };
+    AgentSkillBindingService bindings =
+        new AgentSkillBindingService(root, new SkillMetadataReader());
+    PromptBuilder prompts =
+        new PromptBuilder(
+            new ContextLoader(root, bindings),
+            Map.of("read_file", readFile),
+            Clock.fixed(Instant.parse("2026-07-27T00:00:00Z"), ZoneOffset.UTC));
+    ProviderService provider = mock(ProviderService.class);
+    ToolInvocationAuditor auditor = mock(ToolInvocationAuditor.class);
+    ToolExecutor executor = new ToolExecutor(Map.of("read_file", readFile), auditor);
+    List<ProviderRequest> requests = new ArrayList<>();
+    ToolCallRequest call =
+        new ToolCallRequest(
+            "read_file", "{\"path\":\"" + links.resolve("report-format/SKILL.md") + "\"}");
+    when(provider.chat(eq("s-1"), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              requests.add(invocation.getArgument(2));
+              Files.writeString(
+                  skillFile, "---\nname: report-format\ndescription: 新描述\n---\n只在读取后出现的正文");
+              return new ProviderResponse(null, List.of(call), null);
+            })
+        .thenAnswer(
+            invocation -> {
+              requests.add(invocation.getArgument(2));
+              return new ProviderResponse("完成", List.of(), null);
+            });
+
+    ReActLoop loop = new ReActLoop(prompts, provider, executor);
+    loop.run(new Session("s-1", "reporter"), "生成报告", profile());
+
+    assertTrue(requests.get(0).systemPrompt().contains("旧描述"));
+    assertFalse(requests.get(0).systemPrompt().contains("只在读取后出现的正文"));
+    assertTrue(requests.get(1).systemPrompt().contains("新描述"));
+    assertTrue(
+        requests.get(1).messages().stream()
+            .anyMatch(message -> message.content().contains("只在读取后出现的正文")));
+    verify(auditor).record(eq("s-1"), eq("read_file"), any(), any(), eq(true), eq(null), anyLong());
+  }
+
+  private static Profile profile() {
+    return new Profile(
+        "reporter",
+        "报告助手",
+        null,
+        new Profile.ProviderRef("mock", "mock", null),
+        List.of("read_file"),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        new Profile.Settings(2, 20));
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/context/ContextLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/context/ContextLoaderTest.java
@@ -8,6 +8,8 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import io.oryxos.core.profile.Profile;
+import io.oryxos.core.skill.AgentSkillBindingService;
+import io.oryxos.core.skill.SkillLoader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -32,7 +34,7 @@ class ContextLoaderTest {
   void setUp() throws IOException {
     agentDir = oryxosRoot.resolve("agents").resolve("ops-agent");
     Files.createDirectories(agentDir);
-    loader = new ContextLoader(oryxosRoot, new io.oryxos.core.skill.SkillRegistry());
+    loader = new ContextLoader(oryxosRoot, bindingService());
     logAppender = new ListAppender<>();
     logAppender.start();
     ((Logger) LoggerFactory.getLogger(ContextLoader.class)).addAppender(logAppender);
@@ -109,12 +111,18 @@ class ContextLoaderTest {
   }
 
   @Test
-  @DisplayName("第32节：引用的全局 Skill 正文注入 system prompt；引用不存在的记 WARN 跳过")
-  void referencedGlobalSkillBodyIsInjected() throws IOException {
+  @DisplayName("绑定 Skill 只披露元数据，正文和未绑定项不注入")
+  void boundSkillMetadataIsInjectedWithoutBody() throws IOException {
     writeAgentBody("agent-body");
-    io.oryxos.core.skill.SkillRegistry reg = new io.oryxos.core.skill.SkillRegistry();
-    reg.register(new io.oryxos.core.skill.Skill("report-format", "研报格式", "SKILL-BODY-约束正文"));
-    ContextLoader withSkill = new ContextLoader(oryxosRoot, reg);
+    Path skill = oryxosRoot.resolve("skills/report-format");
+    Files.createDirectories(skill);
+    Files.writeString(
+        skill.resolve("SKILL.md"),
+        "---\nname: report-format\ndescription: 研报格式\n---\nSKILL-BODY-约束正文");
+    Files.createDirectories(agentDir.resolve("skills"));
+    Files.createSymbolicLink(
+        agentDir.resolve("skills/report-format"), Path.of("../../../skills/report-format"));
+    ContextLoader withSkill = new ContextLoader(oryxosRoot, bindingService());
     Profile p =
         new Profile(
             "ops-agent",
@@ -127,19 +135,38 @@ class ContextLoaderTest {
             List.of(),
             List.of(),
             List.of(),
-            List.of("report-format", "no-such-skill"),
             Profile.Settings.defaults());
 
     String context = withSkill.load(p);
 
-    assertTrue(context.contains("SKILL-BODY-约束正文"), "引用到的 Skill 正文应注入 system prompt");
-    boolean warned =
-        logAppender.list.stream()
-            .anyMatch(
-                e ->
-                    "WARN".equals(e.getLevel().toString())
-                        && e.getFormattedMessage().contains("no-such-skill"));
-    assertTrue(warned, "引用不存在的 Skill 记 WARN 跳过");
+    assertTrue(context.contains("report-format"));
+    assertTrue(context.contains("研报格式"));
+    assertFalse(context.contains("SKILL-BODY-约束正文"));
+  }
+
+  @Test
+  @DisplayName("Skill 描述、解绑和链接修复在下一次 load 立即生效")
+  void skillBindingChangesAreReadWithoutCache() throws IOException {
+    writeAgentBody("agent-body");
+    Path skill = Files.createDirectories(oryxosRoot.resolve("skills/report-format"));
+    Path skillFile = skill.resolve("SKILL.md");
+    Files.writeString(skillFile, "---\nname: report-format\ndescription: 版本一\n---\n正文");
+    Path links = Files.createDirectories(agentDir.resolve("skills"));
+    Path link = links.resolve("report-format");
+    Files.createSymbolicLink(link, Path.of("../../../skills/report-format"));
+    Profile profile = profileWith(List.of());
+
+    assertTrue(loader.load(profile).contains("版本一"));
+    Files.writeString(skillFile, "---\nname: report-format\ndescription: 版本二\n---\n正文");
+    assertTrue(loader.load(profile).contains("版本二"));
+
+    Files.delete(link);
+    assertFalse(loader.load(profile).contains("版本二"));
+    Files.createSymbolicLink(link, Path.of("../../outside"));
+    assertFalse(loader.load(profile).contains("版本二"));
+    Files.delete(link);
+    Files.createSymbolicLink(link, Path.of("../../../skills/report-format"));
+    assertTrue(loader.load(profile).contains("版本二"));
   }
 
   @Test
@@ -182,5 +209,9 @@ class ContextLoaderTest {
                     "WARN".equals(e.getLevel().toString())
                         && e.getFormattedMessage().contains("USER.md"));
     assertTrue(warned, "Bootstrap 缺失至少 WARN——静默跳过会造成人格悄悄丢失");
+  }
+
+  private AgentSkillBindingService bindingService() {
+    return new AgentSkillBindingService(oryxosRoot, new SkillLoader(oryxosRoot.resolve("skills")));
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/context/ProgressiveDisclosureTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/context/ProgressiveDisclosureTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.oryxos.core.profile.Profile;
+import io.oryxos.core.skill.AgentSkillBindingService;
+import io.oryxos.core.skill.SkillLoader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,7 +31,11 @@ class ProgressiveDisclosureTest {
   void setUp() throws IOException {
     agentDir = oryxosRoot.resolve("agents").resolve("reconcile");
     Files.createDirectories(agentDir);
-    loader = new ContextLoader(oryxosRoot, new io.oryxos.core.skill.SkillRegistry());
+    loader =
+        new ContextLoader(
+            oryxosRoot,
+            new AgentSkillBindingService(
+                oryxosRoot, new SkillLoader(oryxosRoot.resolve("skills"))));
   }
 
   private Profile profile() {
@@ -82,5 +88,58 @@ class ProgressiveDisclosureTest {
     String reloaded = loader.load(p);
     assertTrue(reloaded.contains("v2-instruction"), "改正文下一次触发即生效");
     assertEquals(-1, reloaded.indexOf("v1-instruction"));
+  }
+
+  @Test
+  @DisplayName("绑定 Skill 每轮只注入 name/description/本地路径，不注入正文或未绑定 Skill")
+  void boundSkillOnlyDisclosesMetadata() throws IOException {
+    writeBody("按需使用 Skill");
+    Path report = oryxosRoot.resolve("skills/report");
+    Path hidden = oryxosRoot.resolve("skills/hidden");
+    Files.createDirectories(report);
+    Files.createDirectories(hidden);
+    Files.writeString(
+        report.resolve("SKILL.md"), "---\nname: report\ndescription: 报告格式\n---\nBOUND_BODY_SECRET");
+    Files.writeString(
+        hidden.resolve("SKILL.md"),
+        "---\nname: hidden\ndescription: 不可见\n---\nUNBOUND_BODY_SECRET");
+    Files.createDirectories(agentDir.resolve("skills"));
+    Files.createSymbolicLink(agentDir.resolve("skills/report"), Path.of("../../../skills/report"));
+
+    String context = loader.load(profile());
+
+    assertTrue(context.contains("report"));
+    assertTrue(context.contains("报告格式"));
+    assertTrue(
+        context.contains(
+            agentDir.resolve("skills/report/SKILL.md").toAbsolutePath().normalize().toString()));
+    assertFalse(context.contains("BOUND_BODY_SECRET"));
+    assertFalse(context.contains("hidden"));
+    assertFalse(context.contains("UNBOUND_BODY_SECRET"));
+  }
+
+  @Test
+  @DisplayName("零绑定不输出 Skill 标题，多绑定按名称稳定排序并跳过坏链接")
+  void zeroAndMultipleBindingsHaveStableMinimalCatalog() throws IOException {
+    writeBody("正文");
+    assertFalse(loader.load(profile()).contains("你可以按需使用以下 Skill"));
+
+    for (String name : List.of("zeta", "alpha")) {
+      Path skill = Files.createDirectories(oryxosRoot.resolve("skills").resolve(name));
+      Files.writeString(
+          skill.resolve("SKILL.md"),
+          "---\nname: " + name + "\ndescription: " + name + "-description\n---\n" + name + "-body");
+    }
+    Path links = Files.createDirectories(agentDir.resolve("skills"));
+    Files.createSymbolicLink(links.resolve("zeta"), Path.of("../../../skills/zeta"));
+    Files.createSymbolicLink(links.resolve("alpha"), Path.of("../../../skills/alpha"));
+    Files.createSymbolicLink(links.resolve("broken"), Path.of("../../../skills/missing"));
+
+    String context = loader.load(profile());
+
+    assertTrue(context.indexOf("- alpha：") < context.indexOf("- zeta："));
+    assertFalse(context.contains("alpha-body"));
+    assertFalse(context.contains("zeta-body"));
+    assertFalse(context.contains("broken"));
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/fs/RealPathBoundaryTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/fs/RealPathBoundaryTest.java
@@ -1,0 +1,64 @@
+package io.oryxos.core.fs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RealPathBoundaryTest {
+
+  @TempDir Path temp;
+
+  @Test
+  void projectsExistingAndNotYetExistingTargets() throws Exception {
+    Path root = Files.createDirectories(temp.resolve("root"));
+    Path file = Files.writeString(root.resolve("a.txt"), "x");
+    assertEquals(file.toRealPath(), RealPathBoundary.requireWithin(root, file));
+
+    Path future = root.resolve("new/child.txt");
+    assertTrue(RealPathBoundary.requireWithin(root, future).startsWith(root.toRealPath()));
+  }
+
+  @Test
+  void rejectsParentLinkEscapeDanglingAndCycle() throws Exception {
+    Path root = Files.createDirectories(temp.resolve("root"));
+    Path outside = Files.createDirectories(temp.resolve("outside"));
+    Files.createSymbolicLink(root.resolve("escape"), outside);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> RealPathBoundary.requireWithin(root, root.resolve("escape/new.txt")));
+
+    Files.createSymbolicLink(root.resolve("second"), outside);
+    Files.createSymbolicLink(root.resolve("first"), Path.of("second"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> RealPathBoundary.requireWithin(root, root.resolve("first/secret.txt")));
+
+    Files.createSymbolicLink(root.resolve("dangling"), Path.of("missing"));
+    assertThrows(
+        UncheckedIOException.class,
+        () -> RealPathBoundary.requireWithin(root, root.resolve("dangling")));
+
+    Files.createSymbolicLink(root.resolve("one"), Path.of("two"));
+    Files.createSymbolicLink(root.resolve("two"), Path.of("one"));
+    assertThrows(
+        UncheckedIOException.class,
+        () -> RealPathBoundary.requireWithin(root, root.resolve("one")));
+  }
+
+  @Test
+  void rootMayItselfBeASymlink() throws Exception {
+    Path actual = Files.createDirectories(temp.resolve("actual"));
+    Path linkedRoot = temp.resolve("linked-root");
+    Files.createSymbolicLink(linkedRoot, actual);
+    Path target = Files.writeString(actual.resolve("ok.txt"), "ok");
+    assertEquals(
+        target.toRealPath(),
+        RealPathBoundary.requireWithin(linkedRoot, linkedRoot.resolve("ok.txt")));
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
@@ -80,7 +80,7 @@ class ProfileLoaderTest {
     assertEquals(0.7, profile.provider().temperature());
     assertEquals(Set.of("http_get", "notify"), Set.copyOf(profile.tools()));
     assertEquals("github-mcp", profile.mcpServers().get(0)); // mcp_servers → mcpServers
-    assertEquals("daily-pr-digest", profile.skills().get(0)); // 第 32 节：skills 解析进 Profile
+    assertTrue(profile.tools().contains("http_get"));
     assertEquals("webhook", profile.notifyChannels().get(0).type()); // notify_channels
     assertEquals("0 0 8 * * *", profile.schedules().get(0).cron());
     assertEquals("Asia/Shanghai", profile.schedules().get(0).zone());

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillBindingServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillBindingServiceTest.java
@@ -1,0 +1,137 @@
+package io.oryxos.core.skill;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AgentSkillBindingServiceTest {
+
+  @TempDir Path root;
+
+  private AgentSkillBindingService bindings;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    Files.createDirectories(root.resolve("agents/ops"));
+    Files.writeString(root.resolve("agents/ops/AGENT.md"), "---\nname: ops\n---\nbody");
+    Files.createDirectories(root.resolve("skills"));
+    bindings = new AgentSkillBindingService(root, new SkillLoader(root.resolve("skills")));
+  }
+
+  private void skill(String name, String description) throws IOException {
+    Path dir = root.resolve("skills").resolve(name);
+    Files.createDirectories(dir);
+    Files.writeString(
+        dir.resolve("SKILL.md"),
+        "---\nname: " + name + "\ndescription: " + description + "\n---\nBODY-" + name);
+  }
+
+  @Test
+  @DisplayName("bind 创建固定相对链接且幂等；unbind 只删链接")
+  void bindAndUnbind() throws IOException {
+    skill("report", "报告规范");
+
+    AgentSkillBinding first = bindings.bind("ops", "report");
+    AgentSkillBinding second = bindings.bind("ops", "report");
+
+    Path link = root.resolve("agents/ops/skills/report");
+    assertTrue(Files.isSymbolicLink(link));
+    assertFalse(Files.readSymbolicLink(link).isAbsolute());
+    assertEquals(Path.of("../../../skills/report"), Files.readSymbolicLink(link));
+    assertEquals(first, second);
+    assertEquals(
+        List.of("ops"),
+        bindings.references("report").stream().map(SkillReference::agentName).toList());
+
+    bindings.unbind("ops", "report");
+    bindings.unbind("ops", "report");
+    assertFalse(Files.exists(link, java.nio.file.LinkOption.NOFOLLOW_LINKS));
+    assertTrue(Files.isRegularFile(root.resolve("skills/report/SKILL.md")));
+  }
+
+  @Test
+  @DisplayName("扫描分类 dangling、escaped、invalid-target、name-mismatch、stale-reference")
+  void reconcileClassifiesAllIssueTypes() throws IOException {
+    skill("good", "合法");
+    skill("other", "另一个");
+    Files.createDirectories(root.resolve("agents/ops/skills"));
+    Path agentSkills = root.resolve("agents/ops/skills");
+    Files.createSymbolicLink(agentSkills.resolve("dangling"), Path.of("../../../skills/dangling"));
+    Files.createSymbolicLink(agentSkills.resolve("escaped"), Path.of("../../../../outside"));
+    Files.writeString(agentSkills.resolve("invalid"), "not a link");
+    Files.createSymbolicLink(agentSkills.resolve("wrong-name"), Path.of("../../../skills/other"));
+
+    Files.createDirectories(root.resolve("agents/stale/skills"));
+    Files.createSymbolicLink(
+        root.resolve("agents/stale/skills/good"), Path.of("../../../skills/good"));
+
+    List<SkillBindingIssue.Type> types =
+        bindings.reconcile().stream().map(SkillBindingIssue::type).toList();
+
+    assertTrue(types.contains(SkillBindingIssue.Type.DANGLING));
+    assertTrue(types.contains(SkillBindingIssue.Type.ESCAPED));
+    assertTrue(types.contains(SkillBindingIssue.Type.INVALID_TARGET));
+    assertTrue(types.contains(SkillBindingIssue.Type.NAME_MISMATCH));
+    assertTrue(types.contains(SkillBindingIssue.Type.STALE_REFERENCE));
+  }
+
+  @Test
+  @DisplayName("绝对链接和普通文件不能伪装成绑定")
+  void invalidBindingsNeverBecomeVisible() throws IOException {
+    skill("good", "合法");
+    Files.createDirectories(root.resolve("agents/ops/skills"));
+    Files.createSymbolicLink(
+        root.resolve("agents/ops/skills/good"), root.resolve("skills/good").toAbsolutePath());
+    Files.writeString(root.resolve("agents/ops/skills/copy"), "bad");
+
+    assertTrue(bindings.validBindings("ops").isEmpty());
+    assertEquals(2, bindings.inspect("ops").issues().size());
+  }
+
+  @Test
+  @DisplayName("非法 Agent/Skill 名被拒绝")
+  void unsafeNamesRejected() throws IOException {
+    skill("good", "合法");
+    assertThrows(IllegalArgumentException.class, () -> bindings.bind("../ops", "good"));
+    assertThrows(IllegalArgumentException.class, () -> bindings.bind("ops", "../good"));
+  }
+
+  @Test
+  @DisplayName("replace 全量预校验，失败不改变现有绑定")
+  void replacePrevalidatesBeforeMutation() throws IOException {
+    skill("good", "合法");
+    bindings.bind("ops", "good");
+
+    assertThrows(
+        IllegalArgumentException.class, () -> bindings.replaceBindings("ops", List.of("missing")));
+
+    assertEquals(
+        List.of("good"),
+        bindings.inspect("ops").bindings().stream().map(BoundSkillDescriptor::name).toList());
+  }
+
+  @Test
+  @DisplayName("归档 Agent 的固定相对链接仍被计为结构化引用")
+  void archivedReferencesAreProtected() throws IOException {
+    skill("report", "报告");
+    bindings.bind("ops", "report");
+    Files.createDirectories(root.resolve("archive"));
+    Files.move(root.resolve("agents/ops"), root.resolve("archive/ops-1"));
+
+    List<SkillReference> references = bindings.references("report");
+
+    assertEquals(1, references.size());
+    assertEquals(SkillReference.AgentState.ARCHIVED, references.get(0).state());
+    assertEquals("ops", references.get(0).agentName());
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillMigrationServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillMigrationServiceTest.java
@@ -1,0 +1,83 @@
+package io.oryxos.core.skill;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AgentSkillMigrationServiceTest {
+
+  @TempDir Path root;
+
+  @Test
+  void validLegacyFieldMigratesOnceAndPreservesOtherText() throws Exception {
+    SkillWorkspaceFixture fixture = new SkillWorkspaceFixture(root);
+    Path agent = fixture.agent("ops", "description: keep\nskills:\n  - report\n");
+    fixture.skill("report", "报告");
+    AgentSkillBindingService bindings =
+        new AgentSkillBindingService(root, new SkillLoader(root.resolve("skills")));
+    AgentSkillMigrationService migration = new AgentSkillMigrationService(root, bindings);
+
+    assertTrue(migration.migrate(agent).status() == AgentSkillMigrationService.Status.MIGRATED);
+    String migrated = Files.readString(agent.resolve("AGENT.md"));
+    assertTrue(migrated.contains("description: keep"));
+    assertFalse(migrated.contains("skills:"));
+    assertTrue(Files.isSymbolicLink(agent.resolve("skills/report")));
+    assertTrue(migration.migrate(agent).status() == AgentSkillMigrationService.Status.NOT_NEEDED);
+  }
+
+  @Test
+  void invalidLegacyReferenceLeavesBytesAndLinksUntouched() throws Exception {
+    SkillWorkspaceFixture fixture = new SkillWorkspaceFixture(root);
+    Path agent = fixture.agent("bad", "skills:\n  - missing\n");
+    byte[] original = Files.readAllBytes(agent.resolve("AGENT.md"));
+    AgentSkillBindingService bindings =
+        new AgentSkillBindingService(root, new SkillLoader(root.resolve("skills")));
+
+    AgentSkillMigrationService.MigrationResult result =
+        new AgentSkillMigrationService(root, bindings).migrate(agent);
+
+    assertTrue(result.status() == AgentSkillMigrationService.Status.FAILED);
+    assertArrayEquals(original, Files.readAllBytes(agent.resolve("AGENT.md")));
+    assertFalse(Files.exists(agent.resolve("skills")));
+  }
+
+  @Test
+  void migrationUnionsExistingLinksAndOneFailureDoesNotBlockOtherAgents() throws Exception {
+    SkillWorkspaceFixture fixture = new SkillWorkspaceFixture(root);
+    fixture.skill("existing", "已有");
+    fixture.skill("legacy", "旧配置");
+    Path good = fixture.agent("good", "skills:\n  - legacy\n");
+    fixture.bind("good", "existing");
+    Path bad = fixture.agent("bad", "skills:\n  - missing\n");
+    byte[] badBefore = Files.readAllBytes(bad.resolve("AGENT.md"));
+    AgentSkillBindingService bindings =
+        new AgentSkillBindingService(root, new SkillMetadataReader());
+
+    AgentSkillStartupReport report = new AgentSkillMigrationService(root, bindings).migrateAll();
+
+    assertEquals(
+        List.of("existing", "legacy"),
+        bindings.inspect("good").bindings().stream().map(BoundSkillDescriptor::name).toList());
+    assertFalse(Files.readString(good.resolve("AGENT.md")).contains("skills:"));
+    assertArrayEquals(badBefore, Files.readAllBytes(bad.resolve("AGENT.md")));
+    assertTrue(
+        report.migrations().stream()
+            .anyMatch(
+                result ->
+                    result.agentName().equals("bad")
+                        && result.status() == AgentSkillMigrationService.Status.FAILED));
+    assertTrue(
+        report.issues().stream()
+            .anyMatch(
+                issue ->
+                    issue.agentName().equals("bad")
+                        && issue.type() == SkillBindingIssue.Type.STALE_REFERENCE));
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillMigrationServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillMigrationServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.oryxos.core.agent.AgentMarkdown;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -30,6 +31,21 @@ class AgentSkillMigrationServiceTest {
     assertFalse(migrated.contains("skills:"));
     assertTrue(Files.isSymbolicLink(agent.resolve("skills/report")));
     assertTrue(migration.migrate(agent).status() == AgentSkillMigrationService.Status.NOT_NEEDED);
+  }
+
+  @Test
+  void quotedLegacyFieldMigratesWithoutResidue() throws Exception {
+    SkillWorkspaceFixture fixture = new SkillWorkspaceFixture(root);
+    Path agent = fixture.agent("quoted", "\"skills\":\n- report\n");
+    fixture.skill("report", "报告");
+    AgentSkillMigrationService migration =
+        new AgentSkillMigrationService(
+            root, new AgentSkillBindingService(root, new SkillMetadataReader()));
+
+    assertEquals(AgentSkillMigrationService.Status.MIGRATED, migration.migrate(agent).status());
+    String migrated = Files.readString(agent.resolve("AGENT.md"));
+    assertFalse(AgentMarkdown.hasLegacySkills(migrated));
+    assertTrue(Files.isSymbolicLink(agent.resolve("skills/report")));
   }
 
   @Test

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillReconciliationTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillReconciliationTest.java
@@ -1,0 +1,50 @@
+package io.oryxos.core.skill;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AgentSkillReconciliationTest {
+
+  @TempDir Path root;
+
+  @Test
+  void classifiesFiveIssuesWhileKeepingValidArchivedLinksClean() throws Exception {
+    SkillWorkspaceFixture fixture = new SkillWorkspaceFixture(root);
+    Path active = fixture.agent("active", "skills:\n  - report\n");
+    fixture.skill("report", "报告");
+    fixture.skill("other", "其它");
+    Path links = Files.createDirectories(active.resolve("skills"));
+    Files.createSymbolicLink(links.resolve("dangling"), Path.of("../../../skills/dangling"));
+    Files.createSymbolicLink(links.resolve("escaped"), root.resolve("skills/report"));
+    Files.writeString(links.resolve("ordinary"), "not-link");
+    Files.createSymbolicLink(links.resolve("wrong"), Path.of("../../../skills/other"));
+
+    Path archived = fixture.agent("archived", "");
+    fixture.bind("archived", "report");
+    Files.createDirectories(root.resolve("archive"));
+    Files.move(archived, root.resolve("archive/archived-1"));
+
+    List<SkillBindingIssue> issues =
+        new AgentSkillBindingService(root, new SkillMetadataReader()).reconcile();
+    List<SkillBindingIssue.Type> types = issues.stream().map(SkillBindingIssue::type).toList();
+
+    assertTrue(
+        types.containsAll(
+            List.of(
+                SkillBindingIssue.Type.DANGLING,
+                SkillBindingIssue.Type.ESCAPED,
+                SkillBindingIssue.Type.INVALID_TARGET,
+                SkillBindingIssue.Type.NAME_MISMATCH,
+                SkillBindingIssue.Type.STALE_REFERENCE)));
+    assertEquals(
+        0,
+        issues.stream().filter(issue -> issue.agentName().equals("archived-1")).count(),
+        "归档 Agent 的合法绑定不是残留");
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillArchiveServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillArchiveServiceTest.java
@@ -1,0 +1,61 @@
+package io.oryxos.core.skill;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SkillArchiveServiceTest {
+
+  @TempDir Path root;
+
+  @Test
+  void referencesBlockArchiveThenCompleteDirectoryIsMoved() throws Exception {
+    SkillWorkspaceFixture fixture = new SkillWorkspaceFixture(root);
+    fixture.agent("ops", "");
+    fixture.skill("report", "报告");
+    Files.writeString(root.resolve("skills/report/REFERENCE.md"), "keep-me");
+    fixture.bind("ops", "report");
+    SkillLoader loader = new SkillLoader(root.resolve("skills"));
+    SkillRegistry registry = loader.loadAll();
+    AgentSkillBindingService bindings = new AgentSkillBindingService(root, loader);
+    SkillService service = new SkillService(new SkillStore(root), registry, loader, bindings);
+
+    assertThrows(SkillReferencedException.class, () -> service.delete("report"));
+    bindings.unbind("ops", "report");
+
+    SkillArchive archive = service.delete("report");
+    assertFalse(Files.exists(root.resolve("skills/report")));
+    assertTrue(Files.isRegularFile(root.resolve(archive.archivedPath()).resolve("REFERENCE.md")));
+  }
+
+  @Test
+  void repeatedArchivesNeverOverwriteAndLegacyAgentNamedSkillsIsPreserved() throws Exception {
+    Path legacy = Files.createDirectories(root.resolve("archive/skills"));
+    Files.writeString(legacy.resolve("AGENT.md"), "---\nname: skills\n---\nlegacy");
+    Clock fixed = Clock.fixed(Instant.parse("2026-07-27T01:02:03Z"), ZoneOffset.UTC);
+    SkillStore store = new SkillStore(root, fixed);
+    store.write("report", "---\nname: report\ndescription: d\n---\nfirst");
+    SkillArchive first = store.archive("report");
+    store.write("report", "---\nname: report\ndescription: d\n---\nsecond");
+    SkillArchive second = store.archive("report");
+
+    assertTrue(Files.isRegularFile(root.resolve(first.archivedPath()).resolve("SKILL.md")));
+    assertTrue(Files.isRegularFile(root.resolve(second.archivedPath()).resolve("SKILL.md")));
+    assertFalse(first.archivedPath().equals(second.archivedPath()));
+    try (java.util.stream.Stream<Path> archives = Files.list(root.resolve("archive"))) {
+      assertTrue(
+          archives.anyMatch(
+              path ->
+                  path.getFileName().toString().startsWith("skills-")
+                      && Files.isRegularFile(path.resolve("AGENT.md"))));
+    }
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillImportFilesTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillImportFilesTest.java
@@ -1,8 +1,11 @@
 package io.oryxos.core.skill;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -51,13 +54,71 @@ class SkillImportFilesTest {
 
   @Test
   @DisplayName("importFiles：nameOverride 优先于 frontmatter 的 name")
-  void importFiles_nameOverrideTakesPriority() {
-    Map<String, String> files = Map.of("SKILL.md", "---\nname: ignored\ndescription: 覆盖名\n---\n正文");
+  void importFiles_nameOverrideTakesPriority() throws Exception {
+    Map<String, String> files =
+        Map.of("SKILL.md", "---\n\"name\": ignored\ndescription: 覆盖名\n---\n正文");
 
     Skill s = service.importFiles("myname", files, "fb");
 
     assertEquals("myname", s.name());
     assertTrue(Files.isRegularFile(oryxosRoot.resolve("skills/myname/SKILL.md")));
+    assertTrue(
+        Files.readString(oryxosRoot.resolve("skills/myname/SKILL.md")).contains("name: myname"));
+  }
+
+  @Test
+  @DisplayName("importFiles：落盘后校验失败会删除完整残留目录")
+  void importFiles_validationFailureRollsBackDirectory() {
+    SkillLoader failingLoader =
+        new SkillLoader(oryxosRoot.resolve("skills")) {
+          @Override
+          public Skill deriveSkill(Path skillDir) {
+            throw new IllegalArgumentException("forced validation failure");
+          }
+        };
+    SkillService failingService = new SkillService(store, new SkillRegistry(), failingLoader);
+    Map<String, String> files =
+        Map.of(
+            "SKILL.md", "---\nname: rollback\ndescription: 回滚\n---\n正文",
+            "scripts/run.sh", "echo bad");
+
+    assertThrows(
+        IllegalArgumentException.class, () -> failingService.importFiles(null, files, "fallback"));
+
+    assertFalse(Files.exists(oryxosRoot.resolve("skills/rollback")));
+  }
+
+  @Test
+  @DisplayName("importFiles：检测无 SKILL.md 的同名残留且不删除已有文件")
+  void importFiles_rejectsResidueWithoutDeletingIt() throws Exception {
+    Path residue = Files.createDirectories(oryxosRoot.resolve("skills/residue/scripts"));
+    Path existing = Files.writeString(residue.resolve("keep.sh"), "keep");
+    Map<String, String> files = Map.of("SKILL.md", "---\nname: residue\ndescription: 新导入\n---\n正文");
+
+    assertThrows(
+        IllegalArgumentException.class, () -> service.importFiles(null, files, "fallback"));
+
+    assertEquals("keep", Files.readString(existing));
+    assertFalse(Files.exists(oryxosRoot.resolve("skills/residue/SKILL.md")));
+  }
+
+  @Test
+  @DisplayName("importFiles：注册后的失败同时回滚磁盘与内存索引")
+  void importFiles_postRegistrationFailureRollsBackRegistry() {
+    AgentSkillBindingService bindings = mock(AgentSkillBindingService.class);
+    doThrow(new IllegalStateException("forced reconcile failure"))
+        .when(bindings)
+        .logCurrentIssues();
+    SkillLoader loader = new SkillLoader(oryxosRoot.resolve("skills"));
+    SkillService failingService = new SkillService(store, registry, loader, bindings);
+    Map<String, String> files =
+        Map.of("SKILL.md", "---\nname: rollback-registry\ndescription: 回滚\n---\n正文");
+
+    assertThrows(
+        IllegalStateException.class, () -> failingService.importFiles(null, files, "fallback"));
+
+    assertFalse(registry.exists("rollback-registry"));
+    assertFalse(Files.exists(oryxosRoot.resolve("skills/rollback-registry")));
   }
 
   @Test

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillImportFilesTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillImportFilesTest.java
@@ -52,7 +52,7 @@ class SkillImportFilesTest {
   @Test
   @DisplayName("importFiles：nameOverride 优先于 frontmatter 的 name")
   void importFiles_nameOverrideTakesPriority() {
-    Map<String, String> files = Map.of("SKILL.md", "---\nname: ignored\n---\n正文");
+    Map<String, String> files = Map.of("SKILL.md", "---\nname: ignored\ndescription: 覆盖名\n---\n正文");
 
     Skill s = service.importFiles("myname", files, "fb");
 

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillLoaderTest.java
@@ -1,0 +1,31 @@
+package io.oryxos.core.skill;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SkillLoaderTest {
+
+  @TempDir Path root;
+
+  @Test
+  @DisplayName("公共目录名、frontmatter name 和 description 必须完整一致")
+  void metadataMustBeCompleteAndMatchDirectory() throws IOException {
+    SkillLoader loader = new SkillLoader(root);
+    Path mismatch = root.resolve("actual");
+    Files.createDirectories(mismatch);
+    Files.writeString(mismatch.resolve("SKILL.md"), "---\nname: other\ndescription: d\n---\nbody");
+    assertThrows(IllegalArgumentException.class, () -> loader.deriveSkill(mismatch));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> loader.parse("---\ndescription: d\n---\nbody", "fallback"));
+    assertThrows(
+        IllegalArgumentException.class, () -> loader.parse("---\nname: valid\n---\nbody", "valid"));
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillMetadataReaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillMetadataReaderTest.java
@@ -1,0 +1,57 @@
+package io.oryxos.core.skill;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SkillMetadataReaderTest {
+
+  @TempDir Path root;
+
+  @Test
+  void readsOnlyRequiredMetadataAndValidatesBodyBoundary() throws IOException {
+    Path valid = Files.createDirectories(root.resolve("report"));
+    Files.writeString(
+        valid.resolve("SKILL.md"), "---\nname: report\ndescription: 报告格式\n---\nSECRET-BODY");
+
+    SkillMetadataReader.Metadata metadata = new SkillMetadataReader().read(valid);
+
+    assertEquals("report", metadata.name());
+    assertEquals("报告格式", metadata.description());
+    assertEquals(2, metadata.getClass().getRecordComponents().length, "目录模型不得携带正文");
+
+    Path empty = Files.createDirectories(root.resolve("empty"));
+    Files.writeString(empty.resolve("SKILL.md"), "---\nname: empty\ndescription: empty\n---\n\n");
+    assertThrows(IllegalArgumentException.class, () -> new SkillMetadataReader().read(empty));
+  }
+
+  @Test
+  void rejectsMissingMetadataAndDirectoryNameMismatch() throws IOException {
+    Path mismatch = Files.createDirectories(root.resolve("actual"));
+    Files.writeString(mismatch.resolve("SKILL.md"), "---\nname: other\ndescription: x\n---\nbody");
+    assertThrows(IllegalArgumentException.class, () -> new SkillMetadataReader().read(mismatch));
+
+    Path missing = Files.createDirectories(root.resolve("missing"));
+    Files.writeString(missing.resolve("SKILL.md"), "---\nname: missing\n---\nbody");
+    assertThrows(IllegalArgumentException.class, () -> new SkillMetadataReader().read(missing));
+
+    Path noFrontmatter = Files.createDirectories(root.resolve("plain"));
+    Files.writeString(noFrontmatter.resolve("SKILL.md"), "plain body");
+    assertThrows(
+        IllegalArgumentException.class, () -> new SkillMetadataReader().read(noFrontmatter));
+
+    Path unclosed = Files.createDirectories(root.resolve("unclosed"));
+    Files.writeString(unclosed.resolve("SKILL.md"), "---\nname: unclosed\ndescription: x");
+    assertThrows(IllegalArgumentException.class, () -> new SkillMetadataReader().read(unclosed));
+
+    Path unreadable = Files.createDirectories(root.resolve("unreadable"));
+    Files.write(unreadable.resolve("SKILL.md"), new byte[] {(byte) 0xC3, (byte) 0x28});
+    assertThrows(UncheckedIOException.class, () -> new SkillMetadataReader().read(unreadable));
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillServiceTest.java
@@ -93,7 +93,7 @@ class SkillServiceTest {
   }
 
   @Test
-  @DisplayName("importMarkdown：解析 frontmatter 建库；name 缺省用 fallback；nameOverride 优先；同名 400")
+  @DisplayName("importMarkdown：完整 frontmatter 建库；nameOverride 优先；元数据缺失和同名均拒绝")
   void importMarkdown_parsesAndCreates() {
     Skill s =
         service.importMarkdown(null, "---\nname: imp\ndescription: 导入的\n---\n\n正文X", "fallback");
@@ -101,10 +101,12 @@ class SkillServiceTest {
     assertEquals("导入的", s.description());
     assertTrue(s.body().contains("正文X"));
 
-    Skill s2 = service.importMarkdown(null, "没有 frontmatter 的正文", "url-derived");
-    assertEquals("url-derived", s2.name());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.importMarkdown(null, "没有 frontmatter 的正文", "url-derived"));
 
-    Skill s3 = service.importMarkdown("myname", "---\nname: ignored\n---\nz", "fb");
+    Skill s3 =
+        service.importMarkdown("myname", "---\nname: ignored\ndescription: 覆盖名\n---\nz", "fb");
     assertEquals("myname", s3.name());
 
     assertThrows(

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillServiceTest.java
@@ -93,6 +93,21 @@ class SkillServiceTest {
   }
 
   @Test
+  @DisplayName("seedBuiltins：同名残留目录不合并也不覆盖")
+  void seedBuiltins_rejectsResidueDirectory() throws Exception {
+    Path residue =
+        Files.createDirectories(
+            oryxosRoot.resolve("skills").resolve(SkillService.BUILTIN_REPORT_FORMAT));
+    Path existing = Files.writeString(residue.resolve("keep.txt"), "keep");
+
+    service.seedBuiltins();
+
+    assertEquals("keep", Files.readString(existing));
+    assertFalse(Files.exists(residue.resolve("SKILL.md")));
+    assertTrue(registry.get(SkillService.BUILTIN_REPORT_FORMAT).isEmpty());
+  }
+
+  @Test
   @DisplayName("importMarkdown：完整 frontmatter 建库；nameOverride 优先；元数据缺失和同名均拒绝")
   void importMarkdown_parsesAndCreates() {
     Skill s =

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillStoreTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillStoreTest.java
@@ -1,0 +1,38 @@
+package io.oryxos.core.skill;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SkillStoreTest {
+
+  @TempDir Path root;
+
+  @Test
+  void writeAllRejectsIntermediateSymlinkEscape() throws Exception {
+    Path outside = Files.createDirectories(root.resolveSibling("skill-store-outside"));
+    Path skill = Files.createDirectories(root.resolve("skills/report"));
+    Files.createSymbolicLink(skill.resolve("scripts"), outside);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new SkillStore(root).writeAll("report", Map.of("scripts/pwned.sh", "bad")));
+    assertFalse(Files.exists(outside.resolve("pwned.sh")));
+
+    Path outsideFile = Files.writeString(outside.resolve("keep.md"), "keep");
+    Files.createSymbolicLink(skill.resolve("REFERENCE.md"), outsideFile);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new SkillStore(root).writeAll("report", Map.of("REFERENCE.md", "bad")));
+    assertEquals("keep", Files.readString(outsideFile));
+
+    new SkillStore(root).writeAll("report", Map.of("examples/ok.md", "ok"));
+    assertEquals("ok", Files.readString(skill.resolve("examples/ok.md")));
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillWorkspaceFixture.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillWorkspaceFixture.java
@@ -1,0 +1,37 @@
+package io.oryxos.core.skill;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+final class SkillWorkspaceFixture {
+
+  private final Path root;
+
+  SkillWorkspaceFixture(Path root) {
+    this.root = root;
+  }
+
+  Path agent(String name, String extraFrontmatter) throws IOException {
+    Path directory = Files.createDirectories(root.resolve("agents").resolve(name));
+    Files.writeString(
+        directory.resolve("AGENT.md"),
+        "---\nname: " + name + "\n" + extraFrontmatter + "---\nbody\n");
+    return directory;
+  }
+
+  Path skill(String name, String description) throws IOException {
+    Path directory = Files.createDirectories(root.resolve("skills").resolve(name));
+    Files.writeString(
+        directory.resolve("SKILL.md"),
+        "---\nname: " + name + "\ndescription: " + description + "\n---\nBODY-" + name);
+    return directory;
+  }
+
+  Path bind(String agent, String skill) throws IOException {
+    Path links = Files.createDirectories(root.resolve("agents").resolve(agent).resolve("skills"));
+    Path link = links.resolve(skill);
+    Files.createSymbolicLink(link, Path.of("../../../skills").resolve(skill));
+    return link;
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -93,7 +93,17 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   }
 
   private static Path normalizeRoot(String rawPath) {
-    return RealPathBoundary.project(Path.of(rawPath)).projectedReal();
+    Path lexical = lexicalRoot(rawPath);
+    try {
+      return RealPathBoundary.project(lexical).projectedReal();
+    } catch (RuntimeException e) {
+      LOG.warn("白名单路径暂时无法解析真实目标，保留词法路径并在访问时失败关闭: {}", sanitize(lexical.toString()));
+      return lexical;
+    }
+  }
+
+  private static Path lexicalRoot(String rawPath) {
+    return Path.of(rawPath).toAbsolutePath().normalize();
   }
 
   @Override
@@ -291,10 +301,18 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
     String entry = requireNonBlank(value);
     boolean changed;
     String canonical; // 入内存的规范形，也是落库/展示/删除对齐的值（FILE 为归一后的绝对路径）
+    String staleCanonical = null;
     if (category == Category.FILE) {
+      Path lexical = lexicalRoot(entry);
       Path root = normalizeRoot(entry);
       canonical = root.toString();
-      changed = allowedRoots.addIfAbsent(root);
+      if (!root.equals(lexical) && allowedRoots.remove(lexical)) {
+        allowedRoots.addIfAbsent(root);
+        staleCanonical = lexical.toString();
+        changed = true;
+      } else {
+        changed = allowedRoots.addIfAbsent(root);
+      }
     } else if (category == Category.SHELL) {
       canonical = entry;
       changed = allowedCommands.add(entry);
@@ -304,6 +322,9 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
     }
     // 写穿：只有内存确有变更才落库（幂等，避免重复写；启动播种重复调用不会重复插入）
     if (changed && store != null) {
+      if (staleCanonical != null) {
+        store.remove(category, staleCanonical);
+      }
       store.add(category, canonical);
     }
     LOG.info("Sandbox 白名单增加 {} -> {}（changed={}）", category, sanitize(entry), changed);
@@ -320,8 +341,9 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
     String canonical;
     if (category == Category.FILE) {
       Path root = normalizeRoot(entry);
-      canonical = root.toString();
-      changed = allowedRoots.remove(root);
+      Path removed = removeFileRoot(root, lexicalRoot(entry));
+      canonical = removed == null ? root.toString() : removed.toString();
+      changed = removed != null;
     } else if (category == Category.SHELL) {
       canonical = entry;
       changed = allowedCommands.remove(entry);
@@ -334,6 +356,16 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
     }
     LOG.info("Sandbox 白名单删除 {} -> {}（changed={}）", category, sanitize(entry), changed);
     return changed;
+  }
+
+  private Path removeFileRoot(Path normalized, Path lexical) {
+    if (allowedRoots.remove(normalized)) {
+      return normalized;
+    }
+    if (!normalized.equals(lexical) && allowedRoots.remove(lexical)) {
+      return lexical;
+    }
+    return null;
   }
 
   private static String requireNonBlank(String value) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -1,7 +1,9 @@
 package io.oryxos.tool.sandbox;
 
+import io.oryxos.core.fs.RealPathBoundary;
 import io.oryxos.core.sandbox.SandboxWhitelist;
 import io.oryxos.core.sandbox.SandboxWhitelistStore;
+import java.net.IDN;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
@@ -35,11 +37,9 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   /** 域名白名单里的通配前缀；命中后转成"以 . 之后部分结尾"的点号边界匹配。 */
   private static final String WILDCARD_PREFIX = "*.";
 
-  /** SSRF 防护：已知内部主机名。 */
   private static final String LOCALHOST = "localhost";
-
-  private static final String METADATA_GOOGLE_INTERNAL = "metadata.google.internal";
-  private static final String INTERNAL_SUFFIX = ".internal";
+  private static final String GOOGLE_METADATA_HOST = "metadata.google.internal";
+  private static final String INTERNAL_DOMAIN_SUFFIX = ".internal";
 
   // 具体类型 CopyOnWriteArrayList（而非 List 接口）：需要 addIfAbsent 的原子"不存在才加"语义
   private final CopyOnWriteArrayList<Path> allowedRoots = new CopyOnWriteArrayList<>();
@@ -93,7 +93,7 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   }
 
   private static Path normalizeRoot(String rawPath) {
-    return Path.of(rawPath).toAbsolutePath().normalize();
+    return RealPathBoundary.project(Path.of(rawPath)).projectedReal();
   }
 
   @Override
@@ -121,7 +121,12 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   }
 
   private void checkFilePath(String rawPath) {
-    Path target = Path.of(rawPath).normalize().toAbsolutePath();
+    Path target;
+    try {
+      target = RealPathBoundary.project(Path.of(rawPath)).projectedReal();
+    } catch (RuntimeException e) {
+      throw new SandboxViolationException("路径真实目标无法安全解析，拒绝访问: " + rawPath);
+    }
     boolean allowed = allowedRoots.stream().anyMatch(target::startsWith);
     if (!allowed) {
       throw new SandboxViolationException(
@@ -180,14 +185,23 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   /** SSRF 兜底：拒绝主机解析到回环/任意本地/链路本地(含云元数据 169.254.169.254)/站点内网/组播/CGNAT，及 localhost、*.internal。 */
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",
-      justification = "toLowerCase(Locale.ROOT) 已是稳定的大小写转换；主机名不含特殊 Unicode 字符，误报。")
+      justification =
+          "IDN.toASCII canonicalizes the complete DNS host before security checks; no substring is transformed independently.")
   private static void assertNotInternalHost(String host) {
-    String h = host.toLowerCase(Locale.ROOT);
-    if (LOCALHOST.equals(h) || METADATA_GOOGLE_INTERNAL.equals(h) || h.endsWith(INTERNAL_SUFFIX)) {
+    String asciiHost;
+    try {
+      asciiHost = IDN.toASCII(host);
+    } catch (IllegalArgumentException e) {
+      throw new SandboxViolationException("非法主机名: " + host);
+    }
+    if (isInternalName(asciiHost)) {
       throw new SandboxViolationException("拒绝访问内网 / 元数据主机（SSRF 防护）: " + host + "。这是安全策略，请勿重试。");
     }
     // IPv6 字面量 getHost() 带方括号（如 [fd00::1]），解析前剥掉，ULA/回环等判断才生效
-    String lookup = h.startsWith("[") && h.endsWith("]") ? h.substring(1, h.length() - 1) : host;
+    String lookup =
+        asciiHost.startsWith("[") && asciiHost.endsWith("]")
+            ? asciiHost.substring(1, asciiHost.length() - 1)
+            : asciiHost;
     InetAddress[] addresses;
     try {
       addresses = InetAddress.getAllByName(lookup);
@@ -206,6 +220,20 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
             "拒绝访问内网 / 保留地址（SSRF 防护）: " + host + " → " + addr.getHostAddress() + "。这是安全策略，请勿重试。");
       }
     }
+  }
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "DNS labels are case-insensitive and the complete IDN-canonicalized host is compared.")
+  private static boolean isInternalName(String host) {
+    if (LOCALHOST.equalsIgnoreCase(host) || GOOGLE_METADATA_HOST.equalsIgnoreCase(host)) {
+      return true;
+    }
+    int offset = host.length() - INTERNAL_DOMAIN_SUFFIX.length();
+    return offset >= 0
+        && host.regionMatches(
+            true, offset, INTERNAL_DOMAIN_SUFFIX, 0, INTERNAL_DOMAIN_SUFFIX.length());
   }
 
   /** 100.64.0.0/10（运营商级 NAT，isSiteLocalAddress 不覆盖，单独判）。 */

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -109,7 +109,20 @@ class FileToolsTest {
     assertThrows(SandboxViolationException.class, () -> guarded.readFile(target.toString()));
     assertThrows(SandboxViolationException.class, () -> guarded.writeFile(target.toString(), "x"));
     assertThrows(SandboxViolationException.class, () -> guarded.listDir(dir.toString()));
+    assertThrows(
+        SandboxViolationException.class, () -> guarded.makeDir(dir.resolve("new").toString()));
+    assertThrows(SandboxViolationException.class, () -> guarded.appendFile(target.toString(), "x"));
+    assertThrows(SandboxViolationException.class, () -> guarded.deleteFile(target.toString()));
+    assertThrows(
+        SandboxViolationException.class,
+        () -> guarded.moveFile(target.toString(), dir.resolve("moved").toString()));
+    assertThrows(
+        SandboxViolationException.class,
+        () -> guarded.copyFile(target.toString(), dir.resolve("copied").toString()));
     assertFalse(Files.exists(target), "校验不过，文件根本不该被创建");
+    assertFalse(Files.exists(dir.resolve("new")));
+    assertFalse(Files.exists(dir.resolve("moved")));
+    assertFalse(Files.exists(dir.resolve("copied")));
   }
 
   @Test

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/SandboxPathFixture.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/SandboxPathFixture.java
@@ -1,0 +1,51 @@
+package io.oryxos.tool.sandbox;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+final class SandboxPathFixture {
+
+  private final Path allowed;
+  private final Path outside;
+
+  SandboxPathFixture(Path temp) throws IOException {
+    this.allowed = Files.createDirectories(temp.resolve("allowed"));
+    this.outside = Files.createDirectories(temp.resolve("outside"));
+  }
+
+  Path allowed() {
+    return allowed;
+  }
+
+  Path outside() {
+    return outside;
+  }
+
+  Path parentEscape() throws IOException {
+    Path link = allowed.resolve("escape");
+    Files.createSymbolicLink(link, outside);
+    return link;
+  }
+
+  Path dangling() throws IOException {
+    Path link = allowed.resolve("dangling");
+    Files.createSymbolicLink(link, Path.of("missing"));
+    return link;
+  }
+
+  Path multiHopEscape() throws IOException {
+    Files.createSymbolicLink(allowed.resolve("second"), outside);
+    Path first = allowed.resolve("first");
+    Files.createSymbolicLink(first, Path.of("second"));
+    return first;
+  }
+
+  Path[] cycle() throws IOException {
+    Path one = allowed.resolve("one");
+    Path two = allowed.resolve("two");
+    Files.createSymbolicLink(one, Path.of("two"));
+    Files.createSymbolicLink(two, Path.of("one"));
+    return new Path[] {one, two};
+  }
+}

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxMutationTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxMutationTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.oryxos.core.sandbox.SandboxWhitelist.Category;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -74,13 +75,13 @@ class WhitelistSandboxMutationTest {
 
   @Test
   @DisplayName("增加文件路径_归一为绝对路径后 enforce 放行")
-  void addFileNormalizesPathAndEnforcePasses(@TempDir Path dir) {
+  void addFileNormalizesPathAndEnforcePasses(@TempDir Path dir) throws IOException {
     WhitelistSandbox sb = emptySandbox();
 
     sb.add(Category.FILE, dir.toString());
 
-    // list 返回归一后的绝对路径
-    assertTrue(sb.list(Category.FILE).contains(dir.toAbsolutePath().normalize().toString()));
+    // list 返回解析软连接后的真实根路径（macOS /var → /private/var 也能稳定匹配）
+    assertTrue(sb.list(Category.FILE).contains(dir.toRealPath().toString()));
     assertDoesNotThrow(
         () ->
             sb.enforce(

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxPersistenceTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxPersistenceTest.java
@@ -4,10 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.oryxos.core.sandbox.SandboxWhitelist.Category;
 import io.oryxos.core.sandbox.SandboxWhitelistStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /** 31 节：store-backed WhitelistSandbox 的加载 / 写穿行为（宪法 VI 白名单持久化）。 */
 class WhitelistSandboxPersistenceTest {
@@ -77,6 +80,46 @@ class WhitelistSandboxPersistenceTest {
 
     assertThat(restored.list(Category.SHELL)).contains("cat");
     assertThat(restored.list(Category.HTTP)).contains("*.feishu.cn");
+  }
+
+  @Test
+  @DisplayName("恢复悬空软连接白名单不阻断启动且访问仍失败关闭")
+  void constructorToleratesDanglingPersistedFileRoot(@TempDir Path temp) throws Exception {
+    Path dangling = temp.resolve("dangling-root");
+    Files.createSymbolicLink(dangling, temp.resolve("missing"));
+    FakeStore store = new FakeStore();
+    store.entries.add(new SandboxWhitelistStore.Entry(Category.FILE, dangling.toString()));
+
+    WhitelistSandbox restored = new WhitelistSandbox(store);
+
+    assertThat(restored.list(Category.FILE)).contains(dangling.toAbsolutePath().toString());
+    org.junit.jupiter.api.Assertions.assertThrows(
+        SandboxViolationException.class,
+        () ->
+            restored.enforce(
+                new SandboxAction(
+                    ActionType.FILE_READ, dangling.resolve("secret.txt").toString())));
+  }
+
+  @Test
+  @DisplayName("悬空白名单链接恢复后可用原值刷新并删除")
+  void danglingFileRootCanBeRemovedAfterTargetAppears(@TempDir Path temp) throws Exception {
+    Path target = temp.resolve("target");
+    Path dangling = temp.resolve("dangling-root");
+    Files.createSymbolicLink(dangling, target);
+    FakeStore store = new FakeStore();
+    store.entries.add(new SandboxWhitelistStore.Entry(Category.FILE, dangling.toString()));
+    WhitelistSandbox restored = new WhitelistSandbox(store);
+    Files.createDirectory(target);
+
+    assertThat(restored.add(Category.FILE, dangling.toString())).isTrue();
+    assertThat(store.loadAll()).hasSize(1);
+    assertThat(restored.list(Category.FILE)).containsExactly(target.toRealPath().toString());
+    restored.enforce(
+        new SandboxAction(ActionType.FILE_READ, dangling.resolve("secret.txt").toString()));
+    assertThat(restored.remove(Category.FILE, dangling.toString())).isTrue();
+    assertThat(store.loadAll()).isEmpty();
+    assertThat(restored.list(Category.FILE)).isEmpty();
   }
 
   @Test

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
@@ -3,6 +3,8 @@ package io.oryxos.tool.sandbox;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -60,6 +62,85 @@ class WhitelistSandboxTest {
       assertThrows(
           SandboxViolationException.class,
           () -> sb.enforce(new SandboxAction(ActionType.FILE_READ, traversal)));
+    }
+
+    @Test
+    @DisplayName("白名单内软连接指向外部时，读与不存在目标写均拒绝")
+    void symlinkEscapeIsBlocked(@TempDir Path allowed) throws IOException {
+      Path outside = Files.createTempDirectory("oryxos-sandbox-outside-");
+      Files.writeString(outside.resolve("secret.txt"), "secret");
+      Files.createSymbolicLink(allowed.resolve("escape"), outside);
+      WhitelistSandbox sb = sandbox(List.of(allowed.toString()), List.of(), List.of());
+
+      assertThrows(
+          SandboxViolationException.class,
+          () ->
+              sb.enforce(
+                  new SandboxAction(
+                      ActionType.FILE_READ, allowed.resolve("escape/secret.txt").toString())));
+      assertThrows(
+          SandboxViolationException.class,
+          () ->
+              sb.enforce(
+                  new SandboxAction(
+                      ActionType.FILE_WRITE, allowed.resolve("escape/new.txt").toString())));
+    }
+
+    @Test
+    @DisplayName("合法 Agent Skill 软连接指向同一白名单根时可读")
+    void controlledSkillSymlinkIsAllowed(@TempDir Path allowed) throws IOException {
+      Path shared = allowed.resolve("skills/report");
+      Path local = allowed.resolve("agents/ops/skills");
+      Files.createDirectories(shared);
+      Files.createDirectories(local);
+      Files.writeString(shared.resolve("SKILL.md"), "body");
+      Files.createSymbolicLink(local.resolve("report"), Path.of("../../../skills/report"));
+      WhitelistSandbox sb = sandbox(List.of(allowed.toString()), List.of(), List.of());
+
+      assertDoesNotThrow(
+          () ->
+              sb.enforce(
+                  new SandboxAction(
+                      ActionType.FILE_READ, local.resolve("report/SKILL.md").toString())));
+    }
+
+    @Test
+    @DisplayName("dangling、多跳逃逸和链接环全部失败关闭")
+    void unresolvableLinkShapesAreBlocked(@TempDir Path temp) throws IOException {
+      SandboxPathFixture paths = new SandboxPathFixture(temp);
+      Path dangling = paths.dangling();
+      Path multiHop = paths.multiHopEscape();
+      Path cycle = paths.cycle()[0];
+      WhitelistSandbox sb = sandbox(List.of(paths.allowed().toString()), List.of(), List.of());
+
+      assertThrows(
+          SandboxViolationException.class,
+          () -> sb.enforce(new SandboxAction(ActionType.FILE_READ, dangling.toString())));
+      assertThrows(
+          SandboxViolationException.class,
+          () ->
+              sb.enforce(
+                  new SandboxAction(ActionType.FILE_WRITE, multiHop.resolve("x").toString())));
+      assertThrows(
+          SandboxViolationException.class,
+          () -> sb.enforce(new SandboxAction(ActionType.FILE_READ, cycle.toString())));
+    }
+
+    @Test
+    @DisplayName("白名单按真实最小根判断，链接的 lexical 位置不能扩大授权")
+    void symlinkUsesRealTargetRoot(@TempDir Path workspace) throws IOException {
+      Path shared = Files.createDirectories(workspace.resolve("skills/report"));
+      Path local = Files.createDirectories(workspace.resolve("agents/ops/skills"));
+      Files.writeString(shared.resolve("SKILL.md"), "body");
+      Files.createSymbolicLink(local.resolve("report"), Path.of("../../../skills/report"));
+      WhitelistSandbox agentOnly = sandbox(List.of(local.toString()), List.of(), List.of());
+
+      assertThrows(
+          SandboxViolationException.class,
+          () ->
+              agentOnly.enforce(
+                  new SandboxAction(
+                      ActionType.FILE_READ, local.resolve("report/SKILL.md").toString())));
     }
   }
 

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -123,8 +123,32 @@ function refresh() {
   if (NAV.find((n) => n.key === key)?.path) load(key)
 }
 
-// —— Skill 列表（第 32 节）：全局 Skill 库 CRUD。Agent 通过 AGENT.md 的 skills:[名] 引用，运行时注入正文约束产出 ——
+// —— Skill 实体、外部 catalog 与绑定一致性。绑定真相源是 Agent 目录中的固定相对软连接。——
 const skills = ref({ loading: false, error: null, data: [] })
+const skillCatalog = ref({ loading: false, error: null, data: [] })
+const skillIssues = ref({ loading: false, error: null, data: [] })
+const skillCatalogFilter = reactive({ q: '', visibility: 'all' })
+async function loadSkillCatalog() {
+  skillCatalog.value = { loading: true, error: null, data: [] }
+  const params = new URLSearchParams()
+  if (skillCatalogFilter.q.trim()) params.set('q', skillCatalogFilter.q.trim())
+  params.set('visibility', skillCatalogFilter.visibility)
+  try {
+    const res = await fetch(`/api/v1/skills/catalog?${params}`)
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || 'catalog 加载失败')
+    skillCatalog.value = { loading: false, error: null, data: body.data || [] }
+  } catch (e) { skillCatalog.value = { loading: false, error: e.message, data: [] } }
+}
+async function loadSkillIssues() {
+  skillIssues.value = { loading: true, error: null, data: [] }
+  try {
+    const res = await fetch('/api/v1/skills/binding-issues')
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '绑定检查失败')
+    skillIssues.value = { loading: false, error: null, data: body.data || [] }
+  } catch (e) { skillIssues.value = { loading: false, error: e.message, data: [] } }
+}
 async function loadSkills() {
   skills.value = { loading: true, error: null, data: [] }
   try {
@@ -133,6 +157,7 @@ async function loadSkills() {
     if (body.code !== 0) throw new Error(body.message || '加载失败')
     skills.value = { loading: false, error: null, data: body.data || [] }
   } catch (e) { skills.value = { loading: false, error: e.message, data: [] } }
+  await Promise.all([loadSkillCatalog(), loadSkillIssues()])
 }
 const skillForm = reactive({ open: false, editing: null, name: '', description: '', body: '', busy: false, error: null })
 function newSkill() {
@@ -166,11 +191,14 @@ async function saveSkill() {
   } catch (e) { skillForm.error = e.message } finally { skillForm.busy = false }
 }
 async function deleteSkill(name) {
-  if (!confirm(`删除 Skill「${name}」？引用它的 Agent 下次触发将跳过该约束。`)) return
+  if (!confirm(`归档 Skill「${name}」？存在活跃或归档 Agent 引用时会拒绝，实体不会被物理删除。`)) return
   try {
     const res = await fetch(`/api/v1/skills/${encodeURIComponent(name)}`, { method: 'DELETE' })
     const body = await res.json()
-    if (body.code !== 0) throw new Error(body.message || '删除失败')
+    if (body.code !== 0) {
+      const refs = (body.data?.references || []).map((r) => `${r.agentName}(${r.state})`).join('、')
+      throw new Error(`${body.message || '归档失败'}${refs ? `：${refs}` : ''}`)
+    }
     await loadSkills()
   } catch (e) { skills.value = { ...skills.value, error: e.message } }
 }
@@ -209,7 +237,7 @@ async function openSkillDetail(row) {
 function closeSkillDetail() { skillDetail.value = null; fileView.value = null }
 // 该 Skill 目录的文件行（扁平带缩进，复用 Agent 工作区同一个 flatten）
 const skillDetailRows = computed(() => (skillDetail.value?.node ? flatten(skillDetail.value.node, 0, []) : []))
-// 回退：旧后端 tree 无 skills 节点时，直接渲染 SKILL.md 正文（body）
+// 回退：工作区树暂不可用时，直接渲染已安装实体返回的 SKILL.md 正文。
 const skillDetailBodyMd = computed(() =>
   skillDetail.value?.body ? DOMPurify.sanitize(marked.parse(skillDetail.value.body)) : ''
 )
@@ -313,7 +341,10 @@ async function loadAgents() {
 
 // 新建 Agent：独立成页（不再是弹框），把「大模型生成」折叠进来。
 // 只填 name + description 可直接按模板脚手架；也可先「用大模型生成」各文件、编辑后再创建。
-const agentCreate = reactive({ open: false, name: '', description: '', provider: '', model: '', notifyChannel: '', skills: [], files: null, busy: false, error: '' })
+const agentCreate = reactive({
+  open: false, name: '', description: '', provider: '', model: '', notifyChannel: '', skills: [],
+  requiredSkills: [], suggestedSkills: [], files: null, busy: false, error: '',
+})
 
 // 新建页用的 provider / model 下拉数据源：provider 来自 GET /providers；model 来自 GET /providers/{name}/models（服务端代理）
 const createProviders = ref({ loading: false, error: null, data: [] })
@@ -348,6 +379,8 @@ function openCreate() {
   agentCreate.model = ''
   agentCreate.notifyChannel = ''
   agentCreate.skills = []
+  agentCreate.requiredSkills = []
+  agentCreate.suggestedSkills = []
   agentCreate.files = null
   agentCreate.busy = false
   agentCreate.error = ''
@@ -365,11 +398,14 @@ async function generateFiles() {
   try {
     const res = await fetch(`/api/v1/agents/${encodeURIComponent(agentCreate.name)}/generate-files`, {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ description: agentCreate.description, notifyChannel: agentCreate.notifyChannel, skills: agentCreate.skills, provider: agentCreate.provider || undefined, model: agentCreate.model || undefined }),
+      body: JSON.stringify({ description: agentCreate.description, notifyChannel: agentCreate.notifyChannel, requiredSkills: agentCreate.skills, provider: agentCreate.provider || undefined, model: agentCreate.model || undefined }),
     })
     const body = await res.json()
     if (body.code !== 0) throw new Error(body.message || '生成失败')
     agentCreate.files = body.data.files || {}
+    agentCreate.requiredSkills = body.data.requiredSkills || []
+    agentCreate.suggestedSkills = body.data.suggestedSkills || []
+    agentCreate.skills = body.data.bindingSkills || []
   } catch (e) { agentCreate.error = e.message } finally { agentCreate.busy = false }
 }
 
@@ -381,11 +417,11 @@ async function submitCreate() {
     const res = agentCreate.files
       ? await fetch(`/api/v1/agents/${encodeURIComponent(agentCreate.name)}/files`, {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ files: agentCreate.files }),
+          body: JSON.stringify({ files: agentCreate.files, skillBindings: agentCreate.skills }),
         })
         : await fetch('/api/v1/agents', {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: agentCreate.name, description: agentCreate.description, provider: agentCreate.provider || undefined, model: agentCreate.model || undefined }),
+          body: JSON.stringify({ name: agentCreate.name, description: agentCreate.description, provider: agentCreate.provider || undefined, model: agentCreate.model || undefined, skillBindings: agentCreate.skills }),
         })
     const body = await res.json()
     if (body.code !== 0) throw new Error(body.message || '创建失败')
@@ -734,9 +770,10 @@ async function deleteWhitelist(category, value) {
 
 // —— Agent 详情：Tab 切换（基本信息 / 文件 / 会话 / 记忆）——
 const agentDetail = ref(null) // { name, agent, tab, loading, error, node, editing }
+const agentBinding = reactive({ selected: [], saving: false, error: null, issues: [] })
 const fileView = ref(null) // { path, loading, error, content, saving, saved }
 // 详情页「编辑基本信息」表单态 + 编辑态的 model 下拉数据源（与新建页的 createModels 分开，避免串台）
-const editBasic = reactive({ description: '', provider: '', model: '', skills: [] })
+const editBasic = reactive({ description: '', provider: '', model: '' })
 const editModels = ref({ loading: false, error: null, data: [] })
 const editSaving = ref(false)
 const editError = ref(null)
@@ -827,20 +864,52 @@ const agentMemory = reactive({ text: '', loading: false, error: null })
 
 async function openAgent(agent) {
   agentDetail.value = { name: agent.name, agent, tab: 'info', loading: true, error: null, node: null, editing: false }
+  agentDetail.value = { name: agent.name, agent, tab: 'info', loading: true, error: null, node: null, editing: false }
+  agentBinding.selected = [...(agent.skills || [])]
+  agentBinding.error = null
+  agentBinding.issues = []
   fileView.value = null
   resetChat()
   resetAgentMemory()
   try {
-    const res = await fetch('/api/v1/workspace/tree')
-    const body = await res.json()
+    const [treeRes, bindingRes] = await Promise.all([
+      fetch('/api/v1/workspace/tree'),
+      fetch(`/api/v1/agents/${encodeURIComponent(agent.name)}/skills`),
+      loadSkillCatalog(),
+    ])
+    const body = await treeRes.json()
+    const bindingBody = await bindingRes.json()
     if (body.code !== 0) throw new Error(body.message || '加载失败')
+    if (bindingBody.code !== 0) throw new Error(bindingBody.message || '绑定加载失败')
     const agentsNode = (body.data.children || []).find((c) => c.name === 'agents')
     const node = (agentsNode?.children || []).find((c) => c.name === agent.name) || null
     const outputTree = (body.data.children || []).find((c) => c.name === 'output') || null
+    agentBinding.selected = (bindingBody.data.bindings || []).map((b) => b.name)
+    agentBinding.issues = bindingBody.data.issues || []
     agentDetail.value = { ...agentDetail.value, loading: false, node, outputTree }
   } catch (e) {
     agentDetail.value = { ...agentDetail.value, loading: false, error: e.message }
   }
+}
+
+async function saveAgentBindings() {
+  if (!agentDetail.value) return
+  agentBinding.saving = true; agentBinding.error = null
+  try {
+    const res = await fetch(`/api/v1/agents/${encodeURIComponent(agentDetail.value.name)}/skills`, {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ skills: agentBinding.selected }),
+    })
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '保存绑定失败')
+    agentBinding.selected = (body.data.bindings || []).map((b) => b.name)
+    agentBinding.issues = body.data.issues || []
+    agentDetail.value = {
+      ...agentDetail.value,
+      agent: { ...agentDetail.value.agent, skills: [...agentBinding.selected] },
+    }
+    await loadAgents()
+  } catch (e) { agentBinding.error = e.message } finally { agentBinding.saving = false }
 }
 
 // 重新拉取当前 Agent 的元数据 + 文件树（保存文件后刷新基本信息）
@@ -891,11 +960,9 @@ function startEditBasic() {
   editBasic.description = a.description || ''
   editBasic.provider = a.provider || ''
   editBasic.model = a.model || ''
-  editBasic.skills = (a.skills || []).slice()
   editError.value = null
   agentDetail.value = { ...agentDetail.value, editing: true }
   loadCreateProviders() // provider 下拉数据源（与新建页共用）
-  loadSkills() // Skill 选择器数据源
   loadEditModels(editBasic.provider) // 拉当前 provider 的模型列表
 }
 function cancelEditBasic() {
@@ -924,7 +991,6 @@ async function saveEditBasic() {
         description: editBasic.description,
         provider: editBasic.provider,
         model: editBasic.model,
-        skills: editBasic.skills,
       }),
     })
     const body = await res.json()
@@ -1186,13 +1252,34 @@ const outputRows = computed(() =>
             <button class="btn" @click="refresh()">刷新</button>
           </div>
 
-          <!-- Skill 列表（第 32 节）：全局 Skill 库 CRUD。Agent 按名引用、运行时注入正文约束产出 -->
+          <!-- Skill：已安装实体、公共/私有 catalog 与软连接绑定一致性 -->
           <div v-if="active === 'skills'">
             <template v-if="!skillDetail">
             <div class="toolbar">
               <button class="btn btn-primary" @click="newImport()">从 GitHub 拉取</button>
               <button class="btn btn-primary" @click="newSkill()">+ 新建 Skill</button>
             </div>
+            <h3 class="sec">候选 catalog</h3>
+            <div class="toolbar">
+              <input v-model="skillCatalogFilter.q" class="gen-input" placeholder="按名称或描述查询" @keyup.enter="loadSkillCatalog" />
+              <select v-model="skillCatalogFilter.visibility" class="gen-input" @change="loadSkillCatalog">
+                <option value="all">全部</option><option value="public">公共</option><option value="private">私有</option>
+              </select>
+              <button class="btn" @click="loadSkillCatalog">查询</button>
+            </div>
+            <p v-if="skillCatalog.loading" class="empty">catalog 加载中…</p>
+            <p v-else-if="skillCatalog.error" class="error">catalog 不可用：{{ skillCatalog.error }}</p>
+            <table v-else>
+              <thead><tr><th>名称</th><th>可见性</th><th>来源</th><th>本机状态</th><th>描述</th></tr></thead>
+              <tbody>
+                <tr v-if="!skillCatalog.data.length"><td colspan="5" class="empty">（没有匹配候选）</td></tr>
+                <tr v-for="s in skillCatalog.data" :key="`${s.source}:${s.name}`">
+                  <td class="mono">{{ s.name }}</td><td>{{ s.visibility }}</td><td>{{ s.source }}</td>
+                  <td>{{ s.installed ? '已安装' : '未安装' }}</td><td>{{ s.description || '—' }}</td>
+                </tr>
+              </tbody>
+            </table>
+            <h3 class="sec">已安装实体</h3>
             <!-- 从 GitHub 拉取 Skill 弹出框：导入整个目录（SKILL.md + 附带文件），不是抓网页正文 -->
             <div v-if="skillImport.open" class="modal-overlay" @click.self="cancelImport()">
               <div class="modal-card">
@@ -1224,7 +1311,7 @@ const outputRows = computed(() =>
                   <input v-model="skillForm.name" class="gen-input" :disabled="!!skillForm.editing"
                          placeholder="Skill 名（字母/数字/下划线/连字符，如 report-format）" />
                   <input v-model="skillForm.description" class="gen-input" placeholder="一句话描述：这个 Skill 约束什么" />
-                  <label class="empty" style="display:block;margin:6px 0 2px">正文（约束指令，会注入引用它的 Agent 的 system prompt）</label>
+                  <label class="empty" style="display:block;margin:6px 0 2px">正文（仅在 Agent 判断任务需要后，经 read_file 按需读取）</label>
                   <textarea v-model="skillForm.body" class="gen-draft" rows="10"
                             placeholder="例如：产出报告时严格遵守——开头一句总览；正文按重要性排序，每条含标题+点评+来源；事实与推断分开；不编造。"></textarea>
                   <p v-if="skillForm.error" class="error">{{ skillForm.error }}</p>
@@ -1252,6 +1339,19 @@ const outputRows = computed(() =>
                 </tr>
               </tbody>
             </table>
+            <h3 class="sec">绑定一致性</h3>
+            <p v-if="skillIssues.loading" class="empty">检查中…</p>
+            <p v-else-if="skillIssues.error" class="error">检查失败：{{ skillIssues.error }}</p>
+            <table v-else>
+              <thead><tr><th>Agent</th><th>状态</th><th>条目</th><th>分类</th><th>说明</th></tr></thead>
+              <tbody>
+                <tr v-if="!skillIssues.data.length"><td colspan="5" class="empty">（未发现残留或损坏绑定）</td></tr>
+                <tr v-for="(issue, i) in skillIssues.data" :key="`${issue.path}:${i}`">
+                  <td class="mono">{{ issue.agentName }}</td><td>{{ issue.agentState }}</td>
+                  <td class="mono">{{ issue.entryName || '—' }}</td><td>{{ issue.type }}</td><td>{{ issue.message }}</td>
+                </tr>
+              </tbody>
+            </table>
             </template>
 
             <!-- Skill 详情：文件列表 + 复用同一套文件浏览器（openFile/fileView + md 预览/源码） -->
@@ -1268,7 +1368,8 @@ const outputRows = computed(() =>
                        :class="['ws-node', { file: node.type === 'file', on: fileView && fileView.path === node.path }]"
                        :style="{ paddingLeft: (node.depth * 14) + 'px' }"
                        @click="openFile(node)">
-                    <span class="mono">{{ node.type === 'dir' ? '📁' : '📄' }} {{ node.name }}</span>
+                    <span class="mono">{{ node.type === 'dir' ? '📁' : node.type === 'link' ? '🔗' : '📄' }} {{ node.name }}</span>
+                    <span v-if="node.type === 'link'" class="empty"> → {{ node.linkTarget }} · {{ node.linkStatus }}</span>
                     <a v-if="node.type === 'file'" class="dl" :href="downloadUrl(node.path)"
                        :download="node.name" @click.stop title="下载">⬇</a>
                   </div>
@@ -1378,15 +1479,16 @@ const outputRows = computed(() =>
                   <option value="">不通知</option>
                   <option v-for="c in (notifyChannels.data || [])" :key="c.name" :value="c.name">{{ c.name }}（{{ c.type }}）</option>
                 </select>
-                <label class="empty" style="display:block;margin:6px 0 2px">Skill（约束产出，勾选=生成时必启用；不勾则由大模型按需自动选）</label>
+                <label class="empty" style="display:block;margin:6px 0 2px">Skill 绑定（勾选=required；作者可从已安装 catalog 再建议）</label>
                 <div class="skill-picker">
-                  <span v-if="!(skills.data || []).length" class="empty">（暂无 Skill · 去「Skill 列表」新建）</span>
-                  <label v-for="s in (skills.data || [])" :key="s.name" class="skill-opt" :title="s.description">
+                  <span v-if="!(skillCatalog.data || []).filter((s) => s.installed).length" class="empty">（catalog 中暂无可绑定的已安装 Skill）</span>
+                  <label v-for="s in (skillCatalog.data || []).filter((s) => s.installed)" :key="`${s.source}:${s.name}`" class="skill-opt" :title="s.description">
                     <input type="checkbox" :value="s.name" v-model="agentCreate.skills" />
-                    <span class="mono">{{ s.name }}</span>
+                    <span class="mono">{{ s.name }}</span><span class="empty">{{ s.visibility }}</span>
                   </label>
                 </div>
-                <p class="empty">可先「用大模型生成」各文件、编辑后再创建；也可直接「创建」，后台按模板脚手架出完整目录（AGENT.md + scripts/ + skills/ + REFERENCE.md）。</p>
+                <p v-if="agentCreate.suggestedSkills.length" class="empty">作者建议：{{ agentCreate.suggestedSkills.join('、') }}；已合并到最终绑定，可在创建前取消。</p>
+                <p class="empty">绑定保存为 agents/&lt;name&gt;/skills/&lt;skill&gt; 固定相对软连接；AGENT.md 不保存 skills 字段，也不预载正文。</p>
                 <div class="ops">
                   <button class="btn" :disabled="agentCreate.busy || !agentCreate.name.trim()" @click="generateFiles">用大模型生成</button>
                   <button class="btn btn-primary" :disabled="agentCreate.busy || !agentCreate.name.trim()" @click="submitCreate">创建</button>
@@ -1441,15 +1543,6 @@ const outputRows = computed(() =>
                     <p v-if="editModels.loading" class="empty">加载模型列表…</p>
                     <p v-else-if="editModels.error" class="error">模型列表加载失败：{{ editModels.error }}</p>
                   </div>
-                  <div class="info-row edit">
-                    <label class="k">skills</label>
-                    <div class="skill-picker">
-                      <label v-for="s in (skills.data || [])" :key="s.name" class="skill-opt">
-                        <input type="checkbox" :value="s.name" v-model="editBasic.skills" /> {{ s.name }}
-                      </label>
-                      <span v-if="!(skills.data || []).length" class="empty">（暂无 Skill）</span>
-                    </div>
-                  </div>
                   <div class="info-actions">
                     <button class="btn btn-primary" :disabled="editSaving" @click="saveEditBasic">保存</button>
                     <button class="btn" :disabled="editSaving" @click="cancelEditBasic">取消</button>
@@ -1464,7 +1557,19 @@ const outputRows = computed(() =>
                   <div class="info-row"><span class="k">provider</span><span>{{ agentDetail.agent.provider || '—' }}</span></div>
                   <div class="info-row"><span class="k">model</span><span>{{ agentDetail.agent.model || '—' }}</span></div>
                   <div class="info-row"><span class="k">tools</span><span>{{ (agentDetail.agent.tools || []).join(', ') || '—' }}</span></div>
-                  <div class="info-row"><span class="k">skills</span><span>{{ (agentDetail.agent.skills || []).join(', ') || '—' }}</span></div>
+                  <div class="info-row"><span class="k">skills</span>
+                    <div>
+                      <div class="skill-picker">
+                        <label v-for="s in (skillCatalog.data || []).filter((s) => s.installed)" :key="`${s.source}:${s.name}`" class="skill-opt" :title="s.description">
+                          <input type="checkbox" :value="s.name" v-model="agentBinding.selected" />
+                          <span class="mono">{{ s.name }}</span><span class="empty">{{ s.visibility }}</span>
+                        </label>
+                      </div>
+                      <div class="ops"><button class="btn" :disabled="agentBinding.saving" @click="saveAgentBindings">{{ agentBinding.saving ? '保存中…' : '保存绑定' }}</button></div>
+                      <p v-if="agentBinding.error" class="error">{{ agentBinding.error }}</p>
+                      <p v-for="(issue, i) in agentBinding.issues" :key="i" class="error">{{ issue.type }}：{{ issue.message }}</p>
+                    </div>
+                  </div>
                   <div class="info-row"><span class="k">定时</span><span class="mono">{{ (agentDetail.agent.schedules || []).map((s) => s.cron + ' (' + s.zone + ')').join('；') || '—' }}</span></div>
                 </template>
               </div>
@@ -1480,7 +1585,8 @@ const outputRows = computed(() =>
                          :class="['ws-node', { file: node.type === 'file', on: fileView && fileView.path === node.path }]"
                          :style="{ paddingLeft: (node.depth * 14) + 'px' }"
                          @click="openFile(node)">
-                      <span class="mono">{{ node.type === 'dir' ? '📁' : '📄' }} {{ node.name }}</span>
+                      <span class="mono">{{ node.type === 'dir' ? '📁' : node.type === 'link' ? '🔗' : '📄' }} {{ node.name }}</span>
+                      <span v-if="node.type === 'link'" class="empty"> → {{ node.linkTarget }} · {{ node.linkStatus }}</span>
                       <a v-if="node.type === 'file'" class="dl" :href="downloadUrl(node.path)"
                          :download="node.name" @click.stop title="下载">⬇</a>
                     </div>

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -123,31 +123,24 @@ function refresh() {
   if (NAV.find((n) => n.key === key)?.path) load(key)
 }
 
-// —— Skill 实体、外部 catalog 与绑定一致性。绑定真相源是 Agent 目录中的固定相对软连接。——
+// —— Skill CRUD：.oryxos/skills/<name>/ 存在即已安装，Agent 通过本地相对软连接绑定。——
 const skills = ref({ loading: false, error: null, data: [] })
-const skillCatalog = ref({ loading: false, error: null, data: [] })
+// 绑定一致性不在页面常驻展示：只在 Skill 变更（新建/编辑/归档/导入）后回检，
+// 发现残留或损坏绑定才展开告警面板，无问题保持静默；检查本身失败也会展开。
 const skillIssues = ref({ loading: false, error: null, data: [] })
-const skillCatalogFilter = reactive({ q: '', visibility: 'all' })
-async function loadSkillCatalog() {
-  skillCatalog.value = { loading: true, error: null, data: [] }
-  const params = new URLSearchParams()
-  if (skillCatalogFilter.q.trim()) params.set('q', skillCatalogFilter.q.trim())
-  params.set('visibility', skillCatalogFilter.visibility)
-  try {
-    const res = await fetch(`/api/v1/skills/catalog?${params}`)
-    const body = await res.json()
-    if (body.code !== 0) throw new Error(body.message || 'catalog 加载失败')
-    skillCatalog.value = { loading: false, error: null, data: body.data || [] }
-  } catch (e) { skillCatalog.value = { loading: false, error: e.message, data: [] } }
-}
-async function loadSkillIssues() {
+const skillIssuesOpen = ref(false)
+async function checkSkillIssues() {
   skillIssues.value = { loading: true, error: null, data: [] }
   try {
     const res = await fetch('/api/v1/skills/binding-issues')
     const body = await res.json()
     if (body.code !== 0) throw new Error(body.message || '绑定检查失败')
     skillIssues.value = { loading: false, error: null, data: body.data || [] }
-  } catch (e) { skillIssues.value = { loading: false, error: e.message, data: [] } }
+    skillIssuesOpen.value = skillIssues.value.data.length > 0
+  } catch (e) {
+    skillIssues.value = { loading: false, error: e.message, data: [] }
+    skillIssuesOpen.value = true
+  }
 }
 async function loadSkills() {
   skills.value = { loading: true, error: null, data: [] }
@@ -157,7 +150,6 @@ async function loadSkills() {
     if (body.code !== 0) throw new Error(body.message || '加载失败')
     skills.value = { loading: false, error: null, data: body.data || [] }
   } catch (e) { skills.value = { loading: false, error: e.message, data: [] } }
-  await Promise.all([loadSkillCatalog(), loadSkillIssues()])
 }
 const skillForm = reactive({ open: false, editing: null, name: '', description: '', body: '', busy: false, error: null })
 function newSkill() {
@@ -187,7 +179,7 @@ async function saveSkill() {
     })
     const body = await res.json()
     if (body.code !== 0) throw new Error(body.message || '保存失败')
-    cancelSkill(); await loadSkills()
+    cancelSkill(); await loadSkills(); await checkSkillIssues()
   } catch (e) { skillForm.error = e.message } finally { skillForm.busy = false }
 }
 async function deleteSkill(name) {
@@ -199,7 +191,7 @@ async function deleteSkill(name) {
       const refs = (body.data?.references || []).map((r) => `${r.agentName}(${r.state})`).join('、')
       throw new Error(`${body.message || '归档失败'}${refs ? `：${refs}` : ''}`)
     }
-    await loadSkills()
+    await loadSkills(); await checkSkillIssues()
   } catch (e) { skills.value = { ...skills.value, error: e.message } }
 }
 // 从 URL 导入 Skill：后端 GET 拉取该地址的 SKILL.md 文本并建库
@@ -215,7 +207,7 @@ async function importSkill() {
     })
     const body = await res.json()
     if (body.code !== 0) throw new Error(body.message || '导入失败')
-    cancelImport(); await loadSkills()
+    cancelImport(); await loadSkills(); await checkSkillIssues()
   } catch (e) { skillImport.error = e.message } finally { skillImport.busy = false }
 }
 // —— Skill 详情：点「详情」→ 拉工作区树里的 skills/<name> 子树，复用同一套文件浏览器（openFile/fileView + md 预览）——
@@ -864,7 +856,6 @@ const agentMemory = reactive({ text: '', loading: false, error: null })
 
 async function openAgent(agent) {
   agentDetail.value = { name: agent.name, agent, tab: 'info', loading: true, error: null, node: null, editing: false }
-  agentDetail.value = { name: agent.name, agent, tab: 'info', loading: true, error: null, node: null, editing: false }
   agentBinding.selected = [...(agent.skills || [])]
   agentBinding.error = null
   agentBinding.issues = []
@@ -875,7 +866,7 @@ async function openAgent(agent) {
     const [treeRes, bindingRes] = await Promise.all([
       fetch('/api/v1/workspace/tree'),
       fetch(`/api/v1/agents/${encodeURIComponent(agent.name)}/skills`),
-      loadSkillCatalog(),
+      loadSkills(), // Skill 绑定选择器的数据源：存在即已安装
     ])
     const body = await treeRes.json()
     const bindingBody = await bindingRes.json()
@@ -1252,34 +1243,13 @@ const outputRows = computed(() =>
             <button class="btn" @click="refresh()">刷新</button>
           </div>
 
-          <!-- Skill：已安装实体、公共/私有 catalog 与软连接绑定一致性 -->
+          <!-- Skill：纯 CRUD 列表（存在即已安装）；绑定一致性仅在变更后回检发现问题时展示 -->
           <div v-if="active === 'skills'">
             <template v-if="!skillDetail">
             <div class="toolbar">
-              <button class="btn btn-primary" @click="newImport()">从 GitHub 拉取</button>
+              <button class="btn" @click="newImport()">从 GitHub 拉取</button>
               <button class="btn btn-primary" @click="newSkill()">+ 新建 Skill</button>
             </div>
-            <h3 class="sec">候选 catalog</h3>
-            <div class="toolbar">
-              <input v-model="skillCatalogFilter.q" class="gen-input" placeholder="按名称或描述查询" @keyup.enter="loadSkillCatalog" />
-              <select v-model="skillCatalogFilter.visibility" class="gen-input" @change="loadSkillCatalog">
-                <option value="all">全部</option><option value="public">公共</option><option value="private">私有</option>
-              </select>
-              <button class="btn" @click="loadSkillCatalog">查询</button>
-            </div>
-            <p v-if="skillCatalog.loading" class="empty">catalog 加载中…</p>
-            <p v-else-if="skillCatalog.error" class="error">catalog 不可用：{{ skillCatalog.error }}</p>
-            <table v-else>
-              <thead><tr><th>名称</th><th>可见性</th><th>来源</th><th>本机状态</th><th>描述</th></tr></thead>
-              <tbody>
-                <tr v-if="!skillCatalog.data.length"><td colspan="5" class="empty">（没有匹配候选）</td></tr>
-                <tr v-for="s in skillCatalog.data" :key="`${s.source}:${s.name}`">
-                  <td class="mono">{{ s.name }}</td><td>{{ s.visibility }}</td><td>{{ s.source }}</td>
-                  <td>{{ s.installed ? '已安装' : '未安装' }}</td><td>{{ s.description || '—' }}</td>
-                </tr>
-              </tbody>
-            </table>
-            <h3 class="sec">已安装实体</h3>
             <!-- 从 GitHub 拉取 Skill 弹出框：导入整个目录（SKILL.md + 附带文件），不是抓网页正文 -->
             <div v-if="skillImport.open" class="modal-overlay" @click.self="cancelImport()">
               <div class="modal-card">
@@ -1339,19 +1309,23 @@ const outputRows = computed(() =>
                 </tr>
               </tbody>
             </table>
-            <h3 class="sec">绑定一致性</h3>
-            <p v-if="skillIssues.loading" class="empty">检查中…</p>
-            <p v-else-if="skillIssues.error" class="error">检查失败：{{ skillIssues.error }}</p>
-            <table v-else>
-              <thead><tr><th>Agent</th><th>状态</th><th>条目</th><th>分类</th><th>说明</th></tr></thead>
-              <tbody>
-                <tr v-if="!skillIssues.data.length"><td colspan="5" class="empty">（未发现残留或损坏绑定）</td></tr>
-                <tr v-for="(issue, i) in skillIssues.data" :key="`${issue.path}:${i}`">
-                  <td class="mono">{{ issue.agentName }}</td><td>{{ issue.agentState }}</td>
-                  <td class="mono">{{ issue.entryName || '—' }}</td><td>{{ issue.type }}</td><td>{{ issue.message }}</td>
-                </tr>
-              </tbody>
-            </table>
+            <!-- 绑定一致性不常驻：Skill 变更后回检，发现残留/损坏绑定（或检查本身失败）才展开 -->
+            <div v-if="skillIssuesOpen" class="issue-banner">
+              <div class="issue-head">
+                <span class="issue-title">绑定一致性问题<template v-if="skillIssues.data.length">（{{ skillIssues.data.length }}）</template></span>
+                <button class="modal-x" @click="skillIssuesOpen = false">✕</button>
+              </div>
+              <p v-if="skillIssues.loading" class="empty">检查中…</p>
+              <p v-else-if="skillIssues.error" class="error">检查失败：{{ skillIssues.error }}</p>
+              <ul v-else class="issue-list">
+                <li v-for="(issue, i) in skillIssues.data" :key="`${issue.path}:${i}`">
+                  <span class="mono">{{ issue.agentName }}（{{ issue.agentState }}）</span>
+                  <span class="issue-type">{{ issue.type }}</span>
+                  <span class="mono">{{ issue.entryName || '—' }}</span>
+                  <span class="empty">{{ issue.message }}</span>
+                </li>
+              </ul>
+            </div>
             </template>
 
             <!-- Skill 详情：文件列表 + 复用同一套文件浏览器（openFile/fileView + md 预览/源码） -->
@@ -1479,12 +1453,12 @@ const outputRows = computed(() =>
                   <option value="">不通知</option>
                   <option v-for="c in (notifyChannels.data || [])" :key="c.name" :value="c.name">{{ c.name }}（{{ c.type }}）</option>
                 </select>
-                <label class="empty" style="display:block;margin:6px 0 2px">Skill 绑定（勾选=required；作者可从已安装 catalog 再建议）</label>
+                <label class="empty" style="display:block;margin:6px 0 2px">Skill 绑定（勾选=required；作者可从已安装 Skill 再建议）</label>
                 <div class="skill-picker">
-                  <span v-if="!(skillCatalog.data || []).filter((s) => s.installed).length" class="empty">（catalog 中暂无可绑定的已安装 Skill）</span>
-                  <label v-for="s in (skillCatalog.data || []).filter((s) => s.installed)" :key="`${s.source}:${s.name}`" class="skill-opt" :title="s.description">
+                  <span v-if="!skills.data.length" class="empty">（暂无已安装 Skill，可先到 Skill 页新建或从 GitHub 拉取）</span>
+                  <label v-for="s in skills.data" :key="s.name" class="skill-opt" :title="s.description">
                     <input type="checkbox" :value="s.name" v-model="agentCreate.skills" />
-                    <span class="mono">{{ s.name }}</span><span class="empty">{{ s.visibility }}</span>
+                    <span class="mono">{{ s.name }}</span>
                   </label>
                 </div>
                 <p v-if="agentCreate.suggestedSkills.length" class="empty">作者建议：{{ agentCreate.suggestedSkills.join('、') }}；已合并到最终绑定，可在创建前取消。</p>
@@ -1560,9 +1534,9 @@ const outputRows = computed(() =>
                   <div class="info-row"><span class="k">skills</span>
                     <div>
                       <div class="skill-picker">
-                        <label v-for="s in (skillCatalog.data || []).filter((s) => s.installed)" :key="`${s.source}:${s.name}`" class="skill-opt" :title="s.description">
+                        <label v-for="s in skills.data" :key="s.name" class="skill-opt" :title="s.description">
                           <input type="checkbox" :value="s.name" v-model="agentBinding.selected" />
-                          <span class="mono">{{ s.name }}</span><span class="empty">{{ s.visibility }}</span>
+                          <span class="mono">{{ s.name }}</span>
                         </label>
                       </div>
                       <div class="ops"><button class="btn" :disabled="agentBinding.saving" @click="saveAgentBindings">{{ agentBinding.saving ? '保存中…' : '保存绑定' }}</button></div>
@@ -2188,6 +2162,18 @@ th { color: var(--text-2); font-weight: 500; }
 .gen-draft { width: 100%; background: var(--bg-mute); color: var(--text-1); border: 1px solid var(--border); border-radius: 6px; padding: 10px; font-size: 12px; margin-bottom: 10px; resize: vertical; }
 /* 列表页新建按钮工具栏：新建类按钮靠右 */
 .toolbar { display: flex; justify-content: flex-end; margin-bottom: 16px; }
+/* 键盘焦点可见性：全站交互控件统一的 focus-visible 描边（hover 已有，focus 不能缺） */
+.btn:focus-visible, .md-seg:focus-visible, .gen-input:focus-visible, .gen-draft:focus-visible, .skill-opt:focus-within {
+  outline: 1px solid var(--brand); outline-offset: 1px;
+}
+/* 绑定一致性告警：不常驻，仅变更后回检发现问题时展开，可关闭 */
+.issue-banner { border: 1px solid var(--warn); background: var(--bg-soft); border-radius: var(--radius); padding: 10px 12px; margin: 0 0 14px; }
+.issue-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; }
+.issue-title { color: var(--warn); font-size: 13px; font-weight: 600; }
+.issue-list { list-style: none; margin: 0; padding: 0; }
+.issue-list li { display: flex; flex-wrap: wrap; gap: 8px; align-items: baseline; padding: 5px 0; border-top: 1px solid var(--border); font-size: 12px; }
+.issue-list li:first-child { border-top: none; }
+.issue-type { color: var(--warn); }
 .skill-picker { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 6px; }
 .skill-opt { display: inline-flex; align-items: center; gap: 4px; padding: 3px 8px; border: 1px solid var(--border); border-radius: 6px; font-size: 12px; cursor: pointer; }
 .skill-opt:hover { border-color: var(--brand); }

--- a/oryxos-web/src/main/java/io/oryxos/web/GlobalExceptionHandler.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package io.oryxos.web;
 
 import io.oryxos.core.profile.ProfileValidationException;
+import io.oryxos.core.skill.SkillReferencedException;
 import io.oryxos.web.common.ApiResponse;
+import io.oryxos.web.controller.dto.SkillReferenceConflictView;
 import io.oryxos.web.error.AgentTimeoutException;
 import io.oryxos.web.error.ProviderUnavailableException;
 import io.oryxos.web.error.ResourceNotFoundException;
@@ -53,6 +55,16 @@ public class GlobalExceptionHandler {
     LOG.error("Service unavailable: {}", sanitize(ex.getMessage()));
     return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
         .body(ApiResponse.error(HttpStatus.SERVICE_UNAVAILABLE.value(), ex.getMessage()));
+  }
+
+  /** 409 — Skill archive is blocked by active or archived Agent references. */
+  @ExceptionHandler(SkillReferencedException.class)
+  public ResponseEntity<ApiResponse<SkillReferenceConflictView>> handleSkillReferenced(
+      SkillReferencedException ex) {
+    SkillReferenceConflictView data =
+        SkillReferenceConflictView.from(ex.skillName(), ex.references());
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(new ApiResponse<>(HttpStatus.CONFLICT.value(), ex.getMessage(), data));
   }
 
   /** 504 — Agent 调用超过 60 秒上限。 */

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/AgentApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/AgentApiController.java
@@ -143,11 +143,7 @@ public class AgentApiController {
     return ApiResponse.ok(
         view(
             lifecycle.create(
-                req.name(),
-                req.description(),
-                req.provider(),
-                req.model(),
-                req.skillBindings())));
+                req.name(), req.description(), req.provider(), req.model(), req.skillBindings())));
   }
 
   @GetMapping
@@ -184,8 +180,7 @@ public class AgentApiController {
 
   /**
    * 结构化编辑基本信息（description / provider / model）：只改 AGENT.md frontmatter 的对应 key，正文与其他配置原样保留。Skill 绑定
-   * 由专用端点管理，不写回 AGENT.md。
-   * 非法定义 → 400（不破坏原文件）；不存在 → 404。
+   * 由专用端点管理，不写回 AGENT.md。 非法定义 → 400（不破坏原文件）；不存在 → 404。
    */
   @PutMapping("/{name}/basic")
   public ApiResponse<AgentView> updateBasic(
@@ -325,6 +320,7 @@ public class AgentApiController {
   public ApiResponse<AgentSkillBindingsView> bind(
       @PathVariable String name, @PathVariable String skill) {
     requireAgent(name);
+    requireSkillsExist(List.of(skill));
     validateCatalog(List.of(skill));
     requireBindings().bind(name, skill);
     return skills(name);
@@ -343,6 +339,7 @@ public class AgentApiController {
       @PathVariable String name, @RequestBody ReplaceSkillBindingsRequest request) {
     requireAgent(name);
     List<String> desired = request == null ? List.of() : request.skills();
+    requireSkillsExist(desired);
     validateCatalog(desired);
     return ApiResponse.ok(
         AgentSkillBindingsView.from(requireBindings().replaceBindings(name, desired)));
@@ -369,6 +366,18 @@ public class AgentApiController {
       throw new IllegalStateException("Agent Skill 绑定服务未装配");
     }
     return skillBindings;
+  }
+
+  private void requireSkillsExist(List<String> names) {
+    if (names == null) {
+      return;
+    }
+    AgentSkillBindingService bindings = requireBindings();
+    for (String name : names) {
+      if (!bindings.skillExists(name)) {
+        throw new ResourceNotFoundException("Skill 不存在: " + name);
+      }
+    }
   }
 
   private void validateCatalog(List<String> names) {

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/AgentApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/AgentApiController.java
@@ -8,21 +8,30 @@ import io.oryxos.core.profile.ProfileRegistry;
 import io.oryxos.core.session.Message;
 import io.oryxos.core.session.Session;
 import io.oryxos.core.session.SessionManager;
+import io.oryxos.core.skill.AgentSkillBindingService;
+import io.oryxos.core.skill.BoundSkillDescriptor;
+import io.oryxos.core.skill.SkillCatalog;
+import io.oryxos.core.skill.SkillCatalogEntry;
 import io.oryxos.web.common.ApiResponse;
 import io.oryxos.web.controller.dto.AgentExecutionView;
+import io.oryxos.web.controller.dto.AgentSkillBindingsView;
 import io.oryxos.web.controller.dto.AgentView;
 import io.oryxos.web.controller.dto.CreateAgentRequest;
 import io.oryxos.web.controller.dto.GenerateFilesRequest;
 import io.oryxos.web.controller.dto.GeneratedFilesView;
 import io.oryxos.web.controller.dto.MessageRequest;
 import io.oryxos.web.controller.dto.MessageResponse;
+import io.oryxos.web.controller.dto.ReplaceSkillBindingsRequest;
 import io.oryxos.web.controller.dto.SaveFilesRequest;
 import io.oryxos.web.controller.dto.SessionView;
 import io.oryxos.web.controller.dto.TriggerResponse;
 import io.oryxos.web.controller.dto.UpdateAgentBasicRequest;
 import io.oryxos.web.controller.dto.UpdateAgentRequest;
 import io.oryxos.web.error.ResourceNotFoundException;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -65,6 +74,8 @@ public class AgentApiController {
   private final ProfileRegistry profileRegistry;
   private final MemoryService memoryService;
   private final AgentExecutionService executionService;
+  private final AgentSkillBindingService skillBindings;
+  private final SkillCatalog skillCatalog;
 
   public AgentApiController(
       AgentLifecycleService lifecycle,
@@ -73,12 +84,54 @@ public class AgentApiController {
       ProfileRegistry profileRegistry,
       MemoryService memoryService,
       AgentExecutionService executionService) {
+    this(
+        lifecycle,
+        agentService,
+        sessionManager,
+        profileRegistry,
+        memoryService,
+        executionService,
+        null,
+        null);
+  }
+
+  public AgentApiController(
+      AgentLifecycleService lifecycle,
+      AgentService agentService,
+      SessionManager sessionManager,
+      ProfileRegistry profileRegistry,
+      MemoryService memoryService,
+      AgentExecutionService executionService,
+      AgentSkillBindingService skillBindings) {
+    this(
+        lifecycle,
+        agentService,
+        sessionManager,
+        profileRegistry,
+        memoryService,
+        executionService,
+        skillBindings,
+        null);
+  }
+
+  @Autowired
+  public AgentApiController(
+      AgentLifecycleService lifecycle,
+      AgentService agentService,
+      SessionManager sessionManager,
+      ProfileRegistry profileRegistry,
+      MemoryService memoryService,
+      AgentExecutionService executionService,
+      AgentSkillBindingService skillBindings,
+      SkillCatalog skillCatalog) {
     this.lifecycle = lifecycle;
     this.agentService = agentService;
     this.sessionManager = sessionManager;
     this.profileRegistry = profileRegistry;
     this.memoryService = memoryService;
     this.executionService = executionService;
+    this.skillBindings = skillBindings;
+    this.skillCatalog = skillCatalog;
   }
 
   /** 创建：只需 name + description，后台按模板脚手架出完整目录 + 派生注册（失败回滚）。 */
@@ -88,13 +141,18 @@ public class AgentApiController {
       throw new IllegalArgumentException("Agent 名为空");
     }
     return ApiResponse.ok(
-        AgentView.from(
-            lifecycle.create(req.name(), req.description(), req.provider(), req.model())));
+        view(
+            lifecycle.create(
+                req.name(),
+                req.description(),
+                req.provider(),
+                req.model(),
+                req.skillBindings())));
   }
 
   @GetMapping
   public ApiResponse<List<AgentView>> list() {
-    return ApiResponse.ok(lifecycle.list().stream().map(AgentView::from).toList());
+    return ApiResponse.ok(lifecycle.list().stream().map(this::view).toList());
   }
 
   @GetMapping("/{name}")
@@ -102,7 +160,7 @@ public class AgentApiController {
     return ApiResponse.ok(
         lifecycle
             .get(name)
-            .map(AgentView::from)
+            .map(this::view)
             .orElseThrow(() -> new ResourceNotFoundException("Agent 不存在: " + name)));
   }
 
@@ -112,7 +170,7 @@ public class AgentApiController {
     if (lifecycle.get(name).isEmpty()) {
       throw new ResourceNotFoundException("Agent 不存在: " + name); // → 404
     }
-    return ApiResponse.ok(AgentView.from(lifecycle.update(name, req.agentMarkdown())));
+    return ApiResponse.ok(view(lifecycle.update(name, req.agentMarkdown())));
   }
 
   @DeleteMapping("/{name}")
@@ -125,7 +183,8 @@ public class AgentApiController {
   }
 
   /**
-   * 结构化编辑基本信息（description / provider / model / skills）：只改 AGENT.md frontmatter 的对应 key，正文与其他配置原样保留。
+   * 结构化编辑基本信息（description / provider / model）：只改 AGENT.md frontmatter 的对应 key，正文与其他配置原样保留。Skill 绑定
+   * 由专用端点管理，不写回 AGENT.md。
    * 非法定义 → 400（不破坏原文件）；不存在 → 404。
    */
   @PutMapping("/{name}/basic")
@@ -136,8 +195,7 @@ public class AgentApiController {
     }
     return ApiResponse.ok(
         AgentView.from(
-            lifecycle.updateBasicInfo(
-                name, req.description(), req.provider(), req.model(), req.skills())));
+            lifecycle.updateBasicInfo(name, req.description(), req.provider(), req.model())));
   }
 
   @PostMapping("/{name}/invoke")
@@ -239,12 +297,12 @@ public class AgentApiController {
       @PathVariable String name, @RequestBody GenerateFilesRequest req) {
     String description = req == null ? null : req.description();
     String notifyChannel = req == null ? null : req.notifyChannel();
-    List<String> skills = req == null ? List.of() : req.skills();
+    List<String> skills = req == null ? List.of() : req.requiredSkills();
     String provider = req == null ? null : req.provider();
     String model = req == null ? null : req.model();
     return ApiResponse.ok(
-        new GeneratedFilesView(
-            lifecycle.generateFiles(name, description, notifyChannel, skills, provider, model)));
+        GeneratedFilesView.from(
+            lifecycle.generateDraft(name, description, notifyChannel, skills, provider, model)));
   }
 
   /** 保存（可能被改过的）一组 Agent 文件，写入即生效（AGENT.md 非法 → 400，不写坏目录）。 */
@@ -252,7 +310,86 @@ public class AgentApiController {
   public ApiResponse<AgentView> saveFiles(
       @PathVariable String name, @RequestBody SaveFilesRequest req) {
     return ApiResponse.ok(
-        AgentView.from(lifecycle.saveFiles(name, req == null ? null : req.files())));
+        view(
+            lifecycle.saveFiles(
+                name, req == null ? null : req.files(), req == null ? null : req.skillBindings())));
+  }
+
+  @GetMapping("/{name}/skills")
+  public ApiResponse<AgentSkillBindingsView> skills(@PathVariable String name) {
+    requireAgent(name);
+    return ApiResponse.ok(AgentSkillBindingsView.from(requireBindings().inspect(name)));
+  }
+
+  @PutMapping("/{name}/skills/{skill}")
+  public ApiResponse<AgentSkillBindingsView> bind(
+      @PathVariable String name, @PathVariable String skill) {
+    requireAgent(name);
+    validateCatalog(List.of(skill));
+    requireBindings().bind(name, skill);
+    return skills(name);
+  }
+
+  @DeleteMapping("/{name}/skills/{skill}")
+  public ApiResponse<AgentSkillBindingsView> unbind(
+      @PathVariable String name, @PathVariable String skill) {
+    requireAgent(name);
+    requireBindings().unbind(name, skill);
+    return skills(name);
+  }
+
+  @PutMapping("/{name}/skills")
+  public ApiResponse<AgentSkillBindingsView> replaceSkills(
+      @PathVariable String name, @RequestBody ReplaceSkillBindingsRequest request) {
+    requireAgent(name);
+    List<String> desired = request == null ? List.of() : request.skills();
+    validateCatalog(desired);
+    return ApiResponse.ok(
+        AgentSkillBindingsView.from(requireBindings().replaceBindings(name, desired)));
+  }
+
+  private AgentView view(io.oryxos.core.profile.Profile profile) {
+    List<String> skills =
+        skillBindings == null
+            ? List.of()
+            : skillBindings.inspect(profile.name()).bindings().stream()
+                .map(BoundSkillDescriptor::name)
+                .toList();
+    return AgentView.from(profile, skills);
+  }
+
+  private void requireAgent(String name) {
+    if (profileRegistry.get(name).isEmpty()) {
+      throw new ResourceNotFoundException("Agent 不存在: " + name);
+    }
+  }
+
+  private AgentSkillBindingService requireBindings() {
+    if (skillBindings == null) {
+      throw new IllegalStateException("Agent Skill 绑定服务未装配");
+    }
+    return skillBindings;
+  }
+
+  private void validateCatalog(List<String> names) {
+    if (names == null || names.isEmpty()) {
+      return;
+    }
+    if (skillCatalog == null) {
+      throw new IllegalStateException("Skill catalog 不可用");
+    }
+    Map<String, SkillCatalogEntry> candidates = new LinkedHashMap<>();
+    for (SkillCatalogEntry entry : skillCatalog.query("", null)) {
+      if (candidates.putIfAbsent(entry.name(), entry) != null) {
+        throw new IllegalArgumentException("Skill catalog 存在同名公共/私有冲突: " + entry.name());
+      }
+    }
+    for (String name : names) {
+      SkillCatalogEntry entry = candidates.get(name);
+      if (entry == null || !entry.installed()) {
+        throw new IllegalArgumentException("Skill 不在可访问且已安装的 catalog 中: " + name);
+      }
+    }
   }
 
   private static List<Message> recent(List<Message> messages) {

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
@@ -1,15 +1,22 @@
 package io.oryxos.web.controller;
 
+import io.oryxos.core.skill.AgentSkillBindingService;
+import io.oryxos.core.skill.SkillCatalog;
+import io.oryxos.core.skill.SkillCatalogEntry;
 import io.oryxos.core.skill.SkillService;
 import io.oryxos.web.common.ApiResponse;
 import io.oryxos.web.controller.dto.CreateSkillRequest;
 import io.oryxos.web.controller.dto.ImportSkillRequest;
+import io.oryxos.web.controller.dto.SkillArchiveView;
+import io.oryxos.web.controller.dto.SkillBindingIssueView;
+import io.oryxos.web.controller.dto.SkillCatalogView;
 import io.oryxos.web.controller.dto.SkillView;
 import io.oryxos.web.controller.dto.UpdateSkillRequest;
 import io.oryxos.web.error.ResourceNotFoundException;
 import io.oryxos.web.skill.GithubFolderFetcher;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.IDN;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
@@ -21,6 +28,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,11 +36,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 全局 Skill 库端点（第 32 节）：list/get/create/update/delete 薄转发给 {@link SkillService}。Agent 通过 AGENT.md 的
- * {@code skills:[名]} 引用这些 Skill，由 {@code ContextLoader} 注入正文来约束产出。
+ * 全局 Skill 库端点：管理已安装实体、查询外部候选目录并报告 Agent 软连接绑定问题。绑定只认 Agent 目录里的固定相对软连接； 运行时仅注入 Skill 元数据与本地入口，正文由
+ * Agent 按需读取。
  *
  * <p>错误码复用既有：name 冲突 / 空 → 400（`IllegalArgumentException`）；不存在 →
  * 404（`ResourceNotFoundException`）；统一 `ApiResponse` 信封。
@@ -47,16 +56,29 @@ public class SkillApiController {
 
   private static final int MAX_SKILL_BYTES = 512 * 1024;
   private static final int MAX_REDIRECTS = 5;
-  private static final String SCHEME_HTTP = "http";
-  private static final String SCHEME_HTTPS = "https";
+  private static final String HTTP_SCHEME = "http";
+  private static final String HTTPS_SCHEME = "https";
   private static final String LOCALHOST = "localhost";
-  private static final String METADATA_GOOGLE_INTERNAL = "metadata.google.internal";
-  private static final String INTERNAL_SUFFIX = ".internal";
+  private static final String GOOGLE_METADATA_HOST = "metadata.google.internal";
+  private static final String INTERNAL_DOMAIN_SUFFIX = ".internal";
+  private static final String VISIBILITY_ALL = "all";
+  private static final String VISIBILITY_PUBLIC = "public";
+  private static final String VISIBILITY_PRIVATE = "private";
 
   private final SkillService skills;
+  private final SkillCatalog catalog;
+  private final AgentSkillBindingService bindings;
 
   public SkillApiController(SkillService skills) {
+    this(skills, null, null);
+  }
+
+  @Autowired
+  public SkillApiController(
+      SkillService skills, SkillCatalog catalog, AgentSkillBindingService bindings) {
     this.skills = skills;
+    this.catalog = catalog;
+    this.bindings = bindings;
   }
 
   @GetMapping
@@ -106,7 +128,7 @@ public class SkillApiController {
       throw new IllegalArgumentException("非法 URL: " + url);
     }
     String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
-    if (!SCHEME_HTTP.equals(scheme) && !SCHEME_HTTPS.equals(scheme)) {
+    if (!HTTP_SCHEME.equals(scheme) && !HTTPS_SCHEME.equals(scheme)) {
       throw new IllegalArgumentException("仅支持 http/https URL: " + url);
     }
     return uri;
@@ -160,18 +182,27 @@ public class SkillApiController {
   /**
    * SSRF 防护：拒绝主机解析到回环/任意本地/链路本地(含 169.254.169.254)/站点内网/组播/CGNAT，以及 localhost、*.internal、云元数据主机名。
    */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "IDN.toASCII canonicalizes the complete DNS host before security checks; no substring is transformed independently.")
   private static void guardPublicHost(URI uri) {
     String host = uri.getHost();
     if (host == null || host.isBlank()) {
       throw new IllegalArgumentException("URL 缺少主机名: " + uri);
     }
-    String h = host.toLowerCase(Locale.ROOT);
-    if (LOCALHOST.equals(h) || METADATA_GOOGLE_INTERNAL.equals(h) || h.endsWith(INTERNAL_SUFFIX)) {
+    String asciiHost;
+    try {
+      asciiHost = IDN.toASCII(host);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("非法主机名: " + host);
+    }
+    if (isInternalName(asciiHost)) {
       throw new IllegalArgumentException("拒绝访问内网 / 元数据主机: " + host);
     }
     InetAddress[] addresses;
     try {
-      addresses = InetAddress.getAllByName(host);
+      addresses = InetAddress.getAllByName(asciiHost);
     } catch (UnknownHostException e) {
       throw new IllegalArgumentException("无法解析主机: " + host);
     }
@@ -186,6 +217,20 @@ public class SkillApiController {
             "拒绝访问内网 / 保留地址: " + host + " → " + addr.getHostAddress());
       }
     }
+  }
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "DNS labels are case-insensitive and the complete IDN-canonicalized host is compared.")
+  private static boolean isInternalName(String host) {
+    if (LOCALHOST.equalsIgnoreCase(host) || GOOGLE_METADATA_HOST.equalsIgnoreCase(host)) {
+      return true;
+    }
+    int offset = host.length() - INTERNAL_DOMAIN_SUFFIX.length();
+    return offset >= 0
+        && host.regionMatches(
+            true, offset, INTERNAL_DOMAIN_SUFFIX, 0, INTERNAL_DOMAIN_SUFFIX.length());
   }
 
   /** 100.64.0.0/10（运营商级 NAT，isSiteLocalAddress 不覆盖，单独判）。 */
@@ -206,11 +251,38 @@ public class SkillApiController {
   }
 
   @DeleteMapping("/{name}")
-  public ApiResponse<Void> delete(@PathVariable String name) {
+  public ApiResponse<SkillArchiveView> delete(@PathVariable String name) {
     if (skills.get(name).isEmpty()) {
       throw new ResourceNotFoundException("Skill 不存在: " + name); // → 404
     }
-    skills.delete(name);
-    return ApiResponse.ok(null);
+    return ApiResponse.ok(SkillArchiveView.from(skills.delete(name)));
+  }
+
+  @GetMapping("/catalog")
+  public ApiResponse<List<SkillCatalogView>> catalog(
+      @RequestParam(required = false) String q,
+      @RequestParam(defaultValue = "all") String visibility) {
+    if (catalog == null) {
+      throw new IllegalStateException("Skill catalog 不可用");
+    }
+    SkillCatalogEntry.Visibility filter;
+    if (VISIBILITY_ALL.equals(visibility)) {
+      filter = null;
+    } else if (VISIBILITY_PUBLIC.equals(visibility)) {
+      filter = SkillCatalogEntry.Visibility.PUBLIC;
+    } else if (VISIBILITY_PRIVATE.equals(visibility)) {
+      filter = SkillCatalogEntry.Visibility.PRIVATE;
+    } else {
+      throw new IllegalArgumentException("非法 visibility: " + visibility);
+    }
+    return ApiResponse.ok(catalog.query(q, filter).stream().map(SkillCatalogView::from).toList());
+  }
+
+  @GetMapping("/binding-issues")
+  public ApiResponse<List<SkillBindingIssueView>> bindingIssues() {
+    if (bindings == null) {
+      throw new IllegalStateException("Agent Skill 绑定服务未装配");
+    }
+    return ApiResponse.ok(bindings.reconcile().stream().map(SkillBindingIssueView::from).toList());
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
@@ -139,6 +139,9 @@ public class WorkspaceApiController {
         && SKILLS_DIR.equals(relative.getName(2).toString())) {
       throw new IllegalArgumentException("Agent skills/ 是绑定视图，禁止从工作区入口写入");
     }
+    if (RealPathBoundary.isWithin(oryxosRoot.resolve(SKILLS_DIR), target)) {
+      throw new IllegalArgumentException("共享 Skill 实体只能通过 Skill 管理入口更新");
+    }
     String content = req.content() == null ? "" : req.content();
     Path agentDir = agentDirOfAgentFile(target);
     if (agentDir != null) {
@@ -208,7 +211,11 @@ public class WorkspaceApiController {
     if (!target.startsWith(oryxosRoot)) {
       throw new IllegalArgumentException("路径越界，拒绝访问: " + path);
     }
-    RealPathBoundary.requireWithin(oryxosRoot, target);
+    try {
+      RealPathBoundary.requireWithin(oryxosRoot, target);
+    } catch (UncheckedIOException e) {
+      throw new IllegalArgumentException("路径真实目标无法安全解析，拒绝访问: " + path, e);
+    }
     return target;
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
@@ -1,6 +1,7 @@
 package io.oryxos.web.controller;
 
 import io.oryxos.core.agent.AgentLifecycleService;
+import io.oryxos.core.fs.RealPathBoundary;
 import io.oryxos.web.common.ApiResponse;
 import io.oryxos.web.controller.dto.FileNode;
 import io.oryxos.web.controller.dto.WriteFileRequest;
@@ -30,19 +31,22 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 工作区文件浏览器（第 30 节）：列 {@code .oryxos/agents/} 与 {@code .oryxos/archive/} 的目录树、读写文件文本。
  *
- * <p>唯一安全要点——**防目录穿越**：{@code file}/{@code writeFile} 把 path 解析成绝对路径 {@code normalize()} 后必须 {@code
- * startsWith(oryxosRoot)}，越界即 400。编辑到某个 Agent 的 {@code AGENT.md} 时走 {@link
- * AgentLifecycleService#update} 写入并即时重注册（macOS WatchService 不监听子目录内文件变更，必须显式重注册）；其余文件直接写盘。
+ * <p>文件入口使用词法路径与真实路径双重边界校验：存在目标解析自身真实路径，不存在目标从最近存在父节点投影，软连接逃逸、悬空链接与链接环均 fail closed。编辑到某个 Agent 的
+ * {@code AGENT.md} 时走 {@link AgentLifecycleService#update} 写入并即时重注册（macOS WatchService
+ * 不监听子目录内文件变更，必须显式重注册）；其余文件直接写盘。
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = {"SPRING_ENDPOINT", "PATH_TRAVERSAL_IN", "PATH_TRAVERSAL_OUT", "EI_EXPOSE_REP2"},
     justification =
-        "core-stage web API is unauthenticated by design (internal network + gateway). path 已做 normalize()+startsWith(oryxosRoot) 白名单校验，越界 400——这正是防目录穿越的正解。lifecycle 是 Spring 注入的共享单例，构造注入共享同一引用正是意图。")
+        "core-stage web API is unauthenticated by design (internal network + gateway). path 通过 RealPathBoundary 做词法与真实路径边界校验，越界返回 400。lifecycle 是 Spring 注入的共享单例，构造注入共享同一引用正是意图。")
 @RestController
 @RequestMapping("/api/v1/workspace")
 public class WorkspaceApiController {
 
   private static final String AGENT_FILE = "AGENT.md";
+  private static final String AGENTS_DIR = "agents";
+  private static final String SKILLS_DIR = "skills";
+  private static final int AGENT_SKILL_PATH_SEGMENTS = 3;
 
   private final Path oryxosRoot;
   private final AgentLifecycleService lifecycle;
@@ -75,10 +79,7 @@ public class WorkspaceApiController {
   /** 读文件文本；防目录穿越：越界 → 400，不存在 → 404。 */
   @GetMapping("/file")
   public ApiResponse<String> file(@RequestParam String path) {
-    Path target = oryxosRoot.resolve(path).normalize();
-    if (!target.startsWith(oryxosRoot)) {
-      throw new IllegalArgumentException("路径越界，拒绝访问: " + path); // → 400
-    }
+    Path target = resolveWithinRoot(path);
     if (!Files.isRegularFile(target)) {
       throw new ResourceNotFoundException("文件不存在: " + path); // → 404
     }
@@ -96,10 +97,7 @@ public class WorkspaceApiController {
    */
   @GetMapping("/download")
   public ResponseEntity<Resource> download(@RequestParam String path) {
-    Path target = oryxosRoot.resolve(path).normalize();
-    if (!target.startsWith(oryxosRoot)) {
-      throw new IllegalArgumentException("路径越界，拒绝访问: " + path); // → 400
-    }
+    Path target = resolveWithinRoot(path);
     if (!Files.isRegularFile(target)) {
       throw new ResourceNotFoundException("文件不存在: " + path); // → 404
     }
@@ -134,9 +132,12 @@ public class WorkspaceApiController {
     if (path == null || path.isBlank()) {
       throw new IllegalArgumentException("path 为空"); // → 400
     }
-    Path target = oryxosRoot.resolve(path).normalize();
-    if (!target.startsWith(oryxosRoot)) {
-      throw new IllegalArgumentException("路径越界，拒绝访问: " + path); // → 400
+    Path target = resolveWithinRoot(path);
+    Path relative = oryxosRoot.relativize(target);
+    if (relative.getNameCount() >= AGENT_SKILL_PATH_SEGMENTS
+        && AGENTS_DIR.equals(relative.getName(0).toString())
+        && SKILLS_DIR.equals(relative.getName(2).toString())) {
+      throw new IllegalArgumentException("Agent skills/ 是绑定视图，禁止从工作区入口写入");
     }
     String content = req.content() == null ? "" : req.content();
     Path agentDir = agentDirOfAgentFile(target);
@@ -172,6 +173,21 @@ public class WorkspaceApiController {
   private FileNode treeOf(Path node) {
     String rel = oryxosRoot.relativize(node).toString();
     String name = String.valueOf(node.getFileName());
+    if (Files.isSymbolicLink(node)) {
+      String target;
+      try {
+        target = Files.readSymbolicLink(node).toString();
+      } catch (IOException e) {
+        target = "";
+      }
+      String status;
+      if (!Files.exists(node)) {
+        status = "dangling";
+      } else {
+        status = RealPathBoundary.isWithin(oryxosRoot, node) ? "valid" : "escaped";
+      }
+      return FileNode.link(name, rel, target, status);
+    }
     if (!Files.isDirectory(node)) {
       return FileNode.file(name, rel);
     }
@@ -185,5 +201,14 @@ public class WorkspaceApiController {
       return FileNode.dir(name, rel, List.of());
     }
     return FileNode.dir(name, rel, children);
+  }
+
+  private Path resolveWithinRoot(String path) {
+    Path target = oryxosRoot.resolve(path).toAbsolutePath().normalize();
+    if (!target.startsWith(oryxosRoot)) {
+      throw new IllegalArgumentException("路径越界，拒绝访问: " + path);
+    }
+    RealPathBoundary.requireWithin(oryxosRoot, target);
+    return target;
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/AgentSkillBindingsView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/AgentSkillBindingsView.java
@@ -1,0 +1,25 @@
+package io.oryxos.web.controller.dto;
+
+import io.oryxos.core.skill.BindingInspection;
+import java.util.List;
+
+public record AgentSkillBindingsView(
+    List<BindingView> bindings, List<SkillBindingIssueView> issues) {
+  public AgentSkillBindingsView {
+    bindings = bindings == null ? List.of() : List.copyOf(bindings);
+    issues = issues == null ? List.of() : List.copyOf(issues);
+  }
+
+  public static AgentSkillBindingsView from(BindingInspection inspection) {
+    return new AgentSkillBindingsView(
+        inspection.bindings().stream()
+            .map(
+                binding ->
+                    new BindingView(
+                        binding.name(), binding.description(), binding.skillFile().toString()))
+            .toList(),
+        inspection.issues().stream().map(SkillBindingIssueView::from).toList());
+  }
+
+  public record BindingView(String name, String description, String skillFile) {}
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/AgentView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/AgentView.java
@@ -20,6 +20,10 @@ public record AgentView(
   }
 
   public static AgentView from(Profile p) {
+    return from(p, List.of());
+  }
+
+  public static AgentView from(Profile p, List<String> liveSkills) {
     Profile.ProviderRef pr = p.provider();
     List<ScheduleView> scheds =
         p.schedules().stream()
@@ -31,7 +35,7 @@ public record AgentView(
         pr == null ? null : pr.name(),
         pr == null ? null : pr.model(),
         p.tools(),
-        p.skills(),
+        liveSkills,
         scheds);
   }
 

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/CreateAgentRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/CreateAgentRequest.java
@@ -1,4 +1,15 @@
 package io.oryxos.web.controller.dto;
 
-/** POST /agents 请求体：Agent 名 + 描述 + 可选的 provider/model（不选则走默认 provider）。 */
-public record CreateAgentRequest(String name, String description, String provider, String model) {}
+import java.util.List;
+
+/** POST /agents request: Agent metadata, selected provider/model, and initial Skill bindings. */
+public record CreateAgentRequest(
+    String name, String description, String provider, String model, List<String> skillBindings) {
+  public CreateAgentRequest {
+    skillBindings = skillBindings == null ? List.of() : List.copyOf(skillBindings);
+  }
+
+  public CreateAgentRequest(String name, String description) {
+    this(name, description, null, null, List.of());
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/FileNode.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/FileNode.java
@@ -2,18 +2,28 @@ package io.oryxos.web.controller.dto;
 
 import java.util.List;
 
-/** 工作区目录树节点：type ∈ {dir, file}；dir 有 children，file 为叶子。 */
-public record FileNode(String name, String path, String type, List<FileNode> children) {
+/** Workspace tree node. Symbolic links are always leaves and are never recursively followed. */
+public record FileNode(
+    String name,
+    String path,
+    String type,
+    List<FileNode> children,
+    String linkTarget,
+    String linkStatus) {
 
   public FileNode {
     children = children == null ? List.of() : List.copyOf(children);
   }
 
   public static FileNode file(String name, String path) {
-    return new FileNode(name, path, "file", List.of());
+    return new FileNode(name, path, "file", List.of(), null, null);
   }
 
   public static FileNode dir(String name, String path, List<FileNode> children) {
-    return new FileNode(name, path, "dir", children);
+    return new FileNode(name, path, "dir", children, null, null);
+  }
+
+  public static FileNode link(String name, String path, String target, String status) {
+    return new FileNode(name, path, "link", List.of(), target, status);
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/GenerateFilesRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/GenerateFilesRequest.java
@@ -7,9 +7,13 @@ import java.util.List;
  * 用户挑好的 provider/model（可空=沿用默认），交大模型生成 AGENT.md（可含脚本/子指令）草稿（不落盘）。
  */
 public record GenerateFilesRequest(
-    String description, String notifyChannel, List<String> skills, String provider, String model) {
+    String description,
+    String notifyChannel,
+    List<String> requiredSkills,
+    String provider,
+    String model) {
 
   public GenerateFilesRequest {
-    skills = skills == null ? List.of() : List.copyOf(skills);
+    requiredSkills = requiredSkills == null ? List.of() : List.copyOf(requiredSkills);
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/GeneratedFilesView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/GeneratedFilesView.java
@@ -1,11 +1,25 @@
 package io.oryxos.web.controller.dto;
 
+import io.oryxos.core.agent.GeneratedAgentDraft;
+import java.util.List;
 import java.util.Map;
 
 /** 生成结果视图：{相对路径 → 文件内容}，返回前端预览可改，满意再保存。 */
-public record GeneratedFilesView(Map<String, String> files) {
+public record GeneratedFilesView(
+    Map<String, String> files,
+    List<String> requiredSkills,
+    List<String> suggestedSkills,
+    List<String> bindingSkills) {
 
   public GeneratedFilesView {
     files = files == null ? Map.of() : Map.copyOf(files);
+    requiredSkills = requiredSkills == null ? List.of() : List.copyOf(requiredSkills);
+    suggestedSkills = suggestedSkills == null ? List.of() : List.copyOf(suggestedSkills);
+    bindingSkills = bindingSkills == null ? List.of() : List.copyOf(bindingSkills);
+  }
+
+  public static GeneratedFilesView from(GeneratedAgentDraft draft) {
+    return new GeneratedFilesView(
+        draft.files(), draft.requiredSkills(), draft.suggestedSkills(), draft.bindingSkills());
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ReplaceSkillBindingsRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ReplaceSkillBindingsRequest.java
@@ -1,0 +1,9 @@
+package io.oryxos.web.controller.dto;
+
+import java.util.List;
+
+public record ReplaceSkillBindingsRequest(List<String> skills) {
+  public ReplaceSkillBindingsRequest {
+    skills = skills == null ? List.of() : List.copyOf(skills);
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/SaveFilesRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/SaveFilesRequest.java
@@ -1,11 +1,17 @@
 package io.oryxos.web.controller.dto;
 
+import java.util.List;
 import java.util.Map;
 
 /** POST /agents/{name}/files 请求体：保存（可能被用户改过的）一组 Agent 文件，写入即生效。 */
-public record SaveFilesRequest(Map<String, String> files) {
+public record SaveFilesRequest(Map<String, String> files, List<String> skillBindings) {
 
   public SaveFilesRequest {
     files = files == null ? Map.of() : Map.copyOf(files);
+    skillBindings = skillBindings == null ? null : List.copyOf(skillBindings);
+  }
+
+  public SaveFilesRequest(Map<String, String> files) {
+    this(files, null);
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/SkillArchiveView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/SkillArchiveView.java
@@ -1,0 +1,11 @@
+package io.oryxos.web.controller.dto;
+
+import io.oryxos.core.skill.SkillArchive;
+import java.time.Instant;
+
+public record SkillArchiveView(String name, String archivedPath, Instant archivedAt) {
+  public static SkillArchiveView from(SkillArchive archive) {
+    return new SkillArchiveView(
+        archive.name(), archive.archivedPath().toString(), archive.archivedAt());
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/SkillBindingIssueView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/SkillBindingIssueView.java
@@ -1,0 +1,21 @@
+package io.oryxos.web.controller.dto;
+
+import io.oryxos.core.skill.SkillBindingIssue;
+
+public record SkillBindingIssueView(
+    String agentName,
+    String agentState,
+    String entryName,
+    String path,
+    String type,
+    String message) {
+  public static SkillBindingIssueView from(SkillBindingIssue issue) {
+    return new SkillBindingIssueView(
+        issue.agentName(),
+        issue.agentState().name(),
+        issue.entryName(),
+        issue.path().toString(),
+        issue.type().name(),
+        issue.message());
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/SkillCatalogView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/SkillCatalogView.java
@@ -1,0 +1,15 @@
+package io.oryxos.web.controller.dto;
+
+import io.oryxos.core.skill.SkillCatalogEntry;
+
+public record SkillCatalogView(
+    String name, String description, String visibility, String source, boolean installed) {
+  public static SkillCatalogView from(SkillCatalogEntry entry) {
+    return new SkillCatalogView(
+        entry.name(),
+        entry.description(),
+        entry.visibility().name(),
+        entry.source(),
+        entry.installed());
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/SkillReferenceConflictView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/SkillReferenceConflictView.java
@@ -1,0 +1,27 @@
+package io.oryxos.web.controller.dto;
+
+import io.oryxos.core.skill.SkillReference;
+import java.util.List;
+
+public record SkillReferenceConflictView(String name, List<ReferenceView> references) {
+  public SkillReferenceConflictView {
+    references = List.copyOf(references);
+  }
+
+  public static SkillReferenceConflictView from(String name, List<SkillReference> references) {
+    return new SkillReferenceConflictView(
+        name,
+        references.stream()
+            .map(
+                reference ->
+                    new ReferenceView(
+                        reference.agentName(),
+                        reference.state().name(),
+                        reference.directoryName(),
+                        reference.linkPath().toString()))
+            .toList());
+  }
+
+  public record ReferenceView(
+      String agentName, String state, String directoryName, String linkPath) {}
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/UpdateAgentBasicRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/UpdateAgentBasicRequest.java
@@ -1,12 +1,4 @@
 package io.oryxos.web.controller.dto;
 
-import java.util.List;
-
 /** PUT /agents/{name}/basic 请求体：结构化编辑 Agent 基本信息（只动 AGENT.md frontmatter 的几个 key）。 */
-public record UpdateAgentBasicRequest(
-    String description, String provider, String model, List<String> skills) {
-
-  public UpdateAgentBasicRequest {
-    skills = skills == null ? List.of() : List.copyOf(skills);
-  }
-}
+public record UpdateAgentBasicRequest(String description, String provider, String model) {}

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/AgentApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/AgentApiControllerTest.java
@@ -75,7 +75,7 @@ class AgentApiControllerTest {
   @Test
   @DisplayName("create 成功_返回 AgentView")
   void create_success_returnsAgentView() throws Exception {
-    when(lifecycle.create(eq("demo"), any(), any(), any())).thenReturn(profile("demo"));
+    when(lifecycle.create(eq("demo"), any(), any(), any(), any())).thenReturn(profile("demo"));
 
     mvc.perform(
             post("/api/v1/agents")
@@ -88,7 +88,7 @@ class AgentApiControllerTest {
   @Test
   @DisplayName("create name 冲突_返回400")
   void create_conflict_returns400() throws Exception {
-    when(lifecycle.create(eq("dup"), any(), any(), any()))
+    when(lifecycle.create(eq("dup"), any(), any(), any(), any()))
         .thenThrow(new IllegalArgumentException("Agent 已存在: dup"));
 
     mvc.perform(
@@ -175,17 +175,17 @@ class AgentApiControllerTest {
   @DisplayName("updateBasic 成功_返回 AgentView")
   void updateBasic_success_returnsAgentView() throws Exception {
     when(lifecycle.get("demo")).thenReturn(Optional.of(profile("demo")));
-    when(lifecycle.updateBasicInfo(eq("demo"), eq("新描述"), eq("openai"), eq("gpt-4o"), any()))
+    when(lifecycle.updateBasicInfo(eq("demo"), eq("新描述"), eq("openai"), eq("gpt-4o")))
         .thenReturn(profile("demo"));
 
     mvc.perform(
             put("/api/v1/agents/demo/basic")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
-                    "{\"description\":\"新描述\",\"provider\":\"openai\",\"model\":\"gpt-4o\",\"skills\":[\"s1\",\"s2\"]}"))
+                    "{\"description\":\"新描述\",\"provider\":\"openai\",\"model\":\"gpt-4o\"}"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.name").value("demo"));
-    verify(lifecycle).updateBasicInfo(eq("demo"), eq("新描述"), eq("openai"), eq("gpt-4o"), any());
+    verify(lifecycle).updateBasicInfo(eq("demo"), eq("新描述"), eq("openai"), eq("gpt-4o"));
   }
 
   @Test
@@ -197,9 +197,9 @@ class AgentApiControllerTest {
             put("/api/v1/agents/ghost/basic")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
-                    "{\"description\":\"x\",\"provider\":\"openai\",\"model\":\"gpt-4o\",\"skills\":[]}"))
+                    "{\"description\":\"x\",\"provider\":\"openai\",\"model\":\"gpt-4o\"}"))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value(404));
-    verify(lifecycle, never()).updateBasicInfo(any(), any(), any(), any(), any());
+    verify(lifecycle, never()).updateBasicInfo(any(), any(), any(), any());
   }
 }

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/AgentApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/AgentApiControllerTest.java
@@ -181,8 +181,7 @@ class AgentApiControllerTest {
     mvc.perform(
             put("/api/v1/agents/demo/basic")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    "{\"description\":\"新描述\",\"provider\":\"openai\",\"model\":\"gpt-4o\"}"))
+                .content("{\"description\":\"新描述\",\"provider\":\"openai\",\"model\":\"gpt-4o\"}"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.name").value("demo"));
     verify(lifecycle).updateBasicInfo(eq("demo"), eq("新描述"), eq("openai"), eq("gpt-4o"));
@@ -196,8 +195,7 @@ class AgentApiControllerTest {
     mvc.perform(
             put("/api/v1/agents/ghost/basic")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    "{\"description\":\"x\",\"provider\":\"openai\",\"model\":\"gpt-4o\"}"))
+                .content("{\"description\":\"x\",\"provider\":\"openai\",\"model\":\"gpt-4o\"}"))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value(404));
     verify(lifecycle, never()).updateBasicInfo(any(), any(), any(), any());

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/AgentSkillBindingApiTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/AgentSkillBindingApiTest.java
@@ -1,0 +1,135 @@
+package io.oryxos.web.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.oryxos.core.agent.AgentExecutionService;
+import io.oryxos.core.agent.AgentLifecycleService;
+import io.oryxos.core.agent.AgentService;
+import io.oryxos.core.memory.MemoryService;
+import io.oryxos.core.profile.Profile;
+import io.oryxos.core.profile.ProfileRegistry;
+import io.oryxos.core.session.SessionManager;
+import io.oryxos.core.skill.AgentSkillBindingService;
+import io.oryxos.core.skill.SkillCatalogEntry;
+import io.oryxos.core.skill.SkillMetadataReader;
+import io.oryxos.web.GlobalExceptionHandler;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class AgentSkillBindingApiTest {
+
+  @TempDir Path root;
+
+  private AgentLifecycleService lifecycle;
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    Files.createDirectories(root.resolve("agents/ops"));
+    Files.writeString(root.resolve("agents/ops/AGENT.md"), "---\nname: ops\n---\nbody");
+    skill("report", "报告");
+    skill("web", "调研");
+    AgentSkillBindingService bindings =
+        new AgentSkillBindingService(root, new SkillMetadataReader());
+    Profile profile = profile();
+    ProfileRegistry profiles = new ProfileRegistry(Map.of("ops", profile));
+    lifecycle = mock(AgentLifecycleService.class);
+    when(lifecycle.list()).thenReturn(List.of(profile));
+    when(lifecycle.saveFiles(eq("ops"), org.mockito.ArgumentMatchers.any(), eq(List.of("web"))))
+        .thenReturn(profile);
+    mvc =
+        MockMvcBuilders.standaloneSetup(
+                new AgentApiController(
+                    lifecycle,
+                    mock(AgentService.class),
+                    mock(SessionManager.class),
+                    profiles,
+                    mock(MemoryService.class),
+                    mock(AgentExecutionService.class),
+                    bindings,
+                    (q, visibility) ->
+                        List.of(
+                            new SkillCatalogEntry(
+                                "report", "报告", SkillCatalogEntry.Visibility.PUBLIC, "test", true),
+                            new SkillCatalogEntry(
+                                "web", "调研", SkillCatalogEntry.Visibility.PRIVATE, "test", true))))
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+  }
+
+  @Test
+  void bindingCrudReplaceAndAgentViewUseLiveLinks() throws Exception {
+    mvc.perform(put("/api/v1/agents/ops/skills/report"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.bindings[0].name").value("report"))
+        .andExpect(jsonPath("$.data.bindings[0].skillFile").isNotEmpty());
+
+    mvc.perform(get("/api/v1/agents"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].skills[0]").value("report"));
+
+    mvc.perform(
+            put("/api/v1/agents/ops/skills")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"skills\":[\"web\"]}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.bindings[0].name").value("web"));
+
+    mvc.perform(delete("/api/v1/agents/ops/skills/web"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.bindings").isEmpty());
+  }
+
+  @Test
+  void saveFilesPassesSkillBindingSidecar() throws Exception {
+    mvc.perform(
+            post("/api/v1/agents/ops/files")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"files\":{\"AGENT.md\":\"---\\nname: ops\\n---\\nbody\"},\"skillBindings\":[\"web\"]}"))
+        .andExpect(status().isOk());
+
+    verify(lifecycle)
+        .saveFiles(
+            eq("ops"), eq(Map.of("AGENT.md", "---\nname: ops\n---\nbody")), eq(List.of("web")));
+  }
+
+  private void skill(String name, String description) throws Exception {
+    Path dir = Files.createDirectories(root.resolve("skills").resolve(name));
+    Files.writeString(
+        dir.resolve("SKILL.md"),
+        "---\nname: " + name + "\ndescription: " + description + "\n---\nbody");
+  }
+
+  private static Profile profile() {
+    return new Profile(
+        "ops",
+        "运维",
+        null,
+        new Profile.ProviderRef("mock", "mock", null),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        Profile.Settings.defaults());
+  }
+}

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/AgentSkillBindingApiTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/AgentSkillBindingApiTest.java
@@ -111,6 +111,20 @@ class AgentSkillBindingApiTest {
             eq("ops"), eq(Map.of("AGENT.md", "---\nname: ops\n---\nbody")), eq(List.of("web")));
   }
 
+  @Test
+  void missingSkillReturns404BeforeCatalogValidation() throws Exception {
+    mvc.perform(put("/api/v1/agents/ops/skills/missing"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value(404));
+
+    mvc.perform(
+            put("/api/v1/agents/ops/skills")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"skills\":[\"missing\"]}"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value(404));
+  }
+
   private void skill(String name, String description) throws Exception {
     Path dir = Files.createDirectories(root.resolve("skills").resolve(name));
     Files.writeString(

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/SkillApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/SkillApiControllerTest.java
@@ -7,11 +7,14 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import io.oryxos.core.skill.AgentSkillBindingService;
+import io.oryxos.core.skill.InstalledSkillCatalog;
 import io.oryxos.core.skill.SkillLoader;
 import io.oryxos.core.skill.SkillRegistry;
 import io.oryxos.core.skill.SkillService;
 import io.oryxos.core.skill.SkillStore;
 import io.oryxos.web.GlobalExceptionHandler;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -146,7 +149,38 @@ class SkillApiControllerTest {
                 .content("{\"description\":\"new\",\"body\":\"new body\"}"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.description").value("new"));
-    mvc.perform(delete("/api/v1/skills/s1")).andExpect(status().isOk());
+    mvc.perform(delete("/api/v1/skills/s1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.name").value("s1"))
+        .andExpect(
+            jsonPath("$.data.archivedPath")
+                .value(org.hamcrest.Matchers.startsWith("archive/skills/s1-")));
     mvc.perform(get("/api/v1/skills/s1")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("活跃或归档 Agent 引用阻止归档并返回结构化 409")
+  void referencedSkillReturnsStructuredConflict() throws Exception {
+    Path agent = Files.createDirectories(oryxosRoot.resolve("agents/ops"));
+    Files.writeString(agent.resolve("AGENT.md"), "---\nname: ops\n---\nbody");
+    SkillStore store = new SkillStore(oryxosRoot);
+    SkillLoader loader = new SkillLoader(oryxosRoot.resolve("skills"));
+    SkillRegistry registry = new SkillRegistry();
+    AgentSkillBindingService bindings = new AgentSkillBindingService(oryxosRoot, loader);
+    SkillService service = new SkillService(store, registry, loader, bindings);
+    service.create("report", "报告", "正文");
+    bindings.bind("ops", "report");
+    mvc =
+        MockMvcBuilders.standaloneSetup(
+                new SkillApiController(service, new InstalledSkillCatalog(registry), bindings))
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+
+    mvc.perform(delete("/api/v1/skills/report"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value(409))
+        .andExpect(jsonPath("$.data.name").value("report"))
+        .andExpect(jsonPath("$.data.references[0].agentName").value("ops"))
+        .andExpect(jsonPath("$.data.references[0].state").value("ACTIVE"));
   }
 }

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/SkillBindingIssuesApiTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/SkillBindingIssuesApiTest.java
@@ -1,0 +1,59 @@
+package io.oryxos.web.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.oryxos.core.skill.AgentSkillBindingService;
+import io.oryxos.core.skill.InstalledSkillCatalog;
+import io.oryxos.core.skill.SkillLoader;
+import io.oryxos.core.skill.SkillRegistry;
+import io.oryxos.core.skill.SkillService;
+import io.oryxos.core.skill.SkillStore;
+import io.oryxos.web.GlobalExceptionHandler;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class SkillBindingIssuesApiTest {
+
+  @TempDir Path root;
+
+  @Test
+  void returnsStableActiveArchivedAndInvalidAgentIssues() throws Exception {
+    createAgent(root.resolve("agents/z-active"), "z-active", true);
+    createAgent(root.resolve("archive/a-archived-1"), "a-archived", true);
+    Path invalid = Files.createDirectories(root.resolve("agents/missing-profile/skills"));
+    Files.writeString(invalid.resolve("bad"), "ordinary");
+    SkillLoader loader = new SkillLoader(root.resolve("skills"));
+    SkillRegistry registry = new SkillRegistry();
+    AgentSkillBindingService bindings = new AgentSkillBindingService(root, loader);
+    SkillService service = new SkillService(new SkillStore(root), registry, loader, bindings);
+    MockMvc mvc =
+        MockMvcBuilders.standaloneSetup(
+                new SkillApiController(service, new InstalledSkillCatalog(registry), bindings))
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+
+    mvc.perform(get("/api/v1/skills/binding-issues"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].agentName").value("a-archived-1"))
+        .andExpect(jsonPath("$.data[0].agentState").value("ARCHIVED"))
+        .andExpect(jsonPath("$.data[1].agentName").value("missing-profile"))
+        .andExpect(jsonPath("$.data[1].agentState").value("INVALID"))
+        .andExpect(jsonPath("$.data[2].agentName").value("z-active"))
+        .andExpect(jsonPath("$.data[2].agentState").value("ACTIVE"));
+  }
+
+  private static void createAgent(Path directory, String name, boolean invalidBinding)
+      throws Exception {
+    Files.createDirectories(directory.resolve("skills"));
+    Files.writeString(directory.resolve("AGENT.md"), "---\nname: " + name + "\n---\nbody");
+    if (invalidBinding) {
+      Files.writeString(directory.resolve("skills/bad"), "ordinary");
+    }
+  }
+}

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/SkillCatalogApiTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/SkillCatalogApiTest.java
@@ -1,0 +1,70 @@
+package io.oryxos.web.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.oryxos.core.skill.SkillCatalog;
+import io.oryxos.core.skill.SkillCatalogEntry;
+import io.oryxos.core.skill.SkillLoader;
+import io.oryxos.core.skill.SkillRegistry;
+import io.oryxos.core.skill.SkillService;
+import io.oryxos.core.skill.SkillStore;
+import io.oryxos.web.GlobalExceptionHandler;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class SkillCatalogApiTest {
+
+  @TempDir Path root;
+
+  @Test
+  void queriesPublicPrivateAndInstalledMetadata() throws Exception {
+    SkillCatalog catalog =
+        (query, visibility) ->
+            List.of(
+                    new SkillCatalogEntry(
+                        "public-report", "报告", SkillCatalogEntry.Visibility.PUBLIC, "team", true),
+                    new SkillCatalogEntry(
+                        "private-ops",
+                        "运维",
+                        SkillCatalogEntry.Visibility.PRIVATE,
+                        "personal",
+                        false))
+                .stream()
+                .filter(entry -> visibility == null || entry.visibility() == visibility)
+                .filter(entry -> query == null || query.isBlank() || entry.name().contains(query))
+                .toList();
+    MockMvc mvc = mvc(catalog);
+
+    mvc.perform(get("/api/v1/skills/catalog").param("visibility", "public"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].name").value("public-report"))
+        .andExpect(jsonPath("$.data[0].visibility").value("PUBLIC"))
+        .andExpect(jsonPath("$.data[0].installed").value(true));
+    mvc.perform(get("/api/v1/skills/catalog").param("visibility", "private").param("q", "ops"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].name").value("private-ops"))
+        .andExpect(jsonPath("$.data[0].installed").value(false));
+  }
+
+  @Test
+  void missingCatalogFailsClosedWith503() throws Exception {
+    mvc(null)
+        .perform(get("/api/v1/skills/catalog"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.code").value(503));
+  }
+
+  private MockMvc mvc(SkillCatalog catalog) {
+    SkillLoader loader = new SkillLoader(root.resolve("skills"));
+    SkillService service = new SkillService(new SkillStore(root), new SkillRegistry(), loader);
+    return MockMvcBuilders.standaloneSetup(new SkillApiController(service, catalog, null))
+        .setControllerAdvice(new GlobalExceptionHandler())
+        .build();
+  }
+}

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
@@ -2,6 +2,7 @@ package io.oryxos.web.controller;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -43,11 +45,10 @@ class WorkspaceApiControllerTest {
   void tree_returnsAgentsAndArchive() throws Exception {
     mvc.perform(get("/api/v1/workspace/tree"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.data.children[0].name").value("agents"))
-        .andExpect(jsonPath("$.data.children[0].children[0].name").value("demo"))
-        .andExpect(jsonPath("$.data.children[1].name").value("skills"))
-        .andExpect(jsonPath("$.data.children[2].name").value("output"))
-        .andExpect(jsonPath("$.data.children[3].name").value("archive"));
+        .andExpect(
+            jsonPath("$.data.children[*].name")
+                .value(org.hamcrest.Matchers.hasItems("agents", "skills", "output", "archive")))
+        .andExpect(jsonPath("$.data.children[0].children[0].name").value("demo"));
   }
 
   @Test
@@ -94,5 +95,39 @@ class WorkspaceApiControllerTest {
     mvc.perform(get("/api/v1/workspace/download").param("path", "agents/demo/output/nope.md"))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value(404));
+  }
+
+  @Test
+  @DisplayName("read/download/write 均拒绝经父软连接逃逸，tree 把链接作为叶节点")
+  void symlinkEscapeIsRejectedAndTreeDoesNotFollow() throws Exception {
+    Path outside = Files.createDirectories(oryxosRoot.resolveSibling("outside-workspace"));
+    Files.writeString(outside.resolve("secret.txt"), "SECRET");
+    Files.createSymbolicLink(oryxosRoot.resolve("agents/demo/escape"), outside);
+
+    mvc.perform(get("/api/v1/workspace/file").param("path", "agents/demo/escape/secret.txt"))
+        .andExpect(status().isBadRequest());
+    mvc.perform(get("/api/v1/workspace/download").param("path", "agents/demo/escape/secret.txt"))
+        .andExpect(status().isBadRequest());
+    mvc.perform(
+            post("/api/v1/workspace/file")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"path\":\"agents/demo/escape/new.txt\",\"content\":\"bad\"}"))
+        .andExpect(status().isBadRequest());
+    org.junit.jupiter.api.Assertions.assertFalse(Files.exists(outside.resolve("new.txt")));
+
+    mvc.perform(get("/api/v1/workspace/tree"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$..[?(@.name == 'escape')].type").value("link"))
+        .andExpect(jsonPath("$..[?(@.name == 'escape')].children.length()").value(0));
+  }
+
+  @Test
+  @DisplayName("工作区写入口禁止写 Agent skills 绑定视图")
+  void writeThroughAgentSkillsIsRejected() throws Exception {
+    mvc.perform(
+            post("/api/v1/workspace/file")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"path\":\"agents/demo/skills/report/SKILL.md\",\"content\":\"bad\"}"))
+        .andExpect(status().isBadRequest());
   }
 }

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
@@ -130,4 +130,37 @@ class WorkspaceApiControllerTest {
                 .content("{\"path\":\"agents/demo/skills/report/SKILL.md\",\"content\":\"bad\"}"))
         .andExpect(status().isBadRequest());
   }
+
+  @Test
+  @DisplayName("工作区写入口禁止直接或经归档 Agent 软连接修改共享 Skill")
+  void writeThroughSharedSkillPathsIsRejected() throws Exception {
+    Path shared = Files.createDirectories(oryxosRoot.resolve("skills/report"));
+    Path skillFile = Files.writeString(shared.resolve("SKILL.md"), "original");
+    Path archivedLinks = Files.createDirectories(oryxosRoot.resolve("archive/ops-old/skills"));
+    Files.createSymbolicLink(archivedLinks.resolve("report"), Path.of("../../../skills/report"));
+
+    mvc.perform(
+            post("/api/v1/workspace/file")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"path\":\"skills/report/SKILL.md\",\"content\":\"bad\"}"))
+        .andExpect(status().isBadRequest());
+    mvc.perform(
+            post("/api/v1/workspace/file")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"path\":\"archive/ops-old/skills/report/SKILL.md\",\"content\":\"bad\"}"))
+        .andExpect(status().isBadRequest());
+    org.junit.jupiter.api.Assertions.assertEquals("original", Files.readString(skillFile));
+  }
+
+  @Test
+  @DisplayName("工作区读取悬空软连接返回 400 而非 500")
+  void danglingLinkReturnsBadRequest() throws Exception {
+    Files.createSymbolicLink(
+        oryxosRoot.resolve("agents/demo/dangling"), Path.of("../../skills/missing"));
+
+    mvc.perform(get("/api/v1/workspace/file").param("path", "agents/demo/dangling/SKILL.md"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(400));
+  }
 }

--- a/specs/012-agent-skill-links/checklists/requirements.md
+++ b/specs/012-agent-skill-links/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Agent Skill 软连接绑定与渐进式加载
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No unnecessary implementation details beyond the approved filesystem contract
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No NEEDS CLARIFICATION markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic where the approved filesystem contract permits
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No accidental implementation choices leak into the specification
+
+## Notes
+
+- The relative-symlink binding model is an approved product requirement from Issue #40, not an inferred implementation detail.

--- a/specs/012-agent-skill-links/contracts/skill-bindings.md
+++ b/specs/012-agent-skill-links/contracts/skill-bindings.md
@@ -1,0 +1,269 @@
+# HTTP and Prompt Contract: Agent Skill Bindings
+
+所有 HTTP 响应继续使用现有 `ApiResponse<T>` 信封。路径中的 Agent/Skill 名仅允许
+`[A-Za-z0-9_-]+`。
+
+## 1. 已安装 Skill 与外部 catalog
+
+### 已安装实体
+
+`GET /api/v1/skills`
+
+只返回 `.oryxos/skills/<name>/` 中校验成功的本机实体；不混入未安装 catalog 项或归档 Skill。
+
+### 候选 catalog
+
+`GET /api/v1/skills/catalog?q=&visibility=all|public|private`
+
+成功 `200`：
+
+```json
+{
+  "code": 0,
+  "data": [
+    {
+      "name": "report-format",
+      "description": "结构化报告规范",
+      "visibility": "PUBLIC",
+      "source": "team-catalog",
+      "installed": true
+    }
+  ]
+}
+```
+
+- OryxOS 只消费 catalog adapter 已过滤的结果，不执行 owner/scope/ACL。
+- 公共/私有同名候选必须作为冲突拒绝，不得按 visibility 建第二命名空间。
+- 作者模型只能看到 `installed=true` 且本机实体再次校验有效的交集。
+- catalog 不可用时返回 `503`；不得把未经 catalog 校验的模型名称降级为可绑定项。
+- 本阶段不因 catalog 结果自动联网安装 Skill。
+
+## 2. 查询 Agent 绑定
+
+`GET /api/v1/agents/{agent}/skills`
+
+成功 `200`：
+
+```json
+{
+  "code": 0,
+  "data": {
+    "bindings": [
+      {
+        "name": "report-format",
+        "description": "结构化报告规范",
+        "skillFile": "/workspace/.oryxos/agents/reporter/skills/report-format/SKILL.md"
+      }
+    ],
+    "issues": []
+  }
+}
+```
+
+`skillFile` 必须是 Agent 本地 lexical absolute 路径，不得替换成公共实体 realpath。Agent 不存在返回
+`404`。
+
+## 3. 单项绑定与解绑
+
+### 绑定
+
+`PUT /api/v1/agents/{agent}/skills/{skill}`
+
+- 创建固定相对软连接；同一合法链接重复调用幂等。
+- 成功 `200`，返回最新绑定快照。
+- Agent/Skill 不存在返回 `404`。
+- 名称非法、实体无效、catalog 不可见、槽位被普通文件/错误链接占用返回 `400`。
+
+### 解绑
+
+`DELETE /api/v1/agents/{agent}/skills/{skill}`
+
+- 只删除 Agent 本地受控链接；不存在时幂等。
+- 成功 `200`，返回最新绑定快照。
+- 不得删除公共实体；槽位不是软连接时返回 `400`，不得代删。
+
+## 4. 原子替换绑定集合
+
+`PUT /api/v1/agents/{agent}/skills`
+
+请求：
+
+```json
+{ "skills": ["report-format", "web-research"] }
+```
+
+- 后端先验证全部名称、catalog 可见性、安装实体和目标槽位，再计算增删集合。
+- 任一校验或 IO 失败，返回 `400`/`503`，迁移前绑定集合保持不变。
+- 成功 `200`，返回最新绑定快照。
+
+## 5. 全工作区一致性问题
+
+`GET /api/v1/skills/binding-issues`
+
+成功 `200`，`data` 为稳定排序的 `SkillBindingIssue[]`；同时覆盖活跃 Agent、平铺归档 Agent 和 legacy
+frontmatter 残留，排除 `.oryxos/archive/skills/`。空数组表示一致。
+
+```json
+{
+  "code": 0,
+  "data": [
+    {
+      "agentName": "ops",
+      "agentState": "ACTIVE",
+      "entryName": "broken",
+      "path": "/workspace/.oryxos/agents/ops/skills/broken",
+      "type": "DANGLING",
+      "message": "绑定目标不存在"
+    }
+  ]
+}
+```
+
+## 6. Skill 删除即归档
+
+`DELETE /api/v1/skills/{skill}`
+
+无引用时成功 `200`：
+
+```json
+{
+  "code": 0,
+  "data": {
+    "name": "report-format",
+    "archivedPath": "archive/skills/report-format-20260727T091500Z",
+    "archivedAt": "2026-07-27T09:15:00Z"
+  }
+}
+```
+
+存在活跃或归档引用时返回 `409 Conflict`，安装实体和所有链接保持不变：
+
+```json
+{
+  "code": 409,
+  "message": "Skill 仍被 Agent 引用",
+  "data": {
+    "name": "report-format",
+    "references": [
+      {
+        "agentName": "ops",
+        "state": "ACTIVE",
+        "directoryName": "ops",
+        "linkPath": "/workspace/.oryxos/agents/ops/skills/report-format"
+      },
+      {
+        "agentName": "reporter",
+        "state": "ARCHIVED",
+        "directoryName": "reporter-1750000000000",
+        "linkPath": "/workspace/.oryxos/archive/reporter-1750000000000/skills/report-format"
+      }
+    ]
+  }
+}
+```
+
+## 7. Agent 创建与作者生成
+
+### 直接创建
+
+`POST /api/v1/agents`
+
+```json
+{
+  "name": "reporter",
+  "description": "生成日报",
+  "skillBindings": ["report-format"]
+}
+```
+
+创建文件、绑定、注册或调度任一步失败时回滚整个新 Agent，不留下目录或链接。
+
+### 生成草稿
+
+`POST /api/v1/agents/{name}/generate-files`
+
+请求：
+
+```json
+{
+  "description": "每天生成技术日报",
+  "notifyChannel": "team-webhook",
+  "requiredSkills": ["report-format"]
+}
+```
+
+响应 sidecar：
+
+```json
+{
+  "code": 0,
+  "data": {
+    "files": {
+      "AGENT.md": "---\nname: reporter\n...\n---\n按职责执行"
+    },
+    "requiredSkills": ["report-format"],
+    "suggestedSkills": ["web-research"],
+    "bindingSkills": ["report-format", "web-research"]
+  }
+}
+```
+
+- required 必须原样保留。
+- suggested 必须来自本次交给作者模型的已安装 catalog 交集；列表外名称丢弃并记录可读错误。
+- `AGENT.md` 不得含 top-level `skills:`，files 不得含 `skills/**`。
+- sidecar 不落盘，不是绑定真相源。
+
+### 保存草稿
+
+`POST /api/v1/agents/{name}/files`
+
+```json
+{
+  "files": { "AGENT.md": "..." },
+  "skillBindings": ["report-format", "web-research"]
+}
+```
+
+后端重新校验文件和全部绑定后一次提交。已有 Agent 未提供 `skillBindings` 时保留当前绑定；显式提供空
+数组表示解绑全部。
+
+## 8. Agent 视图
+
+既有 `GET /api/v1/agents` 和 `GET /api/v1/agents/{agent}` 可保留 `skills` 字段兼容 UI，但值必须由
+`AgentSkillBindingReader` 实时投影，不能从 Profile、frontmatter 或 Registry 获取。
+
+## 9. Prompt contract
+
+存在有效绑定时，Level 1 system prompt 追加：
+
+```text
+你可以按需使用以下 Skill。仅在当前任务需要时，用 read_file 读取给出的 SKILL.md；
+其中的相对资源路径以该 SKILL.md 所在目录为基准并转换成绝对路径，不要猜测未读取的内容：
+- report-format：结构化报告规范
+  SKILL.md：/workspace/.oryxos/agents/reporter/skills/report-format/SKILL.md
+```
+
+约束：
+
+- 每次 provider 调用前重新扫描，按名称稳定排序。
+- 不出现公共 realpath、Skill 正文、附属资源内容或未绑定 Skill。
+- 没有有效绑定时不输出标题。
+- 问题项只进入日志/一致性 API，不进入 prompt。
+- Level 2 只能通过既有 `read_file`；结果按普通 Tool Result 审计并进入下一轮 history。
+- Level 3 继续通过 `read_file`/`shell` 按需获取，不新增 `use_skill`。
+
+## 10. Workspace file contract
+
+- `/api/v1/workspace/tree` 遇软连接返回 `type: "link"` 的叶节点，包含 lexical target 和有效性；不递归
+  跟随。
+- `/file`、`/download`、`/write` 在 IO 前做真实路径边界校验。
+- 通过 `agents/<agent>/skills/**` 的管理台写请求返回 `400`；共享 Skill 只能从顶层 Skill 管理入口
+  更新。
+- 合法工作区内链接可由模型 `read_file` 读取；越界、dangling 或 link cycle 一律拒绝。
+
+## 11. Startup migration contract
+
+- 每个 Agent 独立迁移；合法旧 `skills:` 转为绑定并从 AGENT.md 移除。
+- 任一旧名称或槽位无效时，该 Agent 原始 AGENT.md 字节与迁移前链接集合保持不变，产生
+  `STALE_REFERENCE` 报告；其它 Agent 继续迁移和启动。
+- 新建/更新 API 若收到 top-level `skills:` 直接返回 `400`；只有启动迁移器接受该旧字段。

--- a/specs/012-agent-skill-links/contracts/skill-bindings.md
+++ b/specs/012-agent-skill-links/contracts/skill-bindings.md
@@ -209,7 +209,7 @@ frontmatter 残留，排除 `.oryxos/archive/skills/`。空数组表示一致。
 ```
 
 - required 必须原样保留。
-- suggested 必须来自本次交给作者模型的已安装 catalog 交集；列表外名称丢弃并记录可读错误。
+- suggested 必须来自本次交给作者模型的已安装 catalog 交集；列表外名称拒绝整次生成并返回可读错误。
 - `AGENT.md` 不得含 top-level `skills:`，files 不得含 `skills/**`。
 - sidecar 不落盘，不是绑定真相源。
 

--- a/specs/012-agent-skill-links/data-model.md
+++ b/specs/012-agent-skill-links/data-model.md
@@ -1,0 +1,189 @@
+# Data Model: Agent Skill 绑定与渐进式加载
+
+## InstalledSkill
+
+`.oryxos/skills/<name>/` 中唯一的本机内容实体；公共/私有不产生不同副本。
+
+| Field | Type | Rules |
+|---|---|---|
+| `name` | String | `[A-Za-z0-9_-]+`；等于目录名与 frontmatter `name` |
+| `description` | String | 非空、单行目录说明；Level 1 prompt 可见 |
+| `body` | String | 非空；仅 Level 2 `read_file` 可见 |
+| `directory` | Path | `.oryxos/skills/<name>`；实体目录本身不得是越界链接 |
+| `entrypoint` | Path | `<directory>/SKILL.md`，普通可读文件 |
+| `resources` | files | 可选 references/templates/scripts；Level 3 按需读取 |
+
+### State transitions
+
+```text
+ABSENT ── create/import ──> INSTALLED_VALID
+                              │
+                              ├─ external/manual damage ─> INSTALLED_INVALID
+                              │
+                              └─ archive(no references) ─> ARCHIVED
+```
+
+- `INSTALLED_VALID`: 可进入 catalog 的 installed 交集、可绑定。
+- `INSTALLED_INVALID`: 可诊断，不可新绑定、不进入 prompt。
+- `ARCHIVED`: 位于 `.oryxos/archive/skills/<name>-<timestamp>/`；不进入安装扫描、catalog 交集或 prompt。
+
+## SkillCatalogEntry
+
+外部候选列表返回的瞬时元数据，不是安装实体或绑定。
+
+| Field | Type | Rules |
+|---|---|---|
+| `name` | String | 全工作区候选名称；同名公共/私有项视为冲突 |
+| `description` | String | 作者模型选择依据 |
+| `visibility` | Enum | `PUBLIC` / `PRIVATE`；仅标签，本阶段不执行 ACL |
+| `source` | String | 外部列表提供的来源标识 |
+| `installed` | boolean | 当前是否存在同名合法 InstalledSkill |
+
+关系：只有 `SkillCatalogEntry.name == InstalledSkill.name && installed=true` 的项才能成为生成候选；访问
+过滤由 catalog adapter 在返回前完成。
+
+## AgentSkillBinding
+
+Agent 对 InstalledSkill 的唯一持久绑定事实。
+
+| Field | Type | Rules |
+|---|---|---|
+| `agentName` | String | 安全目录段；活跃或归档 Agent 目录必须有效 |
+| `agentState` | Enum | `ACTIVE` / `ARCHIVED` |
+| `skillName` | String | 安全目录段，等于链接名 |
+| `linkPath` | Path | 活跃时 `.oryxos/agents/<agent>/skills/<skill>` |
+| `linkTarget` | Path | 精确相对路径 `../../../skills/<skill>` |
+| `installedSkill` | reference | 必须指向同名 `INSTALLED_VALID` 实体 |
+
+### Operations
+
+- `bind(agent, skill)`: 先验证 Agent、catalog/安装状态、目标槽位；同一合法链接幂等。
+- `unbind(agent, skill)`: 只删除受控链接；不存在幂等；普通文件/目录冲突时拒绝代删。
+- `replace(agent, desired)`: 全量预校验后原子同步；失败回滚本次增删。
+- `inspect(agent)`: 返回有效 binding + issues，按 skillName 排序。
+- `references(skill)`: 返回所有 ACTIVE/ARCHIVED 引用；归档 Agent 链接仍是有效引用。
+
+## BoundSkillDescriptor
+
+Level 1 system prompt 的最小目录项。
+
+| Field | Type | Visible to model |
+|---|---|---|
+| `name` | String | yes |
+| `description` | String | yes |
+| `linkPath` | lexical absolute Path | 间接；用于资源基准目录 |
+| `skillFile` | lexical absolute Path | yes，必须保留 Agent 本地链接路径 |
+| `body` | absent | no |
+| `resources` | absent | no |
+
+路径校验使用 realpath，但暴露给模型的是 Agent 本地 lexical absolute path，使后续相对资源仍位于该
+Agent 的能力视图中。
+
+## BindingInspection
+
+一次无副作用扫描快照。
+
+| Field | Type | Rules |
+|---|---|---|
+| `bindings` | List&lt;BoundSkillDescriptor&gt; | 仅有效项，按名称稳定排序 |
+| `issues` | List&lt;SkillBindingIssue&gt; | 无效项，稳定排序 |
+
+没有有效绑定时，ContextLoader 不输出 Skill 标题。
+
+## SkillBindingIssue
+
+| Field | Type | Meaning |
+|---|---|---|
+| `agentName` | String | 所属 Agent 或归档目录标识 |
+| `agentState` | Enum | `ACTIVE` / `ARCHIVED` / `INVALID` |
+| `entryName` | String | `skills/` 条目或 legacy 字段标识 |
+| `path` | absolute Path | 问题位置；不得包含文件内容 |
+| `type` | Enum | 五类之一 |
+| `message` | String | 可展示、去 CR/LF 的原因 |
+
+### Classification
+
+- `DANGLING`: 相对链接的目标不存在。
+- `ESCAPED`: 绝对链接、词法目标越过安装根、链式解析后的真实目标越过安装根。
+- `INVALID_TARGET`: 非软连接、替代相对目标、目标不是目录、缺/不可读 `SKILL.md`、缺描述或空正文。
+- `NAME_MISMATCH`: 链接名、安装目录名、frontmatter name 任意不一致。
+- `STALE_REFERENCE`: 未迁移的 top-level `skills:`，或没有有效 `AGENT.md` 的活跃目录残留绑定。
+
+归档 Agent 中仍能解析到已安装 Skill 的链接不是 stale。
+
+## SkillReference
+
+Skill 归档冲突的结构化返回项。
+
+| Field | Type | Rules |
+|---|---|---|
+| `agentName` | String | Agent 定义中的名称 |
+| `state` | Enum | `ACTIVE` / `ARCHIVED` |
+| `directoryName` | String | 实际目录名，保留时间戳后缀定位 |
+| `linkPath` | absolute Path | 引用链接位置 |
+
+## SkillArchive
+
+| Field | Type | Rules |
+|---|---|---|
+| `name` | String | 原安装名称 |
+| `archivedPath` | Path | `.oryxos/archive/skills/<name>-<timestamp>/` |
+| `archivedAt` | Instant | 归档提交时间 |
+
+状态迁移必须在引用列表为空时发生；移动整个目录，不覆盖既有归档。成功后从安装 Registry 移除。
+
+## GeneratedAgentDraft
+
+生成阶段的瞬时 sidecar，不写入 Agent 目录。
+
+| Field | Type | Rules |
+|---|---|---|
+| `files` | Map&lt;relativePath,String&gt; | 必须含 AGENT.md；禁止 `skills:` 与 `skills/**` |
+| `requiredSkills` | List&lt;String&gt; | 用户明确选择，结果必须全部保留 |
+| `suggestedSkills` | List&lt;String&gt; | 作者模型从本次可选 catalog 交集中补充 |
+| `bindingSkills` | List&lt;String&gt; | required ∪ suggested，去重稳定排序 |
+
+保存时 `bindingSkills` 必须重新验证，不能信任草稿或浏览器状态；保存成功后该 DTO 可丢弃。
+
+## LegacySkillMigration
+
+单个 Agent 的启动迁移事务。
+
+| Field | Type | Rules |
+|---|---|---|
+| `agentDirectory` | Path | 当前 Agent 目录 |
+| `legacySkills` | List&lt;String&gt; | 原 top-level frontmatter 值，必须是字符串列表 |
+| `preexistingBindings` | Set&lt;String&gt; | 已存在合法链接，迁移保留 |
+| `createdBindings` | Set&lt;Path&gt; | 本次新增，用于异常回滚 |
+| `status` | Enum | `NOT_NEEDED`, `MIGRATED`, `FAILED` |
+| `message` | String | 失败原因或迁移摘要 |
+
+### Commit order
+
+1. 读取原始字节并全量校验。
+2. 写临时 AGENT.md，创建/验证临时链接。
+3. 原子移动新增链接到最终名。
+4. 最后原子替换 AGENT.md。
+5. 异常时删除本次临时项/新增链接，原 AGENT.md 保持字节一致。
+
+## RealPathProjection
+
+真实路径边界校验的内部值。
+
+| Field | Type | Rules |
+|---|---|---|
+| `input` | Path | 调用者原始目标 |
+| `absoluteNormalized` | Path | 词法绝对规范路径 |
+| `existingAncestorReal` | Path | 最近存在节点的 `toRealPath()` |
+| `unresolvedSuffix` | Path segments | 尚不存在的普通尾段 |
+| `projectedReal` | Path | ancestor real + suffix，用于边界比较 |
+
+dangling link、link cycle 或祖先无法解析时不产生 projection，直接拒绝。
+
+## Persistence and ownership
+
+- 不新增数据库表。
+- `SkillRegistry` 仅为已安装实体 CRUD/管理视图，可重建；不保存 Agent 绑定。
+- `SkillCatalogEntry` 是外部查询结果，不持久化 owner/scope/ACL。
+- AgentSkillBinding 只由软连接持久化。
+- Tool 读取正文继续使用现有 `tool_invocations` 审计；无专用 Skill 使用表。

--- a/specs/012-agent-skill-links/plan.md
+++ b/specs/012-agent-skill-links/plan.md
@@ -1,0 +1,210 @@
+# Implementation Plan: Agent Skill 软连接绑定与三级渐进加载
+
+**Branch**: `codex/agent-skill-progressive-loading` | **Date**: 2026-07-27 | **Spec**: [spec.md](spec.md)
+
+**Input**: Issue #40 已批准方案及 2026-07-26 clarify 结果。
+
+## Summary
+
+把旧的 `AGENT.md skills:` + Skill 正文预载模型替换为单一文件系统绑定模型：已安装 Skill
+统一存放在 `.oryxos/skills/<name>/`，每个 Agent 只通过自身 `skills/<name>` 的固定相对软连接
+选择能力。每一次 LLM 调用都由 `ContextLoader` 重新扫描当前 Agent 的有效绑定，只把 name、
+description 和 Agent 本地绝对 `SKILL.md` 路径放进 system prompt；模型需要时再用现有
+`read_file` 读取正文，随后按正文指引继续读取 references/templates 或用 `shell` 执行 scripts。
+
+本特性同时交付：旧 frontmatter 的单 Agent 原子迁移、公共/私有标签的外部 Skill 列表、用户必选
+加作者模型自动补充的生成流程、绑定 CRUD 与一致性诊断、活跃/归档 Agent 引用保护、Skill 目录
+归档，以及所有文件入口的软连接真实路径安全校验。
+
+## Technical Context
+
+**Language/Version**: Java 21；管理台 Vue 3 + Vite
+
+**Primary Dependencies**: Spring Boot 3.x、Spring MVC、SnakeYAML、Java NIO；不新增运行时依赖
+
+**Storage**: 文件系统（`.oryxos/skills/`、`.oryxos/agents/*/skills/`、
+`.oryxos/archive/skills/`）；继续使用现有 SQLite 工具/LLM 审计，无新增表
+
+**Testing**: JUnit 5、Mockito、Spring MockMvc、Maven Surefire/Failsafe；前端 `npm run build`
+
+**Target Platform**: 支持 Java NIO 符号链接的 Linux/macOS 服务端；自定义相对或绝对
+`oryxos.root` 均须工作
+
+**Project Type**: Maven 多模块企业单体 + 内嵌 Vue 管理台
+
+**Performance Goals**: 每次 LLM 调用仅扫描当前 Agent 的 B 个绑定，时间与临时对象复杂度 O(B)；
+不扫描全 Skill 库、不读取附属资源、不缓存绑定
+
+**Constraints**: 同步阻塞；绑定只有软连接一个真相源；正文不得常驻 system prompt；旧迁移按单 Agent
+原子回滚；应用内 bind/归档在同一同步临界区；无 Skill ACL/RBAC；不得自动下载外部内容
+
+**Scale/Scope**: 单工作区数十至数百 Agent、数百已安装 Skill；涉及 `oryxos-core`、
+`oryxos-tool`、`oryxos-cli` 装配、`oryxos-web` API/管理台和运行时文档，不新增 Maven 模块
+
+## Constitution Check
+
+### 设计前门禁
+
+- **I 自实现 ReAct Loop**: PASS。`ReActLoop` 不改执行权；其每轮既有
+  `PromptBuilder.build()` 调用天然触发一次新的 Skill 元数据扫描。
+- **II Spring AI 使用边界**: PASS。作者模型和运行 Agent 都继续走 `ProviderService`，不启用框架
+  自动工具执行。
+- **III Provider 显式映射**: PASS。无 Provider 发现或路由改动。
+- **IV 目录 Agent + Skill 渐进披露**: PASS。软连接是唯一绑定事实，system prompt 仅有元数据；
+  `SKILL.md` 与资源只经 `read_file`/`shell` 按需进入 ReAct。
+- **V 审计 Day One**: PASS。读取 Skill 正文仍是普通 Tool 调用，继续写 `tool_invocations`；LLM 每轮
+  继续写 `llm_calls`。
+- **VI 真实路径沙箱**: PASS。Tool 文件访问与管理台工作区访问都纳入真实路径校验；合法工作区内
+  Skill 链接放行，越界链拒绝。
+- **VII 同步执行**: PASS。扫描、迁移、绑定和归档均使用同步 Java NIO，不引入异步模型。
+- **VIII 目录配置与状态外置**: PASS。能力边界由 Agent 目录软连接表达，无数据库绑定表。
+
+### Phase 1 设计后复核
+
+- `Profile` 删除 `skills` 字段；启动迁移完成后 frontmatter 不再表达绑定。
+- `SkillRegistry`/Skill 列表可缓存或展示已安装实体，但 `ContextLoader` 不从它读取绑定，避免第二
+  真相源与陈旧元数据。
+- 作者模型返回的建议 Skill 只存在于未保存草稿响应；保存时经后端重新校验并创建软连接，因此草稿
+  列表不是持久绑定索引。
+- 已安装 Skill 的 `visibility`/`source` 只服务查询和作者选择，不实现 ACL，也不改变统一存储路径。
+- Skill “删除”在确认活跃与归档 Agent 均无引用后移动整个目录到
+  `.oryxos/archive/skills/<name>-<timestamp>/`，不物理删除、不级联解绑。
+- 旧配置迁移在 WorkspaceWatcher 和 Profile 扫描前执行；先全量校验，再暂存链接和新 AGENT.md，
+  失败回滚本次新增项，单个 Agent 失败不影响其它 Agent；文件系统不支持原子移动时明确失败，
+  不用非原子覆盖降级。
+- 真实路径策略覆盖已存在目标、不存在写目标、白名单根、工作区浏览器和链接目录树不跟随。
+
+结论：全部宪章门禁通过，无需复杂度豁免。
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-agent-skill-links/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── skill-bindings.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md                 # 下一阶段由 speckit-tasks 重建
+```
+
+### Source Code (repository root)
+
+```text
+oryxos-core/src/main/java/io/oryxos/core/
+├── agent/
+│   ├── AgentLifecycleService.java
+│   ├── AgentMarkdown.java
+│   └── AgentStore.java
+├── context/ContextLoader.java
+├── fs/RealPathBoundary.java
+├── profile/{Profile,ProfileLoader}.java
+└── skill/
+    ├── AgentSkillBindingReader.java
+    ├── AgentSkillBinding.java
+    ├── AgentSkillBindingService.java
+    ├── AgentSkillMigrationService.java
+    ├── SkillBindingIssue.java
+    ├── SkillCatalog.java
+    ├── SkillCatalogEntry.java
+    ├── SkillLoader.java
+    ├── SkillMetadataReader.java
+    ├── SkillService.java
+    └── SkillStore.java
+
+oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+
+oryxos-web/src/main/
+├── java/io/oryxos/web/controller/
+│   ├── AgentApiController.java
+│   ├── SkillApiController.java
+│   └── WorkspaceApiController.java
+├── java/io/oryxos/web/controller/dto/
+└── frontend/src/App.vue
+
+oryxos-core/src/test/java/io/oryxos/core/{context,profile,skill,agent}/
+oryxos-tool/src/test/java/io/oryxos/tool/sandbox/
+oryxos-web/src/test/java/io/oryxos/web/controller/
+```
+
+**Structure Decision**: 绑定、迁移、目录元数据与 Skill catalog 契约都属于 Agent 上下文能力，放在
+`oryxos-core`；实际 Tool 文件白名单仍由 `oryxos-tool` 实现；CLI 只负责严格启动顺序；Web 只做
+HTTP/视图适配。现有模块边界足够，不新建模块。
+
+## Runtime Design
+
+### 三级渐进加载
+
+1. **元数据常驻**：每次 `ReActLoop` 迭代调用 `PromptBuilder.build()`，进而调用
+   `ContextLoader.load()`；它实时扫描当前 Agent 的 `skills/`，验证并按名称排序，只输出 name、
+   description、Agent 本地绝对 `SKILL.md` 路径。`SkillMetadataReader` 仅读第二个 `---` 以前的
+   frontmatter，不为目录构建读取正文。
+2. **正文按需**：模型根据任务调用现有 `read_file(<local-link>/SKILL.md)`；正文作为已审计的 Tool
+   Result 进入下一轮会话历史，不进入全局缓存或永久 system prompt。
+3. **资源再按需**：正文引用的 references/templates/scripts 以 Skill 目录为基准，再经
+   `read_file`/`shell` 逐项获取；未用资源永不进入上下文。
+
+外部 Skill 列表只在 Agent 创建/管理阶段给作者模型候选；运行阶段绝不把未绑定 Skill 暴露给 Agent。
+
+### 绑定、迁移与归档
+
+1. `AgentSkillBindingService` 实现只读 `AgentSkillBindingReader`，使用固定相对目标
+   `../../../skills/<name>`，负责 bind/unbind/atomic replace/inspect/references/reconcile，并以
+   workspace 级同一同步临界区串行化绑定替换、Agent 归档、旧迁移与 Skill 归档。
+2. `AgentSkillMigrationService` 启动时先校验某 Agent 的全部旧 `skills:` 与现有链接；校验成功后创建
+   缺少的链接、用临时文件原子替换移除该键的 `AGENT.md`；异常删除本次新链接并保留原文。进程崩溃
+   后重跑保持幂等并收敛。
+3. 新建/编辑 API 拒绝重新写入 frontmatter `skills:`；`AgentStore.writeAll` 禁止普通文件占用保留的
+   `skills/` 绑定命名空间。
+4. Skill 归档扫描活跃 Agent 与平铺的历史 Agent 归档目录，跳过专用 `archive/skills/`；有引用即
+   返回结构化完整列表，无引用才移动完整目录。`archive/skills` 是保留命名空间：Agent 名为
+   `skills` 时归档到带时间戳的平铺目录；升级前若该路径已是旧归档 Agent，先无损改名再建 Skill
+   归档根。归档区不参与已安装 Skill 扫描和 prompt。
+
+### 作者模型与 Skill 列表
+
+1. `SkillCatalog` 是外部候选查询 port，输出已过滤候选的 name、description、visibility、source、
+   installed；visibility/source 只属于查询结果，不写进 `SKILL.md`、Profile 或数据库，OryxOS 不做
+   ACL。现有 `SkillService`/Registry 仍只表示本机已安装实体。
+2. Web 暴露独立 catalog 查询；作者模型只看到“外部 catalog 结果 ∩ 本机合法已安装 Skill”。未安装项
+   可以展示但禁选，本阶段不得因模型建议而隐式联网安装。
+3. 用户所选 Skill 作为 required 集合；作者模型可在同一候选列表中建议额外 Skill，但不能发明名称。
+4. 生成响应用瞬时 sidecar 分开返回 files、required、suggested、bindingSkills；该列表只属于草稿，
+   不写入任一 Agent 文件。
+5. 保存时后端重新计算并验证最终集合仍来自可用 catalog 且已安装，然后原子同步 Agent 本地
+   软连接。生成文件不得包含 `skills:` 或 `skills/**` 内容。
+
+### 真实路径安全
+
+1. core 提供无状态 `RealPathBoundary` 供 `WhitelistSandbox`、Workspace API、AgentStore 与 SkillStore
+   复用；白名单根、已存在目标均解析 `toRealPath()` 后比较。
+2. 不存在目标从目标向上用 `NOFOLLOW_LINKS` 找最近已存在节点，解析其真实路径再拼回尚不存在的
+   后缀；最终/中间悬空链接、链接环或无法解析路径直接拒绝。
+3. Agent Skill 绑定额外校验：链接必须相对、词法和真实目标均在公共 Skill 根、链接名/目录名/
+   frontmatter name 一致。
+4. `WorkspaceApiController` 的读、写、下载使用同一边界规则；目录树把软连接渲染为 link 叶节点而
+   不递归跟随，避免越界遍历、内容重复和链接环。Agent 文件浏览器禁止经 `agents/*/skills/**`
+   编辑共享 Skill，修改共享内容必须走顶层 Skill 管理入口。
+5. Java 便携 NIO 无法彻底消除同一主机恶意进程在校验后换链的 TOCTOU；本阶段威胁模型覆盖配置、
+   手工残留和 Agent 发起的确定性路径逃逸，不覆盖同 OS 用户恶意进程竞态。
+
+## Delivery Order
+
+1. 用失败测试固定绑定分类、三级 prompt、原子迁移和真实路径行为。
+2. 完成 core 绑定/迁移/catalog 模型，移除 `Profile.skills`，再切换 `ContextLoader`。
+3. 完成 Skill 归档与 Agent 生命周期/作者生成流程，随后以显式 bean 参数依赖接入启动顺序：已安装
+   Skill 加载/内置播种 → 绑定服务 → legacy 迁移 → reconcile → Profile 扫描/调度 → Watcher。
+4. 更新 Web contracts、DTO 和管理台；封住工作区树与文件入口的软连接问题。
+5. 跑目标测试、前端构建、全量 `mvn test`/`mvn verify` 和 quickstart 场景。
+
+## Complexity Tracking
+
+无宪章违例。新增 `SkillCatalog` 是为了隔离“外部候选查询”和“已安装文件实体”，但它不保存 Agent
+绑定、不引入网络客户端或数据库；新增迁移服务是一次性兼容旧格式所需，迁移完成后不会留并行模型。

--- a/specs/012-agent-skill-links/quickstart.md
+++ b/specs/012-agent-skill-links/quickstart.md
@@ -1,0 +1,173 @@
+# Quickstart: 验证 Agent Skill 三级渐进加载
+
+## Prerequisites
+
+- Java 21、Maven、支持符号链接的本地文件系统。
+- 使用临时 `oryxos.root`，不要对真实工作区做归档测试。
+- 已启动 OryxOS Web 服务，或使用 MockMvc/MockProvider 集成测试。
+
+## 1. 创建已安装 Skill
+
+```bash
+curl -X POST http://localhost:8080/api/v1/skills \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"report-format","description":"结构化报告规范","body":"正文标记 SKILL_BODY_SENTINEL"}'
+```
+
+预期：`.oryxos/skills/report-format/SKILL.md` 存在，`GET /api/v1/skills` 可见该实体。
+
+## 2. 直接创建 Agent 并绑定
+
+```bash
+curl -X POST http://localhost:8080/api/v1/agents \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"reporter","description":"生成日报","skillBindings":["report-format"]}'
+```
+
+预期文件系统：
+
+```text
+.oryxos/agents/reporter/skills/report-format -> ../../../skills/report-format
+```
+
+`AGENT.md` 中不得出现 top-level `skills:`，Agent 目录不得出现复制的 `SKILL.md`。
+
+## 3. 查询绑定与 catalog
+
+```bash
+curl http://localhost:8080/api/v1/agents/reporter/skills
+curl 'http://localhost:8080/api/v1/skills/catalog?visibility=all'
+```
+
+绑定响应只含 name、description、Agent 本地绝对 `skillFile` 和 issues，不含 body。catalog 响应可以
+包含公共/私有标签，但只有 `installed=true` 的合法项可用于生成绑定。
+
+## 4. 验证 Level 1：元数据常驻、正文缺席
+
+用 MockProvider 捕获首次 `ProviderRequest.systemPrompt`，或运行目标测试：
+
+```bash
+mvn -pl oryxos-core -Dtest=ProgressiveDisclosureTest,ContextLoaderTest test
+```
+
+预期：
+
+- 包含 `report-format`、`结构化报告规范` 和
+  `.oryxos/agents/reporter/skills/report-format/SKILL.md` 的绝对路径。
+- 不包含 `SKILL_BODY_SENTINEL`、references、templates 或 scripts 内容。
+- 未绑定 Skill 完全不可见；无绑定时没有空 Skill 标题。
+
+## 5. 验证 Level 2/3：工具按需读取
+
+让 MockProvider 首轮返回：
+
+```text
+read_file(<Agent 本地绝对路径>/skills/report-format/SKILL.md)
+```
+
+预期第二轮：
+
+- `SKILL_BODY_SENTINEL` 仅作为 Tool Result 出现在 history。
+- `tool_invocations` 有对应 `read_file` 成功记录。
+- 两次 provider chat 前都重新扫描绑定；在两轮之间更新 description 或解绑，第二轮 system prompt
+  立即反映新状态。
+- 若正文引用 `references/example.md` 或 `scripts/check.py`，只有模型再次调用 `read_file`/`shell` 后
+  对应内容或输出才进入后续 history。
+
+## 6. 验证作者模型自动补充但不持久化 sidecar
+
+```bash
+curl -X POST http://localhost:8080/api/v1/agents/reporter-2/generate-files \
+  -H 'Content-Type: application/json' \
+  -d '{"description":"每天调研并生成日报","requiredSkills":["report-format"]}'
+```
+
+用 catalog/author stub 让模型补充 `web-research`。预期响应分别给出 required、suggested 和二者并集
+bindingSkills；生成的 `AGENT.md` 不含 `skills:`。把 files + bindingSkills 发到保存端点后，两个 Skill
+均成为软连接。模型返回列表外或未安装名称时必须被拒绝，不能创建链接或触发下载。
+
+## 7. 验证旧 frontmatter 原子迁移
+
+在启动前准备旧 Agent：
+
+```yaml
+---
+name: legacy-agent
+provider:
+  name: mock
+  model: mock
+skills:
+  - report-format
+---
+旧正文
+```
+
+重启后预期：
+
+- `skills/report-format` 链接存在。
+- `AGENT.md` 其它 frontmatter 与正文保持，只有 top-level `skills:` 被移除。
+- 再次重启不产生额外变化。
+
+再构造一个引用不存在 Skill 的旧 Agent。预期该 Agent 原始文件字节不变、没有部分链接、问题 API
+返回 `STALE_REFERENCE`，其它 Agent 正常迁移和启动。
+
+## 8. 验证活跃/归档引用保护与 Skill 归档
+
+绑定存在时：
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/skills/report-format
+```
+
+预期 `409`，响应结构化列出活跃引用。将 Agent 归档后再次请求，仍为 `409`，引用状态变为
+`ARCHIVED`；归档 Agent 的 `../../../skills/report-format` 仍可解析。
+
+在所有活跃与归档引用都解绑后再次删除，预期：
+
+- `.oryxos/skills/report-format` 消失。
+- `.oryxos/archive/skills/report-format-<timestamp>/` 完整保留 `SKILL.md` 和附属资源。
+- `GET /api/v1/skills`、catalog installed 交集和所有 prompt 均不再包含它。
+
+## 9. 验证一致性与真实路径沙箱
+
+```bash
+curl http://localhost:8080/api/v1/skills/binding-issues
+mvn -pl oryxos-core,oryxos-tool,oryxos-web test
+```
+
+必须覆盖：
+
+- dangling、escaped、invalid-target、name-mismatch、stale-reference 五类问题。
+- 白名单根内链接指向根外文件时 read/write/download 全部拒绝。
+- 父目录链接逃逸下的不存在写目标不在根外产生文件。
+- dangling link、多跳 link 和 link cycle fail closed。
+- 合法 Agent Skill 链接在白名单包含整个 `.oryxos` 时允许读取；只允许 Agent 子目录而未允许共享
+  Skill 根时拒绝。
+- Workspace tree 把链接作为叶节点，不递归越界或死循环。
+
+## 10. Quality gates
+
+```bash
+cd oryxos-web/src/main/frontend && npm run build
+cd ../../../..
+mvn test
+mvn verify
+git diff --check
+```
+
+全部通过后，再按 [HTTP contract](contracts/skill-bindings.md) 核对响应字段和状态码。
+
+## 11. 最终验证记录（2026-07-27）
+
+- `npm run build`：通过；Vite 生产构建完成，15 个模块转换成功。
+- `mvn test`：通过；全仓 397 个测试，0 failure、0 error、0 skipped。
+- `mvn verify`：通过；Spotless、P3C/PMD、Checkstyle、SpotBugs/Find Security Bugs 均为 0
+  violation。仓库当前配置明确输出 `Skipping dependency-check`，因此本次没有生成 OWASP 依赖漏洞报告。
+- 三级 prompt 与实时刷新：`ProgressiveDisclosureTest`、`ContextLoaderTest`、
+  `ReActLoopSkillDisclosureTest` 覆盖仅注入元数据/入口、按需 `read_file`、工具审计及下一轮刷新。
+- catalog、作者建议、绑定 CRUD 与完整归档：core 生命周期测试和 Web MockMvc 合同测试覆盖 PUBLIC/PRIVATE
+  查询、required ∪ suggested、失败回滚、活跃/归档引用 409 与无引用完整目录归档。
+- legacy 与一致性：迁移及启动顺序测试覆盖单 Agent 原子迁移、幂等、坏 Agent 隔离，以及 dangling、
+  escaped、invalid-target、name-mismatch、stale-reference 五类问题。
+- 真实路径边界：core/tool/web 测试覆盖最终链接、父链接、多跳、dangling、链接环、不存在写目标、
+  Workspace tree 叶节点和 Agent 本地合法 Skill 链接。

--- a/specs/012-agent-skill-links/research.md
+++ b/specs/012-agent-skill-links/research.md
@@ -1,0 +1,218 @@
+# Research: Agent Skill 软连接绑定与三级渐进加载
+
+## D1：Agent 本地固定相对软连接是唯一绑定事实
+
+**Decision**: `.oryxos/agents/<agent>/skills/<skill>` 必须精确指向
+`../../../skills/<skill>`；Agent 与 Skill 名均为安全单目录段。frontmatter、Registry、生成草稿和
+catalog 都不得作为运行时绑定来源。
+
+**Rationale**: 单一文件系统事实同时表达能力边界和共享关系；固定相对目标可验证、可迁移，而且
+Agent 从 `agents/<name>` 移到同深度 `archive/<name[-timestamp]>` 后仍有效。
+
+**Alternatives considered**:
+
+- frontmatter `skills:`：会形成第二真相源，已否决。
+- 复制 Skill 内容到 Agent：更新漂移且浪费空间，已否决。
+- 任意安全相对路径：语义虽可能等价，但不利于残留检测和一致性修复，已否决。
+- 绝对链接：工作区迁移即失效，也扩大越界风险，已否决。
+
+## D2：每次 LLM 调用执行三级渐进披露
+
+**Decision**:
+
+1. `ContextLoader` 每次只注入有效绑定的 name、description 和 Agent 本地绝对 `SKILL.md` 路径。
+2. 模型需要时用现有 `read_file` 读取 `SKILL.md`，正文以 Tool Result 进入下一轮 ReAct history。
+3. 正文提到的 references/templates/scripts 再经 `read_file`/`shell` 按需获取。
+
+**Rationale**: 现有调用链 `ReActLoop` 每轮都执行 `PromptBuilder.build()`，后者每次调用
+`ContextLoader.load()`；把扫描放这里即可保证“一次 provider chat 对应一次新目录快照”。
+
+**Alternatives considered**:
+
+- 每个用户请求只扫一次：同一 ReAct 中途修改无法生效，已否决。
+- 预载全部正文：绑定越多 system prompt 越大，违反宪章 IV，已否决。
+- 新增 `use_skill`：把上下文资源误建模成 Tool，已否决。
+- 扫描所有安装 Skill：暴露未绑定能力，已否决。
+
+## D3：目录构建只读 Skill frontmatter
+
+**Decision**: 新增 `SkillMetadataReader`，只读取 `SKILL.md` 第二个 `---` 之前的 frontmatter；要求
+name、description 和非空正文边界可验证，但目录构建不得把正文装入 `Skill`/prompt。完整正文只允许
+通过工具读取。
+
+**Rationale**: “不注入正文”之外，还应避免每轮为了目录发现构造完整正文对象；元数据读取与完整
+Skill CRUD 解析职责分开更符合渐进披露。
+
+**Alternatives considered**:
+
+- 复用 `SkillLoader.deriveSkill()` 全文读取再丢弃 body：输出正确但不是真正元数据级加载，已否决。
+- 缓存元数据：会让手工编辑在下一轮不生效，已否决。
+
+## D4：core 内区分只读发现边界和写协调服务
+
+**Decision**: `AgentSkillBindingReader.inspect(agent)` 返回稳定排序的 bindings + issues；
+`AgentSkillBindingService` 实现它，并提供 bind、unbind、atomic replace、references、reconcileAll。
+`ContextLoader` 只依赖 Reader，不依赖 `SkillRegistry` 或 CRUD。
+
+**Rationale**: prompt 只需要实时只读视图；写操作、引用反查和锁策略不应渗入上下文组装。
+
+**Alternatives considered**:
+
+- Web Controller 直接操作链接：启动、CLI 和 prompt 无法复用，已否决。
+- 放入 `oryxos-tool`：Skill 不是可执行 Tool，违反模块边界，已否决。
+- 新建 Maven 模块：当前规模不需要，已否决。
+
+## D5：坏绑定结构化报告、跳过但不自动修复
+
+**Decision**: 统一分类 `DANGLING`、`ESCAPED`、`INVALID_TARGET`、`NAME_MISMATCH`、
+`STALE_REFERENCE`。其中 stale 包括残留旧 frontmatter 或非有效 Agent 目录中的绑定；归档 Agent 的
+合法链接不是 stale。prompt 只消费有效项，协调扫描不删除用户文件。
+
+**Rationale**: 文件系统允许外部手工修改；安全默认应是“不注入 + 可观察”，而不是静默接受或擅自
+破坏现场。
+
+**Alternatives considered**:
+
+- 遇一个坏链接阻断整个 Agent：合法能力也不可用，可用性差。
+- 自动删除坏链接：可能删除运营者正在修复的文件。
+- 只写普通日志：管理台无法呈现结构化问题。
+
+## D6：旧 `skills:` 在启动时按单 Agent 原子迁移
+
+**Decision**: `AgentSkillMigrationService` 在 Profile 扫描和 Watcher 启动前运行。它先验证全部 legacy
+名称、安装实体和现有槽位；再写 AGENT.md 临时文件、创建并验证临时链接、原子移动链接，最后用
+`ATOMIC_MOVE + REPLACE_EXISTING` 提交去掉顶层 `skills` 键的新 AGENT.md。任何异常回滚本次新增，
+不支持原子移动的文件系统明确失败。
+
+**Rationale**: AGENT.md 最后提交可保证不会出现“旧字段已删但链接缺失”；进程若在提交前崩溃，
+下次把已存在合法链接当作幂等状态即可收敛。
+
+**Alternatives considered**:
+
+- 在 `ProfileLoader` 边解析边迁移：让纯解析器产生文件副作用，已否决。
+- 先删 frontmatter 再建链接：崩溃会丢失能力，已否决。
+- 非原子覆盖或部分成功：违反 clarify 结论，已否决。
+
+## D7：绑定替换、迁移和 Skill 归档共用工作区临界区
+
+**Decision**: 同一 `AgentSkillBindingService` 实例持有 workspace 级同步锁；bind/unbind/replace、legacy
+迁移、Agent 归档和 Skill 归档都在该边界内先全量验证、记录变更、执行并在失败时回滚。当前保证同一
+OryxOS 进程内不产生已确认成功的悬空状态。
+
+**Rationale**: 只分别给 `SkillService.delete` 和 `bind` 加锁无法关闭查引用到移动目录之间的竞态。
+
+**Alternatives considered**:
+
+- 数据库绑定表/分布式锁：本阶段绑定真相在文件系统且是单实例，复杂度不必要。
+- 逐项 replace 不回滚：中途 IO 失败会形成半套能力，已否决。
+
+## D8：Skill 删除改为完整目录归档
+
+**Decision**: 先扫描活跃与归档 Agent 引用；非空返回结构化引用并拒绝。无引用时把整个目录移动到
+`.oryxos/archive/skills/<name>-<timestamp>/`，绝不覆盖已有归档，成功后再移出安装 Registry。
+
+**Rationale**: 保留来源、正文和所有附属资源，符合项目对 Agent 删除同样采用归档的可追溯原则。
+
+**Alternatives considered**:
+
+- 物理递归删除：不可恢复，已被 clarify 否决。
+- 级联解绑：影响多个 Agent，违反最小惊讶原则。
+- 把归档留在 `.oryxos/skills/.archive`：容易被安装扫描误收录，已否决。
+
+## D9：保留平铺 Agent 归档并预留 `archive/skills`
+
+**Decision**: Agent 继续归档到 `.oryxos/archive/<agent[-timestamp]>`，保持链接相对深度；
+`archive/skills` 作为 Skill 归档保留命名空间。Agent 名为 `skills` 时强制带时间戳。升级时若
+`archive/skills/AGENT.md` 是旧归档 Agent，先无损改名再建立 Skill 归档根。
+
+**Rationale**: 把 Agent 改到 `archive/agents/` 会多一层目录，使现有 `../../../skills/...` 链接失效。
+
+**Alternatives considered**:
+
+- 重构全部 Agent 归档并重写链接：范围大、升级风险高，已否决。
+- 不处理保留名冲突：真实存在数据覆盖风险，已否决。
+
+## D10：外部 catalog 与本机安装列表分离
+
+**Decision**: `SkillCatalog` port 查询 name、description、visibility、source、installed；访问过滤由
+adapter 负责，OryxOS 不保存 owner/scope 或实现 ACL。现有 `SkillService`/Registry 仍表示
+`.oryxos/skills` 中的本机安装实体。作者模型只看到 catalog 结果与合法已安装集合的交集；未安装项
+可展示但禁选，本阶段不自动联网安装。
+
+**Rationale**: 公共/私有是候选列表属性，不应污染绑定或复制 Skill；外部协议尚未确定，以 core port
+隔离可避免锁死某个服务。
+
+**Alternatives considered**:
+
+- 把 visibility/source 写进 Profile 或绑定索引：与能力绑定无关，已否决。
+- OryxOS 自建 Skill ACL：当前核心阶段明确无认证/RBAC，已否决。
+- 模型建议即自动下载：供应链和失败语义未定义，已否决。
+
+## D11：作者建议使用瞬时 sidecar，不写 Agent 文件
+
+**Decision**: 生成响应分别携带 files、requiredSkills、suggestedSkills、bindingSkills。模型建议必须
+来自本次 catalog 候选；保存请求显式携带最终 `skillBindings`，后端再次验证后建立链接。新建/保存
+拒绝 `AGENT.md skills:` 和任何 `skills/**` 普通文件。
+
+**Rationale**: 草稿可以表达自动选择且允许管理台预览，但保存成功后唯一事实仍是软连接。
+
+**Alternatives considered**:
+
+- 模型继续写 frontmatter：直接违反宪章 IV。
+- 生成隐藏 manifest 并落盘：形成第二持久化索引，已否决。
+- 只支持用户手选：不符合 clarify 选定的“用户必选 + 模型补充”。
+
+## D12：真实路径投影集中复用
+
+**Decision**: core 提供 `RealPathBoundary.project(path)`：absolute+normalize 后，从目标向上用
+`NOFOLLOW_LINKS` 找最近已存在节点，调用 `toRealPath()` 解析链接链，再拼回未存在尾段。白名单根也
+投影一次，目标每次投影后用 `startsWith(canonicalRoot)` 比较。dangling、链接环和无法解析路径均拒绝。
+
+**Rationale**: 默认 `Files.exists()` 会跟随链接，把 dangling link 错当不存在；纯
+`normalize()+startsWith()` 又无法识别允许根中的外跳链接。
+
+**Alternatives considered**:
+
+- 禁止所有软连接：会阻断合法 Skill 绑定。
+- 只解析最终目标：不存在写目标和父目录软连接仍可逃逸。
+- 只修 `WhitelistSandbox`：Workspace API 与 Store 仍能绕过，已否决。
+
+## D13：所有文件入口与目录树同步加固
+
+**Decision**: `WhitelistSandbox`、`WorkspaceApiController`、`AgentStore`、`SkillStore` 复用真实路径
+边界。工作区 tree 把软连接显示为 link 叶节点而不递归；Agent 文件浏览器拒绝通过
+`agents/*/skills/**` 编辑共享内容，共享 Skill 修改走顶层管理入口。
+
+**Rationale**: 当前 Workspace tree 会跟随链接递归，既可能越界，也可能因链接环无限递归；Store 的
+lexical startsWith 也会沿现有恶意链接写到工作区外。
+
+**Alternatives considered**:
+
+- 只靠 Tool 沙箱：管理 API 和 Store 不经过它，覆盖不完整。
+- 对链接递归但维护 visited set：仍重复展示共享内容，且让 Agent 文件入口绕过 Skill CRUD。
+
+## D14：启动顺序用显式依赖表达
+
+**Decision**: 装配顺序为：安装 Skill 加载 → 内置 Skill 播种 → 绑定服务 → legacy 迁移 → reconcile
+报告 → Profile 扫描/调度 → AgentLifecycle/WorkspaceWatcher → ContextLoader/PromptBuilder/ReActLoop。
+用 bean 参数依赖或 startup report 表达，不依赖源码声明顺序。
+
+**Rationale**: legacy 可能引用内置 Skill；迁移必须在 Profile/Watcher 观察 Agent 前完成。
+
+**Alternatives considered**:
+
+- 靠 `@Bean` 方法排列：Spring 不保证语义足够清晰，测试也难固定。
+- Watcher 启动后迁移：会产生重复注册和中间状态，已否决。
+
+## D15：TOCTOU 威胁边界
+
+**Decision**: 本阶段防御配置错误、手工残留和 Agent 发起的确定性链接逃逸；不承诺阻止同一 OS 用户
+恶意进程在校验与 IO 之间替换链接。所有项目内 CRUD 仍通过共享锁和先校验后 IO 缩小窗口。
+
+**Rationale**: Java 便携 NIO 没有能覆盖所有操作与平台的目录句柄式原子 API；
+`SecureDirectoryStream` 也非普遍可用。
+
+**Alternatives considered**:
+
+- 声称完全消除本地 TOCTOU：无法验证，已否决。
+- 引入本地守护进程/原生 syscall：超出本阶段范围。

--- a/specs/012-agent-skill-links/spec.md
+++ b/specs/012-agent-skill-links/spec.md
@@ -1,0 +1,198 @@
+# Feature Specification: Agent Skill 软连接绑定与渐进式加载
+
+**Feature Branch**: `codex/agent-skill-progressive-loading`
+
+**Created**: 2026-07-26
+
+**Status**: Approved
+
+**Input**: Issue #40 已商议通过：公共 Skill 统一存储，每个 Agent 通过自身 `skills/` 下的相对软连接
+选择可见 Skill；每轮 prompt 只加载这些 Skill 的名称、描述和读取路径，正文与附属资源按需加载；
+CRUD 和启动恢复必须检测残留、悬空与越界链接。
+
+## Clarifications
+
+### Session 2026-07-26
+
+- Q: 旧版 `AGENT.md` 中已有的 `skills:` 应如何处理？ → A: 启动时原子转换为本地软连接；全部成功后删除 frontmatter 字段，失败则保持原文件并报告。
+- Q: 删除公共 Skill 时，归档 Agent 中的软连接是否也算引用？ → A: 算；活跃与归档 Agent 的引用均阻止删除并完整列出，且无引用时的“删除”改为归档整个 Skill 目录，不物理删除。
+- Q: 无引用 Skill 被“删除”后归档到哪里？ → A: `.oryxos/archive/skills/<name>-<timestamp>/`。
+- Q: 创建或生成 Agent 时初始 Skill 绑定由谁决定，公共/私有 Skill 如何存储？ → A: 用户选择是必选项，作者模型可从外部列表自动补充公共或私有 Skill；两类安装后都统一存放在 `.oryxos/skills/<name>/`，公共/私有仅是列表的来源或可见性属性，Agent 一律用本地软连接绑定，不保存私有副本。
+- Q: 私有 Skill 的访问控制由谁负责？ → A: 外部 Skill 列表只返回调用者可访问的结果；OryxOS 本阶段不实现 Skill ACL，暂不考虑 owner/scope、认证或 RBAC。
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Agent 按需使用已绑定 Skill (Priority: P1)
+
+Agent 被触发时能看到自己已绑定 Skill 的名称与用途，但不会为未使用的 Skill 消耗正文上下文。
+当任务命中某个 Skill 时，Agent 才读取完整指令并继续执行。
+
+**Why this priority**: 这是渐进式加载的核心用户价值：既能发现能力，又控制上下文成本。
+
+**Independent Test**: 给 Agent 绑定两个带独特正文标记的 Skill，触发一次 prompt 组装；结果只含
+两者名称、描述与本地读取路径，不含正文标记。随后让模型调用文件工具读取其中一个，只有该 Skill
+正文进入下一轮上下文并产生审计记录。
+
+**Acceptance Scenarios**:
+
+1. **Given** Agent 绑定两个 Skill，**When** 组装 prompt，**Then** 两个 Skill 的名称、描述和读取路径
+   按名称稳定出现，正文和附属资源均不出现。
+2. **Given** prompt 含某 Skill 的描述和读取路径，**When** 模型选择并读取它，**Then** 正文作为
+   工具结果进入下一轮 ReAct 上下文，调用写入工具审计。
+3. **Given** 公共库还有未绑定 Skill，**When** 组装该 Agent prompt，**Then** 未绑定 Skill 不可见。
+4. **Given** Skill 描述或绑定关系已修改，**When** 下一轮组装 prompt，**Then** 新状态立即生效，
+   无需重启。
+
+---
+
+### User Story 2 - 管理员安全管理公共 Skill 与 Agent 绑定 (Priority: P1)
+
+管理员可以创建、导入和更新公共 Skill，并为指定 Agent 绑定或解绑；绑定不会复制 Skill 内容，
+一个公共实体更新后所有绑定 Agent 下一轮都看到新元数据。
+
+**Why this priority**: 公共复用和 Agent 能力边界必须同时成立，否则会出现内容复制或全局能力泄漏。
+
+**Independent Test**: 创建一个公共 Skill，将其绑定到两个 Agent，核对两个 Agent 均生成相对软连接；
+更新描述后两者下一轮 prompt 同步变化；解绑其中一个只移除本地绑定，不影响公共实体和另一个 Agent。
+
+**Acceptance Scenarios**:
+
+1. **Given** 公共 Skill 存在，**When** 为 Agent 绑定，**Then** Agent 本地出现指向公共实体的相对
+   软连接，重复绑定不会产生重复状态。
+2. **Given** 两个 Agent 绑定同一 Skill，**When** 更新公共 Skill，**Then** 两者下一轮均读取新描述
+   和新正文。
+3. **Given** Agent 已绑定 Skill，**When** 解绑，**Then** 只删除该 Agent 的绑定，公共实体不受影响。
+4. **Given** 公共 Skill 仍被 Agent 引用，**When** 删除它，**Then** 删除被拒绝并返回引用 Agent
+   列表，不产生悬空链接。
+5. **Given** 用户在创建 Agent 时选择必选 Skill，且外部列表提供其它可访问的公共或私有 Skill，
+   **When** 作者模型生成 Agent，**Then** 用户所选项全部绑定，模型可按任务额外选择列表中的 Skill；
+   后端只为有效选择创建软连接，不复制内容、不接受列表外名称。
+
+---
+
+### User Story 3 - 运行时发现损坏或残留绑定 (Priority: P2)
+
+运维人员在启动或 CRUD 后能发现不一致的 Skill 绑定，系统不会把损坏绑定静默注入 Agent prompt。
+
+**Why this priority**: 软连接是文件系统状态，手工变更、异常中断或归档都可能产生残留，必须可观测。
+
+**Independent Test**: 构造悬空、越界、缺少主文件、名称不一致的绑定，执行协调扫描；结果逐项分类，
+无效绑定不进入 prompt，合法绑定继续工作。
+
+**Acceptance Scenarios**:
+
+1. **Given** Agent 目录存在悬空或越界链接，**When** 启动扫描，**Then** 系统记录分类明确的错误，
+   跳过无效绑定且不阻断其它 Agent。
+2. **Given** CRUD 或 Agent 归档/删除完成，**When** 执行一致性检查，**Then** 不残留 stale reference。
+3. **Given** 合法绑定与损坏绑定并存，**When** 组装 prompt，**Then** 只包含合法绑定。
+
+---
+
+### User Story 4 - 软连接不能绕过沙箱 (Priority: P1)
+
+企业管理员允许工作区文件访问时，恶意或误配置软连接不能让 Agent 读取工作区外文件。
+
+**Why this priority**: 引入软连接会让纯字符串路径白名单失效，这是不可妥协的安全边界。
+
+**Independent Test**: 在允许根内创建指向根外文件的软连接并调用文件读取；请求必须在接触目标内容前
+被拒绝。合法的 Agent Skill 软连接仍能读取。
+
+**Acceptance Scenarios**:
+
+1. **Given** 白名单目录内软连接指向目录外，**When** 读取，**Then** 请求被拒绝且目标内容未泄漏。
+2. **Given** 新文件路径的父目录经软连接逃逸，**When** 写入，**Then** 请求被拒绝且目录外不产生文件。
+3. **Given** Agent Skill 使用受控相对软连接指向公共 Skill 根，**When** 读取，**Then** 沙箱放行。
+
+### Edge Cases
+
+- Agent 没有 `skills/` 目录或目录为空时，不注入空标题和噪声。
+- `SKILL.md` 缺 name、description、正文为空或编码不可读时，绑定被分类为无效并给出可读原因。
+- 链接名、公共目录名和 `SKILL.md` name 不一致时，不进入 prompt。
+- Agent/Skill 名含路径分隔符、`.`、`..` 或绝对路径时，CRUD 必须拒绝。
+- 公共 Skill 删除与 Agent bind 并发时，最终状态不能出现已确认成功的悬空绑定。
+- Agent 归档后相对软连接仍须正确指向公共实体；物理删除 Agent 时不得删除公共 Skill。
+- 公共 Skill 归档前必须确认活跃与归档 Agent 均无引用；归档保留 `SKILL.md` 和全部附属资源。
+- 同名 Skill 多次创建、归档时，时间戳归档目录不得覆盖已有历史版本；归档目录不得被公共 Skill
+  扫描或进入任何 Agent prompt。
+- 自定义相对或绝对工作区根时，绑定、prompt 路径和沙箱判断保持一致。
+- 公共与私有 Skill 同名时属于同一安装名称冲突，系统必须拒绝第二个实体，不得靠来源或可见性
+  形成两个同名目录。
+- 旧版 `skills:` 引用含不存在或无效 Skill 时，本次迁移整体失败：不得创建部分链接、不得改写
+  `AGENT.md`；该 Agent 的旧字段不作为运行时绑定，只报告明确迁移错误。
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 系统 MUST 以共享 Skill 目录保存唯一已安装内容实体，每个实体 MUST 有可校验的名称
+  和描述；公共/私有只作为外部列表的来源或可见性属性，不改变安装路径与全工作区名称唯一性。
+- **FR-002**: Agent 可见 Skill MUST 且只能由 Agent 本地 `skills/` 中的受控相对软连接表达；
+  frontmatter 或其它索引 MUST NOT 成为第二绑定真相源。
+- **FR-003**: 每轮 prompt MUST 重新发现当前 Agent 的全部有效绑定，按名称稳定排列，只暴露名称、
+  描述和 Agent 本地读取路径。
+- **FR-004**: 系统 MUST NOT 在 prompt 中预载 Skill 正文、参考、模板或脚本。
+- **FR-005**: Skill 正文与附属资源 MUST 通过既有文件/命令能力按需进入 ReAct 上下文，并保留审计。
+- **FR-006**: 系统 MUST 支持已安装 Skill 的创建、导入、读取、更新和安全归档；用户发起“删除”时
+  MUST 将完整 Skill 目录移动到 `.oryxos/archive/skills/<name>-<timestamp>/` 而非物理删除，且不得
+  覆盖已有归档。
+- **FR-007**: 系统 MUST 支持 Agent Skill 的绑定、解绑和查询；绑定创建必须幂等且不得复制内容。
+- **FR-008**: 归档仍被引用的公共 Skill MUST 被拒绝，并返回所有活跃与归档引用 Agent；不得制造
+  悬空链接。
+- **FR-009**: CRUD、Agent 归档/删除与启动恢复 MUST 检测 dangling、escaped、invalid-target、
+  name-mismatch 和 stale-reference，且无效绑定 MUST NOT 进入 prompt。
+- **FR-010**: 文件沙箱 MUST 按真实路径判断已存在目标；创建路径 MUST 按最近已存在父目录的真实路径
+  判断，阻止软连接逃逸。
+- **FR-011**: Agent Skill 绑定 MUST 拒绝绝对软连接、链式越界和公共 Skill 根之外的目标。
+- **FR-012**: Skill 内容或绑定修改 MUST 在下一轮 prompt 生效，不依赖进程重启或缓存失效。
+- **FR-013**: 工作区浏览、Agent 管理与 Skill 管理界面 MUST 展示新的绑定模型和可读一致性错误。
+- **FR-014**: 系统 MUST 支持自定义工作区根，所有暴露给模型的读取路径 MUST 是规范化绝对路径。
+- **FR-015**: 启动时发现旧版 `AGENT.md` 的 `skills:` MUST 执行单 Agent 原子迁移：先校验全部
+  引用，再创建对应本地软连接并删除该 frontmatter 字段；任一步失败 MUST 回滚本次创建的链接、
+  保持原文件不变并报告，旧字段本身 MUST NOT 参与运行时绑定。
+- **FR-016**: 外部 Skill 列表 MUST 支持查询公共和私有 Skill，并为作者模型提供名称、描述、
+  来源/可见性元数据；访问过滤由外部列表负责，OryxOS MUST 只消费其返回结果且 MUST NOT 在本阶段
+  实现 Skill ACL。列表结果 MUST NOT 直接成为 Agent 绑定。
+- **FR-017**: 创建或生成 Agent 时，用户明确选择的 Skill MUST 全部绑定；作者模型 MAY 从外部列表
+  自动补充公共或私有 Skill。所有候选 MUST 经存在性、可见性和名称校验后创建 Agent 本地软连接，
+  列表外或不可访问候选 MUST 被拒绝，Agent 目录 MUST NOT 保存 Skill 内容副本。
+
+### Key Entities
+
+- **已安装 Skill 实体**: `.oryxos/skills/<name>/` 下唯一的可复用指令目录，包含名称、描述、正文和
+  可选附属资源；公共/私有不产生不同的物理副本。
+- **外部 Skill 列表项**: 可供查询和自动选择的候选元数据，包含名称、描述及公共/私有来源或可见性；
+  只有安装并绑定后才成为 Agent 能力。
+- **Agent Skill 绑定**: Agent 本地、指向公共 Skill 实体的相对软连接，是唯一绑定事实。
+- **Skill 元数据目录**: 当前 Agent 每轮可见的有效 Skill 名称、描述和本地读取路径集合。
+- **一致性问题**: 某个绑定的分类结果，包括 dangling、escaped、invalid-target、name-mismatch、
+  stale-reference 及可读原因。
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 对任意绑定集合，prompt 中 100% 出现有效绑定的名称和描述，0% 出现正文标记或未绑定 Skill。
+- **SC-002**: 绑定 Skill 被选择后，一个标准 ReAct 流程可在下一轮获得完整正文，并留下对应工具审计。
+- **SC-003**: 公共 Skill 更新后，所有绑定 Agent 在下一轮 prompt 中看到新描述，无需重启。
+- **SC-004**: 所有公共 Skill 归档操作均不会产生悬空绑定或物理删除内容；存在引用时 100% 返回
+  完整的活跃与归档引用 Agent 列表。
+- **SC-005**: dangling、escaped、invalid-target、name-mismatch、stale-reference 五类问题均有自动化测试，
+  且无效绑定注入率为 0。
+- **SC-006**: 工作区内指向工作区外的读/写软连接逃逸测试 100% 被拦截，合法 Skill 软连接 100% 放行。
+- **SC-007**: 新增功能与既有功能通过全部项目质量门禁，自动化测试无失败。
+- **SC-008**: 对合法旧配置，启动迁移 100% 生成等价绑定且移除 `skills:`；对含任一非法引用的
+  旧配置，100% 保持原文件和迁移前绑定状态不变并返回可读错误。
+- **SC-009**: Agent 生成结果 100% 保留用户必选 Skill；模型补充项 100% 来自调用者可访问列表且
+  通过后端校验，0% 产生 Skill 内容副本或列表外绑定。
+
+## Assumptions
+
+- 公共 Skill CRUD 继续复用现有管理入口；本特性调整绑定语义和安全行为，不引入新的持久化表。
+- 一个 Agent 可以绑定零到多个 Skill，同一个公共 Skill 可以被多个 Agent 复用。
+- 公共 Skill 被活跃或归档 Agent 引用时拒绝归档；本阶段不提供强制级联解绑或物理删除。
+- 损坏绑定默认报告并跳过，不自动删除用户文件；显式解绑和删除操作保证自身不制造残留。
+- Agent 运行阶段只从当前绑定元数据中按需选择；基于外部列表的公共/私有 Skill 自动选择只发生在
+  Agent 创建或生成阶段。
+- 私有 Skill 的 owner/scope、认证、授权和 RBAC 不在本特性范围；外部列表负责只返回调用者可访问
+  的候选，OryxOS 不保存或推断访问策略。
+- 旧版 frontmatter 迁移以单个 Agent 为原子边界；一个 Agent 迁移失败不阻断其它 Agent 的迁移与启动。

--- a/specs/012-agent-skill-links/tasks.md
+++ b/specs/012-agent-skill-links/tasks.md
@@ -1,0 +1,270 @@
+# Tasks: Agent Skill 软连接绑定与三级渐进加载
+
+**Input**: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/skill-bindings.md`,
+`quickstart.md`
+
+**Tests**: 本特性的 spec 明确要求自动化验证渐进加载、工具审计、原子迁移、五类一致性问题和软连接
+逃逸；所有故事均按“先写失败测试，再实现”执行。
+
+**Organization**: 任务按 User Story 分组。US1 是运行时 MVP；US2、US4 在共享基础完成后可独立推进；
+US3 最后把迁移、启动恢复和运维诊断接入完整生命周期。
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: 可与同阶段其它标记任务并行，修改不同文件且不依赖未完成任务。
+- **[Story]**: 对应 `spec.md` 中的 US1/US2/US3/US4。
+
+## Phase 1: Setup — 测试地基与旧草稿对齐
+
+**Purpose**: 建立跨故事可复用的文件系统测试夹具，并把现有 pre-clarify 草稿显式纳入重构范围。
+
+- [x] T001 在 `oryxos-core/src/test/java/io/oryxos/core/skill/SkillWorkspaceFixture.java` 建立可创建临时 Agent、已安装 Skill、固定相对链接和损坏链接的共享测试夹具
+- [x] T002 [P] 在 `oryxos-tool/src/test/java/io/oryxos/tool/sandbox/SandboxPathFixture.java` 建立外部目录、父链接、多跳链接、dangling 链接和链接环测试夹具
+- [x] T003 [P] 在 `oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java`、`oryxos-core/src/test/java/io/oryxos/core/context/ContextLoaderTest.java`、`oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleServiceTest.java` 中移除旧 `Profile.skills` 与 Skill 正文预载夹具，保留 legacy 迁移专用样例
+
+---
+
+## Phase 2: Foundational — 所有故事的阻塞基础
+
+**Purpose**: 固定元数据读取、真实路径投影和无 `Profile.skills` 的公共契约。
+
+**⚠️ CRITICAL**: 本阶段完成前不得开始任何 User Story 实现。
+
+### Tests
+
+- [x] T004 [P] 在 `oryxos-core/src/test/java/io/oryxos/core/skill/SkillMetadataReaderTest.java` 添加仅解析 frontmatter、name/description/正文边界校验、目录名不一致和不可读文件的失败测试
+- [x] T005 [P] 在 `oryxos-core/src/test/java/io/oryxos/core/fs/RealPathBoundaryTest.java` 添加存在目标、不存在普通目标、父链接、dangling、多跳、链接环和根自身为链接的投影失败测试
+- [x] T006 [P] 在 `oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java` 添加运行时 Profile 不再产生 `skills` 字段且新建/更新可识别 legacy 顶层键的失败测试
+
+### Implementation
+
+- [x] T007 [P] 在 `oryxos-core/src/main/java/io/oryxos/core/skill/BoundSkillDescriptor.java`、`BindingInspection.java`、`SkillBindingIssue.java`、`SkillReference.java`、`SkillArchive.java` 创建不可变共享模型
+- [x] T008 [P] 在 `oryxos-core/src/main/java/io/oryxos/core/skill/SkillMetadataReader.java` 实现流式 frontmatter 读取与名称、描述、非空正文边界校验，不把正文保存进目录模型
+- [x] T009 [P] 在 `oryxos-core/src/main/java/io/oryxos/core/fs/RealPathBoundary.java` 实现基于 `NOFOLLOW_LINKS` 最近存在节点的真实路径投影和根边界判断
+- [x] T010 在 `oryxos-core/src/main/java/io/oryxos/core/profile/Profile.java` 与 `oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java` 删除 `skills` 字段、访问器和解析分支，并让 legacy 检测留给迁移服务
+- [x] T011 在 `oryxos-core/src/main/java/io/oryxos/core/skill/SkillLoader.java` 与 `oryxos-core/src/main/java/io/oryxos/core/skill/SkillStore.java` 对齐 InstalledSkill 元数据完整性、目录名一致性和安全目录入口
+
+**Checkpoint**: 元数据可独立读取、真实路径可复用、Profile 不再承载绑定；所有故事可以开始。
+
+---
+
+## Phase 3: User Story 1 — Agent 按需使用已绑定 Skill (Priority: P1) 🎯 MVP
+
+**Goal**: 每次 LLM 调用只加载当前 Agent 有效 Skill 的 name/description/本地入口，正文和资源只经
+`read_file`/`shell` 按需进入后续 ReAct。
+
+**Independent Test**: 两个有效绑定、一个未绑定和一个坏绑定并存；首次 prompt 只有有效元数据且无
+正文。模型调用 `read_file` 后，正文只作为已审计 Tool Result 进入第二轮；两轮之间更新描述或解绑，
+第二轮立即反映。
+
+### Tests for User Story 1
+
+- [x] T012 [P] [US1] 在 `oryxos-core/src/test/java/io/oryxos/core/context/ProgressiveDisclosureTest.java` 添加零绑定无标题、稳定排序、仅 name/description/local absolute path、无正文/附属资源/未绑定项的失败测试
+- [x] T013 [P] [US1] 在 `oryxos-core/src/test/java/io/oryxos/core/agent/ReActLoopSkillDisclosureTest.java` 添加两轮 ReAct 集成测试，断言 `read_file` 结果与 `tool_invocations` 审计进入第二轮 history
+- [x] T014 [P] [US1] 在 `oryxos-core/src/test/java/io/oryxos/core/context/ContextLoaderTest.java` 添加两次 build 间修改 Skill 描述、解绑和修复链接后下一轮立即生效的无缓存测试
+
+### Implementation for User Story 1
+
+- [x] T015 [P] [US1] 在 `oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBindingReader.java` 定义只读 `inspect(agentName)` 边界
+- [x] T016 [US1] 在 `oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBindingService.java` 实现当前 Agent 固定相对链接的实时发现、lexical/realpath 双校验和有效绑定排序
+- [x] T017 [US1] 在 `oryxos-core/src/main/java/io/oryxos/core/context/ContextLoader.java` 改为每次调用 Reader，只渲染三级加载说明、name、description 和 Agent 本地绝对 `SKILL.md` 路径
+- [x] T018 [US1] 在 `oryxos-core/src/main/java/io/oryxos/core/agent/PromptBuilder.java` 与 `oryxos-core/src/main/java/io/oryxos/core/agent/ReActLoop.java` 保持每次 provider 调用前重新 build，并明确相对资源以 Skill 入口目录解析的 prompt 契约
+- [x] T019 [US1] 在 `oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java` 注入唯一 `AgentSkillBindingReader` 实例，移除 `ContextLoader(Path, SkillRegistry)` 兼容装配
+- [x] T020 [US1] 运行 `oryxos-core/pom.xml` 的 `ProgressiveDisclosureTest,ContextLoaderTest,ReActLoopSkillDisclosureTest`，确认 US1 独立验收全绿
+
+**Checkpoint**: US1 MVP 可独立演示，未使用 Skill 不占正文上下文，按需读取保留既有审计。
+
+---
+
+## Phase 4: User Story 2 — 管理公共 Skill 与 Agent 绑定 (Priority: P1)
+
+**Goal**: 支持 catalog 查询、绑定 CRUD/原子替换、用户必选 + 作者建议、Agent 保存，以及无引用 Skill
+完整归档；任何流程都不写 frontmatter `skills:` 或复制 Skill。
+
+**Independent Test**: 用户选择一个必选 Skill，作者模型补充一个 catalog 内已安装 Skill；保存后两个
+都是固定相对链接。两个 Agent 共享更新即时可见；解绑互不影响；活跃/归档引用阻止 Skill 归档，
+全部解绑后完整目录进入 `archive/skills`。
+
+### Tests for User Story 2
+
+- [x] T021 [P] [US2] 在 `oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillBindingServiceTest.java` 添加 bind/unbind 幂等、固定 target、普通文件冲突、原子 replace 回滚和 active/archive references 失败测试
+- [x] T022 [P] [US2] 在 `oryxos-core/src/test/java/io/oryxos/core/skill/SkillArchiveServiceTest.java` 添加有引用拒绝、无引用完整归档、不覆盖历史和 `archive/skills` 保留名兼容测试
+- [x] T023 [P] [US2] 在 `oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleSkillBindingTest.java` 添加直接创建、生成 sidecar、required ∪ suggested、列表外/未安装拒绝和全流程失败回滚测试
+- [x] T024 [P] [US2] 在 `oryxos-web/src/test/java/io/oryxos/web/controller/AgentSkillBindingApiTest.java` 添加绑定查询、单项 CRUD、原子替换、AgentView 实时 skills 和保存 skillBindings 的 MockMvc 合同测试
+- [x] T025 [P] [US2] 在 `oryxos-web/src/test/java/io/oryxos/web/controller/SkillCatalogApiTest.java` 与 `oryxos-web/src/test/java/io/oryxos/web/controller/SkillApiControllerTest.java` 添加 catalog public/private/installed 查询、503 fail-closed、409 结构化引用和归档响应合同测试
+
+### Implementation for User Story 2
+
+- [x] T026 [P] [US2] 在 `oryxos-core/src/main/java/io/oryxos/core/skill/SkillCatalog.java` 与 `oryxos-core/src/main/java/io/oryxos/core/skill/SkillCatalogEntry.java` 定义已过滤外部候选 port 和 PUBLIC/PRIVATE/installed 元数据
+- [x] T027 [US2] 在 `oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBindingService.java` 实现 bind、unbind、原子 replace、结构化 references 与 workspace 级共享临界区
+- [x] T028 [US2] 在 `oryxos-core/src/main/java/io/oryxos/core/skill/SkillStore.java` 实现移动到 `.oryxos/archive/skills/<name>-<timestamp>` 的非覆盖归档，并兼容旧 `archive/skills/AGENT.md` 数据
+- [x] T029 [US2] 在 `oryxos-core/src/main/java/io/oryxos/core/skill/SkillService.java` 将 delete 改为锁内引用检查 + archive，成功后再更新 Registry，并返回 `SkillArchive`
+- [x] T030 [US2] 在 `oryxos-core/src/main/java/io/oryxos/core/agent/AgentStore.java` 保留平铺归档深度、处理 Agent 名 `skills`，并拒绝 `writeAll` 写入保留的 `skills/**` 普通文件
+- [x] T031 [US2] 在 `oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java` 删除 frontmatter Skill 生成逻辑，改为瞬时 `GeneratedAgentDraft` sidecar、catalog 交集校验和创建/保存/调度/绑定失败回滚
+- [x] T032 [P] [US2] 在 `oryxos-web/src/main/java/io/oryxos/web/controller/dto/GeneratedFilesView.java`、`GenerateFilesRequest.java`、`SaveFilesRequest.java`、`CreateAgentRequest.java`、`AgentSkillBindingsView.java`、`SkillArchiveView.java` 创建最终 HTTP DTO
+- [x] T033 [US2] 在 `oryxos-web/src/main/java/io/oryxos/web/controller/AgentApiController.java` 与 `oryxos-web/src/main/java/io/oryxos/web/controller/dto/AgentView.java` 接入绑定查询/单项 CRUD/原子替换、sidecar 保存和实时 skills 投影
+- [x] T034 [US2] 在 `oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java` 与 `oryxos-web/src/main/java/io/oryxos/web/GlobalExceptionHandler.java` 接入 catalog 查询、SkillArchive 返回和 409 结构化引用冲突
+- [x] T035 [US2] 在 `oryxos-web/src/main/frontend/src/App.vue` 改造 Skill catalog 筛选、required/建议标识、最终 skillBindings 保存、Agent 绑定 CRUD 和归档引用展示，删除所有 frontmatter/正文预载旧文案
+- [x] T036 [US2] 运行 `oryxos-core/pom.xml` 与 `oryxos-web/pom.xml` 的 US2 core/MockMvc 测试，确认共享更新、生成保存和归档流程独立全绿
+
+**Checkpoint**: US2 管理闭环成立，外部候选/生成草稿不是绑定真相源，Skill 删除可追溯。
+
+---
+
+## Phase 5: User Story 4 — 软连接不能绕过沙箱 (Priority: P1)
+
+**Goal**: 合法工作区 Skill 链接可读；存在/不存在目标、Workspace API 和 Store 均不能借软连接访问或
+写入工作区外，目录树不跟随链接递归。
+
+**Independent Test**: 在允许根内创建指向根外的最终链接和父目录链接；read/write/download/store
+全部在 IO 前拒绝且外部不变。合法 Skill 链接在允许根覆盖真实公共实体时放行，tree 只显示 link
+叶节点并能终止链接环。
+
+### Tests for User Story 4
+
+- [x] T037 [P] [US4] 在 `oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java` 添加存在读写、不存在写、dangling、多跳、链接环、合法 Skill 链接和最小白名单根测试矩阵
+- [x] T038 [P] [US4] 在 `oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java` 添加 file/download/write 越界链接拒绝、外部不变、link 叶节点和 cycle 终止测试
+- [x] T039 [P] [US4] 在 `oryxos-core/src/test/java/io/oryxos/core/agent/AgentStoreTest.java` 与 `oryxos-core/src/test/java/io/oryxos/core/skill/SkillStoreTest.java` 添加 write/writeAll 经最终或中间链接逃逸时拒绝且普通写正常的测试
+
+### Implementation for User Story 4
+
+- [x] T040 [US4] 在 `oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java` 使用 `RealPathBoundary` 规范白名单根并在每次 FILE_READ/FILE_WRITE 前投影目标真实路径
+- [x] T041 [US4] 在 `oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java` 对 file/download/write 使用真实路径边界，拒绝经 `agents/*/skills/**` 写共享 Skill，并让 tree 不递归软连接
+- [x] T042 [P] [US4] 在 `oryxos-web/src/main/java/io/oryxos/web/controller/dto/FileNode.java` 与 `oryxos-web/src/main/frontend/src/App.vue` 增加 link 叶节点展示及 dangling/escaped 状态
+- [x] T043 [US4] 在 `oryxos-core/src/main/java/io/oryxos/core/agent/AgentStore.java` 与 `oryxos-core/src/main/java/io/oryxos/core/skill/SkillStore.java` 对目录和每个写目标复用 `RealPathBoundary`
+- [x] T044 [US4] 在 `oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java` 增加所有文件写类 Tool 在 sandbox 拒绝后零 IO 的集成回归，并运行 `oryxos-tool/pom.xml`、`oryxos-web/pom.xml` 的 US4 测试
+
+**Checkpoint**: US4 安全边界独立全绿；字符串 normalize 不再作为任何新链接入口的最终安全判断。
+
+---
+
+## Phase 6: User Story 3 — 发现损坏、残留与旧配置 (Priority: P2)
+
+**Goal**: 启动、CRUD 和 Agent 生命周期能分类报告五类问题；旧 frontmatter 单 Agent 原子迁移，坏
+绑定不进入 prompt且不阻断其它 Agent。
+
+**Independent Test**: 构造五类问题与两个旧 Agent（一个合法、一个含不存在 Skill），启动后合法项
+完成幂等迁移，失败 Agent 原文件字节和链接集合不变；全局问题 API 分类完整，合法 Agent 正常运行。
+
+### Tests for User Story 3
+
+- [x] T045 [P] [US3] 在 `oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillReconciliationTest.java` 添加 dangling、escaped、invalid-target、name-mismatch、stale-reference 及归档合法链接非 stale 的失败测试
+- [x] T046 [P] [US3] 在 `oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillMigrationServiceTest.java` 添加成功仅移除顶层键、原文保真、已有链接并集、重复启动幂等、非法引用零变更和 IO/atomic-move 回滚测试
+- [x] T047 [P] [US3] 在 `oryxos-cli/src/test/java/io/oryxos/cli/AgentSkillStartupOrderTest.java` 添加内置 Skill 播种先于迁移、迁移先于 Profile/Watcher、单 Agent 失败不阻断启动的装配测试
+- [x] T048 [P] [US3] 在 `oryxos-web/src/test/java/io/oryxos/web/controller/SkillBindingIssuesApiTest.java` 添加全局 issues 稳定排序、活跃/归档状态和无 Profile stale 条目的 MockMvc 合同测试
+
+### Implementation for User Story 3
+
+- [x] T049 [US3] 在 `oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBindingService.java` 完成 active/archive 全量 reconcile、五类分类、日志消毒和排除 `archive/skills` 命名空间
+- [x] T050 [P] [US3] 在 `oryxos-core/src/main/java/io/oryxos/core/agent/AgentMarkdown.java` 实现保留其它 frontmatter/正文格式且只移除顶层 `skills` 的文本变换 helper
+- [x] T051 [US3] 在 `oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillMigrationService.java` 实现全量预校验、临时链接、AGENT.md 最后原子提交、异常回滚和崩溃后幂等收敛
+- [x] T052 [US3] 在 `oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java` 增加 `AgentSkillStartupReport` 显式依赖链，按 seed → migrate → reconcile → Profile/调度 → Watcher 顺序启动
+- [x] T053 [US3] 在 `oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java` 的 register/save/archive/delete 后触发协调检查，并拒绝运行期新写入 legacy `skills:`
+- [x] T054 [US3] 在 `oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java`、`oryxos-web/src/main/java/io/oryxos/web/controller/dto/SkillBindingIssueView.java` 与 `oryxos-web/src/main/frontend/src/App.vue` 增加全局问题查询和可读分类展示
+- [x] T055 [US3] 运行 `oryxos-core/pom.xml`、`oryxos-cli/pom.xml` 与 `oryxos-web/pom.xml` 的迁移/协调/启动测试，确认 US3 独立验收全绿
+
+**Checkpoint**: 五类问题可观测，旧模型被原子收敛，运行期只认软连接。
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: 同步最终术语、运行全部质量门禁，并按 quickstart 做端到端验收。
+
+- [x] T056 [P] 在 `README.md`、`CLAUDE.md`、`docs/DemandAnalysis.md`、`docs/TechnicalSolution.md` 与 `.specify/memory/constitution.md` 同步三级加载、catalog sidecar、legacy 迁移和 Skill 归档最终语义
+- [x] T057 [P] 在 `specs/012-agent-skill-links/quickstart.md` 逐项补齐实际命令/响应差异并记录所有场景的最终验证结果
+- [x] T058 在 `oryxos-web/src/main/frontend/package.json` 执行 `npm run build`，修复 `oryxos-web/src/main/frontend/src/App.vue` 的编译或类型问题
+- [x] T059 在根 `pom.xml` 执行 `mvn test`，修复全部模块回归并确认既有 Workspace tree 测试不再依赖固定 children 索引
+- [x] T060 在根 `pom.xml` 执行 `mvn verify`，通过 Spotless、P3C、Checkstyle、SpotBugs/Find Security Bugs 与依赖检查门禁
+- [x] T061 按 `specs/012-agent-skill-links/quickstart.md` 完成三级 prompt、作者建议、legacy 迁移、活跃/归档引用、完整 Skill 归档和真实路径逃逸的端到端验收
+- [x] T062 在 `specs/012-agent-skill-links/tasks.md` 标记已完成任务，并对整个工作树执行 `git diff --check`、占位符扫描和最终 constitution compliance 复核
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 Setup**: 可立即开始。
+- **Phase 2 Foundational**: 依赖 Phase 1，阻塞所有 User Story。
+- **US1 / Phase 3**: 依赖 Foundational；先完成，提供 runtime binding reader 和 MVP。
+- **US2 / Phase 4**: 依赖 Foundational，并复用 US1 的 binding reader/service；完成管理、生成和归档。
+- **US4 / Phase 5**: 依赖 Foundational 的 RealPathBoundary；可与 US1/US2 的非 Store 文件并行，但合并
+  AgentStore/SkillStore 前须协调 T030/T028 与 T043。
+- **US3 / Phase 6**: 依赖 US1 的 inspect、US2 的写协调/归档和 US4 的安全写入口；最后接入迁移与启动。
+- **Polish / Phase 7**: 依赖所有计划交付的 User Story。
+
+### User Story Dependency Graph
+
+```text
+Setup → Foundational → US1 (MVP)
+                    ├→ US2 ─┐
+                    └→ US4 ─┼→ US3 → Polish
+                            ┘
+```
+
+### Within Each User Story
+
+- 对应 Tests 任务必须先写并确认失败。
+- 数据模型/接口先于服务实现，服务先于 Controller/UI。
+- 所有 I/O 变更先全量验证，再执行并覆盖失败回滚。
+- 每个 Checkpoint 的目标测试全绿后才能进入依赖它的后续故事。
+
+## Parallel Opportunities
+
+### User Story 1
+
+```text
+并行：T012 ProgressiveDisclosureTest
+并行：T013 ReActLoopSkillDisclosureTest
+并行：T014 ContextLoader 无缓存测试
+随后：T015 → T016 → T017/T018 → T019 → T020
+```
+
+### User Story 2
+
+```text
+并行：T021 绑定服务测试、T022 归档测试、T023 生命周期测试、T024/T025 Web 合同测试
+并行：T026 catalog port、T032 HTTP DTO
+随后：T027 → T028/T030 → T029/T031 → T033/T034 → T035 → T036
+```
+
+### User Story 4
+
+```text
+并行：T037 Sandbox 测试、T038 Workspace 测试、T039 Store 测试
+随后：T040；并行推进 T041/T042 与 T043；最后 T044
+```
+
+### User Story 3
+
+```text
+并行：T045 reconcile 测试、T046 迁移测试、T047 启动顺序测试、T048 API 合同测试
+并行：T049 reconcile 与 T050 Markdown helper
+随后：T051 → T052/T053 → T054 → T055
+```
+
+## Implementation Strategy
+
+### MVP First
+
+1. 完成 Phase 1–2。
+2. 完成 US1（T012–T020）。
+3. 停止并独立验证：每次 prompt 只有元数据；`read_file` 后正文才进入已审计 history。
+4. US1 通过后再引入管理 CRUD、归档和迁移，避免一次改变所有运行时入口。
+
+### Incremental Delivery
+
+1. **MVP**: US1 — 三级渐进加载与实时软连接发现。
+2. **Management**: US2 — catalog、生成 sidecar、绑定 CRUD、Skill 归档。
+3. **Security**: US4 — 所有文件入口的真实路径边界。
+4. **Operations**: US3 — legacy 原子迁移、五类问题与启动恢复。
+5. **Release**: 文档、前端、全量质量门禁、quickstart。
+
+## Notes
+
+- 所有任务初始保持 `[ ]`；现有 pre-clarify 代码草稿不自动视为已完成。
+- `[P]` 仅表示文件和依赖允许并行；共享 `AgentStore`/`SkillStore` 修改必须在合并前串行协调。
+- 不新增 `use_skill`、绑定数据库表、自动远程安装或 OryxOS Skill ACL。
+- 外部 catalog unavailable 时 fail closed；具体重试/缓存协议不在本特性范围。
+- Java NIO 下同 OS 用户恶意进程的校验后换链 TOCTOU 不在当前威胁模型，确定性链接逃逸必须全拦。


### PR DESCRIPTION
## Summary

- revise the constitution for Agent-local Skill bindings backed by shared installed Skills
- add metadata-only prompt disclosure with on-demand SKILL.md/reference/script loading
- add binding/catalog/archive APIs, startup migration and reconciliation, and real-path sandbox checks
- update the web manager and Speckit design artifacts

## Verification

- mvn verify (397 tests, 0 failures/errors/skips)
- Vite production build
- git diff --check

Note: OWASP dependency-check remains skipped by the repository configuration.

Closes #40


<img width="1469" height="1310" alt="image" src="https://github.com/user-attachments/assets/7237bd2d-ede8-43d9-af74-0bfb5153163c" />