### PR TITLE
docs: link contributing guide from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,10 @@ All endpoints are prefixed with `/api/v1` and every response is wrapped in a uni
 | Logging | Logback + SLF4J (structured JSON) |
 | Build | Maven multi-module |
 
+## Contributing
+
+First PRs are welcome — see the [Contributing Guide](https://oryx-labs.github.io/oryxos/docs/contributing) and the [GitHub workflow primer](https://oryx-labs.github.io/oryxos/docs/github-workflow).
+
 ## License
 
 [Apache License 2.0](LICENSE) · [oryx-labs](https://github.com/oryx-labs) · Goal: Apache Software Foundation top-level project


### PR DESCRIPTION
## What

Add a short `Contributing` section to README.md (between `Tech Stack` and `License`), linking to the docs-site Contributing Guide and the GitHub workflow primer.

## Why

The README currently has no pointer to the contributing guide at all — a newcomer landing on the repo page has no visible entry point for contributing. The guide itself (`website/docs/contributing.md`) explicitly welcomes first PRs and typo-level fixes, but nothing on the repo front door leads to it. The repo also has no root `CONTRIBUTING.md`, so this section closes that gap with one small step.

## How verified

- Both links return HTTP 200 on the live docs site (VitePress `cleanUrls`, base `/oryxos/`):
  - https://oryx-labs.github.io/oryxos/docs/contributing
  - https://oryx-labs.github.io/oryxos/docs/github-workflow
- Docs-only change; no code touched.

This is my first PR to the project — happy to adjust wording or placement per your preference.
