### PR TITLE
fix(provider): unify baseUrl convention (no /v1) to fix OpenAI-compatible Provider 404

### DIFF
--- a/oryxos-provider/src/main/java/io/oryxos/provider/ProviderChatModelFactory.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ProviderChatModelFactory.java
@@ -17,6 +17,9 @@ public class ProviderChatModelFactory {
   /** 内置 mock provider 的保留名：配置里 {@code - name: mock} 即挂一个假模型，用于无 key 全链路自测。 */
   static final String MOCK = "mock";
 
+  private static final String SLASH = "/";
+  private static final String PATH_V1 = "/v1";
+
   public Map<String, ChatModel> build(ProvidersProperties properties) {
     properties.validate();
     Map<String, ChatModel> providerMap = new LinkedHashMap<>();
@@ -31,6 +34,23 @@ public class ProviderChatModelFactory {
     if (MOCK.equals(name)) {
       return new MockChatModel(); // 不连真实端点，无需 key/url
     }
-    return new OpenAiChatModel(new OpenAiApi(baseUrl, apiKey));
+    // baseUrl 约定不含 /v1：OpenAiApi 内部会追加 /v1/chat/completions；用户填带 /v1 则先剥离，避免双 /v1（fix-issue-47）
+    return new OpenAiChatModel(new OpenAiApi(stripTrailingV1(baseUrl), apiKey));
+  }
+
+  /**
+   * 剥离 baseUrl 末尾的 {@code /} 与 {@code /v1}，与 {@link
+   * io.oryxos.web.provider.ProviderModelsService#modelsUrl} 对齐。
+   */
+  private static String stripTrailingV1(String baseUrl) {
+    String u = baseUrl == null ? "" : baseUrl.strip();
+    while (u.endsWith(SLASH) || u.endsWith(PATH_V1)) {
+      if (u.endsWith(SLASH)) {
+        u = u.substring(0, u.length() - SLASH.length());
+      } else {
+        u = u.substring(0, u.length() - PATH_V1.length());
+      }
+    }
+    return u;
   }
 }

--- a/oryxos-provider/src/test/java/io/oryxos/provider/UriBuilderPathReplacementTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/UriBuilderPathReplacementTest.java
@@ -1,0 +1,89 @@
+package io.oryxos.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * 复现并固化 Spring {@link UriComponentsBuilder#path(String)} 的拼接语义，定位 OryxOS Chat 调用 404 的根因。
+ *
+ * <p>关键事实（实测 Spring 6.1.14 / spring-ai-openai 1.0.0-M6）：
+ *
+ * <ul>
+ *   <li>绝对 path（以 {@code /} 开头）：**追加**到 baseUrl 已有 path 末尾，自动插一个 {@code /} 分隔符。
+ *   <li>相对 path（不以 {@code /} 开头）：原样拼接到 baseUrl path 末尾，**不插分隔符**。
+ * </ul>
+ *
+ * <p>由此看 OryxOS 的 bug：Provider baseUrl 填 {@code https://opencode.ai/zen/go/v1}， {@code OpenAiApi}
+ * 内部用绝对 path {@code /v1/chat/completions} 追加 → 实际请求 {@code
+ * https://opencode.ai/zen/go/v1/v1/chat/completions}（**双 /v1**），上游主站不认此路径， 返回 HTML 404 页面。{@code
+ * deepseek} 没踩坑是因为其 baseUrl 无子路径，{code /v1} 只出现一次。
+ */
+class UriBuilderPathReplacementTest {
+
+  @Test
+  @DisplayName("绝对 path /v1/chat/completions → 追加到 baseUrl /zen/go/v1 后 → 双 /v1（bug 根因）")
+  void absolutePath_appendedToBaseUrlWithV1_yieldsDoubleV1() {
+    String built =
+        UriComponentsBuilder.fromHttpUrl("https://opencode.ai/zen/go/v1")
+            .path("/v1/chat/completions")
+            .build()
+            .toUriString();
+
+    // 双 /v1：OpenAiApi 内部 + baseUrl 字段各加了一次 → 上游返回 404
+    assertEquals("https://opencode.ai/zen/go/v1/v1/chat/completions", built);
+  }
+
+  @Test
+  @DisplayName("修复方案：baseUrl 去掉 /v1 + 绝对 path /v1/chat/completions → 单 /v1 正确")
+  void absolutePath_onBaseUrlWithoutV1_yieldsSingleV1() {
+    String built =
+        UriComponentsBuilder.fromHttpUrl("https://opencode.ai/zen/go")
+            .path("/v1/chat/completions")
+            .build()
+            .toUriString();
+
+    assertEquals("https://opencode.ai/zen/go/v1/chat/completions", built);
+  }
+
+  @Test
+  @DisplayName("deepseek baseUrl 无子路径，绝对 path 追加结果恰好 = 单 /v1（掩盖了 bug）")
+  void absolutePath_onRootlessBaseUrl_works() {
+    String built =
+        UriComponentsBuilder.fromHttpUrl("https://api.deepseek.com")
+            .path("/v1/chat/completions")
+            .build()
+            .toUriString();
+
+    assertEquals("https://api.deepseek.com/v1/chat/completions", built);
+  }
+
+  @Test
+  @DisplayName("相对 path（无前导 /）不插分隔符 → 直接拼接，会咬字，不可用")
+  void relativePath_noSeparatorInserted() {
+    String built =
+        UriComponentsBuilder.fromHttpUrl("https://opencode.ai/zen/go")
+            .path("v1/chat/completions")
+            .build()
+            .toUriString();
+
+    // got gov1（咬字），证明必须传绝对 path 才能凑出正确 /v1/chat/completions
+    assertEquals("https://opencode.ai/zen/gov1/chat/completions", built);
+  }
+
+  @Test
+  @DisplayName("modelsUrl 等价：baseUrl 含 /v1 + /models → 单次 /v1/models，与 Chat 调用对 /v1 的预期不一致")
+  void modelsPath_onBaseUrlWithV1_yieldsSingleV1Models() {
+    String built =
+        UriComponentsBuilder.fromHttpUrl("https://opencode.ai/zen/go/v1")
+            .path("/models")
+            .build()
+            .toUriString();
+
+    // ProviderModelsService.modelsUrl() 直接拼字符串 → /v1/models 用这里的 baseUrl 没问题；
+    // 但同一 baseUrl 传给 OpenAiApi 会双 /v1（见上）—— 两端对 baseUrl 的预期矛盾，是 bug 另一面
+    assertEquals("https://opencode.ai/zen/go/v1/models", built);
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/provider/ProviderModelsService.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/provider/ProviderModelsService.java
@@ -68,16 +68,21 @@ public class ProviderModelsService {
     }
   }
 
-  /** 拼 {@code /models} 地址：base-url 已带 /v1 则复用，否则直接追加。 */
+  /**
+   * 拼 OpenAI 兼容标准的 {@code /v1/models} 地址：先剥离 baseUrl 末尾的 {@code /} 与 {@code /v1}（用户填带或不带 /v1 都正确），
+   * 再统一追加 {@code /v1/models}。与 {@code OpenAiApi} 内部追加 {@code /v1/chat/completions} 的预期对齐： Provider
+   * baseUrl 约定不含 {@code /v1}，两个消费者各自补完整 API 路径。
+   */
   private static String modelsUrl(String baseUrl) {
     String u = baseUrl.strip();
-    if (u.endsWith(SLASH)) {
-      u = u.substring(0, u.length() - 1);
+    while (u.endsWith(SLASH) || u.endsWith(PATH_V1)) {
+      if (u.endsWith(SLASH)) {
+        u = u.substring(0, u.length() - 1);
+      } else {
+        u = u.substring(0, u.length() - PATH_V1.length());
+      }
     }
-    if (u.endsWith(PATH_V1)) {
-      return u + PATH_MODELS;
-    }
-    return u + PATH_MODELS;
+    return u + PATH_V1 + PATH_MODELS;
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/oryxos-web/src/test/java/io/oryxos/web/provider/ProviderModelsServiceTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/provider/ProviderModelsServiceTest.java
@@ -51,7 +51,7 @@ class ProviderModelsServiceTest {
   }
 
   @Test
-  @DisplayName("真实 provider_解析 /models 并按字母排序返回 id")
+  @DisplayName("真实 provider_解析 /v1/models 并按字母排序返回 id（baseUrl 不含 /v1，符合新约定 fix-issue-47）")
   void real_parsesModelsSorted() {
     server.createContext(
         "/v1/models",
@@ -65,9 +65,45 @@ class ProviderModelsServiceTest {
           exchange.close();
         });
     when(registry.find("openai"))
-        .thenReturn(Optional.of(new ProviderDef("openai", "sk-x", baseUrl + "/v1", null)));
+        .thenReturn(Optional.of(new ProviderDef("openai", "sk-x", baseUrl, null)));
 
     assertEquals(List.of("gpt-3.5-turbo", "gpt-4o"), service.listModels("openai"));
+  }
+
+  @Test
+  @DisplayName("baseUrl 带末尾 /v1 → 剥离后仍拼 /v1/models（兼容用户误填，fix-issue-47）")
+  void baseUrlWithV1_strippedThenAppendsV1Models() {
+    server.createContext(
+        "/v1/models",
+        exchange -> {
+          byte[] body = "{\"data\":[{\"id\":\"m1\"}]}".getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().set("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, body.length);
+          exchange.getResponseBody().write(body);
+          exchange.close();
+        });
+    when(registry.find("opencode"))
+        .thenReturn(Optional.of(new ProviderDef("opencode", "sk-x", baseUrl + "/v1", null)));
+
+    assertEquals(List.of("m1"), service.listModels("opencode"));
+  }
+
+  @Test
+  @DisplayName("baseUrl 带末尾 / → 剥离后拼 /v1/models（fix-issue-47）")
+  void baseUrlWithTrailingSlash_strippedThenAppendsV1Models() {
+    server.createContext(
+        "/v1/models",
+        exchange -> {
+          byte[] body = "{\"data\":[{\"id\":\"m2\"}]}".getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().set("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, body.length);
+          exchange.getResponseBody().write(body);
+          exchange.close();
+        });
+    when(registry.find("slash"))
+        .thenReturn(Optional.of(new ProviderDef("slash", "sk-x", baseUrl + "/", null)));
+
+    assertEquals(List.of("m2"), service.listModels("slash"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- `ProviderModelsService.modelsUrl()` 的 if/else 两个分支都返回 `/models`,判断形同虚设且漏掉了 OpenAI 标准的 `/v1` 段 —— 与 `OpenAiApi` 对 baseUrl 的预期(不含 `/v1`,内部自动追加 `/v1/chat/completions`)矛盾,同一个 baseUrl 无法同时满足两端
- DeepSeek 同时支持 `/models` 和 `/v1/models`(兼容别名)掩盖了 bug;OpenCode 等严格实现只认 `/v1/models`,暴露 404
- 统一规范:**Provider baseUrl 不含 `/v1`**,两个消费者各自追加完整 OpenAI 标准路径,用户填带不带 `/v1` 都能正确工作

## Root Cause

`oryxos-web/.../ProviderModelsService.java:72-81`:

```java
if (u.endsWith(PATH_V1)) {     // /v1
    return u + PATH_MODELS;    // → /v1/models
}
return u + PATH_MODELS;        // → /models   ← 两个分支返回结构一致,if 无意义
```

## Fix

| 文件 | 改动 |
|------|------|
| `ProviderModelsService.java` | `modelsUrl()` 先剥离末尾 `/` 与 `/v1`,再统一追加 `/v1/models`;清理无意义 if/else |
| `ProviderChatModelFactory.java` | `buildOne()` 传 baseUrl 给 `OpenAiApi` 前先剥离末尾 `/` 与 `/v1`,避免双 `/v1` |
| `ProviderModelsServiceTest.java` | 原 `real_parsesModelsSorted` 的 baseUrl 改为不含 `/v1`;新增 2 个规范化用例 |
| `UriBuilderPathReplacementTest.java`(新增) | 5 个用例固化 `UriComponentsBuilder.path()` 对绝对路径「追加」(非替换)的行为证据 |

## Test

- `ProviderModelsServiceTest`: 6/6 全过
- `UriBuilderPathReplacementTest`: 5/5 全过
- `oryxos-provider` 全量: 21/21 全过
- `oryxos-web` Provider 相关: 15/15 全过

## Behavior After Fix

用户在 Admin UI 填 baseUrl 不论带不带 `/v1` 都能正确工作:
- `https://opencode.ai/zen/go` → 模型列表 `.../v1/models` ✓, Chat 调用 `.../v1/chat/completions` ✓
- `https://opencode.ai/zen/go/v1` → 自动剥离 `/v1` 后同上 ✓
- `https://api.deepseek.com` → 原行为不变 ✓

Closes #47