### PR TITLE
fix(provider): 支持 baseUrl 自带版本段的 OpenAI 兼容端点（如智谱 GLM /api/paas/v4）

### DIFF
--- a/oryxos-provider/src/main/java/io/oryxos/provider/ProviderChatModelFactory.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ProviderChatModelFactory.java
@@ -20,6 +20,10 @@ public class ProviderChatModelFactory {
   private static final String SLASH = "/";
   private static final String PATH_V1 = "/v1";
 
+  /** 末尾版本段（如 GLM 的 /api/paas/v4）：此类端点版本在 baseUrl 里，不能再补 /v1。 */
+  private static final java.util.regex.Pattern TRAILING_VERSION =
+      java.util.regex.Pattern.compile(".*/v\\d+$");
+
   public Map<String, ChatModel> build(ProvidersProperties properties) {
     properties.validate();
     Map<String, ChatModel> providerMap = new LinkedHashMap<>();
@@ -35,7 +39,13 @@ public class ProviderChatModelFactory {
       return new MockChatModel(); // 不连真实端点，无需 key/url
     }
     // baseUrl 约定不含 /v1：OpenAiApi 内部会追加 /v1/chat/completions；用户填带 /v1 则先剥离，避免双 /v1（fix-issue-47）
-    return new OpenAiChatModel(new OpenAiApi(stripTrailingV1(baseUrl), apiKey));
+    String base = stripTrailingV1(baseUrl);
+    OpenAiApi.Builder api = OpenAiApi.builder().baseUrl(base).apiKey(apiKey);
+    if (TRAILING_VERSION.matcher(base).matches()) {
+      // 端点版本在 baseUrl 里（如 GLM 的 /api/paas/v4），改补无版本的 /chat/completions
+      api.completionsPath("/chat/completions");
+    }
+    return new OpenAiChatModel(api.build());
   }
 
   /**

--- a/oryxos-web/src/main/java/io/oryxos/web/provider/ProviderModelsService.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/provider/ProviderModelsService.java
@@ -71,7 +71,8 @@ public class ProviderModelsService {
   /**
    * 拼 OpenAI 兼容标准的 {@code /v1/models} 地址：先剥离 baseUrl 末尾的 {@code /} 与 {@code /v1}（用户填带或不带 /v1 都正确），
    * 再统一追加 {@code /v1/models}。与 {@code OpenAiApi} 内部追加 {@code /v1/chat/completions} 的预期对齐： Provider
-   * baseUrl 约定不含 {@code /v1}，两个消费者各自补完整 API 路径。
+   * baseUrl 约定不含 {@code /v1}，两个消费者各自补完整 API 路径。 例外：剥离后仍以版本段结尾（如 GLM 的 {@code /api/paas/v4}）
+   * 说明版本在 baseUrl 里，只补 {@code /models}——与 {@code ProviderChatModelFactory} 的判断规则保持一致。
    */
   private static String modelsUrl(String baseUrl) {
     String u = baseUrl.strip();
@@ -81,6 +82,9 @@ public class ProviderModelsService {
       } else {
         u = u.substring(0, u.length() - PATH_V1.length());
       }
+    }
+    if (u.matches(".*/v\\d+$")) {
+      return u + PATH_MODELS;
     }
     return u + PATH_V1 + PATH_MODELS;
   }


### PR DESCRIPTION
## 问题
GLM（智谱）这类 OpenAI 兼容端点的版本段在 baseUrl 里（/api/paas/v4/chat/completions），
原逻辑固定追加 /v1/chat/completions，拼出 /v4/v1/... 导致 404。

## 修复
- ProviderChatModelFactory：剥离 /v1 后 baseUrl 仍以 /v\d+ 结尾时，改用
  completionsPath("/chat/completions") 不再补 /v1
- ProviderModelsService.modelsUrl：同规则只补 /models，两处判断一致
- DeepSeek 等原有 provider 行为不变

## 验证
本地配置 GLM（base-url: https://open.bigmodel.cn/api/paas/v4，模型 glm-5.2），
weather-agent 通过 /api/v1/agents/{name}/invoke 完整跑通 ReAct 循环
（http_get 调 Open-Meteo 查实时天气并生成穿衣建议）。