### PR TITLE
fix(provider): preserve database config across restarts

### DIFF
--- a/docs/superpowers/plans/2026-08-01-provider-config-source-of-truth.md
+++ b/docs/superpowers/plans/2026-08-01-provider-config-source-of-truth.md
@@ -1,0 +1,934 @@
+# Provider Config Source-of-Truth Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修复 Issue #42，使 YAML 只首次播种缺失 Provider，SQLite `ProviderRegistry` 成为唯一运行时事实源，并证明管理台配置跨重启不被覆盖。
+
+**Architecture:** 在 `oryxos-provider` 增加一个只校验最终注册表的 `ProviderRegistryValidator`，以及一个只播种缺失且有效 YAML 条目的 `ProviderRegistryBootstrap`。`OryxOsRuntime` 负责把两者接入注册表创建流程，Servlet 启动检查和 `chat` 复用同一个 Validator；一个默认 CI 会执行的双 Spring Context 测试证明数据库配置跨重启保持不变。
+
+**Tech Stack:** Java 21、Spring Boot 3.x、Spring MVC、Spring Data JPA、SQLite、JUnit 5、Mockito、Maven 多模块。
+
+## Global Constraints
+
+- Java 运行时必须是 21；保持同步阻塞模型，不引入 Reactor、WebFlux 或 `CompletableFuture`。
+- SQLite `ProviderRegistry` 是唯一运行时事实源；YAML 只首次播种数据库中不存在的 Provider。
+- 数据库已有同名 Provider 时，启动代码不得调用 `ProviderRegistry.save()` 覆盖它。
+- 普通 Provider 的空白或未解析 YAML API key 不得写入数据库；`mock` 继续免 key/base URL。
+- `serve`、`gateway`、`chat` 校验最终注册表；不调用模型的轻命令不做 Provider 可用性校验。
+- 历史无效数据库记录只报错，不自动修复、删除或用 YAML 覆盖。
+- 日志和异常不得包含 API key、请求头或其他凭证值。
+- 不改变 Provider REST API、Agent 配置格式、`providers` 表结构或显式名称映射机制。
+- 不夹带 Issue #41、#43、#49 或其他重构。
+- 保留用户已有未提交文件；每次只暂存本任务列出的精确路径。
+- 执行前必须通过 `superpowers:using-git-worktrees` 为现有分支
+  `codex/fix-provider-config-seeding` 创建隔离 worktree；不得在含用户未提交
+  `.vscode/settings.json` 等修改的主检出目录中执行 rebase、格式化或实现。
+
+## File Map
+
+- Create: `oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryValidator.java` — 校验最终 `ProviderRegistry`。
+- Create: `oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryValidatorTest.java` — Validator 契约测试。
+- Create: `oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryBootstrap.java` — 首次播种缺失且有效的 YAML Provider。
+- Create: `oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryBootstrapTest.java` — 播种、不覆盖、空 key 和 mock 回归。
+- Modify: `oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java:139` — 注册 Bootstrap/Validator Bean，并替换无条件 upsert。
+- Modify: `oryxos-cli/src/main/java/io/oryxos/cli/command/ChatCommand.java:18` — 在进入 `CliChannel` 前校验最终注册表。
+- Create: `oryxos-cli/src/test/java/io/oryxos/cli/command/ChatCommandTest.java` — 证明 `chat` 调用共享 Validator。
+- Modify: `oryxos-web/src/main/java/io/oryxos/web/security/ProviderStartupCheck.java:20` — 从原始 YAML 校验改为最终注册表校验。
+- Create: `oryxos-web/src/test/java/io/oryxos/web/security/ProviderStartupCheckTest.java` — 证明 Servlet 启动检查调用共享 Validator。
+- Create: `oryxos-boot/src/test/java/io/oryxos/boot/ProviderConfigRestartTest.java` — 默认门禁内的跨重启 SQLite 回归。
+- Modify: `oryxos-storage/src/main/resources/schema.sql:111` — 把首次播种、不覆盖已有记录的注释写明确；不改 DDL。
+
+---
+
+### Task 1: Validate the Effective Provider Registry
+
+**Files:**
+- Create: `oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryValidator.java`
+- Create: `oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryValidatorTest.java`
+
+**Interfaces:**
+- Consumes: `ProviderRegistry.list(): List<ProviderDef>`、`ProviderDef(String name, String apiKey, String baseUrl, String description)`。
+- Produces: `ProviderRegistryValidator.validate(ProviderRegistry): void`。
+- Produces for Task 2: package-private `ProviderRegistryValidator.violation(ProviderDef): Optional<String>`，只返回缺失字段说明，不返回凭证值。
+
+- [ ] **Step 1: 在 Issue #42 留下认领和实现口径评论**
+
+通过 GitHub connector 在 `oryx-labs/oryxos#42` 发布：
+
+```markdown
+我准备处理这个 Issue，修复范围已收敛为：
+
+1. SQLite ProviderRegistry 是唯一运行时事实源；
+2. YAML 只首次播种数据库中不存在且有效的 Provider；
+3. 已有同名 Provider 不被 YAML 或空环境变量覆盖；
+4. serve/gateway/chat 校验最终注册表；
+5. 增加默认 CI 会执行的双 Spring Context + 共享 SQLite 重启回归。
+
+历史无效数据库记录只清晰报错，不自动覆盖或迁移。完成后会提交聚焦 PR，并以 `Closes #42` 关联。
+```
+
+确认评论创建成功并记录返回 URL；如果 GitHub connector 拒绝写入，停止外部动作并向用户报告权限阻塞，不得假称评论已经发布。
+
+- [ ] **Step 2: 写 Validator 的失败测试**
+
+创建 `ProviderRegistryValidatorTest`，至少包含以下断言：
+
+```java
+package io.oryxos.provider;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.oryxos.core.provider.ProviderDef;
+import io.oryxos.core.provider.ProviderRegistry;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ProviderRegistryValidatorTest {
+
+  private ProviderRegistry registry;
+  private ProviderRegistryValidator validator;
+
+  @BeforeEach
+  void setUp() {
+    registry = mock(ProviderRegistry.class);
+    validator = new ProviderRegistryValidator();
+  }
+
+  @Test
+  void validDatabaseProvider_passesWithoutReadingYaml() {
+    when(registry.list())
+        .thenReturn(List.of(new ProviderDef("deepseek", "db-key", "https://db.example/v1", null)));
+
+    assertDoesNotThrow(() -> validator.validate(registry));
+  }
+
+  @Test
+  void mockProvider_allowsMissingKeyAndBaseUrl() {
+    when(registry.list()).thenReturn(List.of(new ProviderDef("mock", null, null, null)));
+
+    assertDoesNotThrow(() -> validator.validate(registry));
+  }
+
+  @Test
+  void emptyRegistry_failsClearly() {
+    when(registry.list()).thenReturn(List.of());
+
+    IllegalStateException error =
+        assertThrows(IllegalStateException.class, () -> validator.validate(registry));
+    assertTrue(error.getMessage().contains("Provider"));
+  }
+
+  @Test
+  void blankKey_failsWithoutLeakingOtherCredentialValues() {
+    String secret = "must-not-leak";
+    when(registry.list())
+        .thenReturn(
+            List.of(
+                new ProviderDef("broken", " ", "https://broken.example/v1", secret)));
+
+    IllegalStateException error =
+        assertThrows(IllegalStateException.class, () -> validator.validate(registry));
+    assertTrue(error.getMessage().contains("broken"));
+    assertTrue(error.getMessage().contains("api-key"));
+    assertFalse(error.getMessage().contains(secret));
+  }
+
+  @Test
+  void blankBaseUrl_failsAndNamesProvider() {
+    when(registry.list())
+        .thenReturn(List.of(new ProviderDef("broken", "db-key", " ", null)));
+
+    IllegalStateException error =
+        assertThrows(IllegalStateException.class, () -> validator.validate(registry));
+    assertTrue(error.getMessage().contains("broken"));
+    assertTrue(error.getMessage().contains("base-url"));
+  }
+}
+```
+
+- [ ] **Step 3: 运行测试并确认因 Validator 尚不存在而失败**
+
+Run:
+
+```bash
+mvn test -pl oryxos-provider -am \
+  -Dtest=ProviderRegistryValidatorTest \
+  -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+Expected: FAIL，编译错误包含 `cannot find symbol: class ProviderRegistryValidator`。
+
+- [ ] **Step 4: 实现最小 Validator**
+
+创建 `ProviderRegistryValidator`：
+
+```java
+package io.oryxos.provider;
+
+import io.oryxos.core.provider.ProviderDef;
+import io.oryxos.core.provider.ProviderRegistry;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public final class ProviderRegistryValidator {
+
+  private static final String MOCK = "mock";
+
+  public void validate(ProviderRegistry registry) {
+    List<ProviderDef> providers = registry.list();
+    if (providers.isEmpty()) {
+      throw new IllegalStateException("没有可用的 Provider，请先配置 Provider");
+    }
+    Set<String> names = new HashSet<>();
+    for (ProviderDef provider : providers) {
+      Optional<String> violation = violation(provider);
+      if (violation.isPresent()) {
+        throw new IllegalStateException(
+            "provider " + safeName(provider == null ? null : provider.name()) + " " + violation.get());
+      }
+      if (!names.add(provider.name())) {
+        throw new IllegalStateException("Provider 注册表名称重复: " + safeName(provider.name()));
+      }
+    }
+  }
+
+  Optional<String> violation(ProviderDef provider) {
+    if (provider == null || provider.name() == null || provider.name().isBlank()) {
+      return Optional.of("名称为空");
+    }
+    if (MOCK.equals(provider.name())) {
+      return Optional.empty();
+    }
+    if (provider.apiKey() == null
+        || provider.apiKey().isBlank()
+        || provider.apiKey().contains("${")) {
+      return Optional.of("的 api-key 未配置");
+    }
+    if (provider.baseUrl() == null || provider.baseUrl().isBlank()) {
+      return Optional.of("的 base-url 未配置");
+    }
+    return Optional.empty();
+  }
+
+  private static String safeName(String name) {
+    return name == null ? "<unknown>" : name.replace('\r', '_').replace('\n', '_');
+  }
+}
+```
+
+如 google-java-format 调整换行，以格式化结果为准；不得改变错误消息的无密钥属性。
+
+- [ ] **Step 5: 运行 Validator 测试并确认通过**
+
+Run:
+
+```bash
+mvn test -pl oryxos-provider -am \
+  -Dtest=ProviderRegistryValidatorTest \
+  -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+Expected: `ProviderRegistryValidatorTest` 全部 PASS。
+
+- [ ] **Step 6: 运行 provider 模块回归**
+
+Run:
+
+```bash
+mvn test -pl oryxos-provider -am
+```
+
+Expected: provider 与依赖模块测试全绿，现有 `ProvidersPropertiesTest` 保持通过。
+
+- [ ] **Step 7: 提交 Task 1**
+
+```bash
+git add \
+  oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryValidator.java \
+  oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryValidatorTest.java
+git commit -m "fix(provider): validate effective provider registry"
+```
+
+---
+
+### Task 2: Seed Only Missing Valid YAML Providers
+
+**Files:**
+- Create: `oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryBootstrap.java`
+- Create: `oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryBootstrapTest.java`
+
+**Interfaces:**
+- Consumes: `ProviderRegistry.exists(String): boolean`、`ProviderRegistry.save(ProviderDef): ProviderDef`。
+- Consumes from Task 1: `ProviderRegistryValidator.violation(ProviderDef): Optional<String>`。
+- Produces: `ProviderRegistryBootstrap(ProviderRegistryValidator)`。
+- Produces: `ProviderRegistryBootstrap.seedMissing(ProviderRegistry, ProvidersProperties): void`。
+
+- [ ] **Step 1: 写 Bootstrap 的失败测试**
+
+创建 `ProviderRegistryBootstrapTest`，覆盖“已有记录先跳过，再判断 YAML 是否有效”的顺序：
+
+```java
+package io.oryxos.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.oryxos.core.provider.ProviderDef;
+import io.oryxos.core.provider.ProviderRegistry;
+import io.oryxos.provider.ProvidersProperties.ProviderConfig;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ProviderRegistryBootstrapTest {
+
+  private ProviderRegistry registry;
+  private ProviderRegistryBootstrap bootstrap;
+
+  @BeforeEach
+  void setUp() {
+    registry = mock(ProviderRegistry.class);
+    bootstrap = new ProviderRegistryBootstrap(new ProviderRegistryValidator());
+  }
+
+  @Test
+  void missingValidProvider_isSeededOnce() {
+    when(registry.exists("deepseek")).thenReturn(false);
+    ProvidersProperties properties =
+        new ProvidersProperties(
+            List.of(new ProviderConfig("deepseek", "yaml-key", "https://seed.example/v1")));
+
+    bootstrap.seedMissing(registry, properties);
+
+    ArgumentCaptor<ProviderDef> saved = ArgumentCaptor.forClass(ProviderDef.class);
+    verify(registry).save(saved.capture());
+    assertEquals("deepseek", saved.getValue().name());
+    assertEquals("yaml-key", saved.getValue().apiKey());
+  }
+
+  @Test
+  void existingProvider_isNeverOverwrittenEvenWhenYamlDiffers() {
+    when(registry.exists("deepseek")).thenReturn(true);
+    ProvidersProperties properties =
+        new ProvidersProperties(
+            List.of(new ProviderConfig("deepseek", "yaml-old", "https://yaml.example/v1")));
+
+    bootstrap.seedMissing(registry, properties);
+
+    verify(registry, never()).save(any());
+  }
+
+  @Test
+  void existingProvider_isKeptWhenYamlKeyIsBlank() {
+    when(registry.exists("deepseek")).thenReturn(true);
+    ProvidersProperties properties =
+        new ProvidersProperties(
+            List.of(new ProviderConfig("deepseek", "", "https://yaml.example/v1")));
+
+    bootstrap.seedMissing(registry, properties);
+
+    verify(registry, never()).save(any());
+  }
+
+  @Test
+  void missingProviderWithBlankOrUnresolvedKey_isNotPersisted() {
+    ProvidersProperties blank =
+        new ProvidersProperties(
+            List.of(new ProviderConfig("deepseek", " ", "https://seed.example/v1")));
+    ProvidersProperties unresolved =
+        new ProvidersProperties(
+            List.of(
+                new ProviderConfig(
+                    "kimi", "${KIMI_API_KEY}", "https://api.moonshot.cn/v1")));
+
+    bootstrap.seedMissing(registry, blank);
+    bootstrap.seedMissing(registry, unresolved);
+
+    verify(registry, never()).save(any());
+  }
+
+  @Test
+  void mockProvider_canSeedWithoutKeyOrBaseUrl() {
+    when(registry.exists("mock")).thenReturn(false);
+
+    bootstrap.seedMissing(
+        registry, new ProvidersProperties(List.of(new ProviderConfig("mock", null, null))));
+
+    verify(registry).save(new ProviderDef("mock", null, null, null));
+  }
+}
+```
+
+- [ ] **Step 2: 运行测试并确认因 Bootstrap 尚不存在而失败**
+
+Run:
+
+```bash
+mvn test -pl oryxos-provider -am \
+  -Dtest=ProviderRegistryBootstrapTest \
+  -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+Expected: FAIL，编译错误包含 `cannot find symbol: class ProviderRegistryBootstrap`。
+
+- [ ] **Step 3: 实现最小 Bootstrap**
+
+创建 `ProviderRegistryBootstrap`：
+
+```java
+package io.oryxos.provider;
+
+import io.oryxos.core.provider.ProviderDef;
+import io.oryxos.core.provider.ProviderRegistry;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ProviderRegistryBootstrap {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ProviderRegistryBootstrap.class);
+
+  private final ProviderRegistryValidator validator;
+
+  public ProviderRegistryBootstrap(ProviderRegistryValidator validator) {
+    this.validator = validator;
+  }
+
+  public void seedMissing(ProviderRegistry registry, ProvidersProperties properties) {
+    for (ProvidersProperties.ProviderConfig config : properties.providers()) {
+      String name = config.name();
+      if (name != null && !name.isBlank() && registry.exists(name)) {
+        continue;
+      }
+      ProviderDef candidate =
+          new ProviderDef(config.name(), config.apiKey(), config.baseUrl(), null);
+      Optional<String> violation = validator.violation(candidate);
+      if (violation.isPresent()) {
+        LOG.warn(
+            "跳过 provider {} 的启动播种: {}",
+            safeName(config.name()),
+            violation.get());
+        continue;
+      }
+      registry.save(candidate);
+    }
+  }
+
+  private static String safeName(String name) {
+    return name == null ? "<unknown>" : name.replace('\r', '_').replace('\n', '_');
+  }
+}
+```
+
+关键顺序不得改变：名称有效且数据库已存在时必须先 `continue`，不能先用空 YAML key 判无效。
+
+- [ ] **Step 4: 运行 Bootstrap 和 Validator 测试**
+
+Run:
+
+```bash
+mvn test -pl oryxos-provider -am \
+  -Dtest='ProviderRegistryBootstrapTest,ProviderRegistryValidatorTest' \
+  -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+Expected: 两个测试类全部 PASS。
+
+- [ ] **Step 5: 运行 provider 模块回归**
+
+Run:
+
+```bash
+mvn test -pl oryxos-provider -am
+```
+
+Expected: provider 与依赖模块测试全绿；日志测试输出不得出现测试 key 值。
+
+- [ ] **Step 6: 提交 Task 2**
+
+```bash
+git add \
+  oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryBootstrap.java \
+  oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryBootstrapTest.java
+git commit -m "fix(provider): seed only missing valid providers"
+```
+
+---
+
+### Task 3: Wire Registry-First Startup and Prove Restart Safety
+
+**Files:**
+- Modify: `oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java:139-151`
+- Modify: `oryxos-cli/src/main/java/io/oryxos/cli/command/ChatCommand.java:18-32`
+- Create: `oryxos-cli/src/test/java/io/oryxos/cli/command/ChatCommandTest.java`
+- Modify: `oryxos-web/src/main/java/io/oryxos/web/security/ProviderStartupCheck.java:20-39`
+- Create: `oryxos-web/src/test/java/io/oryxos/web/security/ProviderStartupCheckTest.java`
+- Create: `oryxos-boot/src/test/java/io/oryxos/boot/ProviderConfigRestartTest.java`
+- Modify: `oryxos-storage/src/main/resources/schema.sql:111-113`
+
+**Interfaces:**
+- Consumes from Task 1: `ProviderRegistryValidator.validate(ProviderRegistry): void`。
+- Consumes from Task 2: `ProviderRegistryBootstrap.seedMissing(ProviderRegistry, ProvidersProperties): void`。
+- Produces: Spring Beans `ProviderRegistryValidator`、`ProviderRegistryBootstrap`。
+- Produces for testing: package-private static `ChatCommand.validateProviderRegistry(ConfigurableApplicationContext): void`。
+
+- [ ] **Step 1: 写 Web 和 Chat 接线的失败测试**
+
+创建 `ProviderStartupCheckTest`：
+
+```java
+package io.oryxos.web.security;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.oryxos.core.provider.ProviderRegistry;
+import io.oryxos.provider.ProviderRegistryValidator;
+import org.junit.jupiter.api.Test;
+
+class ProviderStartupCheckTest {
+
+  @Test
+  void validatesEffectiveRegistry() {
+    ProviderRegistry registry = mock(ProviderRegistry.class);
+    ProviderRegistryValidator validator = mock(ProviderRegistryValidator.class);
+
+    new ProviderStartupCheck(registry, validator).afterSingletonsInstantiated();
+
+    verify(validator).validate(registry);
+  }
+}
+```
+
+创建 `ChatCommandTest`：
+
+```java
+package io.oryxos.cli.command;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.oryxos.core.provider.ProviderRegistry;
+import io.oryxos.provider.ProviderRegistryValidator;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ConfigurableApplicationContext;
+
+class ChatCommandTest {
+
+  @Test
+  void validatesEffectiveRegistryBeforeConversation() {
+    ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
+    ProviderRegistry registry = mock(ProviderRegistry.class);
+    ProviderRegistryValidator validator = mock(ProviderRegistryValidator.class);
+    when(context.getBean(ProviderRegistry.class)).thenReturn(registry);
+    when(context.getBean(ProviderRegistryValidator.class)).thenReturn(validator);
+
+    ChatCommand.validateProviderRegistry(context);
+
+    verify(validator).validate(registry);
+  }
+}
+```
+
+- [ ] **Step 2: 写默认门禁内的重启失败测试**
+
+创建不带 `@Tag("integration")` 的 `ProviderConfigRestartTest`：
+
+```java
+package io.oryxos.boot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.oryxos.cli.OryxOsRuntime;
+import io.oryxos.core.provider.ProviderDef;
+import io.oryxos.core.provider.ProviderRegistry;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+class ProviderConfigRestartTest {
+
+  @TempDir Path root;
+
+  @Test
+  void databaseManagedProviderSurvivesRestartWithBlankYamlKey() throws Exception {
+    Path workspace = Files.createDirectories(root.resolve("workspace"));
+    Files.createDirectories(workspace.resolve("agents"));
+    Files.createDirectories(workspace.resolve("memory"));
+    String dbUrl = "jdbc:sqlite:" + root.resolve("provider-restart.db");
+
+    try (ConfigurableApplicationContext first =
+        boot(workspace, dbUrl, "yaml-seed-key", "https://seed.example/v1")) {
+      ProviderRegistry registry = first.getBean(ProviderRegistry.class);
+      registry.save(
+          new ProviderDef(
+              "deepseek", "db-rotated-key", "https://db.example/v1", "managed"));
+    }
+
+    try (ConfigurableApplicationContext second =
+        boot(workspace, dbUrl, "", "https://seed.example/v1")) {
+      ProviderDef restored =
+          second
+              .getBean(ProviderRegistry.class)
+              .find("deepseek")
+              .orElseThrow();
+      assertEquals("db-rotated-key", restored.apiKey());
+      assertEquals("https://db.example/v1", restored.baseUrl());
+      assertEquals("managed", restored.description());
+    }
+  }
+
+  @Test
+  void nonWebRuntimeStartsWithEmptyEffectiveRegistry() throws Exception {
+    Path workspace = Files.createDirectories(root.resolve("non-web-workspace"));
+    Files.createDirectories(workspace.resolve("agents"));
+    Files.createDirectories(workspace.resolve("memory"));
+    String dbUrl = "jdbc:sqlite:" + root.resolve("non-web.db");
+
+    try (ConfigurableApplicationContext context =
+        new SpringApplicationBuilder(OryxOsRuntime.class)
+            .web(WebApplicationType.NONE)
+            .properties(
+                "spring.main.banner-mode=off",
+                "oryxos.root=" + workspace,
+                "spring.datasource.url=" + dbUrl,
+                "oryxos.providers[0].name=deepseek",
+                "oryxos.providers[0].api-key=",
+                "oryxos.providers[0].base-url=https://seed.example/v1")
+            .run()) {
+      assertEquals(0, context.getBean(ProviderRegistry.class).list().size());
+    }
+  }
+
+  private static ConfigurableApplicationContext boot(
+      Path workspace, String dbUrl, String apiKey, String baseUrl) {
+    return new SpringApplicationBuilder(OryxOsRuntime.class)
+        .web(WebApplicationType.SERVLET)
+        .properties(
+            "server.port=0",
+            "spring.main.banner-mode=off",
+            "oryxos.root=" + workspace,
+            "spring.datasource.url=" + dbUrl,
+            "oryxos.providers[0].name=deepseek",
+            "oryxos.providers[0].api-key=" + apiKey,
+            "oryxos.providers[0].base-url=" + baseUrl)
+        .run();
+  }
+}
+```
+
+该测试使用假 key、假 URL，不发起模型调用，不依赖网络。
+
+- [ ] **Step 3: 运行三个新测试并确认旧接线失败**
+
+Run:
+
+```bash
+mvn test -pl oryxos-cli,oryxos-web,oryxos-boot -am \
+  -Dtest='ChatCommandTest,ProviderStartupCheckTest,ProviderConfigRestartTest' \
+  -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+Expected: FAIL；至少包含以下一个或多个信号：
+
+- `ProviderStartupCheck` 构造签名不匹配；
+- `ChatCommand.validateProviderRegistry` 不存在；
+- 重启后 API key 实际变为 YAML 空字符串或第二次 Context 启动失败。
+
+- [ ] **Step 4: 在 `OryxOsRuntime` 注册 Bootstrap/Validator 并替换无条件 upsert**
+
+增加 Bean：
+
+```java
+@Bean
+ProviderRegistryValidator providerRegistryValidator() {
+  return new ProviderRegistryValidator();
+}
+
+@Bean
+ProviderRegistryBootstrap providerRegistryBootstrap(
+    ProviderRegistryValidator validator) {
+  return new ProviderRegistryBootstrap(validator);
+}
+```
+
+把 `providerRegistry()` 改为：
+
+```java
+@Bean
+ProviderRegistry providerRegistry(
+    LlmProviderRepository repository,
+    ProvidersProperties properties,
+    ProviderRegistryBootstrap bootstrap) {
+  ProviderRegistry registry = new JpaProviderRegistry(repository);
+  bootstrap.seedMissing(registry, properties);
+  return registry;
+}
+```
+
+同时把方法注释明确为“YAML 仅首次播种缺失且有效条目；之后数据库为唯一事实源”。
+
+- [ ] **Step 5: 把 `ProviderStartupCheck` 改为校验最终注册表**
+
+字段和构造器改为：
+
+```java
+private final ProviderRegistry registry;
+private final ProviderRegistryValidator validator;
+
+public ProviderStartupCheck(
+    ProviderRegistry registry, ProviderRegistryValidator validator) {
+  this.registry = registry;
+  this.validator = validator;
+}
+
+@Override
+public void afterSingletonsInstantiated() {
+  validator.validate(registry);
+  LOG.debug(
+      "Provider startup check passed ({} provider(s) configured)",
+      registry.list().size());
+}
+```
+
+删除对 `ProvidersProperties.validate()` 的调用和相关 import；保留
+`@ConditionalOnWebApplication(SERVLET)` 与 `SmartInitializingSingleton` 时序。
+
+- [ ] **Step 6: 把 `ChatCommand` 改为进入会话前校验最终注册表**
+
+在 `CliChannel.run()` 之前增加：
+
+```java
+validateProviderRegistry(context);
+context.getBean(CliChannel.class).run(profileName, currentUser());
+```
+
+添加测试缝：
+
+```java
+static void validateProviderRegistry(ConfigurableApplicationContext context) {
+  ProviderRegistry registry = context.getBean(ProviderRegistry.class);
+  context.getBean(ProviderRegistryValidator.class).validate(registry);
+}
+```
+
+导入 `ProviderRegistry` 与 `ProviderRegistryValidator`。不要把校验放进
+`OryxOsRuntime` Bean 创建阶段，否则 `user` 等轻命令会被阻断。
+
+- [ ] **Step 7: 同步 `schema.sql` 注释，不改 DDL**
+
+把 Provider 表上方注释改为：
+
+```sql
+-- 启动时仅把 config/application.yml 中数据库尚不存在且有效的 Provider 作为首次种子；
+-- 已有同名记录绝不从 YAML 覆盖，之后以本表为唯一运行时事实源。
+```
+
+除注释外不修改 `CREATE TABLE providers`。
+
+- [ ] **Step 8: 运行接线与重启测试并确认通过**
+
+Run:
+
+```bash
+mvn test -pl oryxos-cli,oryxos-web,oryxos-boot -am \
+  -Dtest='ChatCommandTest,ProviderStartupCheckTest,ProviderConfigRestartTest' \
+  -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+Expected: 三个测试类全部 PASS；第二个 Servlet Spring Context 能在 YAML key
+为空时启动，非 Web Context 能在最终注册表为空时启动。
+
+- [ ] **Step 9: 运行受影响模块全量回归**
+
+Run:
+
+```bash
+mvn test -pl oryxos-provider,oryxos-cli,oryxos-web,oryxos-boot -am
+```
+
+Expected: 全绿；`ProviderConfigRestartTest` 出现在默认 Surefire 结果中，不因
+`integration` 标签被跳过。
+
+- [ ] **Step 10: 提交 Task 3**
+
+```bash
+git add \
+  oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java \
+  oryxos-cli/src/main/java/io/oryxos/cli/command/ChatCommand.java \
+  oryxos-cli/src/test/java/io/oryxos/cli/command/ChatCommandTest.java \
+  oryxos-web/src/main/java/io/oryxos/web/security/ProviderStartupCheck.java \
+  oryxos-web/src/test/java/io/oryxos/web/security/ProviderStartupCheckTest.java \
+  oryxos-boot/src/test/java/io/oryxos/boot/ProviderConfigRestartTest.java \
+  oryxos-storage/src/main/resources/schema.sql
+git commit -m "fix(provider): preserve database config across restarts"
+```
+
+---
+
+### Task 4: Quality Gate, Push, and Pull Request
+
+**Files:**
+- Modify only if format tools require it: files already listed in Tasks 1–3.
+- Read-only review: `docs/superpowers/specs/2026-08-01-provider-config-source-of-truth-design.md`
+- Read-only review: `docs/superpowers/plans/2026-08-01-provider-config-source-of-truth.md`
+
+**Interfaces:**
+- Consumes: all Tasks 1–3 deliverables.
+- Produces: verified branch `codex/fix-provider-config-seeding` and a PR targeting `oryx-labs/oryxos:main` with `Closes #42`.
+
+- [ ] **Step 1: 运行格式化并检查格式化差异**
+
+Run:
+
+```bash
+mvn spotless:apply
+git status --short
+git diff --check
+```
+
+Expected: Java 文件符合 google-java-format；状态中不出现用户已有
+`.vscode/settings.json`、`.agents/`、`AGENTS.md`、`docs/.DS_Store`，因为这些
+内容只保留在主检出目录；实现 worktree 中只应出现本计划涉及的文件。
+
+如果 Spotless 改动了 Tasks 1–3 的 Java 文件，只暂存这些精确路径并提交：
+
+```bash
+git add \
+  oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryValidator.java \
+  oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryBootstrap.java \
+  oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryValidatorTest.java \
+  oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryBootstrapTest.java \
+  oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java \
+  oryxos-cli/src/main/java/io/oryxos/cli/command/ChatCommand.java \
+  oryxos-cli/src/test/java/io/oryxos/cli/command/ChatCommandTest.java \
+  oryxos-web/src/main/java/io/oryxos/web/security/ProviderStartupCheck.java \
+  oryxos-web/src/test/java/io/oryxos/web/security/ProviderStartupCheckTest.java \
+  oryxos-boot/src/test/java/io/oryxos/boot/ProviderConfigRestartTest.java
+git commit -m "style: format provider config fix"
+```
+
+若没有格式化差异，不创建空提交。
+
+- [ ] **Step 2: 运行完整质量门禁**
+
+Run:
+
+```bash
+mvn clean verify
+```
+
+Expected: exit code 0；Spotless、Checkstyle、P3C/PMD、SpotBugs、FindSecBugs 和全部默认测试通过。
+
+- [ ] **Step 3: 审查相对上游的精确差异**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline upstream/main..HEAD
+git diff --stat upstream/main...HEAD
+git diff --check upstream/main...HEAD
+```
+
+Expected:
+
+- 提交只包含设计、实现、测试和必要注释；
+- 用户原有未提交文件仍未暂存；
+- 不包含密钥、数据库文件、日志、`target/` 或前端构建产物；
+- 分支至少包含设计提交和 Tasks 1–3 的聚焦提交。
+
+- [ ] **Step 4: 同步最新上游并在需要时安全 rebase**
+
+Run:
+
+```bash
+git fetch upstream
+git rebase upstream/main
+```
+
+Expected: 分支基于最新 `upstream/main`；如发生冲突，只解决本计划涉及文件，
+不得覆盖用户未提交内容。rebase 后重新运行：
+
+```bash
+mvn clean verify
+```
+
+Expected: exit code 0。
+
+- [ ] **Step 5: 推送分支到 fork**
+
+Run:
+
+```bash
+git push -u origin codex/fix-provider-config-seeding
+```
+
+Expected: 远端 fork 出现同名分支。若 rebase 后已经推送过，使用
+`git push --force-with-lease origin codex/fix-provider-config-seeding`，不得使用
+裸 `--force`。
+
+- [ ] **Step 6: 创建 Pull Request**
+
+通过 GitHub connector 创建 PR：
+
+- Repository: `oryx-labs/oryxos`
+- Base: `main`
+- Head: fork 中的 `codex/fix-provider-config-seeding`
+- Title: `fix(provider): preserve database config across restarts`
+- Draft: `false`
+- Body:
+
+```markdown
+## Summary
+
+- treat SQLite `ProviderRegistry` as the runtime source of truth
+- seed only missing, valid YAML providers without overwriting database-managed values
+- validate the effective registry for serve/gateway/chat
+- add a default-gate restart regression using two Spring contexts and one SQLite database
+
+## Why
+
+Provider bootstrap previously upserted YAML values on every startup. This could roll back
+admin-managed configuration or replace a valid database API key with an empty environment
+fallback.
+
+## Testing
+
+- `mvn test -pl oryxos-provider,oryxos-cli,oryxos-web,oryxos-boot -am`
+- `mvn clean verify`
+
+Closes #42
+```
+
+Expected: PR 创建成功并返回 URL。
+
+- [ ] **Step 7: 在 Issue #42 回贴 PR 链接**
+
+通过 GitHub connector 评论。第一行由固定文本“修复 PR 已提交：”与 Step 6
+返回对象的真实 `display_url` 拼接，第二段固定为：
+
+```markdown
+核心回归覆盖：数据库已有有效 Provider、YAML key 为空时，重启仍保留数据库配置并正常启动。
+```
+
+发送前断言 `display_url` 以 `https://github.com/oryx-labs/oryxos/pull/` 开头；
+不满足时停止并报告，不发送评论。

--- a/docs/superpowers/specs/2026-08-01-provider-config-source-of-truth-design.md
+++ b/docs/superpowers/specs/2026-08-01-provider-config-source-of-truth-design.md
@@ -1,0 +1,239 @@
+# Provider 配置单一事实源修复设计
+
+## 背景
+
+Issue [#42](https://github.com/oryx-labs/oryxos/issues/42) 指出 Provider 配置存在双事实源：
+
+- `config/application.yml` 中的 `oryxos.providers`；
+- SQLite `providers` 表中的运行时注册表。
+
+当前 `OryxOsRuntime.providerRegistry()` 每次启动都会把 YAML 配置无条件
+`save()` 到注册表。由于 `save()` 是按 Provider 名称 upsert，管理台已经修改的
+API key 或 base URL 会在重启时被旧 YAML 覆盖；当环境变量未设置、YAML 中的
+API key 解析为空字符串时，还会把数据库中的有效 key 清空。
+
+这与现有契约“YAML 只在数据库没有对应 Provider 时做首次播种，之后以数据库
+为准”不一致，也破坏了动态 Provider 管理的持久化语义。
+
+## 已确认的产品语义
+
+1. SQLite `ProviderRegistry` 是唯一运行时事实源。
+2. YAML 只负责首次播种数据库中尚不存在的 Provider。
+3. 数据库已有有效 Provider 时，即使当前环境没有设置对应 API key，
+   `serve`、`gateway` 和 `chat` 仍使用数据库配置正常启动。
+4. 空白或未解析的 YAML API key 不得写入数据库。
+5. 历史版本已经写入数据库的无效记录不自动修复或覆盖；需要在启动时清晰报错。
+6. 不调用模型的轻命令不应被 Provider 可用性校验阻断。
+
+## 目标
+
+- 防止启动过程覆盖数据库中已有的 Provider。
+- 防止空白或未解析的 YAML API key 被持久化。
+- 让所有需要 LLM 的启动入口校验最终生效的注册表，而不是原始 YAML。
+- 保留 Provider 显式名称映射、动态 CRUD 和现有 REST 契约。
+- 用真正的跨 Spring Context、共享 SQLite 文件测试证明重启后配置不回滚。
+
+## 非目标
+
+- 不迁移或自动修复历史无效数据库记录。
+- 不改变 `providers` 表结构。
+- 不改变 Provider REST API、Agent 配置格式或模型路由协议。
+- 不实现密钥加密、外部 Secret Manager 或凭证轮换。
+- 不修改 Provider API 的创建和更新校验规则；本修复只处理启动播种与运行前校验。
+- 不把 YAML 和数据库做字段级合并。
+
+## 方案比较
+
+### 方案一：只给现有 `save()` 增加存在性判断
+
+在 `OryxOsRuntime` 中仅当 `registry.exists(name)` 为 false 时调用 `save()`。
+
+优点是改动最小。缺点是 `ProviderStartupCheck` 仍校验原始 YAML，因此数据库
+已有有效 Provider、YAML key 为空时，Web 启动依旧失败，不能满足已确认语义。
+
+### 方案二：首次播种并校验最终注册表
+
+把首次播种和运行前校验分成独立职责：
+
+- 播种器只写入数据库中不存在且 YAML 配置完整的 Provider；
+- 校验器只校验播种完成后的 `ProviderRegistry`；
+- `serve`、`gateway`、`chat` 复用同一个校验器。
+
+该方案完整解决 Issue，保持数据库单一事实源，且能独立测试。采用此方案。
+
+### 方案三：YAML 与数据库按字段合并
+
+数据库缺字段时用 YAML 补齐，YAML 有新值时按规则更新数据库。
+
+该方案看似灵活，但会继续保留双事实源，需要定义复杂的字段优先级和覆盖规则，
+容易再次产生静默数据回滚，因此不采用。
+
+## 架构与职责
+
+### `ProviderRegistryBootstrap`
+
+放在 `oryxos-provider` 模块，负责启动播种，不负责判断应用是否可以提供 LLM
+能力。
+
+输入：
+
+- `ProviderRegistry`；
+- `ProvidersProperties`。
+
+行为：
+
+1. 遍历 YAML Provider。
+2. 同名记录已存在时直接跳过，不调用 `save()`。
+3. 同名记录不存在且配置可作为种子时调用 `save()`。
+4. 普通 Provider 的 seed 必须包含非空名称、非空且已解析的 API key、非空
+   base URL。
+5. `mock` Provider 允许 API key 和 base URL 为空。
+6. 无效 YAML seed 不写数据库，记录不包含凭证值的告警。
+
+### `ProviderRegistryValidator`
+
+放在 `oryxos-provider` 模块，负责校验最终注册表是否可供 LLM 入口使用。
+
+规则：
+
+- 注册表必须至少包含一个 Provider。
+- Provider 名称必须非空且唯一；注册表以名称为主键，重复属于防御性检查。
+- `mock` Provider 不要求 API key 和 base URL。
+- 普通 Provider 必须有非空 API key 和 base URL。
+- 错误消息只点名 Provider 和缺失字段，不回显任何凭证内容。
+
+### `OryxOsRuntime`
+
+`providerRegistry()` 继续创建 `JpaProviderRegistry`，随后调用
+`ProviderRegistryBootstrap.seedMissing()`。删除当前内联的无条件 upsert。
+
+Bean 创建阶段只播种，不做“必须存在可用 Provider”的严格校验，以保证
+`user` 等不使用 LLM 的非 Web 命令仍能启动。
+
+### `ProviderStartupCheck`
+
+继续只在 Servlet Web 应用中生效，但改为注入 `ProviderRegistry` 和
+`ProviderRegistryValidator`，校验最终注册表。校验仍发生在 Web Server
+开始监听端口之前。
+
+因此 `serve` 和当前以 Servlet 模式启动的 `gateway` 都使用数据库最终状态，
+不再受空 YAML key 影响。
+
+### `ChatCommand`
+
+`chat` 使用 `WebApplicationType.NONE`，不会触发 `ProviderStartupCheck`。
+它在 Spring Context 创建后、进入 `CliChannel` 之前，显式调用同一个
+`ProviderRegistryValidator`。
+
+校验失败时不进入交互循环，并向用户返回点名 Provider 的配置错误。
+
+## 数据流
+
+```text
+启动
+  -> 创建 JpaProviderRegistry
+  -> ProviderRegistryBootstrap 遍历 YAML
+       -> DB 已有同名记录：跳过
+       -> DB 无记录 + YAML 有效：首次写入
+       -> DB 无记录 + YAML 无效：告警并跳过
+  -> 得到最终 ProviderRegistry
+       -> serve/gateway：ProviderStartupCheck 校验
+       -> chat：ChatCommand 显式校验
+       -> user 等轻命令：不校验
+  -> LLM 调用始终按名称从 ProviderRegistry 读取配置
+```
+
+## 决策表
+
+| 数据库状态 | YAML 状态 | 播种结果 | LLM 入口结果 |
+|---|---|---|---|
+| 无同名记录 | 有效 | 首次写入 | 校验通过 |
+| 无同名记录 | key 为空或未解析 | 不写入 | 无其他可用 Provider 时清晰失败 |
+| 已有有效同名记录 | 有效但值不同 | 保留数据库值 | 校验通过 |
+| 已有有效同名记录 | key 为空 | 保留数据库值 | 校验通过 |
+| 已有无效同名记录 | 任意 | 保留数据库值，不自动修复 | 清晰失败 |
+| `mock` 不存在 | 无 key/base URL 的有效 mock 定义 | 首次写入 | 校验通过 |
+
+## 错误处理与安全
+
+- 日志和异常不得包含 API key、请求头或其他凭证值。
+- 无效 YAML seed 使用告警说明“未播种哪个 Provider 及缺少什么”，但不把
+  原始值写入日志。
+- 无效数据库记录由 Validator 阻止 LLM 入口继续启动，避免把错误推迟到第一
+  次模型调用才暴露。
+- 本修复不删除、不覆盖历史记录，避免以“自动修复”为名造成第二次数据损坏。
+- 数据库读写异常保持现有显式失败行为，不静默降级为 YAML。
+
+## 测试策略
+
+### 单元测试
+
+`ProviderRegistryBootstrapTest`：
+
+1. 数据库无记录、YAML 有效时写入一次。
+2. 数据库已有同名 Provider 时不调用 `save()`。
+3. 数据库已有 Provider、YAML 值不同时保留数据库值。
+4. 数据库无记录、YAML key 为空或未解析时不写入。
+5. `mock` Provider 可在无 key/base URL 时播种。
+
+`ProviderRegistryValidatorTest`：
+
+1. 有效普通 Provider 校验通过。
+2. 有效 `mock` Provider 校验通过。
+3. 空注册表清晰失败。
+4. 普通 Provider 缺 key 或 base URL 时点名失败。
+5. 错误消息不包含凭证内容。
+
+### 重启集成测试
+
+新增默认测试门禁会执行的 `ProviderConfigRestartTest`，不标记
+`@Tag("integration")`，使用 mock/本地假配置、两个 Spring Context 和同一个
+临时 SQLite 文件，不依赖真实网络或外部 API key：
+
+1. 第一次启动用有效 YAML seed 创建 Provider。
+2. 通过 `ProviderRegistry.save()` 模拟管理台轮换 key 和 base URL。
+3. 关闭第一个 Context。
+4. 第二次以相同数据库、空 YAML key 启动 Servlet Context。
+5. 断言第二次启动成功，且数据库仍保留管理台写入的值。
+
+另加首次启动失败场景：数据库为空且 YAML key 为空时，不产生 Provider
+记录，LLM 入口返回清晰的启动错误。该场景通过 Bootstrap/Validator 单元测试
+覆盖，避免为预期启动失败引入脆弱的整机异常断言。
+
+### 回归门禁
+
+先运行受影响模块：
+
+```bash
+mvn test -pl oryxos-provider,oryxos-cli,oryxos-web,oryxos-boot -am
+```
+
+再运行完整门禁：
+
+```bash
+mvn clean verify
+```
+
+## 预计修改范围
+
+- `oryxos-provider`：新增 Bootstrap、Validator 及单元测试。
+- `oryxos-cli`：调整 `OryxOsRuntime` 播种接线和 `ChatCommand` 校验。
+- `oryxos-web`：调整 `ProviderStartupCheck`。
+- `oryxos-boot`：新增跨重启集成测试。
+- `oryxos-storage/src/main/resources/schema.sql`：只同步注释，不改表结构。
+
+## 验收标准
+
+1. 数据库已有 Provider 时，启动过程不再对其执行 YAML upsert。
+2. 管理台更新的 Provider key/base URL 在重启后保持不变。
+3. 数据库已有有效 Provider、YAML key 为空时，`serve` 和 `chat` 可正常使用
+   数据库配置。
+4. 数据库为空、YAML key 为空时，不写入空记录，LLM 入口清晰失败。
+5. 历史无效数据库记录不被自动覆盖，并在 LLM 入口启动时清晰失败。
+6. `mock` Provider 与不使用 LLM 的轻命令保持现有行为。
+7. 相关测试和 `mvn clean verify` 全部通过。
+
+## PR 交付边界
+
+该 PR 只修复 Provider 启动播种和运行前校验，正文关联 `Closes #42`。不夹带
+API 校验重构、密钥存储改造、SQLite 并发配置或其他开放 Issue。

--- a/oryxos-boot/src/test/java/io/oryxos/boot/ProviderConfigRestartTest.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/ProviderConfigRestartTest.java
@@ -28,14 +28,12 @@ class ProviderConfigRestartTest {
         boot(workspace, dbUrl, "yaml-seed-key", "https://seed.example/v1")) {
       ProviderRegistry registry = first.getBean(ProviderRegistry.class);
       registry.save(
-          new ProviderDef(
-              "deepseek", "db-rotated-key", "https://db.example/v1", "managed"));
+          new ProviderDef("deepseek", "db-rotated-key", "https://db.example/v1", "managed"));
     }
 
     try (ConfigurableApplicationContext second =
         boot(workspace, dbUrl, "", "https://seed.example/v1")) {
-      ProviderDef restored =
-          second.getBean(ProviderRegistry.class).find("deepseek").orElseThrow();
+      ProviderDef restored = second.getBean(ProviderRegistry.class).find("deepseek").orElseThrow();
       assertEquals("db-rotated-key", restored.apiKey());
       assertEquals("https://db.example/v1", restored.baseUrl());
       assertEquals("managed", restored.description());

--- a/oryxos-boot/src/test/java/io/oryxos/boot/ProviderConfigRestartTest.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/ProviderConfigRestartTest.java
@@ -1,0 +1,80 @@
+package io.oryxos.boot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.oryxos.cli.OryxOsRuntime;
+import io.oryxos.core.provider.ProviderDef;
+import io.oryxos.core.provider.ProviderRegistry;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+class ProviderConfigRestartTest {
+
+  @TempDir Path root;
+
+  @Test
+  void databaseManagedProviderSurvivesRestartWithBlankYamlKey() throws Exception {
+    Path workspace = Files.createDirectories(root.resolve("workspace"));
+    Files.createDirectories(workspace.resolve("agents"));
+    Files.createDirectories(workspace.resolve("memory"));
+    String dbUrl = "jdbc:sqlite:" + root.resolve("provider-restart.db");
+
+    try (ConfigurableApplicationContext first =
+        boot(workspace, dbUrl, "yaml-seed-key", "https://seed.example/v1")) {
+      ProviderRegistry registry = first.getBean(ProviderRegistry.class);
+      registry.save(
+          new ProviderDef(
+              "deepseek", "db-rotated-key", "https://db.example/v1", "managed"));
+    }
+
+    try (ConfigurableApplicationContext second =
+        boot(workspace, dbUrl, "", "https://seed.example/v1")) {
+      ProviderDef restored =
+          second.getBean(ProviderRegistry.class).find("deepseek").orElseThrow();
+      assertEquals("db-rotated-key", restored.apiKey());
+      assertEquals("https://db.example/v1", restored.baseUrl());
+      assertEquals("managed", restored.description());
+    }
+  }
+
+  @Test
+  void nonWebRuntimeStartsWithEmptyEffectiveRegistry() throws Exception {
+    Path workspace = Files.createDirectories(root.resolve("non-web-workspace"));
+    Files.createDirectories(workspace.resolve("agents"));
+    Files.createDirectories(workspace.resolve("memory"));
+    String dbUrl = "jdbc:sqlite:" + root.resolve("non-web.db");
+
+    try (ConfigurableApplicationContext context =
+        new SpringApplicationBuilder(OryxOsRuntime.class)
+            .web(WebApplicationType.NONE)
+            .run(
+                "--spring.main.banner-mode=off",
+                "--oryxos.root=" + workspace,
+                "--spring.datasource.url=" + dbUrl,
+                "--oryxos.providers[0].name=deepseek",
+                "--oryxos.providers[0].api-key=",
+                "--oryxos.providers[0].base-url=https://seed.example/v1")) {
+      assertEquals(0, context.getBean(ProviderRegistry.class).list().size());
+    }
+  }
+
+  private static ConfigurableApplicationContext boot(
+      Path workspace, String dbUrl, String apiKey, String baseUrl) {
+    return new SpringApplicationBuilder(OryxOsRuntime.class)
+        .web(WebApplicationType.SERVLET)
+        .run(
+            "--server.address=127.0.0.1",
+            "--server.port=0",
+            "--spring.main.banner-mode=off",
+            "--oryxos.root=" + workspace,
+            "--spring.datasource.url=" + dbUrl,
+            "--oryxos.providers[0].name=deepseek",
+            "--oryxos.providers[0].api-key=" + apiKey,
+            "--oryxos.providers[0].base-url=" + baseUrl);
+  }
+}

--- a/oryxos-boot/src/test/java/io/oryxos/boot/ProviderDefaultSelectionTest.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/ProviderDefaultSelectionTest.java
@@ -1,0 +1,133 @@
+package io.oryxos.boot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.oryxos.cli.OryxOsRuntime;
+import io.oryxos.core.agent.AgentLifecycleService;
+import io.oryxos.core.profile.Profile;
+import io.oryxos.core.provider.ProviderDef;
+import io.oryxos.core.provider.ProviderRegistry;
+import io.oryxos.core.provider.ProviderRequest;
+import io.oryxos.core.provider.ProviderResponse;
+import io.oryxos.core.provider.ProviderService;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+class ProviderDefaultSelectionTest {
+
+  @TempDir Path root;
+
+  @Test
+  void agentDefaultsUseEffectiveRegistryWhenYamlProviderWasNotSeeded() throws Exception {
+    Path workspace = Files.createDirectories(root.resolve("workspace"));
+    Files.createDirectories(workspace.resolve("agents"));
+    Files.createDirectories(workspace.resolve("memory"));
+    String dbUrl = "jdbc:sqlite:" + root.resolve("provider-default.db");
+    initializeProviderDatabase(dbUrl);
+
+    ConfigurableApplicationContext context = boot(workspace, dbUrl);
+    try {
+      ProviderRegistry registry = context.getBean(ProviderRegistry.class);
+      assertEquals(List.of("qwen"), registry.list().stream().map(ProviderDef::name).toList());
+
+      AgentLifecycleService lifecycle = context.getBean(AgentLifecycleService.class);
+      Profile created = lifecycle.create("created", "created from the effective registry");
+      assertEquals("qwen", created.provider().name());
+
+      lifecycle.generateDraft("generated", "generate from the effective registry", null, List.of());
+      assertEquals("qwen", context.getBean(RecordingProviderService.class).lastProvider());
+    } finally {
+      context.getBean("workspaceWatcherExecutor", ThreadPoolTaskExecutor.class).shutdown();
+      context.close();
+    }
+  }
+
+  private static void initializeProviderDatabase(String dbUrl) throws SQLException {
+    try (var connection = DriverManager.getConnection(dbUrl);
+        var statement = connection.createStatement()) {
+      statement.execute(
+          """
+          CREATE TABLE providers (
+              name VARCHAR(128) PRIMARY KEY,
+              api_key TEXT,
+              base_url TEXT,
+              description TEXT,
+              created_at TIMESTAMP NOT NULL,
+              updated_at TIMESTAMP NOT NULL
+          )
+          """);
+      statement.execute(
+          """
+          INSERT INTO providers
+              (name, api_key, base_url, description, created_at, updated_at)
+          VALUES
+              ('qwen', 'db-key', 'https://db.example/v1', 'database-managed',
+               CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+          """);
+    }
+  }
+
+  private static ConfigurableApplicationContext boot(Path workspace, String dbUrl) {
+    return new SpringApplicationBuilder(OryxOsRuntime.class, RecordingProviderConfiguration.class)
+        .web(WebApplicationType.NONE)
+        .run(
+            "--spring.main.banner-mode=off",
+            "--oryxos.root=" + workspace,
+            "--spring.datasource.url=" + dbUrl,
+            "--oryxos.providers[0].name=deepseek",
+            "--oryxos.providers[0].api-key=",
+            "--oryxos.providers[0].base-url=https://yaml.example/v1",
+            "--oryxos.author.provider=",
+            "--oryxos.author.model=author-model");
+  }
+
+  @TestConfiguration
+  static class RecordingProviderConfiguration {
+
+    @Bean
+    @Primary
+    RecordingProviderService recordingProviderService() {
+      return new RecordingProviderService();
+    }
+  }
+
+  static final class RecordingProviderService implements ProviderService {
+
+    private final AtomicReference<String> lastProvider = new AtomicReference<>();
+
+    @Override
+    public ProviderResponse chat(String sessionId, Profile profile, ProviderRequest request) {
+      lastProvider.set(profile.provider().name());
+      String generated =
+          """
+          ---
+          name: generated
+          description: generated agent
+          provider:
+            name: qwen
+            model: qwen-model
+          ---
+
+          Generated instructions.
+          """;
+      return new ProviderResponse(generated, List.of(), null);
+    }
+
+    String lastProvider() {
+      return lastProvider.get();
+    }
+  }
+}

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -220,7 +220,7 @@ public class OryxOsRuntime {
     return new AgentStore(oryxosRoot());
   }
 
-  /** 30 节：Agent 生命周期编排。创建脚手架的 AGENT.md 模板里 provider 缺省取 oryxos.providers 第一个（保证可注册）。 */
+  /** 30 节：Agent 生命周期编排。创建脚手架的 AGENT.md 模板里 provider 缺省取最终注册表按名称排序后的第一项。 */
   @Bean
   AgentLifecycleService agentLifecycleService(
       AgentLoader agentLoader,
@@ -228,7 +228,7 @@ public class OryxOsRuntime {
       AgentScheduler agentScheduler,
       AgentStore agentStore,
       ProviderService providerService,
-      ProvidersProperties providers,
+      ProviderRegistry providerRegistry,
       Map<String, OryxTool> tools,
       NotifyChannelRegistry notifyChannelRegistry,
       io.oryxos.core.mcp.McpServerAdmin mcpServerAdmin,
@@ -238,8 +238,13 @@ public class OryxOsRuntime {
       @Value("${oryxos.author.provider:}") String authorProvider,
       @Value("${oryxos.author.model:}") String authorModel) {
     String defaultProvider =
-        providers.providers().isEmpty() ? null : providers.providers().get(0).name();
-    // 生成用 provider 缺省取 providers 第一个（宪法 III 显式映射的 key）
+        providerRegistry.list().stream()
+            .map(ProviderDef::name)
+            .filter(name -> name != null && !name.isBlank())
+            .sorted()
+            .findFirst()
+            .orElse(null);
+    // 生成用 provider 缺省取最终注册表的确定性默认；显式 oryxos.author.provider 仍按原行为覆盖。
     String genProvider =
         authorProvider == null || authorProvider.isBlank() ? defaultProvider : authorProvider;
     // 30 节：把真实工具清单 + notify 渠道注入作者提示词，让"一句话生成"只用真实能力、可直接运行

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -42,6 +42,8 @@ import io.oryxos.memory.MemoryServiceImpl;
 import io.oryxos.memory.SqliteMemoryStore;
 import io.oryxos.memory.builtin.MemoryTools;
 import io.oryxos.provider.ProviderChatModelFactory;
+import io.oryxos.provider.ProviderRegistryBootstrap;
+import io.oryxos.provider.ProviderRegistryValidator;
 import io.oryxos.provider.ProvidersProperties;
 import io.oryxos.provider.SpringAiProviderServiceImpl;
 import io.oryxos.provider.ToolSchemaAdapter;
@@ -136,17 +138,26 @@ public class OryxOsRuntime {
     return Path.of(oryxosRootProp);
   }
 
-  /** 31 节：Provider 动态注册表（SQLite）。启动把 config 的 oryxos.providers 播种进 DB（库里没有才写），之后以 DB 为准。 */
+  @Bean
+  ProviderRegistryValidator providerRegistryValidator() {
+    return new ProviderRegistryValidator();
+  }
+
+  @Bean
+  ProviderRegistryBootstrap providerRegistryBootstrap(ProviderRegistryValidator validator) {
+    return new ProviderRegistryBootstrap(validator);
+  }
+
+  /**
+   * 31 节：Provider 动态注册表（SQLite）。YAML 仅首次播种数据库中缺失且有效的条目；之后数据库为唯一事实源。
+   */
   @Bean
   ProviderRegistry providerRegistry(
-      LlmProviderRepository repository, ProvidersProperties properties) {
+      LlmProviderRepository repository,
+      ProvidersProperties properties,
+      ProviderRegistryBootstrap bootstrap) {
     ProviderRegistry registry = new JpaProviderRegistry(repository);
-    // 012-web-auth fix: 不在此处做严格校验——user 命令（WebApplicationType.NONE）不依赖 LLM，
-    // 不应因 api-key 未配而阻断账号管理。严格校验由 ProviderStartupCheck 在 serve/gateway 做。
-    for (ProvidersProperties.ProviderConfig c : properties.providers()) {
-      // 无条件 save（JpaProviderRegistry.save 本身是 upsert），确保 config 变更同步到 DB
-      registry.save(new ProviderDef(c.name(), c.apiKey(), c.baseUrl(), null));
-    }
+    bootstrap.seedMissing(registry, properties);
     return registry;
   }
 

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -148,9 +148,7 @@ public class OryxOsRuntime {
     return new ProviderRegistryBootstrap(validator);
   }
 
-  /**
-   * 31 节：Provider 动态注册表（SQLite）。YAML 仅首次播种数据库中缺失且有效的条目；之后数据库为唯一事实源。
-   */
+  /** 31 节：Provider 动态注册表（SQLite）。YAML 仅首次播种数据库中缺失且有效的条目；之后数据库为唯一事实源。 */
   @Bean
   ProviderRegistry providerRegistry(
       LlmProviderRepository repository,

--- a/oryxos-cli/src/main/java/io/oryxos/cli/command/ChatCommand.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/command/ChatCommand.java
@@ -2,6 +2,8 @@ package io.oryxos.cli.command;
 
 import io.oryxos.channel.cli.CliChannel;
 import io.oryxos.cli.OryxOsRuntime;
+import io.oryxos.core.provider.ProviderRegistry;
+import io.oryxos.provider.ProviderRegistryValidator;
 import org.springframework.boot.Banner;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -24,8 +26,14 @@ public class ChatCommand implements Runnable {
             .web(WebApplicationType.NONE)
             .bannerMode(Banner.Mode.OFF)
             .run()) {
+      validateProviderRegistry(context);
       context.getBean(CliChannel.class).run(profileName, currentUser());
     }
+  }
+
+  static void validateProviderRegistry(ConfigurableApplicationContext context) {
+    ProviderRegistry registry = context.getBean(ProviderRegistry.class);
+    context.getBean(ProviderRegistryValidator.class).validate(registry);
   }
 
   /** 核心阶段无认证体系，"当前用户"取运行环境的系统用户名（clarify 既定默认）。 */

--- a/oryxos-cli/src/test/java/io/oryxos/cli/command/ChatCommandTest.java
+++ b/oryxos-cli/src/test/java/io/oryxos/cli/command/ChatCommandTest.java
@@ -1,0 +1,26 @@
+package io.oryxos.cli.command;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.oryxos.core.provider.ProviderRegistry;
+import io.oryxos.provider.ProviderRegistryValidator;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ConfigurableApplicationContext;
+
+class ChatCommandTest {
+
+  @Test
+  void validatesEffectiveRegistryBeforeConversation() {
+    ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
+    ProviderRegistry registry = mock(ProviderRegistry.class);
+    ProviderRegistryValidator validator = mock(ProviderRegistryValidator.class);
+    when(context.getBean(ProviderRegistry.class)).thenReturn(registry);
+    when(context.getBean(ProviderRegistryValidator.class)).thenReturn(validator);
+
+    ChatCommand.validateProviderRegistry(context);
+
+    verify(validator).validate(registry);
+  }
+}

--- a/oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryBootstrap.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryBootstrap.java
@@ -26,14 +26,17 @@ public final class ProviderRegistryBootstrap {
           new ProviderDef(config.name(), config.apiKey(), config.baseUrl(), null);
       Optional<String> violation = validator.violation(candidate);
       if (violation.isPresent()) {
-        LOG.warn("跳过 provider {} 的启动播种: {}", safeName(config.name()), violation.get());
+        LOG.warn(
+            "跳过 provider {} 的启动播种: {}",
+            sanitizeLogValue(config.name()),
+            sanitizeLogValue(violation.get()));
         continue;
       }
       registry.save(candidate);
     }
   }
 
-  private static String safeName(String name) {
-    return name == null ? "<unknown>" : name.replace('\r', '_').replace('\n', '_');
+  private static String sanitizeLogValue(String value) {
+    return value == null ? "<unknown>" : value.replace('\r', '_').replace('\n', '_');
   }
 }

--- a/oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryBootstrap.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryBootstrap.java
@@ -1,0 +1,42 @@
+package io.oryxos.provider;
+
+import io.oryxos.core.provider.ProviderDef;
+import io.oryxos.core.provider.ProviderRegistry;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ProviderRegistryBootstrap {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ProviderRegistryBootstrap.class);
+
+  private final ProviderRegistryValidator validator;
+
+  public ProviderRegistryBootstrap(ProviderRegistryValidator validator) {
+    this.validator = validator;
+  }
+
+  public void seedMissing(ProviderRegistry registry, ProvidersProperties properties) {
+    for (ProvidersProperties.ProviderConfig config : properties.providers()) {
+      String name = config.name();
+      if (name != null && !name.isBlank() && registry.exists(name)) {
+        continue;
+      }
+      ProviderDef candidate =
+          new ProviderDef(config.name(), config.apiKey(), config.baseUrl(), null);
+      Optional<String> violation = validator.violation(candidate);
+      if (violation.isPresent()) {
+        LOG.warn(
+            "跳过 provider {} 的启动播种: {}",
+            safeName(config.name()),
+            violation.get());
+        continue;
+      }
+      registry.save(candidate);
+    }
+  }
+
+  private static String safeName(String name) {
+    return name == null ? "<unknown>" : name.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryBootstrap.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryBootstrap.java
@@ -26,10 +26,7 @@ public final class ProviderRegistryBootstrap {
           new ProviderDef(config.name(), config.apiKey(), config.baseUrl(), null);
       Optional<String> violation = validator.violation(candidate);
       if (violation.isPresent()) {
-        LOG.warn(
-            "跳过 provider {} 的启动播种: {}",
-            safeName(config.name()),
-            violation.get());
+        LOG.warn("跳过 provider {} 的启动播种: {}", safeName(config.name()), violation.get());
         continue;
       }
       registry.save(candidate);

--- a/oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryValidator.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryValidator.java
@@ -21,7 +21,10 @@ public final class ProviderRegistryValidator {
       Optional<String> violation = violation(provider);
       if (violation.isPresent()) {
         throw new IllegalStateException(
-            "provider " + safeName(provider == null ? null : provider.name()) + " " + violation.get());
+            "provider "
+                + safeName(provider == null ? null : provider.name())
+                + " "
+                + violation.get());
       }
       if (!names.add(provider.name())) {
         throw new IllegalStateException("Provider 注册表名称重复: " + safeName(provider.name()));
@@ -36,7 +39,9 @@ public final class ProviderRegistryValidator {
     if (MOCK.equals(provider.name())) {
       return Optional.empty();
     }
-    if (provider.apiKey() == null || provider.apiKey().isBlank() || provider.apiKey().contains("${")) {
+    if (provider.apiKey() == null
+        || provider.apiKey().isBlank()
+        || provider.apiKey().contains("${")) {
       return Optional.of("的 api-key 未配置");
     }
     if (provider.baseUrl() == null || provider.baseUrl().isBlank()) {

--- a/oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryValidator.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ProviderRegistryValidator.java
@@ -1,0 +1,51 @@
+package io.oryxos.provider;
+
+import io.oryxos.core.provider.ProviderDef;
+import io.oryxos.core.provider.ProviderRegistry;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public final class ProviderRegistryValidator {
+
+  private static final String MOCK = "mock";
+
+  public void validate(ProviderRegistry registry) {
+    List<ProviderDef> providers = registry.list();
+    if (providers.isEmpty()) {
+      throw new IllegalStateException("没有可用的 Provider，请先配置 Provider");
+    }
+    Set<String> names = new HashSet<>();
+    for (ProviderDef provider : providers) {
+      Optional<String> violation = violation(provider);
+      if (violation.isPresent()) {
+        throw new IllegalStateException(
+            "provider " + safeName(provider == null ? null : provider.name()) + " " + violation.get());
+      }
+      if (!names.add(provider.name())) {
+        throw new IllegalStateException("Provider 注册表名称重复: " + safeName(provider.name()));
+      }
+    }
+  }
+
+  Optional<String> violation(ProviderDef provider) {
+    if (provider == null || provider.name() == null || provider.name().isBlank()) {
+      return Optional.of("名称为空");
+    }
+    if (MOCK.equals(provider.name())) {
+      return Optional.empty();
+    }
+    if (provider.apiKey() == null || provider.apiKey().isBlank() || provider.apiKey().contains("${")) {
+      return Optional.of("的 api-key 未配置");
+    }
+    if (provider.baseUrl() == null || provider.baseUrl().isBlank()) {
+      return Optional.of("的 base-url 未配置");
+    }
+    return Optional.empty();
+  }
+
+  private static String safeName(String name) {
+    return name == null ? "<unknown>" : name.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryBootstrapTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryBootstrapTest.java
@@ -1,0 +1,94 @@
+package io.oryxos.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.oryxos.core.provider.ProviderDef;
+import io.oryxos.core.provider.ProviderRegistry;
+import io.oryxos.provider.ProvidersProperties.ProviderConfig;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ProviderRegistryBootstrapTest {
+
+  private ProviderRegistry registry;
+  private ProviderRegistryBootstrap bootstrap;
+
+  @BeforeEach
+  void setUp() {
+    registry = mock(ProviderRegistry.class);
+    bootstrap = new ProviderRegistryBootstrap(new ProviderRegistryValidator());
+  }
+
+  @Test
+  void missingValidProvider_isSeededOnce() {
+    when(registry.exists("deepseek")).thenReturn(false);
+    ProvidersProperties properties =
+        new ProvidersProperties(
+            List.of(new ProviderConfig("deepseek", "yaml-key", "https://seed.example/v1")));
+
+    bootstrap.seedMissing(registry, properties);
+
+    ArgumentCaptor<ProviderDef> saved = ArgumentCaptor.forClass(ProviderDef.class);
+    verify(registry).save(saved.capture());
+    assertEquals("deepseek", saved.getValue().name());
+    assertEquals("yaml-key", saved.getValue().apiKey());
+  }
+
+  @Test
+  void existingProvider_isNeverOverwrittenEvenWhenYamlDiffers() {
+    when(registry.exists("deepseek")).thenReturn(true);
+    ProvidersProperties properties =
+        new ProvidersProperties(
+            List.of(new ProviderConfig("deepseek", "yaml-old", "https://yaml.example/v1")));
+
+    bootstrap.seedMissing(registry, properties);
+
+    verify(registry, never()).save(any());
+  }
+
+  @Test
+  void existingProvider_isKeptWhenYamlKeyIsBlank() {
+    when(registry.exists("deepseek")).thenReturn(true);
+    ProvidersProperties properties =
+        new ProvidersProperties(
+            List.of(new ProviderConfig("deepseek", "", "https://yaml.example/v1")));
+
+    bootstrap.seedMissing(registry, properties);
+
+    verify(registry, never()).save(any());
+  }
+
+  @Test
+  void missingProviderWithBlankOrUnresolvedKey_isNotPersisted() {
+    ProvidersProperties blank =
+        new ProvidersProperties(
+            List.of(new ProviderConfig("deepseek", " ", "https://seed.example/v1")));
+    ProvidersProperties unresolved =
+        new ProvidersProperties(
+            List.of(
+                new ProviderConfig(
+                    "kimi", "${KIMI_API_KEY}", "https://api.moonshot.cn/v1")));
+
+    bootstrap.seedMissing(registry, blank);
+    bootstrap.seedMissing(registry, unresolved);
+
+    verify(registry, never()).save(any());
+  }
+
+  @Test
+  void mockProvider_canSeedWithoutKeyOrBaseUrl() {
+    when(registry.exists("mock")).thenReturn(false);
+
+    bootstrap.seedMissing(
+        registry, new ProvidersProperties(List.of(new ProviderConfig("mock", null, null))));
+
+    verify(registry).save(new ProviderDef("mock", null, null, null));
+  }
+}

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryBootstrapTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryBootstrapTest.java
@@ -7,13 +7,18 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.oryxos.core.provider.ProviderDef;
 import io.oryxos.core.provider.ProviderRegistry;
 import io.oryxos.provider.ProvidersProperties.ProviderConfig;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
 
 class ProviderRegistryBootstrapTest {
 
@@ -80,6 +85,34 @@ class ProviderRegistryBootstrapTest {
     bootstrap.seedMissing(registry, blank);
     bootstrap.seedMissing(registry, unresolved);
 
+    verify(registry, never()).save(any());
+  }
+
+  @Test
+  void invalidProvider_logReasonCannotInjectNewline() {
+    ProviderRegistryValidator validator = mock(ProviderRegistryValidator.class);
+    when(validator.violation(any())).thenReturn(Optional.of("invalid\r\nforged"));
+    bootstrap = new ProviderRegistryBootstrap(validator);
+    Logger logger = (Logger) LoggerFactory.getLogger(ProviderRegistryBootstrap.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    boolean previousAdditive = logger.isAdditive();
+    appender.start();
+    logger.addAppender(appender);
+    logger.setAdditive(false);
+
+    try {
+      bootstrap.seedMissing(
+          registry,
+          new ProvidersProperties(
+              List.of(new ProviderConfig("deepseek", "test-key", "https://seed.example/v1"))));
+    } finally {
+      logger.detachAppender(appender);
+      logger.setAdditive(previousAdditive);
+      appender.stop();
+    }
+
+    assertEquals(1, appender.list.size());
+    assertEquals("invalid__forged", appender.list.getFirst().getArgumentArray()[1]);
     verify(registry, never()).save(any());
   }
 

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryBootstrapTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryBootstrapTest.java
@@ -75,9 +75,7 @@ class ProviderRegistryBootstrapTest {
             List.of(new ProviderConfig("deepseek", " ", "https://seed.example/v1")));
     ProvidersProperties unresolved =
         new ProvidersProperties(
-            List.of(
-                new ProviderConfig(
-                    "kimi", "${KIMI_API_KEY}", "https://api.moonshot.cn/v1")));
+            List.of(new ProviderConfig("kimi", "${KIMI_API_KEY}", "https://api.moonshot.cn/v1")));
 
     bootstrap.seedMissing(registry, blank);
     bootstrap.seedMissing(registry, unresolved);

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryBootstrapTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryBootstrapTest.java
@@ -55,6 +55,8 @@ class ProviderRegistryBootstrapTest {
 
   @Test
   void existingProvider_isKeptWhenYamlKeyIsBlank() {
+    ProviderRegistryValidator validator = mock(ProviderRegistryValidator.class);
+    bootstrap = new ProviderRegistryBootstrap(validator);
     when(registry.exists("deepseek")).thenReturn(true);
     ProvidersProperties properties =
         new ProvidersProperties(
@@ -62,6 +64,7 @@ class ProviderRegistryBootstrapTest {
 
     bootstrap.seedMissing(registry, properties);
 
+    verify(validator, never()).violation(any());
     verify(registry, never()).save(any());
   }
 

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryValidatorTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryValidatorTest.java
@@ -1,0 +1,74 @@
+package io.oryxos.provider;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.oryxos.core.provider.ProviderDef;
+import io.oryxos.core.provider.ProviderRegistry;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ProviderRegistryValidatorTest {
+
+  private ProviderRegistry registry;
+  private ProviderRegistryValidator validator;
+
+  @BeforeEach
+  void setUp() {
+    registry = mock(ProviderRegistry.class);
+    validator = new ProviderRegistryValidator();
+  }
+
+  @Test
+  void validDatabaseProvider_passesWithoutReadingYaml() {
+    when(registry.list())
+        .thenReturn(List.of(new ProviderDef("deepseek", "db-key", "https://db.example/v1", null)));
+
+    assertDoesNotThrow(() -> validator.validate(registry));
+  }
+
+  @Test
+  void mockProvider_allowsMissingKeyAndBaseUrl() {
+    when(registry.list()).thenReturn(List.of(new ProviderDef("mock", null, null, null)));
+
+    assertDoesNotThrow(() -> validator.validate(registry));
+  }
+
+  @Test
+  void emptyRegistry_failsClearly() {
+    when(registry.list()).thenReturn(List.of());
+
+    IllegalStateException error =
+        assertThrows(IllegalStateException.class, () -> validator.validate(registry));
+    assertTrue(error.getMessage().contains("Provider"));
+  }
+
+  @Test
+  void blankKey_failsWithoutLeakingOtherCredentialValues() {
+    String secret = "must-not-leak";
+    when(registry.list())
+        .thenReturn(
+            List.of(new ProviderDef("broken", " ", "https://broken.example/v1", secret)));
+
+    IllegalStateException error =
+        assertThrows(IllegalStateException.class, () -> validator.validate(registry));
+    assertTrue(error.getMessage().contains("broken"));
+    assertTrue(error.getMessage().contains("api-key"));
+    assertFalse(error.getMessage().contains(secret));
+  }
+
+  @Test
+  void blankBaseUrl_failsAndNamesProvider() {
+    when(registry.list()).thenReturn(List.of(new ProviderDef("broken", "db-key", " ", null)));
+
+    IllegalStateException error =
+        assertThrows(IllegalStateException.class, () -> validator.validate(registry));
+    assertTrue(error.getMessage().contains("broken"));
+    assertTrue(error.getMessage().contains("base-url"));
+  }
+}

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryValidatorTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ProviderRegistryValidatorTest.java
@@ -52,8 +52,7 @@ class ProviderRegistryValidatorTest {
   void blankKey_failsWithoutLeakingOtherCredentialValues() {
     String secret = "must-not-leak";
     when(registry.list())
-        .thenReturn(
-            List.of(new ProviderDef("broken", " ", "https://broken.example/v1", secret)));
+        .thenReturn(List.of(new ProviderDef("broken", " ", "https://broken.example/v1", secret)));
 
     IllegalStateException error =
         assertThrows(IllegalStateException.class, () -> validator.validate(registry));

--- a/oryxos-storage/src/main/resources/schema.sql
+++ b/oryxos-storage/src/main/resources/schema.sql
@@ -109,7 +109,8 @@ CREATE TABLE IF NOT EXISTS notify_channels (
 );
 
 -- providers：LLM Provider 动态注册表（31 节）——name → api_key + base_url + 描述；管理台可 CRUD、运行时按名动态建 ChatModel。
--- 启动时把 config/application.yml 的 oryxos.providers 播种进来（库里没有才写），之后以本表为准。
+-- 启动时仅把 config/application.yml 中数据库尚不存在且有效的 Provider 作为首次种子；
+-- 已有同名记录绝不从 YAML 覆盖，之后以本表为唯一运行时事实源。
 -- 注意：api_key 明文落库（本地 gitignored 库）——这是"可动态管理"对宪法"凭证走环境变量"的核心阶段让步。
 CREATE TABLE IF NOT EXISTS providers (
     name VARCHAR(128) PRIMARY KEY,

--- a/oryxos-web/src/main/java/io/oryxos/web/security/ProviderStartupCheck.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/ProviderStartupCheck.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Component;
 /**
  * Provider 配置启动校验（012-web-auth fix）。
  *
- * <p>仅在 SERVLET web 模式（serve/gateway）执行——WebApplicationType.NONE 自身不触发；chat 在进入会话前显式校验，
- * user 等轻命令仍不会因 Provider 未配置而被阻断。
+ * <p>仅在 SERVLET web 模式（serve/gateway）执行——WebApplicationType.NONE 自身不触发；chat 在进入会话前显式校验， user
+ * 等轻命令仍不会因 Provider 未配置而被阻断。
  *
  * <p>实现 {@link SmartInitializingSingleton} 而非 {@code ApplicationRunner}：校验在所有单例 Bean 初始化完成后、Web
  * Server 开始监听端口之前执行。配置不合法时 ApplicationContext 启动直接失败， 端口不会打开，避免健康检查在 Provider 校验之前返回 200
@@ -37,7 +37,6 @@ public class ProviderStartupCheck implements SmartInitializingSingleton {
   @Override
   public void afterSingletonsInstantiated() {
     validator.validate(registry);
-    LOG.debug(
-        "Provider startup check passed ({} provider(s) configured)", registry.list().size());
+    LOG.debug("Provider startup check passed ({} provider(s) configured)", registry.list().size());
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/security/ProviderStartupCheck.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/ProviderStartupCheck.java
@@ -1,6 +1,7 @@
 package io.oryxos.web.security;
 
-import io.oryxos.provider.ProvidersProperties;
+import io.oryxos.core.provider.ProviderRegistry;
+import io.oryxos.provider.ProviderRegistryValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.SmartInitializingSingleton;
@@ -10,14 +11,14 @@ import org.springframework.stereotype.Component;
 /**
  * Provider 配置启动校验（012-web-auth fix）。
  *
- * <p>仅在 SERVLET web 模式（serve/gateway）执行——user/chat 等 WebApplicationType.NONE 命令不触发， 确保账号管理等不依赖 LLM
- * 的命令不会因 api-key 未配而被阻断。
+ * <p>仅在 SERVLET web 模式（serve/gateway）执行——WebApplicationType.NONE 自身不触发；chat 在进入会话前显式校验，
+ * user 等轻命令仍不会因 Provider 未配置而被阻断。
  *
  * <p>实现 {@link SmartInitializingSingleton} 而非 {@code ApplicationRunner}：校验在所有单例 Bean 初始化完成后、Web
  * Server 开始监听端口之前执行。配置不合法时 ApplicationContext 启动直接失败， 端口不会打开，避免健康检查在 Provider 校验之前返回 200
  * 的竞态（false-positive startup）。
  *
- * <p>校验逻辑委托给 {@link ProvidersProperties#validate()}。
+ * <p>校验逻辑委托给 {@link ProviderRegistryValidator}，确保检查的是 YAML 播种后的最终注册表。
  */
 @Component
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
@@ -25,16 +26,18 @@ public class ProviderStartupCheck implements SmartInitializingSingleton {
 
   private static final Logger LOG = LoggerFactory.getLogger(ProviderStartupCheck.class);
 
-  private final ProvidersProperties properties;
+  private final ProviderRegistry registry;
+  private final ProviderRegistryValidator validator;
 
-  public ProviderStartupCheck(ProvidersProperties properties) {
-    this.properties = properties;
+  public ProviderStartupCheck(ProviderRegistry registry, ProviderRegistryValidator validator) {
+    this.registry = registry;
+    this.validator = validator;
   }
 
   @Override
   public void afterSingletonsInstantiated() {
-    properties.validate();
+    validator.validate(registry);
     LOG.debug(
-        "Provider startup check passed ({} provider(s) configured)", properties.providers().size());
+        "Provider startup check passed ({} provider(s) configured)", registry.list().size());
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/security/ProviderStartupCheck.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/ProviderStartupCheck.java
@@ -29,6 +29,11 @@ public class ProviderStartupCheck implements SmartInitializingSingleton {
   private final ProviderRegistry registry;
   private final ProviderRegistryValidator validator;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "ProviderRegistry is a shared Spring bean dependency and is intentionally retained; "
+              + "copying or wrapping it would break bean semantics.")
   public ProviderStartupCheck(ProviderRegistry registry, ProviderRegistryValidator validator) {
     this.registry = registry;
     this.validator = validator;

--- a/oryxos-web/src/test/java/io/oryxos/web/security/ProviderStartupCheckTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/security/ProviderStartupCheckTest.java
@@ -1,0 +1,21 @@
+package io.oryxos.web.security;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.oryxos.core.provider.ProviderRegistry;
+import io.oryxos.provider.ProviderRegistryValidator;
+import org.junit.jupiter.api.Test;
+
+class ProviderStartupCheckTest {
+
+  @Test
+  void validatesEffectiveRegistry() {
+    ProviderRegistry registry = mock(ProviderRegistry.class);
+    ProviderRegistryValidator validator = mock(ProviderRegistryValidator.class);
+
+    new ProviderStartupCheck(registry, validator).afterSingletonsInstantiated();
+
+    verify(validator).validate(registry);
+  }
+}


### PR DESCRIPTION
## Summary

- treat SQLite `ProviderRegistry` as the runtime source of truth
- seed only missing, valid YAML providers without overwriting database-managed values
- derive Agent lifecycle defaults from the effective registry rather than YAML
- validate the effective registry for serve/gateway/chat
- add default-gate regressions for restart persistence and mismatched database/YAML provider names

## Why

Provider bootstrap previously upserted YAML values on every startup. This could roll back
admin-managed configuration or replace a valid database API key with an empty environment
fallback. Agent lifecycle defaults also continued to read the YAML list, leaving a runtime
source-of-truth bypass when the database and YAML provider names differed.

## Testing

- `mvn test -pl oryxos-cli,oryxos-boot -am`
- `mvn clean verify`
- Java 21; all 10 reactor modules passed; SpotBugs reported 0 bugs / 0 errors

Closes #42