### PR TITLE
fix(web): make agent invoke stateless

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentService.java
@@ -8,13 +8,15 @@ import io.oryxos.core.session.Message;
 import io.oryxos.core.session.Session;
 import io.oryxos.core.session.SessionManager;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * 一次处理的编排者：三种触发源（CLI / Web / 定时）最终都调同一个 {@link #process}。
+ * 一次处理的编排者：有状态触发源（CLI / Web 会话 / 定时 / 管理台）走 {@link #process}；无状态 Web invoke 走 {@link
+ * #processStateless}。
  *
  * <p>ProfileContext 生命周期在此收口：入口 set、出口 finally clear——即使循环中途抛异常也必须清， 否则复用线程的下一个请求会拿到别人的
  * Profile（单请求测试永远测不出的串号 bug）。
@@ -29,6 +31,7 @@ import java.util.concurrent.locks.ReentrantLock;
 public class AgentService {
 
   private static final int MEMORY_LINE_MAX = 200;
+  private static final String STATELESS_EXECUTION_ID_PREFIX = "invoke-exec:";
 
   /** 会话 id → 该会话的串行锁。会话数是有限的（channel:user:profile 三元组），增长有界，可接受。 */
   private final ConcurrentMap<String, Lock> sessionLocks = new ConcurrentHashMap<>();
@@ -85,6 +88,31 @@ public class AgentService {
       }
     } finally {
       lock.unlock(); // 无论成功失败必须放锁，否则该会话永久卡死
+    }
+  }
+
+  /**
+   * 无状态调用：使用带唯一执行标识的内存 Session，不创建或更新持久会话。
+   *
+   * <p>单次请求内的 ReAct 多轮仍完整执行；审计沿用 Session 标识关联到本次执行，请求结束后临时消息丢弃。
+   */
+  public String processStateless(String agentName, String userMessage) {
+    Profile profile =
+        profileRegistry
+            .get(agentName)
+            .orElseThrow(() -> new IllegalStateException("Agent 不存在: " + agentName));
+    Session session =
+        new Session(STATELESS_EXECUTION_ID_PREFIX + UUID.randomUUID(), profile.name());
+    ProfileContext.set(profile);
+    try {
+      String reply = reActLoop.run(session, userMessage, profile);
+      if (ReActLoop.MAX_ITERATIONS_REPLY.equals(reply)) {
+        throw new AgentMaxIterationsExceededException(reply);
+      }
+      recordTrigger(profile.name(), userMessage, reply);
+      return reply;
+    } finally {
+      ProfileContext.clear();
     }
   }
 

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentServiceTest.java
@@ -1,10 +1,12 @@
 package io.oryxos.core.agent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -23,6 +25,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 /** 课件《第17节》验收 harness：AgentServiceTest——统一入口与 ProfileContext 生命周期。 */
 class AgentServiceTest {
@@ -193,5 +196,37 @@ class AgentServiceTest {
 
     assertEquals(List.of("问题3", "问题4"), latest.messages().stream().map(Message::content).toList());
     verify(sessionManager).saveIfUnchanged(latest, baseline);
+  }
+
+  @Test
+  @DisplayName("无状态处理不保存会话且每次使用独立审计标识")
+  void statelessProcessingDoesNotSaveSessionAndUsesUniqueExecutionIds() {
+    when(reActLoop.run(any(), any(), any())).thenReturn("无状态答复");
+
+    assertEquals("无状态答复", agentService.processStateless("ops-agent", "first"));
+    assertEquals("无状态答复", agentService.processStateless("ops-agent", "second"));
+
+    ArgumentCaptor<Session> sessions = ArgumentCaptor.forClass(Session.class);
+    verify(reActLoop, org.mockito.Mockito.times(2)).run(sessions.capture(), any(), eq(profile));
+    String firstExecutionId = sessions.getAllValues().get(0).sessionId();
+    String secondExecutionId = sessions.getAllValues().get(1).sessionId();
+    assertTrue(firstExecutionId.startsWith("invoke-exec:"));
+    assertTrue(secondExecutionId.startsWith("invoke-exec:"));
+    assertNotEquals(firstExecutionId, secondExecutionId);
+    verify(sessionManager, never()).save(any());
+    assertNull(ProfileContext.current());
+  }
+
+  @Test
+  @DisplayName("无状态处理达到迭代上限仍抛异常且不保存会话")
+  void statelessMaxIterationsThrowsWithoutSavingSession() {
+    when(reActLoop.run(any(), any(), any())).thenReturn(ReActLoop.MAX_ITERATIONS_REPLY);
+
+    assertThrows(
+        AgentMaxIterationsExceededException.class,
+        () -> agentService.processStateless("ops-agent", "hi"));
+
+    verify(sessionManager, never()).save(any());
+    assertNull(ProfileContext.current());
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/AgentApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/AgentApiController.java
@@ -43,7 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Agent 端点（第 26 节的 invoke + 第 30 节的动态管理 CRUD）：generate/create/get/list/update/delete 薄转发给 {@link
- * AgentLifecycleService}；invoke 走 {@link AgentService#process} 同一入口。
+ * AgentLifecycleService}；invoke 走 {@link AgentService#processStateless}，不创建持久会话。
  *
  * <p>错误码复用既有：name 冲突 / 定义非法 → 400（`IllegalArgumentException`/`ProfileValidationException`）； 不存在 →
  * 404（`ResourceNotFoundException`）；统一 `ApiResponse` 信封。
@@ -58,8 +58,6 @@ public class AgentApiController {
 
   private static final int MAX_MESSAGE_LENGTH = 32 * 1024;
   private static final int MAX_HISTORY_MESSAGES = 100;
-  private static final String INVOKE_CHANNEL = "invoke";
-  private static final String DEFAULT_USER = "default";
   // 管理台「一个 Agent 一个固定会话」：固定 channel+user，profile=Agent 名 → 每个 Agent 恰好一条会话（上下文累积）。
   private static final String CONSOLE_CHANNEL = "admin";
   private static final String CONSOLE_USER = "console";
@@ -203,8 +201,7 @@ public class AgentApiController {
       throw new IllegalArgumentException("消息超过 32KB 上限"); // → 400
     }
     requireAgent(name);
-    Session session = sessionManager.getOrCreate(INVOKE_CHANNEL, DEFAULT_USER, name);
-    String reply = agentService.process(session, req.content());
+    String reply = agentService.processStateless(name, req.content());
     return ApiResponse.ok(new MessageResponse(reply));
   }
 

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/AgentApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/AgentApiControllerTest.java
@@ -17,7 +17,6 @@ import io.oryxos.core.agent.AgentLifecycleService;
 import io.oryxos.core.agent.AgentService;
 import io.oryxos.core.profile.Profile;
 import io.oryxos.core.profile.ProfileRegistry;
-import io.oryxos.core.session.Session;
 import io.oryxos.core.session.SessionManager;
 import io.oryxos.web.GlobalExceptionHandler;
 import java.util.List;
@@ -30,7 +29,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-/** 端点切片：动态管理 CRUD 薄转发（冲突→400、不存在→404）；invoke 走 AgentService.process 同一入口。 */
+/** 端点切片：动态管理 CRUD 薄转发（冲突→400、不存在→404）；invoke 走无状态编排入口。 */
 class AgentApiControllerTest {
 
   private AgentLifecycleService lifecycle;
@@ -132,11 +131,9 @@ class AgentApiControllerTest {
   }
 
   @Test
-  @DisplayName("invoke 已存在 Agent_走编排入口返回回复")
-  void invokeKnownAgent_callsProcess() throws Exception {
-    Session session = new Session("invoke:default:ops", "ops");
-    when(sessionManager.getOrCreate("invoke", "default", "ops")).thenReturn(session);
-    when(agentService.process(eq(session), eq("查天气"))).thenReturn("晴");
+  @DisplayName("invoke 已存在 Agent_走无状态编排且不创建持久会话")
+  void invokeKnownAgent_callsStatelessProcess() throws Exception {
+    when(agentService.processStateless(eq("ops"), eq("查天气"))).thenReturn("晴");
 
     mvc.perform(
             post("/api/v1/agents/ops/invoke")
@@ -144,7 +141,9 @@ class AgentApiControllerTest {
                 .content("{\"content\":\"查天气\"}"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.reply").value("晴"));
-    verify(agentService).process(eq(session), eq("查天气"));
+    verify(agentService).processStateless(eq("ops"), eq("查天气"));
+    verify(sessionManager, never()).getOrCreate(eq("invoke"), any(), any());
+    verify(agentService, never()).process(any(), any());
   }
 
   @Test
@@ -156,6 +155,7 @@ class AgentApiControllerTest {
                 .content("{\"content\":\"hi\"}"))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value(404));
+    verify(agentService, never()).processStateless(any(), any());
     verify(agentService, never()).process(any(), any());
   }
 
@@ -168,6 +168,7 @@ class AgentApiControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"content\":\"" + huge + "\"}"))
         .andExpect(status().isBadRequest());
+    verify(agentService, never()).processStateless(any(), any());
     verify(agentService, never()).process(any(), any());
   }
 


### PR DESCRIPTION
## What changed

- route `POST /api/v1/agents/{name}/invoke` through a dedicated stateless `AgentService` entry point
- use a fresh in-memory `Session` for every request instead of `invoke:default:<agent>`
- assign each execution a unique `invoke-exec:<uuid>` identifier so existing LLM/tool audit records remain traceable
- preserve the existing stateful session paths used by console, CLI, scheduler, and session APIs
- add focused service and controller regression tests for no persistence, unique execution IDs, validation failures, and max-iteration behavior

## Root cause

The endpoint reused `SessionManager.getOrCreate("invoke", "default", name)` and then called the stateful `AgentService.process` path, which saves the session after each invocation. That made later requests inherit prior messages and exposed the hidden session through the session APIs, contrary to the documented stateless contract.

## Validation

- `mvn test -pl oryxos-core,oryxos-web -am -Dtest='AgentServiceTest,AgentApiControllerTest' -Dsurefire.failIfNoSpecifiedTests=false`
- `mvn clean verify`
- `git diff --check`

All 10 Maven reactor modules passed, including Spotless, Checkstyle, PMD, SpotBugs, unit tests, and integration tests.

## Attribution

This minimal patch was adapted from the public `linjk/oryxos:feat/013-stateless-agent-invoke` branch linked in the issue. The original author and their co-author are retained in the commit trailers.

Closes #49
