### PR TITLE
fix(ci): 恢复 main 绿——spotless 格式 + P3C 误报/魔法值 + 掩码测试对齐

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentScheduler.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentScheduler.java
@@ -64,8 +64,8 @@ public class AgentScheduler {
 
   /**
    * 可注销句柄表（为 30 节运行时注销/更新 Agent 铺路）。 键是 {@code profileName@taskId} 复合（review 高危 7）：schedule id 只在
-   * 单个 Agent 内唯一，跨 Agent 撞 id 时若用裸 taskId 作键，后注册覆盖先注册的句柄（旧 future 泄漏、任务双跑）， 删除先注册的 Agent 还会
-   * cancel 掉另一个 Agent 的任务。
+   * 单个 Agent 内唯一，跨 Agent 撞 id 时若用裸 taskId 作键，后注册覆盖先注册的句柄（旧 future 泄漏、任务双跑）， 删除先注册的 Agent 还会 cancel
+   * 掉另一个 Agent 的任务。
    */
   private final Map<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
 

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentService.java
@@ -18,8 +18,8 @@ import java.util.concurrent.locks.ReentrantLock;
  * Profile（单请求测试永远测不出的串号 bug）。
  *
  * <p>并发（review 高危 4）：同一会话（sessionId）的并发请求在此按会话串行化。web 的 send/invoke/trigger 与定时触发
- * 都可能并发操作同一会话（Session 无锁 ArrayList + JpaSessionManager.save 整段覆写），不加锁会 last-write-wins 丢消息。
- * 锁是进程内、按 sessionId 隔离——跨会话并行不受影响（宪法 VII 虚拟线程并发仍成立）。
+ * 都可能并发操作同一会话（Session 无锁 ArrayList + JpaSessionManager.save 整段覆写），不加锁会 last-write-wins 丢消息。 锁是进程内、按
+ * sessionId 隔离——跨会话并行不受影响（宪法 VII 虚拟线程并发仍成立）。
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",
@@ -49,7 +49,8 @@ public class AgentService {
 
   public String process(Session session, String userMessage) {
     // 同一会话的读写整段互斥；sessionId 理论上永不为 null（来自 SessionManager），mock 场景兜底防 NPE
-    String sessionKey = session.sessionId() == null ? profileNameOrFallback(session) : session.sessionId();
+    String sessionKey =
+        session.sessionId() == null ? profileNameOrFallback(session) : session.sessionId();
     Lock lock = sessionLocks.computeIfAbsent(sessionKey, id -> new ReentrantLock());
     lock.lock();
     try {

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBindingService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/AgentSkillBindingService.java
@@ -177,8 +177,8 @@ public class AgentSkillBindingService implements AgentSkillBindingReader {
 
   /**
    * 返回 Agent 的 skills/ 绑定目录，但先校验它不是一个越界符号链接（review 高危 5）。 skills/ 被替换成指向任意目录的软链接时，
-   * bind/unbind/replaceBindings 会直接在那里面建/删链接——写操作前必须确认其真实路径仍落在 Agent 目录内。 目录不存在时投影到
-   * Agent 目录下的正常位置（真实路径仍在 agentDir 内），放行。
+   * bind/unbind/replaceBindings 会直接在那里面建/删链接——写操作前必须确认其真实路径仍落在 Agent 目录内。 目录不存在时投影到 Agent
+   * 目录下的正常位置（真实路径仍在 agentDir 内），放行。
    */
   private Path requireRealSkillsDir(Path agentDir) {
     Path linksDir = agentDir.resolve("skills");

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
@@ -18,8 +18,8 @@ import org.springframework.ai.tool.annotation.ToolParam;
 /**
  * 内置 Shell 工具：执行 bash 命令，带超时兜底——命令挂死不能拖死整个 ReAct 循环。
  *
- * <p>命令首词白名单归 24 节（SHELL_COMMAND 检查位已过 enforce，含命令注入元字符扫描）；超时默认 30 秒。 两个运维细节（review 高危 6）：
- * (1) stdout/stderr 在 waitFor 前就并发排空——否则输出超过管道缓冲（~64KB）的命令会写阻塞、被误判超时； (2) 超时后递归杀进程树——{@code bash -c}
+ * <p>命令首词白名单归 24 节（SHELL_COMMAND 检查位已过 enforce，含命令注入元字符扫描）；超时默认 30 秒。 两个运维细节（review 高危 6）： (1)
+ * stdout/stderr 在 waitFor 前就并发排空——否则输出超过管道缓冲（~64KB）的命令会写阻塞、被误判超时； (2) 超时后递归杀进程树——{@code bash -c}
  * 派生的孙进程不在 bash 的进程组内，只杀 bash 会留孤儿继续跑。
  */
 public class ShellTools {
@@ -28,6 +28,7 @@ public class ShellTools {
   static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
 
   /** 排空子进程输出的虚拟线程执行器（宪法 VII）：流读取是 IO 等待，虚拟线程天然适配。 */
+  @SuppressWarnings("PMD.ThreadPoolCreationRule") // Java 21 虚拟线程无池参数可配，非 P3C 针对的固定线程池反模式。
   private static final ExecutorService DRAINER = Executors.newVirtualThreadPerTaskExecutor();
 
   private final Sandbox sandbox;

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -163,8 +163,8 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   }
 
   /**
-   * 命令串是否含可被 bash 解释为"追加执行/命令替换/重定向"的元字符。逐字符状态机：单引号内全字面； 双引号内仅 {@code $}、{@code `} 仍特殊（命令替换在双引号内照常执行）；引号外所有分隔/替换/重定向符一律拒绝。
-   * 反斜杠转义跳过下一字符。未闭合引号视为不合法命令，拒绝。
+   * 命令串是否含可被 bash 解释为"追加执行/命令替换/重定向"的元字符。逐字符状态机：单引号内全字面； 双引号内仅 {@code $}、{@code `}
+   * 仍特殊（命令替换在双引号内照常执行）；引号外所有分隔/替换/重定向符一律拒绝。 反斜杠转义跳过下一字符。未闭合引号视为不合法命令，拒绝。
    */
   private static boolean hasShellInjection(String command) {
     boolean inSingle = false;

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
@@ -157,7 +157,8 @@ class WhitelistSandboxTest {
       // 引号/转义不追加执行：允许
       assertDoesNotThrow(
           () -> sb.enforce(new SandboxAction(ActionType.SHELL_COMMAND, "echo \"a;b\"")));
-      assertDoesNotThrow(() -> sb.enforce(new SandboxAction(ActionType.SHELL_COMMAND, "echo 'a;b'")));
+      assertDoesNotThrow(
+          () -> sb.enforce(new SandboxAction(ActionType.SHELL_COMMAND, "echo 'a;b'")));
     }
 
     @Test

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/ProviderApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/ProviderApiController.java
@@ -81,7 +81,10 @@ public class ProviderApiController {
             .orElseThrow(() -> new ResourceNotFoundException("provider 不存在: " + name)); // → 404
     validate(name, req.baseUrl());
     // 前端编辑表单回填的是掩码值；提交掩码 = 未修改，保留原 key——否则打码值会覆盖真实 key
-    String apiKey = ProviderView.mask(existing.apiKey()).equals(req.apiKey()) ? existing.apiKey() : req.apiKey();
+    String apiKey =
+        ProviderView.mask(existing.apiKey()).equals(req.apiKey())
+            ? existing.apiKey()
+            : req.apiKey();
     ProviderDef saved =
         registry.save(new ProviderDef(name, apiKey, req.baseUrl(), req.description()));
     return ApiResponse.ok(ProviderView.from(saved));

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ProviderView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ProviderView.java
@@ -5,8 +5,8 @@ import io.oryxos.core.provider.ProviderDef;
 /**
  * Provider 视图（列表/详情返回）。
  *
- * <p>api-key 只回显掩码（保留末 4 位），杜绝明文经 /api/v1/**（无认证）泄露；掩码值被前端原样提交时由
- * {@code ProviderApiController} 识别为"未修改"，保留原 key。mask 是确定性的，供该识别复用。
+ * <p>api-key 只回显掩码（保留末 4 位），杜绝明文经 /api/v1/**（无认证）泄露；掩码值被前端原样提交时由 {@code ProviderApiController}
+ * 识别为"未修改"，保留原 key。mask 是确定性的，供该识别复用。
  */
 public record ProviderView(String name, String apiKey, String baseUrl, String description) {
 
@@ -14,14 +14,17 @@ public record ProviderView(String name, String apiKey, String baseUrl, String de
     return new ProviderView(d.name(), mask(d.apiKey()), d.baseUrl(), d.description());
   }
 
+  /** 掩码保留的末尾明文位数：只回显末 4 位，其余打码。 */
+  private static final int VISIBLE_SUFFIX = 4;
+
   /** 掩码：空/短 key 全打码，其余只留末 4 位。幂等——mask(mask(k)) == mask(k)，是"未修改"判定的基础。 */
   public static String mask(String key) {
     if (key == null || key.isBlank()) {
       return "";
     }
-    if (key.length() <= 4) {
+    if (key.length() <= VISIBLE_SUFFIX) {
       return "****";
     }
-    return "****" + key.substring(key.length() - 4);
+    return "****" + key.substring(key.length() - VISIBLE_SUFFIX);
   }
 }

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/ProviderApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/ProviderApiControllerTest.java
@@ -17,11 +17,11 @@ import io.oryxos.core.provider.ProviderRegistry;
 import io.oryxos.web.GlobalExceptionHandler;
 import io.oryxos.web.provider.ProviderModelsService;
 import java.util.Optional;
-import org.mockito.ArgumentCaptor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -110,17 +110,16 @@ class ProviderApiControllerTest {
         .thenReturn(
             Optional.of(
                 new ProviderDef("kimi", "sk-secretvalue", "https://api.moonshot.cn", "月之暗面")));
-    when(registry.save(any()))
-        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(registry.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
     mvc.perform(
             put("/api/v1/providers/kimi")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
-                    "{\"apiKey\":\"****value\",\"baseUrl\":\"https://api.moonshot.cn\",\"description\":\"月之暗面\"}"))
+                    "{\"apiKey\":\"****alue\",\"baseUrl\":\"https://api.moonshot.cn\",\"description\":\"月之暗面\"}"))
         .andExpect(status().isOk());
 
-    // 掩码（****value）被识别为未修改，落库的仍是原 key sk-secretvalue
+    // 掩码（****alue，mask() 留末 4 位）被识别为未修改，落库的仍是原 key sk-secretvalue
     ArgumentCaptor<ProviderDef> captor = ArgumentCaptor.forClass(ProviderDef.class);
     verify(registry).save(captor.capture());
     Assertions.assertEquals("sk-secretvalue", captor.getValue().apiKey());


### PR DESCRIPTION
## 背景 / Problem

`main` 分支近期每次 CI 的 **Build & quality gate** 都失败（`mvn -B clean verify`）。根因是它在**第一道门禁 spotless 就 fail-fast**，把后面几道门禁（PMD·P3C、测试）里**自 #58 起就存在**的问题一并掩盖了。逐层放绿后确认：本地 `mvn clean verify` **十个模块全绿**。

## 修改 / Changes（每处都小而机械）

1. **style（格式）**：`mvn spotless:apply` 修复 `core`/`tool`/`web` 共 **9 处** google-java-format 的 javadoc 换行违规——纯格式、无语义变化。
2. **fix(tool)**：`ShellTools` 的虚拟线程执行器补 `@SuppressWarnings("PMD.ThreadPoolCreationRule")`。与 `OryxOsRuntime` 里**既有的同一约定**一致；`Executors.newVirtualThreadPerTaskExecutor()` 是宪法七要求的 Java 21 虚拟线程写法，无池参数可配，并非 P3C `ThreadPoolCreationRule` 针对的「固定线程池」反模式。
3. **fix(web)**：`ProviderView.mask()` 里的魔法值 `4` 抽成命名常量 `VISIBLE_SUFFIX`（P3C `UndefineMagicConstantRule`）。
4. **test(web)**：`ProviderApiControllerTest.update_maskedKey_keepsOriginal` 的掩码示例 `****value`（末 5 位）改为 `****alue`。`mask()` 及其 javadoc 的既定契约是**保留末 4 位**（`mask("sk-secretvalue")` → `****alue`），测试用例的 `****value` 与该契约不符，导致「提交掩码=未修改」的判定走进 else 分支、把打码值当成新 key。该用例自 #58 起一直失败。

> 说明：#58 同一提交里 `mask()`（末 4 位）与该测试（末 5 位示例）就不自洽；这里以**实现 + 其 javadoc 的文档化契约**（末 4 位，符合常见的「只露末 4 位」安全惯例）为准，修正测试示例。若维护者本意是「末 5 位」，请指出，我改为改实现而非改测试。

## 验证 / Verification

本地 `mvn clean verify`（= CI 的 Build & quality gate 同命令）：`OryxOS Core / Provider / Storage / Memory / Tool / Channel CLI / Web / CLI / Boot` 全部 `SUCCESS`，`BUILD SUCCESS`。spotless / checkstyle / pmd·p3c / spotbugs+findsecbugs / 测试全过。

（OWASP Dependency-Check 那个 job 需要 `NVD_API_KEY`，与本 PR 无关。）

Made with [Cursor](https://cursor.com)