### PR TITLE
docs: fix stale "lesson 26 wiring" wording in serve command help

### DIFF
--- a/docs/CliGuide.md
+++ b/docs/CliGuide.md
@@ -60,7 +60,7 @@ oryxos chat --profile weather      # ⑤ 开聊
 | `oryxos init` | 轻 | 初始化 `.oryxos/` 工作区 |
 | `oryxos status` | 轻 | 查看工作区与数据文件状态 |
 | `oryxos chat [--profile <name>]` | **重** | 交互式对话（默认 profile：`default`） |
-| `oryxos serve [--port 8080]` | **重** | 启动 HTTP API 服务（REST 端点第 26 节接线） |
+| `oryxos serve [--port 8080]` | **重** | 启动 HTTP API 服务（REST 端点 + Web 管理台） |
 | `oryxos gateway` | **重** | 守护进程模式（多 Channel 挂载属扩展阶段） |
 | `oryxos profile list` | 轻 | 列出全部 Profile |
 | `oryxos profile create <name>` | 轻 | 创建 Profile（最小模板，不覆盖已有） |

--- a/oryxos-cli/src/main/java/io/oryxos/cli/command/ServeCommand.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/command/ServeCommand.java
@@ -5,10 +5,10 @@ import org.springframework.boot.SpringApplication;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
-/** 重命令：启动骨架——起完整运行时常驻；REST 端点第 26 节接线（届时挂 Web 层）。 */
+/** 重命令：启动骨架——起完整运行时常驻；REST 端点已在 Web 层交付。 */
 @Command(
     name = "serve",
-    description = "启动 HTTP API 服务（REST 端点 26 节接线）",
+    description = "启动 HTTP API 服务（REST 端点 + Web 管理台）",
     mixinStandardHelpOptions = true)
 public class ServeCommand implements Runnable {
 
@@ -18,7 +18,7 @@ public class ServeCommand implements Runnable {
   @Override
   public void run() {
     System.setProperty("server.port", String.valueOf(port));
-    System.out.println("OryxOS 运行时已启动（serve 骨架；REST 端点将在第 26 节接线）。Ctrl-C 退出。");
+    System.out.println("OryxOS 运行已启动（REST API: /api/v1, Web 管理台: /admin/）。Ctrl-C 退出。");
     SpringApplication.run(OryxOsRuntime.class, new String[0]);
     keepAlive();
   }


### PR DESCRIPTION
## What

`oryxos serve --help` 的描述写的是"REST 端点 26 节接线",启动时也提示"REST 端点将在第 26 节接线"。

这是课件开发阶段的内部说法(指第 26 节课接上 REST 层),泄露到了面向用户的 CLI 文本里,且信息已过时——main 上 REST 端点早已交付,`docs/CliGuide.md` 自身亦写明"serve 的 REST 端点已交付"。

## Change

- `oryxos-cli/.../ServeCommand.java`:类注释 / `--help` 描述 / 启动提示三处,去掉"第 N 节接线"措辞,改为描述实际行为
- `docs/CliGuide.md`:同步该行

| 位置 | 改前 | 改后 |
|---|---|---|
| 类注释 | `REST 端点第 26 节接线（届时挂 Web 层）` | `REST 端点已在 Web 层交付` |
| `--help` 描述 | `启动 HTTP API 服务（REST 端点 26 节接线）` | `启动 HTTP API 服务（REST 端点 + Web 管理台）` |
| 启动提示 | `OryxOS 运行时已启动（serve 骨架；REST 端点将在第 26 节接线）` | `OryxOS 运行已启动（REST API: /api/v1, Web 管理台: /admin/）` |

## How verified

- 纯文本改动,无逻辑变更
- 未改任何控制流或签名

First PR 🙏  欢迎指正。