### PR TITLE
docs: add root CONTRIBUTING.md linking to contributing guide 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing to OryxOS
+
+First PRs are welcome! See the [Contributing Guide](website/docs/contributing.md) and the
+[GitHub Workflow Primer](website/docs/github-workflow.md) to get started.


### PR DESCRIPTION
GitHub auto-detects CONTRIBUTING.md at the repo root and shows a banner to new issue/PR creators. The full guide lives under website/docs/ — this file bridges the gap so contributors find it.