### PR TITLE
fix(core): WorkspaceWatcher 递归监听 Agent 子目录，修复 AGENT.md 变更漏检

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
@@ -397,6 +397,16 @@ public class AgentLifecycleService {
     return profile;
   }
 
+  /** WorkspaceWatcher 刷新用（issue #61）：先注销旧定时，再按目录重注册。 */
+  public Profile refresh(Path agentDir) {
+    // 同名 Profile 已在册时先注销其旧定时：否则重复编辑会让旧 cron 句柄被
+    // registerProfile 覆盖而永不 cancel（句柄泄漏 + 同一任务双跑）。
+    // 首次出现（无旧 Profile）时 ifPresent 跳过，等价于 register。
+    String name = String.valueOf(agentDir.getFileName());
+    profileRegistry.get(name).ifPresent(agentScheduler::unregisterProfile);
+    return register(agentDir);
+  }
+
   public Optional<Profile> get(String name) {
     return profileRegistry.get(name);
   }

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/WorkspaceWatcher.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/WorkspaceWatcher.java
@@ -5,24 +5,29 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 
 import java.io.IOException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * 第二条录入路径的执行者（第 30 节）：实时监听 {@code .oryxos/agents/}——用 JDK {@link WatchService} 监听变更， 任何 Agent 目录新增
- * / 改 / 删都汇到与 API 上传**同一段** {@link AgentLifecycleService#register(Path)} / 注销。
- * 启动时的全量扫描由装配层既有链路完成（{@code AgentLoader.loadAll} + {@code AgentScheduler.registerAll}），
- * 本类只负责启动**之后**的实时变更——避免与启动扫描重复登记（尤其重复排定时）。
- *
- * <p>基础设施守护线程（与 25 节 {@code AgentScheduler} 调度线程同类），不把异步编程模型引进请求链路（不违反宪法七）。 单个坏目录 try/catch
- * 跳过、不拖垮监听。事件处理逻辑抽成 {@link #handleChange} 以便单测（不依赖真实事件时序）。
- */
+// 第二条录入路径（第 30 节）：实时监听 .oryxos/agents/，任何 Agent 目录新增/改/删都汇到与
+// API 上传同一段 AgentLifecycleService（register / refresh / 注销）。启动全量扫描由装配层既有链路
+// （AgentLoader.loadAll + AgentScheduler.registerAll）完成，本类只管启动之后的实时变更。
+//
+// issue #61：JDK WatchService 注册不递归——只盯根目录会漏掉 agents/<agent>/AGENT.md 的增/改/删，
+// 于是新建或编辑器改动的 Agent 直到重启才生效、定时变更运行时不落地。故本类维护
+// WatchKey → 被监听目录 的映射：根目录盯直接子目录的增删，每个 Agent 子目录各自盯自己的
+// AGENT.md；新目录一出现即补挂监听，被删即注销并撤挂。
+//
+// 基础设施守护线程（与 25 节 AgentScheduler 同类），不把异步编程模型引进请求链路（不违反宪法七）。
+/** 实时监听 {@code .oryxos/agents/}，把 Agent 目录变更汇到 {@link AgentLifecycleService}。 */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",
     justification = "lifecycle/executor 是 Spring 注入的共享单例，构造注入共享同一引用正是意图（无法也不应防御性拷贝）。")
@@ -30,9 +35,15 @@ public class WorkspaceWatcher {
 
   private static final Logger LOG = LoggerFactory.getLogger(WorkspaceWatcher.class);
 
+  /** Agent 定义文件名——只有它的增/改/删才牵动该 Agent 的注册/注销。 */
+  private static final String AGENT_FILE = "AGENT.md";
+
   private final AgentLifecycleService lifecycle;
   private final Path agentsDir;
   private final Executor watcherExecutor;
+
+  /** {@link WatchKey} → 被监听目录（根目录或某个 Agent 子目录），把事件解析回来源目录。 */
+  private final Map<WatchKey, Path> watchedDirs = new ConcurrentHashMap<>();
 
   public WorkspaceWatcher(
       AgentLifecycleService lifecycle, Path oryxosRoot, Executor watcherExecutor) {
@@ -41,19 +52,31 @@ public class WorkspaceWatcher {
     this.watcherExecutor = watcherExecutor;
   }
 
-  /** 装配层 {@code @Bean(initMethod="start")} 调用：在守护线程执行器上跑监听循环（启动全量扫由既有链路完成）。 */
+  /** 装配层 {@code @Bean(initMethod="start")} 调用：在守护线程执行器上跑监听循环。 */
   public void start() {
     WatchService watchService;
     try {
       Files.createDirectories(agentsDir);
       watchService = agentsDir.getFileSystem().newWatchService();
-      agentsDir.register(watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);
+      registerDir(watchService, agentsDir); // 根目录：盯直接子 Agent 目录的增删
+      // WatchService 不递归：已存在的每个 Agent 子目录必须各自挂，才能收到其 AGENT.md 事件
+      try (DirectoryStream<Path> children =
+          Files.newDirectoryStream(agentsDir, Files::isDirectory)) {
+        for (Path child : children) {
+          registerDir(watchService, child);
+        }
+      }
     } catch (IOException e) {
       LOG.warn("WorkspaceWatcher 启动失败，实时监听不可用: {}", sanitize(e.getMessage()));
       return;
     }
-    // 交给装配层注入的守护线程执行器（同 25 节 AgentScheduler 用 Spring 线程池，不手工 new Thread）
     watcherExecutor.execute(() -> loop(watchService));
+  }
+
+  /** 把目录注册进 WatchService 并记入映射；同一目录重复注册返回同一 {@link WatchKey}（幂等）。 */
+  private void registerDir(WatchService watchService, Path dir) throws IOException {
+    WatchKey key = dir.register(watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);
+    watchedDirs.put(key, dir);
   }
 
   private void loop(WatchService watchService) {
@@ -65,25 +88,71 @@ public class WorkspaceWatcher {
         Thread.currentThread().interrupt();
         return;
       }
-      for (WatchEvent<?> event : key.pollEvents()) {
-        Object context = event.context();
-        if (context instanceof Path child) {
-          handleChange(agentsDir.resolve(child), event.kind());
+      Path dir = watchedDirs.get(key);
+      if (dir != null) {
+        for (WatchEvent<?> event : key.pollEvents()) {
+          if (event.context() instanceof Path relative) {
+            dispatch(watchService, dir, dir.resolve(relative), event.kind());
+          }
         }
       }
       if (!key.reset()) {
-        return; // 监听目录不可用，退出线程
+        watchedDirs.remove(key);
+        if (agentsDir.equals(dir)) {
+          return; // 根目录不可用：整体退出监听线程
+        }
+        if (dir != null) {
+          handleChange(dir, ENTRY_DELETE); // 子 Agent 目录被删：注销该 Agent
+        }
       }
     }
   }
 
-  /** 单个 Agent 目录变更 → 同一段注册 / 注销；坏目录记 WARN 跳过、不拖垮监听。包级可见供单测直接调。 */
+  // 把一个 WatchService 事件翻成对某个 Agent 的登记/刷新/注销。包级可见供单测直接调（不依赖真实事件时序）。
+  //  - 根目录事件：只认直接子目录的新增（补挂监听 + 试登记）与删除（注销）；
+  //  - 子 Agent 目录事件：只认 AGENT.md 的增/改（登记或刷新）与删（注销）。
+  /** 把一个目录事件翻成对某个 Agent 的登记/刷新/注销。 */
+  void dispatch(WatchService watchService, Path dir, Path changed, WatchEvent.Kind<?> kind) {
+    if (agentsDir.equals(dir)) {
+      if (kind == ENTRY_CREATE && Files.isDirectory(changed)) {
+        watchDirQuietly(watchService, changed); // 新 Agent 目录：开始盯它的 AGENT.md
+        handleChange(changed, ENTRY_CREATE); // AGENT.md 若随目录一起就位则立即登记
+      } else if (kind == ENTRY_DELETE) {
+        handleChange(changed, ENTRY_DELETE); // 子目录被删：注销
+      }
+      // 根目录层的 MODIFY 不处理：AGENT.md 变更由子目录自己的 watch 捕获
+      return;
+    }
+    if (!AGENT_FILE.equals(String.valueOf(changed.getFileName()))) {
+      return; // 子目录里只有 AGENT.md 的变更牵动注册
+    }
+    if (kind == ENTRY_DELETE) {
+      handleChange(dir, ENTRY_DELETE); // AGENT.md 被删：注销该 Agent
+    } else {
+      handleChange(dir, ENTRY_MODIFY); // AGENT.md 增/改：登记或刷新
+    }
+  }
+
+  /** 补挂对新 Agent 目录的监听；挂不上只记 WARN、不拖垮监听线程。 */
+  private void watchDirQuietly(WatchService watchService, Path dir) {
+    try {
+      registerDir(watchService, dir);
+    } catch (IOException e) {
+      LOG.warn(
+          "监听 Agent 目录 {} 失败：{}",
+          sanitize(String.valueOf(dir.getFileName())),
+          sanitize(e.getMessage()));
+    }
+  }
+
+  /** 单个 Agent 目录变更 → 同一段登记/刷新/注销；坏目录记 WARN 跳过、不拖垮监听。包级可见供单测直接调。 */
   void handleChange(Path agentDir, WatchEvent.Kind<?> kind) {
     try {
       if (kind == ENTRY_DELETE) {
         lifecycle.unregisterByDir(agentDir);
       } else if (Files.isDirectory(agentDir)) {
-        lifecycle.register(agentDir); // CREATE/MODIFY：与 API 上传同一段 register
+        // CREATE/MODIFY：与 API 上传同一段；refresh 会先注销旧定时再重注册（重复编辑不残留旧 cron）
+        lifecycle.refresh(agentDir);
       }
     } catch (RuntimeException e) {
       LOG.warn(

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/WorkspaceWatcherTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/WorkspaceWatcherTest.java
@@ -2,28 +2,35 @@ package io.oryxos.core.agent;
 
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import io.oryxos.core.profile.ProfileRegistry;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.WatchService;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-/** 课件《第30节》验收 harness：WorkspaceWatcherTest——丢目录即上线、删目录注销、坏目录不拖垮。 */
+/** WorkspaceWatcher harness：丢目录即上线、删目录注销、坏目录不拖垮；issue #61 递归监听 + 刷新不残留旧定时。 */
 class WorkspaceWatcherTest {
 
   @TempDir Path oryxosRoot;
 
   private Path agentsDir;
   private ProfileRegistry registry;
+  private AgentScheduler scheduler;
   private WorkspaceWatcher watcher;
 
   @BeforeEach
@@ -31,12 +38,13 @@ class WorkspaceWatcherTest {
     agentsDir = oryxosRoot.resolve("agents");
     Files.createDirectories(agentsDir);
     registry = new ProfileRegistry();
+    scheduler = mock(AgentScheduler.class);
     AgentLoader loader = new AgentLoader(agentsDir, Set.of("deepseek"));
     AgentLifecycleService lifecycle =
         new AgentLifecycleService(
             loader,
             registry,
-            mock(AgentScheduler.class),
+            scheduler,
             new AgentStore(oryxosRoot),
             mock(io.oryxos.core.provider.ProviderService.class),
             "deepseek",
@@ -82,5 +90,44 @@ class WorkspaceWatcherTest {
 
     assertDoesNotThrow(() -> watcher.handleChange(bad, ENTRY_CREATE));
     assertFalse(registry.exists("bad"), "坏目录未登记");
+  }
+
+  @Test
+  @DisplayName("issue #61：重复编辑（refresh）先注销旧定时，再注册——旧 cron 不残留")
+  void handleChange_repeatedEdit_cancelsPreviousSchedulesBeforeReregister() throws IOException {
+    Path dir = writeAgent("demo", "name: demo\nprovider:\n  name: deepseek\n  model: m");
+
+    watcher.handleChange(dir, ENTRY_CREATE); // 首次登记：无旧 Profile，不应注销
+    verify(scheduler, never()).unregisterProfile(any());
+
+    watcher.handleChange(dir, ENTRY_MODIFY); // 再次编辑：必须先注销旧的，避免句柄泄漏 + 双跑
+    verify(scheduler, times(1)).unregisterProfile(any());
+  }
+
+  @Test
+  @DisplayName("issue #61：子目录里 AGENT.md 新增/删除也被捕获（不再只盯根目录）")
+  void dispatch_agentFileInsideSubdir_registersThenUnregisters() throws IOException {
+    Path dir = writeAgent("demo", "name: demo\nprovider:\n  name: deepseek\n  model: m");
+    Path agentFile = dir.resolve("AGENT.md");
+    try (WatchService ws = agentsDir.getFileSystem().newWatchService()) {
+      watcher.dispatch(ws, dir, agentFile, ENTRY_CREATE);
+      assertTrue(registry.exists("demo"), "子目录内 AGENT.md 出现即上线");
+
+      watcher.dispatch(ws, dir, agentFile, ENTRY_DELETE);
+      assertFalse(registry.exists("demo"), "AGENT.md 被删即注销");
+    }
+  }
+
+  @Test
+  @DisplayName("issue #61：新建 Agent 目录（AGENT.md 已就位）在根事件中即登记并补挂监听")
+  void dispatch_newAgentDirAtRoot_registersAndWatches() throws IOException {
+    Path dir = writeAgent("demo", "name: demo\nprovider:\n  name: deepseek\n  model: m");
+    try (WatchService ws = agentsDir.getFileSystem().newWatchService()) {
+      watcher.dispatch(ws, agentsDir, dir, ENTRY_CREATE);
+      assertTrue(registry.exists("demo"), "丢一整个 Agent 目录进来即上线");
+
+      watcher.dispatch(ws, agentsDir, dir, ENTRY_DELETE);
+      assertFalse(registry.exists("demo"), "根事件里目录被删即注销");
+    }
   }
 }


### PR DESCRIPTION
## 背景 / Problem

`WorkspaceWatcher` 只把根 `.oryxos/agents/` 目录注册进 `WatchService`，且注册**不递归**。JDK `WatchService` 只上报被注册目录的直接条目，因此 `agents/<name>/AGENT.md` 的增/改/删收不到事件——新建或编辑器改动的 Agent 直到重启才生效、定时（cron）变更运行时不落地。

## 修改 / Changes

- **递归监听**：`WorkspaceWatcher` 维护 `WatchKey → 被监听目录` 映射。根目录盯直接子目录的增删，**每个 Agent 子目录各自盯自己的 `AGENT.md`**；新目录一出现即补挂监听，被删即注销并撤挂。`key.reset()` 失败时区分「根目录消失→退出监听线程」与「子目录被删→注销该 Agent」。
- **刷新不残留旧定时**：新增 `AgentLifecycleService#refresh(Path)`，同名 Profile 已在册时**先注销旧定时再重注册**。原先 watcher 走 `register()` 不注销旧调度，而 `AgentScheduler.registerProfile` 以 `profileName@taskId` 为键 `put` 句柄——重复编辑会覆盖旧 `ScheduledFuture` 却不 `cancel`，导致句柄泄漏 + 同一任务双跑。
- 事件派发抽成包级 `dispatch(...)` / `handleChange(...)`，便于单测（不依赖真实文件系统事件时序）。

## 兼容性 / Compatibility

纯增量、不破坏既有契约：`WorkspaceWatcher` 构造器 `(lifecycle, oryxosRoot, executor)` 与 `start()` 签名不变，唯一调用方 `OryxOsRuntime` 无需改动；`register()` 语义不变（API create、启动扫描两条录入路径不受影响）；`refresh()` 为新增方法。

## 遵循的约束 / Constitution

- 同步 + 守护线程执行器，未引入异步编程模型（原则七）。
- 单个坏目录 `try/catch` 记 WARN 跳过，不拖垮监听线程（FR-007）。

## 测试 / Tests

`WorkspaceWatcherTest` 新增 3 个用例（原有 3 个保留，共 6/6 绿）：

- `handleChange_repeatedEdit_cancelsPreviousSchedulesBeforeReregister`：重复编辑先注销旧定时（首次不注销、二次注销一次）。
- `dispatch_agentFileInsideSubdir_registersThenUnregisters`：子目录内 `AGENT.md` 增/删被捕获。
- `dispatch_newAgentDirAtRoot_registersAndWatches`：根事件里整目录增/删的登记/注销。

本地 `mvn -pl oryxos-core verify`（checkstyle / pmd·p3c / spotbugs+findsecbugs / 测试）全绿。

Closes #61

Made with [Cursor](https://cursor.com)