### PR TITLE
docs: fix broken logo link in OryxOS overview

### DIFF
--- a/docs/oryxos.md
+++ b/docs/oryxos.md
@@ -4,7 +4,7 @@
 
 企业私有部署的 Agent 操作系统：**你用一句自然语言发布一个任务 → 底座把它拆解 → 组织一支 Agent 团队 → 多个 Agent 分工协作 → 交付一个结果。** 让每一家公司，都能用自然语言跑起来自己的 Agent。
 
-![OryxOS](../docs/images/logo.svg)
+![OryxOS](../website/public/images/logo.svg)
 
 ## 愿景
 


### PR DESCRIPTION
## What

Fix the broken OryxOS logo link in `docs/oryxos.md`.

## Why

The current link points to `docs/images/logo.svg`, which does not exist. The logo asset is stored at `website/public/images/logo.svg`.

## Impact

The OryxOS overview now renders its logo correctly on GitHub.

## Verification

- Confirmed `docs/images/logo.svg` does not exist.
- Confirmed `website/public/images/logo.svg` exists.
- Ran `git diff --check` successfully.
- Ran `mvn clean verify`; it could not complete in the local environment because only Java 24 is installed, while the project requires Java 21. The current Byte Buddy test dependency supports up to Java 23, causing Mockito instrumentation errors in `oryxos-core`.
