### PR TITLE
fix(web): move provider validation before port bind to prevent false-positive startup

### DIFF
--- a/oryxos-web/src/main/java/io/oryxos/web/security/ProviderStartupCheck.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/ProviderStartupCheck.java
@@ -3,8 +3,7 @@ package io.oryxos.web.security;
 import io.oryxos.provider.ProvidersProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.ApplicationArguments;
-import org.springframework.boot.ApplicationRunner;
+import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.stereotype.Component;
 
@@ -14,11 +13,15 @@ import org.springframework.stereotype.Component;
  * <p>仅在 SERVLET web 模式（serve/gateway）执行——user/chat 等 WebApplicationType.NONE 命令不触发， 确保账号管理等不依赖 LLM
  * 的命令不会因 api-key 未配而被阻断。
  *
- * <p>校验逻辑委托给 {@link ProvidersProperties#validate()}，镜像 {@link AuthStartupCheck} 的模式。
+ * <p>实现 {@link SmartInitializingSingleton} 而非 {@code ApplicationRunner}：校验在所有单例 Bean 初始化完成后、Web
+ * Server 开始监听端口之前执行。配置不合法时 ApplicationContext 启动直接失败， 端口不会打开，避免健康检查在 Provider 校验之前返回 200
+ * 的竞态（false-positive startup）。
+ *
+ * <p>校验逻辑委托给 {@link ProvidersProperties#validate()}。
  */
 @Component
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
-public class ProviderStartupCheck implements ApplicationRunner {
+public class ProviderStartupCheck implements SmartInitializingSingleton {
 
   private static final Logger LOG = LoggerFactory.getLogger(ProviderStartupCheck.class);
 
@@ -29,7 +32,7 @@ public class ProviderStartupCheck implements ApplicationRunner {
   }
 
   @Override
-  public void run(ApplicationArguments args) {
+  public void afterSingletonsInstantiated() {
     properties.validate();
     LOG.debug(
         "Provider startup check passed ({} provider(s) configured)", properties.providers().size());


### PR DESCRIPTION
## 问题

`ProviderStartupCheck` 实现 `ApplicationRunner`，校验在 Web Server 监听端口之后才执行。
`bin/start.sh` 的健康检查可能在校验之前拿到 200，报 [OK] 后进程随即退出——用户看到"已就绪"但服务已死。

## 修复

改为 `SmartInitializingSingleton`，校验在端口打开之前执行。配置不合法时端口不会打开，健康检查不可能返回 200。

## 验证

- [x] 空 key + `bin/start.sh` → `[ERROR] 进程已退出`，端口从未打开
- [x] 正常 key + `bin/start.sh` → `[OK]`，health 200，管理台可访问