### PR TITLE
fix(security): 修复七项高风险安全与并发问题

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -41,8 +41,8 @@ shell:
     - cat
     - echo
     - grep
-    - python                    # 与 jar 默认对齐（部分环境 python 即 python3）
-    - python3                   # GitHub 日报 Agent 跑 scripts/github_trending.py（31 节 Demo 三）
+    # 解释器（python/python3 等）不入默认白名单：bash -c 执行下是任意代码执行入口。
+    # 确需跑脚本的 Agent 请在此显式加入并自担风险（如 GitHub 日报脚本）。
 http:
   allowed_domains:
     - api.deepseek.com          # Provider 端点（精确匹配）

--- a/oryxos-boot/src/main/resources/application.yml
+++ b/oryxos-boot/src/main/resources/application.yml
@@ -42,8 +42,8 @@ shell:
     - cat
     - echo
     - grep
-    - python          # GitHub 日报 Agent 跑 scripts/github_trending.py（31 节 Demo 三）
-    - python3
+    # 解释器（python/python3 等）刻意不入默认白名单：bash -c 执行下是任意代码执行入口。
+    # 确需跑脚本的 Agent 请在部署配置里显式加入并自担风险。
 http:
   allowed_domains:
     - api.deepseek.com      # Provider 端点（精确匹配）

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentScheduler.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentScheduler.java
@@ -45,6 +45,9 @@ public class AgentScheduler {
 
   private static final String SCHEDULER_USER = "scheduler";
 
+  /** 任务句柄复合键分隔符：schedule id 是 Agent 内的，跨 Agent 用 profileName@taskId 区分。 */
+  private static final String KEY_SEP = "@";
+
   private final TaskScheduler taskScheduler;
   private final ProfileRegistry profileRegistry;
   private final AgentService agentService;
@@ -59,7 +62,11 @@ public class AgentScheduler {
   /** 任务 id → 锁：防同一任务重叠执行。进程内锁，核心阶段单实例足够（非分布式锁）。 */
   private final ConcurrentMap<String, Lock> taskLocks = new ConcurrentHashMap<>();
 
-  /** 任务 id → 可注销句柄：为 30 节运行时注销/更新 Agent 铺路（本节只登记、留句柄）。 */
+  /**
+   * 可注销句柄表（为 30 节运行时注销/更新 Agent 铺路）。 键是 {@code profileName@taskId} 复合（review 高危 7）：schedule id 只在
+   * 单个 Agent 内唯一，跨 Agent 撞 id 时若用裸 taskId 作键，后注册覆盖先注册的句柄（旧 future 泄漏、任务双跑）， 删除先注册的 Agent 还会
+   * cancel 掉另一个 Agent 的任务。
+   */
   private final Map<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
 
   public AgentScheduler(
@@ -107,7 +114,7 @@ public class AgentScheduler {
         CronTrigger trigger = new CronTrigger(sc.cron(), resolveZone(sc.zone()));
         ScheduledFuture<?> future = taskScheduler.schedule(() -> runOnce(profile, sc), trigger);
         if (future != null) {
-          scheduledTasks.put(sc.id(), future); // 留可注销句柄（30 节用）
+          scheduledTasks.put(taskKey(sc.id(), profile.name()), future); // 留可注销句柄（30 节用）
         }
         // 28 节：登记任务状态 + 下次触发到 SQLite（重启后可查；已存在则保留启用状态与运行次数）
         taskStore.register(
@@ -119,9 +126,10 @@ public class AgentScheduler {
     }
   }
 
-  /** 某任务是否已留下可注销句柄（30 节注销前提；harness 守点）。 */
+  /** 某任务是否已留下可注销句柄（30 节注销前提；harness 守点）。键为复合键，按 taskId 前缀匹配。 */
   public boolean hasScheduledTask(String taskId) {
-    return scheduledTasks.containsKey(taskId);
+    String suffix = KEY_SEP + taskId;
+    return scheduledTasks.keySet().stream().anyMatch(key -> key.endsWith(suffix));
   }
 
   /**
@@ -133,7 +141,7 @@ public class AgentScheduler {
       justification = "日志里的 sc.id() 来自运营方手写的 AGENT.md 配置（非请求输入），仅用于诊断")
   public void unregisterProfile(Profile profile) {
     for (ScheduleConfig sc : profile.schedules()) {
-      ScheduledFuture<?> future = scheduledTasks.remove(sc.id());
+      ScheduledFuture<?> future = scheduledTasks.remove(taskKey(sc.id(), profile.name()));
       if (future != null) {
         future.cancel(false);
         LOG.info("已注销定时任务 {}", sc.id());
@@ -243,6 +251,11 @@ public class AgentScheduler {
   /** 按任务 id 取同一把锁。public 为可测（harness 占锁模拟"上一次还在跑"）。 */
   public Lock lockFor(String taskId) {
     return taskLocks.computeIfAbsent(taskId, id -> new ReentrantLock());
+  }
+
+  /** 句柄表复合键：profileName@taskId。taskId 来自 AGENT.md，SAFE 名不含 @，不会与分隔符撞。 */
+  private static String taskKey(String taskId, String profileName) {
+    return profileName + KEY_SEP + taskId;
   }
 
   /** 时区显式（坑四）：空/blank 时才退回服务器系统时区，否则按配置解析。 */

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentService.java
@@ -6,12 +6,20 @@ import io.oryxos.core.profile.Profile;
 import io.oryxos.core.profile.ProfileRegistry;
 import io.oryxos.core.session.Session;
 import io.oryxos.core.session.SessionManager;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * 一次处理的编排者：三种触发源（CLI / Web / 定时）最终都调同一个 {@link #process}。
  *
  * <p>ProfileContext 生命周期在此收口：入口 set、出口 finally clear——即使循环中途抛异常也必须清， 否则复用线程的下一个请求会拿到别人的
  * Profile（单请求测试永远测不出的串号 bug）。
+ *
+ * <p>并发（review 高危 4）：同一会话（sessionId）的并发请求在此按会话串行化。web 的 send/invoke/trigger 与定时触发
+ * 都可能并发操作同一会话（Session 无锁 ArrayList + JpaSessionManager.save 整段覆写），不加锁会 last-write-wins 丢消息。
+ * 锁是进程内、按 sessionId 隔离——跨会话并行不受影响（宪法 VII 虚拟线程并发仍成立）。
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",
@@ -19,6 +27,9 @@ import io.oryxos.core.session.SessionManager;
 public class AgentService {
 
   private static final int MEMORY_LINE_MAX = 200;
+
+  /** 会话 id → 该会话的串行锁。会话数是有限的（channel:user:profile 三元组），增长有界，可接受。 */
+  private final ConcurrentMap<String, Lock> sessionLocks = new ConcurrentHashMap<>();
 
   private final ProfileRegistry profileRegistry;
   private final ReActLoop reActLoop;
@@ -37,27 +48,41 @@ public class AgentService {
   }
 
   public String process(Session session, String userMessage) {
-    Profile profile =
-        profileRegistry
-            .get(session.profileName())
-            .orElseThrow(
-                () ->
-                    new IllegalStateException("Session 引用的 Profile 不存在: " + session.profileName()));
-    ProfileContext.set(profile); // 工具执行时靠它知道"当前是哪个 Agent"
+    // 同一会话的读写整段互斥；sessionId 理论上永不为 null（来自 SessionManager），mock 场景兜底防 NPE
+    String sessionKey = session.sessionId() == null ? profileNameOrFallback(session) : session.sessionId();
+    Lock lock = sessionLocks.computeIfAbsent(sessionKey, id -> new ReentrantLock());
+    lock.lock();
     try {
-      String reply = reActLoop.run(session, userMessage, profile);
-      // 达到最大迭代上限时 ReAct 返回占位文本（不抛异常），这里检测并转为异常，
-      // 让 triggerAsync 把执行记成失败状态（否则前端显示"执行成功"——错误引导用户）
-      boolean exhausted = ReActLoop.MAX_ITERATIONS_REPLY.equals(reply);
-      sessionManager.save(session); // 无论是正常结束还是迭代耗尽，保存现场供审计/排查
-      if (exhausted) {
-        throw new AgentMaxIterationsExceededException(reply);
+      Profile profile =
+          profileRegistry
+              .get(session.profileName())
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "Session 引用的 Profile 不存在: " + session.profileName()));
+      ProfileContext.set(profile); // 工具执行时靠它知道"当前是哪个 Agent"
+      try {
+        String reply = reActLoop.run(session, userMessage, profile);
+        // 达到最大迭代上限时 ReAct 返回占位文本（不抛异常），这里检测并转为异常，
+        // 让 triggerAsync 把执行记成失败状态（否则前端显示"执行成功"——错误引导用户）
+        boolean exhausted = ReActLoop.MAX_ITERATIONS_REPLY.equals(reply);
+        sessionManager.save(session); // 无论是正常结束还是迭代耗尽，保存现场供审计/排查
+        if (exhausted) {
+          throw new AgentMaxIterationsExceededException(reply);
+        }
+        recordTrigger(profile.name(), userMessage, reply); // 正常完成才记运行足迹
+        return reply;
+      } finally {
+        ProfileContext.clear(); // 虚拟线程每请求独立，用完必须清
       }
-      recordTrigger(profile.name(), userMessage, reply); // 正常完成才记运行足迹
-      return reply;
     } finally {
-      ProfileContext.clear(); // 虚拟线程每请求独立，用完必须清
+      lock.unlock(); // 无论成功失败必须放锁，否则该会话永久卡死
     }
+  }
+
+  private static String profileNameOrFallback(Session session) {
+    String name = session.profileName();
+    return name == null ? "(null-session)" : name;
   }
 
   /** 每次触发都往这个 Agent 的记忆归档区记一条运行足迹（这个 Agent 干过什么，事后可回看）。 */

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBindingService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBindingService.java
@@ -53,7 +53,7 @@ public class AgentSkillBindingService implements AgentSkillBindingReader {
     String skill = safe(skillName, "Skill");
     Path agentDir = requireAgent(agent);
     requireSkill(skill);
-    Path linksDir = agentDir.resolve("skills");
+    Path linksDir = requireRealSkillsDir(agentDir);
     Path link = linksDir.resolve(skill);
     if (Files.exists(link, LinkOption.NOFOLLOW_LINKS)) {
       BoundSkillDescriptor existing =
@@ -81,7 +81,7 @@ public class AgentSkillBindingService implements AgentSkillBindingReader {
   public synchronized void unbind(String agentName, String skillName) {
     String agent = safe(agentName, "Agent");
     String skill = safe(skillName, "Skill");
-    Path link = requireAgent(agent).resolve("skills").resolve(skill);
+    Path link = requireRealSkillsDir(requireAgent(agent)).resolve(skill);
     if (!Files.exists(link, LinkOption.NOFOLLOW_LINKS)) {
       return;
     }
@@ -113,7 +113,7 @@ public class AgentSkillBindingService implements AgentSkillBindingReader {
     if (current.equals(new LinkedHashSet<>(desired))) {
       return before;
     }
-    Path linksDir = agentDir.resolve("skills");
+    Path linksDir = requireRealSkillsDir(agentDir);
     List<Path> created = new ArrayList<>();
     List<Move> removed = new ArrayList<>();
     try {
@@ -173,6 +173,21 @@ public class AgentSkillBindingService implements AgentSkillBindingReader {
     Path directory = skillsDir.resolve(skill);
     return Files.isDirectory(directory, LinkOption.NOFOLLOW_LINKS)
         && RealPathBoundary.isWithin(skillsDir, directory);
+  }
+
+  /**
+   * 返回 Agent 的 skills/ 绑定目录，但先校验它不是一个越界符号链接（review 高危 5）。 skills/ 被替换成指向任意目录的软链接时，
+   * bind/unbind/replaceBindings 会直接在那里面建/删链接——写操作前必须确认其真实路径仍落在 Agent 目录内。 目录不存在时投影到
+   * Agent 目录下的正常位置（真实路径仍在 agentDir 内），放行。
+   */
+  private Path requireRealSkillsDir(Path agentDir) {
+    Path linksDir = agentDir.resolve("skills");
+    if (Files.exists(linksDir, LinkOption.NOFOLLOW_LINKS)
+        && !RealPathBoundary.isWithin(agentDir, linksDir)) {
+      throw new IllegalArgumentException(
+          "Agent skills/ 目录真实路径越界（疑似被替换为符号链接），拒绝操作: " + sanitize(linksDir.toString()));
+    }
+    return linksDir;
   }
 
   public List<AgentSkillBinding> validBindings(String agentName) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.StandardCopyOption;
@@ -123,11 +124,14 @@ public class FileTools {
     Pattern regex = Pattern.compile(pattern);
     List<String> matches = new ArrayList<>();
     try (Stream<Path> files = Files.walk(root)) {
-      for (Path file : (Iterable<Path>) files.filter(Files::isRegularFile)::iterator) {
+      // NOFOLLOW_LINKS：白名单根内被植入指向外部的软链接时，链接项不算普通文件，内容不外泄
+      for (Path file : (Iterable<Path>) files.filter(FileTools::isRealRegularFile)::iterator) {
         if (matches.size() >= MAX_MATCHES) {
           matches.add("...（已达 " + MAX_MATCHES + " 条上限，结果截断）");
           break;
         }
+        // 纵深防御：每个实际读取的文件再过一次文件白名单（防根校验到读取间符号链接被替换）
+        sandbox.enforce(new SandboxAction(ActionType.FILE_READ, file.toString()));
         appendMatches(file, regex, matches);
       }
     } catch (IOException e) {
@@ -149,14 +153,24 @@ public class FileTools {
     List<String> hits = new ArrayList<>();
     try (Stream<Path> files = Files.walk(root)) {
       files
-          .filter(Files::isRegularFile)
+          .filter(FileTools::isRealRegularFile)
           .filter(p -> matcher.matches(root.relativize(p)))
           .limit(MAX_MATCHES)
-          .forEach(p -> hits.add(p.toString()));
+          // 每个命中路径再过一次文件白名单（与 grep 同款纵深防御）
+          .forEach(
+              p -> {
+                sandbox.enforce(new SandboxAction(ActionType.FILE_READ, p.toString()));
+                hits.add(p.toString());
+              });
     } catch (IOException e) {
       throw new UncheckedIOException("查找失败: " + path, e);
     }
     return hits.isEmpty() ? "（无匹配）" : String.join("\n", hits);
+  }
+
+  /** 普通文件判定不跟随符号链接：链接项（无论指向内部还是外部）都不作为可读文件参与搜索。 */
+  private static boolean isRealRegularFile(Path file) {
+    return Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS);
   }
 
   private void appendMatches(Path file, Pattern regex, List<String> matches) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
@@ -7,6 +7,10 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -14,12 +18,17 @@ import org.springframework.ai.tool.annotation.ToolParam;
 /**
  * 内置 Shell 工具：执行 bash 命令，带超时兜底——命令挂死不能拖死整个 ReAct 循环。
  *
- * <p>命令首词白名单归 24 节（SHELL_COMMAND 检查位已过 enforce）；超时默认 30 秒 （课件未给数值的推定默认，配置化随 24 节 shell 白名单配置一并处理）。
+ * <p>命令首词白名单归 24 节（SHELL_COMMAND 检查位已过 enforce，含命令注入元字符扫描）；超时默认 30 秒。 两个运维细节（review 高危 6）：
+ * (1) stdout/stderr 在 waitFor 前就并发排空——否则输出超过管道缓冲（~64KB）的命令会写阻塞、被误判超时； (2) 超时后递归杀进程树——{@code bash -c}
+ * 派生的孙进程不在 bash 的进程组内，只杀 bash 会留孤儿继续跑。
  */
 public class ShellTools {
 
   /** 默认超时：30 秒（clarify 既定默认）。 */
   static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+
+  /** 排空子进程输出的虚拟线程执行器（宪法 VII）：流读取是 IO 等待，虚拟线程天然适配。 */
+  private static final ExecutorService DRAINER = Executors.newVirtualThreadPerTaskExecutor();
 
   private final Sandbox sandbox;
   private final Duration timeout;
@@ -37,27 +46,47 @@ public class ShellTools {
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "COMMAND_INJECTION",
       justification =
-          "shell 工具的功能本质就是执行 LLM 给出的命令；命令白名单由首行 Sandbox.enforce 前置校验（24 节 WhitelistSandbox）")
+          "shell 工具的功能本质就是执行 LLM 给出的命令；命令白名单由首行 Sandbox.enforce 前置校验（24 节 WhitelistSandbox，含元字符扫描）")
   public String shell(@ToolParam(description = "要执行的 bash 命令") String command) {
     sandbox.enforce(new SandboxAction(ActionType.SHELL_COMMAND, command));
+    Process process;
     try {
-      Process process = new ProcessBuilder("bash", "-c", command).start();
-      boolean finished = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
-      if (!finished) {
-        process.destroyForcibly();
-        throw new IllegalStateException("命令超时（" + timeout.toSeconds() + "s）被终止: " + command);
-      }
-      String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-      if (process.exitValue() != 0) {
-        String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
-        throw new IllegalStateException("命令退出码 " + process.exitValue() + ": " + stderr.trim());
-      }
-      return stdout;
+      process = new ProcessBuilder("bash", "-c", command).start();
     } catch (IOException e) {
       throw new UncheckedIOException("命令启动失败: " + command, e);
+    }
+    // 先起并发排空再 waitFor：管道不被写满阻塞，waitFor 只在"命令真没跑完"时超时
+    Future<byte[]> stdout = DRAINER.submit(() -> process.getInputStream().readAllBytes());
+    Future<byte[]> stderr = DRAINER.submit(() -> process.getErrorStream().readAllBytes());
+    boolean finished;
+    try {
+      finished = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      killTree(process);
+      throw new IllegalStateException("命令执行被中断: " + command, e);
+    }
+    if (!finished) {
+      killTree(process);
+      throw new IllegalStateException("命令超时（" + timeout.toSeconds() + "s）被终止: " + command);
+    }
+    try {
+      if (process.exitValue() != 0) {
+        String err = new String(stderr.get(), StandardCharsets.UTF_8);
+        throw new IllegalStateException("命令退出码 " + process.exitValue() + ": " + err.trim());
+      }
+      return new String(stdout.get(), StandardCharsets.UTF_8);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IllegalStateException("命令执行被中断: " + command, e);
+    } catch (ExecutionException e) {
+      throw new IllegalStateException("命令输出读取失败: " + command, e.getCause());
     }
+  }
+
+  /** 先递归杀 bash 派生的子孙进程，再杀 bash 本身（只 destroyForcibly(bash) 会留孤儿继续执行）。 */
+  private static void killTree(Process process) {
+    process.toHandle().descendants().forEach(ProcessHandle::destroyForcibly);
+    process.destroyForcibly();
   }
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -154,6 +154,59 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
       throw new SandboxViolationException(
           "命令不在白名单内: " + firstToken + "。这是安全策略，请勿反复重试；确需该命令，请在管理台「SandBox 列表」把它加入 shell 白名单。");
     }
+    // 首 token 通过还不够：执行器是 bash -c <整串>，命令分隔/替换元字符可让白名单形同虚设
+    // （ls && cat /etc/passwd、echo $(curl ...)、`rm -rf` 等）。元字符命中即拒。
+    if (hasShellInjection(command)) {
+      throw new SandboxViolationException(
+          "命令含 shell 元字符，拒绝执行（防命令注入）: " + command + "。这是安全策略，请勿反复重试；如需组合命令，请拆分执行。");
+    }
+  }
+
+  /**
+   * 命令串是否含可被 bash 解释为"追加执行/命令替换/重定向"的元字符。逐字符状态机：单引号内全字面； 双引号内仅 {@code $}、{@code `} 仍特殊（命令替换在双引号内照常执行）；引号外所有分隔/替换/重定向符一律拒绝。
+   * 反斜杠转义跳过下一字符。未闭合引号视为不合法命令，拒绝。
+   */
+  private static boolean hasShellInjection(String command) {
+    boolean inSingle = false;
+    boolean inDouble = false;
+    boolean escaped = false;
+    for (int i = 0; i < command.length(); i++) {
+      char c = command.charAt(i);
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (inSingle) {
+        if (c == '\'') {
+          inSingle = false;
+        }
+        continue;
+      }
+      if (c == '\\') {
+        escaped = true;
+        continue;
+      }
+      if (inDouble) {
+        if (c == '"') {
+          inDouble = false;
+        } else if (c == '$' || c == '`') {
+          return true; // 双引号内 $() / `cmd` 仍会执行
+        }
+        continue;
+      }
+      if (c == '\'') {
+        inSingle = true;
+        continue;
+      }
+      if (c == '"') {
+        inDouble = true;
+        continue;
+      }
+      if (";&|<>`$(){}!\n\r\t".indexOf(c) >= 0) {
+        return true;
+      }
+    }
+    return inSingle || inDouble;
   }
 
   /** HTTP 读（GET 类）：默认放行，只挡内网/回环/云元数据等 SSRF 目标。无主机的伪目标（如 web_search）放行。 */

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
@@ -148,12 +148,16 @@ class WhitelistSandboxTest {
   @DisplayName("Shell 命令白名单")
   class ShellCommandWhitelist {
 
-    private final WhitelistSandbox sb = sandbox(List.of(), List.of("ls", "cat"), List.of());
+    private final WhitelistSandbox sb = sandbox(List.of(), List.of("ls", "cat", "echo"), List.of());
 
     @Test
     @DisplayName("白名单内命令_首token放行")
     void firstTokenInWhitelistAllowed() {
       assertDoesNotThrow(() -> sb.enforce(new SandboxAction(ActionType.SHELL_COMMAND, "ls -la")));
+      // 引号/转义不追加执行：允许
+      assertDoesNotThrow(
+          () -> sb.enforce(new SandboxAction(ActionType.SHELL_COMMAND, "echo \"a;b\"")));
+      assertDoesNotThrow(() -> sb.enforce(new SandboxAction(ActionType.SHELL_COMMAND, "echo 'a;b'")));
     }
 
     @Test
@@ -162,6 +166,36 @@ class WhitelistSandboxTest {
       assertThrows(
           SandboxViolationException.class,
           () -> sb.enforce(new SandboxAction(ActionType.SHELL_COMMAND, "rm -rf /")));
+    }
+
+    @Test
+    @DisplayName("命令注入绕过_分隔符/替换符/重定向一律拒绝")
+    void shellInjectionBlocked() {
+      // 首 token 全在白名单内，但元字符可追加/替换执行——必须拒绝
+      String[] injections = {
+        "ls && cat /etc/passwd",
+        "ls ; cat /etc/passwd",
+        "ls | cat /etc/passwd",
+        "cat /etc/passwd > /tmp/x",
+        "echo $(cat /etc/passwd)",
+        "echo `cat /etc/passwd`",
+        "ls && { rm -rf / ; }",
+        "ls\ncat /etc/passwd"
+      };
+      for (String injection : injections) {
+        assertThrows(
+            SandboxViolationException.class,
+            () -> sb.enforce(new SandboxAction(ActionType.SHELL_COMMAND, injection)),
+            "应拒绝注入命令: " + injection);
+      }
+    }
+
+    @Test
+    @DisplayName("未闭合引号_视为不合法命令拒绝")
+    void unterminatedQuoteRejected() {
+      assertThrows(
+          SandboxViolationException.class,
+          () -> sb.enforce(new SandboxAction(ActionType.SHELL_COMMAND, "echo \"unterminated")));
     }
   }
 

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/ProviderApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/ProviderApiController.java
@@ -75,12 +75,15 @@ public class ProviderApiController {
   @PutMapping("/{name}")
   public ApiResponse<ProviderView> update(
       @PathVariable String name, @RequestBody UpdateProviderRequest req) {
-    if (!registry.exists(name)) {
-      throw new ResourceNotFoundException("provider 不存在: " + name); // → 404
-    }
+    ProviderDef existing =
+        registry
+            .find(name)
+            .orElseThrow(() -> new ResourceNotFoundException("provider 不存在: " + name)); // → 404
     validate(name, req.baseUrl());
+    // 前端编辑表单回填的是掩码值；提交掩码 = 未修改，保留原 key——否则打码值会覆盖真实 key
+    String apiKey = ProviderView.mask(existing.apiKey()).equals(req.apiKey()) ? existing.apiKey() : req.apiKey();
     ProviderDef saved =
-        registry.save(new ProviderDef(name, req.apiKey(), req.baseUrl(), req.description()));
+        registry.save(new ProviderDef(name, apiKey, req.baseUrl(), req.description()));
     return ApiResponse.ok(ProviderView.from(saved));
   }
 

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ProviderView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ProviderView.java
@@ -2,10 +2,26 @@ package io.oryxos.web.controller.dto;
 
 import io.oryxos.core.provider.ProviderDef;
 
-/** Provider 视图（列表/详情返回）。按用户选择：api-key 明文回显。 */
+/**
+ * Provider 视图（列表/详情返回）。
+ *
+ * <p>api-key 只回显掩码（保留末 4 位），杜绝明文经 /api/v1/**（无认证）泄露；掩码值被前端原样提交时由
+ * {@code ProviderApiController} 识别为"未修改"，保留原 key。mask 是确定性的，供该识别复用。
+ */
 public record ProviderView(String name, String apiKey, String baseUrl, String description) {
 
   public static ProviderView from(ProviderDef d) {
-    return new ProviderView(d.name(), d.apiKey(), d.baseUrl(), d.description());
+    return new ProviderView(d.name(), mask(d.apiKey()), d.baseUrl(), d.description());
+  }
+
+  /** 掩码：空/短 key 全打码，其余只留末 4 位。幂等——mask(mask(k)) == mask(k)，是"未修改"判定的基础。 */
+  public static String mask(String key) {
+    if (key == null || key.isBlank()) {
+      return "";
+    }
+    if (key.length() <= 4) {
+      return "****";
+    }
+    return "****" + key.substring(key.length() - 4);
   }
 }

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/ProviderApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/ProviderApiControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -16,6 +17,8 @@ import io.oryxos.core.provider.ProviderRegistry;
 import io.oryxos.web.GlobalExceptionHandler;
 import io.oryxos.web.provider.ProviderModelsService;
 import java.util.Optional;
+import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,7 +45,7 @@ class ProviderApiControllerTest {
   }
 
   @Test
-  @DisplayName("create 成功_返回 provider 视图（api-key 明文回显）")
+  @DisplayName("create 成功_返回 provider 视图（api-key 掩码回显，非明文）")
   void create_success_returnsView() throws Exception {
     when(registry.exists("kimi")).thenReturn(false);
     when(registry.save(any()))
@@ -55,7 +58,7 @@ class ProviderApiControllerTest {
                     "{\"name\":\"kimi\",\"apiKey\":\"sk-x\",\"baseUrl\":\"https://api.moonshot.cn\",\"description\":\"月之暗面\"}"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.name").value("kimi"))
-        .andExpect(jsonPath("$.data.apiKey").value("sk-x"));
+        .andExpect(jsonPath("$.data.apiKey").value("****")); // 掩码回显，明文不落 HTTP 响应
   }
 
   @Test
@@ -98,6 +101,29 @@ class ProviderApiControllerTest {
                 .content("{\"name\":\"mock\"}"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.name").value("mock"));
+  }
+
+  @Test
+  @DisplayName("update 回传掩码 apiKey_视为未修改_保留原 key")
+  void update_maskedKey_keepsOriginal() throws Exception {
+    when(registry.find("kimi"))
+        .thenReturn(
+            Optional.of(
+                new ProviderDef("kimi", "sk-secretvalue", "https://api.moonshot.cn", "月之暗面")));
+    when(registry.save(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    mvc.perform(
+            put("/api/v1/providers/kimi")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"apiKey\":\"****value\",\"baseUrl\":\"https://api.moonshot.cn\",\"description\":\"月之暗面\"}"))
+        .andExpect(status().isOk());
+
+    // 掩码（****value）被识别为未修改，落库的仍是原 key sk-secretvalue
+    ArgumentCaptor<ProviderDef> captor = ArgumentCaptor.forClass(ProviderDef.class);
+    verify(registry).save(captor.capture());
+    Assertions.assertEquals("sk-secretvalue", captor.getValue().apiKey());
   }
 
   @Test


### PR DESCRIPTION
## 背景

代码审查发现 7 项高风险问题，集中在**安全边界**与**并发控制**两块：

1. **API Key 明文经无认证接口泄露**：`ProviderView` 明文回显 apiKey，而 `/api/v1/**` 无认证。
2. **Shell 命令白名单可被注入绕过**：只校验首 token，`bash -c <整串>` 下 `ls && cat /etc/passwd`、`$(...)` 全穿透；默认白名单还带 `python/python3` 解释器 = 任意代码执行。
3. **grep/glob 符号链接逃逸**：递归搜索只校验根，白名单根内 symlink 可读任意文件。
4. **同会话并发丢消息**：web 并发请求对同一会话 last-write-wins 覆盖，对话历史丢失。
5. **skills/ 目录 symlink 透穿**：bind/unbind/replaceBindings 写路径未校验 `skills/` 真实目录。
6. **Shell 超时假超时 + 孤儿进程**：stdout 在 waitFor 后读 → 大输出误杀；destroyForcibly 只杀 bash 不杀孙进程。
7. **定时任务 id 跨 Agent 冲突**：句柄表按裸 `sc.id()` 作键，跨 Agent 撞 id 会覆盖句柄 / 误 cancel。

## 改动

| 修复 | 文件 |
|------|------|
| 1. apiKey 掩码回显 + update 识别掩码保留原 key | `ProviderView`、`ProviderApiController` |
| 2. 命令串引号感知元字符扫描；移除默认 python/python3 | `WhitelistSandbox`、`application.yml`×2 |
| 3. grep/glob NOFOLLOW_LINKS + 逐文件过沙箱 | `FileTools` |
| 4. AgentService 按会话加锁 | `AgentService` |
| 5. skills/ 写路径真实目录校验 | `AgentSkillBindingService` |
| 6. 并发排空 stdout/stderr + 超时递归杀进程树 | `ShellTools` |
| 7. 句柄键改 profileName@taskId | `AgentScheduler` |

新增/更新测试：`WhitelistSandboxTest`（注入绕过 + 引号放行 + 未闭合引号）、`ProviderApiControllerTest`（掩码回显 + update 保留原 key）。

## 行为变更说明

- **`python`/`python3` 从默认 shell 白名单移除**（含 jar 内置与 `config/application.yml.example`）。确需跑脚本的 Agent（如 GitHub 日报 demo）须在部署配置显式加回并自担风险。
- 含 shell 元字符的命令（管道 `|`、`&&`、`;`、重定向 `>`、命令替换 `$()` 等）现在会被沙箱拒绝——`echo "a;b"`、`grep 'x y'` 这类引号内字面量不受影响。写重定向类命令（`ls > file`）需改用 `write_file` 工具。

## 验证说明 ⚠️

本提交环境无 JDK/Maven 工具链，**未能本地运行 `mvn test`**。改动已做静态自查（import 完整性、方法引用、控制流），建议 CI / 本地验证后再合并，重点跑：
- `WhitelistSandboxTest`（新增注入绕过用例）
- `ShellToolsTest`、`FileToolsTest`
- `AgentServiceTest`、`AgentSchedulerTest` / `AgentSchedulerRegisterTest`
- `ProviderApiControllerTest`（新增 update 掩码用例）

🤖 Generated with [Claude Code](https://claude.com/claude-code)