### PR TITLE
fix(storage): prevent session history loss

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -20,6 +20,10 @@ server:
 spring:
   datasource:
     url: jdbc:sqlite:oryxos.db  # SQLite 数据文件（会话 + 审计表），相对启动目录
+    hikari:
+      data-source-properties:
+        journal_mode: WAL        # 允许读写并发，避免默认 rollback journal 放大锁竞争
+        busy_timeout: 5000       # 短暂写锁时最多等待 5 秒，而不是立即报 database is locked
   threads:
     virtual:
       enabled: true             # 宪法七：Java 21 虚拟线程扛并发，不引入异步框架

--- a/oryxos-boot/src/main/resources/application.yml
+++ b/oryxos-boot/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
   datasource:
     url: jdbc:sqlite:oryxos.db
     driver-class-name: org.sqlite.JDBC
+    hikari:
+      data-source-properties:
+        journal_mode: WAL
+        busy_timeout: 5000
   jpa:
     database-platform: org.hibernate.community.dialect.SQLiteDialect
     hibernate:

--- a/oryxos-boot/src/test/java/io/oryxos/boot/SqliteDataSourceConfigTest.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/SqliteDataSourceConfigTest.java
@@ -1,0 +1,48 @@
+package io.oryxos.boot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/** 只加载 DataSource 自动配置，验证内置 application.yml 的 SQLite 连接参数。 */
+class SqliteDataSourceConfigTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void sqliteConnectionsEnableWalAndBusyTimeout() {
+    new ApplicationContextRunner()
+        .withInitializer(new ConfigDataApplicationContextInitializer())
+        .withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
+        .withPropertyValues(
+            "spring.datasource.url=jdbc:sqlite:" + tempDir.resolve("config-test.db"),
+            "spring.datasource.driver-class-name=org.sqlite.JDBC")
+        .run(
+            context -> {
+              assertTrue(context.isRunning());
+              DataSource dataSource = context.getBean(DataSource.class);
+              assertEquals("wal", pragmaText(dataSource, "journal_mode"));
+              assertEquals("5000", pragmaText(dataSource, "busy_timeout"));
+            });
+  }
+
+  private static String pragmaText(DataSource dataSource, String name) throws Exception {
+    try (Connection connection = dataSource.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet result = statement.executeQuery("PRAGMA " + name)) {
+      assertTrue(result.next(), "PRAGMA " + name + " 应返回一行");
+      return result.getString(1).toLowerCase();
+    }
+  }
+}

--- a/oryxos-cli/src/main/java/io/oryxos/cli/command/SessionListCommand.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/command/SessionListCommand.java
@@ -28,6 +28,8 @@ public class SessionListCommand implements Runnable {
     /** 与重命令 application.yml 的 datasource 保持同一相对路径——两边看到的必须是同一个库。 */
     private static final String DB_FILE = "oryxos.db";
 
+    private static final String DB_URL = "jdbc:sqlite:" + DB_FILE + "?busy_timeout=5000";
+
     @Override
     public void run() {
       if (!Files.exists(Path.of(DB_FILE))) {
@@ -37,7 +39,7 @@ public class SessionListCommand implements Runnable {
       String sql =
           "SELECT session_id, profile_name, status, last_active_at FROM sessions"
               + " ORDER BY last_active_at DESC";
-      try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + DB_FILE);
+      try (Connection conn = DriverManager.getConnection(DB_URL);
           Statement stmt = conn.createStatement();
           ResultSet rs = stmt.executeQuery(sql)) {
         boolean any = false;

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentService.java
@@ -4,8 +4,10 @@ import io.oryxos.core.memory.MemoryScope;
 import io.oryxos.core.memory.MemoryService;
 import io.oryxos.core.profile.Profile;
 import io.oryxos.core.profile.ProfileRegistry;
+import io.oryxos.core.session.Message;
 import io.oryxos.core.session.Session;
 import io.oryxos.core.session.SessionManager;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.Lock;
@@ -19,7 +21,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * <p>并发（review 高危 4）：同一会话（sessionId）的并发请求在此按会话串行化。web 的 send/invoke/trigger 与定时触发
  * 都可能并发操作同一会话（Session 无锁 ArrayList + JpaSessionManager.save 整段覆写），不加锁会 last-write-wins 丢消息。 锁是进程内、按
- * sessionId 隔离——跨会话并行不受影响（宪法 VII 虚拟线程并发仍成立）。
+ * sessionId 隔离——跨会话并行不受影响（宪法 VII 虚拟线程并发仍成立）。进入锁后必须重读最新快照；保存时再由 SessionManager 做条件更新， 防止跨进程旧快照静默覆盖。
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",
@@ -54,20 +56,25 @@ public class AgentService {
     Lock lock = sessionLocks.computeIfAbsent(sessionKey, id -> new ReentrantLock());
     lock.lock();
     try {
+      // Controller / Channel 在进入本锁前已拿到 Session；等待锁期间它可能过期，因此必须在锁内重读。
+      Session activeSession = sessionManager.get(sessionKey).orElse(session);
+      List<Message> expectedMessages = activeSession.messages();
       Profile profile =
           profileRegistry
-              .get(session.profileName())
+              .get(activeSession.profileName())
               .orElseThrow(
                   () ->
                       new IllegalStateException(
-                          "Session 引用的 Profile 不存在: " + session.profileName()));
+                          "Session 引用的 Profile 不存在: " + activeSession.profileName()));
       ProfileContext.set(profile); // 工具执行时靠它知道"当前是哪个 Agent"
       try {
-        String reply = reActLoop.run(session, userMessage, profile);
+        String reply = reActLoop.run(activeSession, userMessage, profile);
         // 达到最大迭代上限时 ReAct 返回占位文本（不抛异常），这里检测并转为异常，
         // 让 triggerAsync 把执行记成失败状态（否则前端显示"执行成功"——错误引导用户）
         boolean exhausted = ReActLoop.MAX_ITERATIONS_REPLY.equals(reply);
-        sessionManager.save(session); // 无论是正常结束还是迭代耗尽，保存现场供审计/排查
+        activeSession.retainRecentTurns(profile.settings().maxHistoryTurns());
+        // 无论正常结束还是迭代耗尽都保存现场；条件更新确保跨进程旧快照不会覆盖新历史。
+        sessionManager.saveIfUnchanged(activeSession, expectedMessages);
         if (exhausted) {
           throw new AgentMaxIterationsExceededException(reply);
         }

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/PromptBuilder.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/PromptBuilder.java
@@ -67,25 +67,9 @@ public class PromptBuilder {
     }
     // ③ 会话历史：结构化透传（不再拍平成文本），保留 assistant tool_calls / tool tool_call_id 配对——
     //    多步 ReAct 里模型才能看出工具已调过、继续下一步（31 节修复）；仍只留最近 N 轮（坑二）
-    List<Message> history = recentTurns(session, profile.settings().maxHistoryTurns());
+    List<Message> history = session.recentTurns(profile.settings().maxHistoryTurns());
     // ④ 工具列表经 availableTools 传递，Provider 侧翻译成 Function Calling 格式
     return new ProviderRequest(system.toString(), history, resolveTools(profile));
-  }
-
-  /** 截断以轮为界整体保留/丢弃：一轮 = 一条 user 消息及其后到下一条 user 消息前的全部消息。 */
-  private static List<Message> recentTurns(Session session, int maxHistoryTurns) {
-    List<Message> messages = session.messages();
-    List<Integer> turnStarts = new ArrayList<>();
-    for (int i = 0; i < messages.size(); i++) {
-      if (Message.ROLE_USER.equals(messages.get(i).role())) {
-        turnStarts.add(i);
-      }
-    }
-    if (turnStarts.size() <= maxHistoryTurns) {
-      return messages;
-    }
-    int from = turnStarts.get(turnStarts.size() - maxHistoryTurns);
-    return messages.subList(from, messages.size());
   }
 
   private List<OryxTool> resolveTools(Profile profile) {

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/ToolExecutor.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/ToolExecutor.java
@@ -67,7 +67,13 @@ public class ToolExecutor {
     // 置入当前 Agent 名（30 节 Agent 专属记忆）：save_memory 等工具据此落到本 Agent 自己的 MEMORY.md；执行后必清除。
     ToolExecutionContext.setAgentName(agentName);
     try {
-      ToolResult result = tool.execute(input);
+      ToolResult result;
+      try {
+        result = tool.execute(input);
+      } catch (RuntimeException e) {
+        return fail(sessionId, call, e.getMessage(), startedAt);
+      }
+      // 审计异常不属于工具异常，必须向上抛出，不能重试工具或伪造第二条失败审计。
       auditor.record(
           sessionId,
           call.name(),
@@ -77,8 +83,6 @@ public class ToolExecutor {
           result.success() ? null : result.errorMessage(),
           System.currentTimeMillis() - startedAt);
       return result;
-    } catch (RuntimeException e) {
-      return fail(sessionId, call, e.getMessage(), startedAt);
     } finally {
       ToolExecutionContext.clear();
     }

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/ToolInvocationAuditor.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/ToolInvocationAuditor.java
@@ -3,7 +3,7 @@ package io.oryxos.core.agent;
 /**
  * tool_invocations 审计写入口（宪法 V：Day One 落库）——一次工具调用不管成没成，事后都得能查到。
  *
- * <p>实现方（oryxos-storage 的 JPA 实现）必须自吞内部异常并记 ERROR——审计自身失败不阻断工具结果返回， 口径与 16 节 LlmCallAuditor 一致。
+ * <p>实现方必须在写入失败时抛出异常，调用链不得在缺少审计记录的情况下返回工具结果。
  */
 public interface ToolInvocationAuditor {
 

--- a/oryxos-core/src/main/java/io/oryxos/core/provider/LlmCallAuditor.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/provider/LlmCallAuditor.java
@@ -3,7 +3,7 @@ package io.oryxos.core.provider;
 /**
  * llm_calls 审计写入口（宪法 V：Day One 落库）。
  *
- * <p>实现方（oryxos-storage 的 JPA 实现）必须自吞内部异常并记 ERROR——审计自身失败不阻断模型调用（research D5）。
+ * <p>实现方必须在写入失败时抛出异常，调用链不得在缺少审计记录的情况下返回成功。
  */
 public interface LlmCallAuditor {
 

--- a/oryxos-core/src/main/java/io/oryxos/core/session/Session.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/session/Session.java
@@ -46,6 +46,31 @@ public class Session {
     return List.copyOf(messages);
   }
 
+  /** 最近 N 个完整用户轮次；一轮从 user 消息开始，包含其后的 assistant / tool 消息。 */
+  public List<Message> recentTurns(int maxHistoryTurns) {
+    if (maxHistoryTurns <= 0) {
+      return List.of();
+    }
+    List<Integer> turnStarts = new ArrayList<>();
+    for (int i = 0; i < messages.size(); i++) {
+      if (Message.ROLE_USER.equals(messages.get(i).role())) {
+        turnStarts.add(i);
+      }
+    }
+    if (turnStarts.size() <= maxHistoryTurns) {
+      return messages();
+    }
+    int from = turnStarts.get(turnStarts.size() - maxHistoryTurns);
+    return List.copyOf(messages.subList(from, messages.size()));
+  }
+
+  /** 原地只保留最近 N 个完整用户轮次，用于限制持久化历史的长期增长。 */
+  public void retainRecentTurns(int maxHistoryTurns) {
+    List<Message> retained = recentTurns(maxHistoryTurns);
+    messages.clear();
+    messages.addAll(retained);
+  }
+
   public void appendUser(String content) {
     messages.add(new Message(Message.ROLE_USER, content, null));
   }

--- a/oryxos-core/src/main/java/io/oryxos/core/session/SessionManager.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/session/SessionManager.java
@@ -19,6 +19,13 @@ public interface SessionManager {
   void save(Session session);
 
   /**
+   * 仅当持久化历史仍与调用方读取时的 {@code expectedMessages} 相同时保存。
+   *
+   * <p>用于防止跨线程或跨进程的旧快照覆盖新历史；发生竞争时抛 {@link SessionUpdateConflictException}。
+   */
+  void saveIfUnchanged(Session session, List<Message> expectedMessages);
+
+  /**
    * 归档一个会话（status→archived、记 archived_at）。26 节 DELETE /sessions/{id} 接线；sessions 的
    * status/archived_at 列自 18 节 data model 即在，此前未接对外入口。
    *

--- a/oryxos-core/src/main/java/io/oryxos/core/session/SessionUpdateConflictException.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/session/SessionUpdateConflictException.java
@@ -1,0 +1,9 @@
+package io.oryxos.core.session;
+
+/** 会话在处理期间已被其他执行更新；拒绝用旧快照覆盖较新的历史。 */
+public class SessionUpdateConflictException extends RuntimeException {
+
+  public SessionUpdateConflictException(String sessionId) {
+    super("会话已被其他请求更新，请重新获取后重试: " + sessionId);
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentServiceTest.java
@@ -12,10 +12,12 @@ import static org.mockito.Mockito.when;
 
 import io.oryxos.core.profile.Profile;
 import io.oryxos.core.profile.ProfileRegistry;
+import io.oryxos.core.session.Message;
 import io.oryxos.core.session.Session;
 import io.oryxos.core.session.SessionManager;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -96,7 +98,7 @@ class AgentServiceTest {
     String reply = agentService.process(session, "hi");
 
     assertEquals("最终答复", reply);
-    verify(sessionManager).save(session);
+    verify(sessionManager).saveIfUnchanged(session, List.of());
     assertNull(ProfileContext.current()); // 正常路径同样清干净
   }
 
@@ -107,7 +109,7 @@ class AgentServiceTest {
 
     assertThrows(RuntimeException.class, () -> agentService.process(session, "hi"));
 
-    verify(sessionManager, never()).save(any());
+    verify(sessionManager, never()).saveIfUnchanged(any(), any());
   }
 
   @Test
@@ -131,7 +133,65 @@ class AgentServiceTest {
             AgentMaxIterationsExceededException.class, () -> agentService.process(session, "hi"));
 
     assertEquals(ReActLoop.MAX_ITERATIONS_REPLY, ex.getMessage());
-    verify(sessionManager).save(session); // 对话现场保留，供排查为什么不收敛
+    verify(sessionManager).saveIfUnchanged(session, List.of()); // 对话现场保留，供排查为什么不收敛
     assertNull(ProfileContext.current());
+  }
+
+  @Test
+  @DisplayName("进入会话锁后重读最新快照并基于原始历史做条件保存")
+  void processingReloadsLatestSessionInsideLockAndSavesConditionally() {
+    Session stale = new Session("s-1", "ops-agent");
+    Session latest = new Session("s-1", "ops-agent");
+    latest.appendUser("已经保存的上一轮");
+    List<Message> expectedMessages = latest.messages();
+    when(sessionManager.get("s-1")).thenReturn(Optional.of(latest));
+    when(reActLoop.run(any(), any(), any())).thenReturn("ok");
+
+    agentService.process(stale, "下一轮");
+
+    verify(reActLoop).run(latest, "下一轮", profile);
+    verify(sessionManager).saveIfUnchanged(latest, expectedMessages);
+    verify(sessionManager, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("保存前按 Agent 的 maxHistoryTurns 截断持久历史")
+  void persistedHistoryIsTrimmedToProfileLimit() {
+    Profile boundedProfile =
+        new Profile(
+            "ops-agent",
+            null,
+            null,
+            new Profile.ProviderRef("deepseek", "deepseek-chat", null),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            new Profile.Settings(10, 2));
+    AgentService boundedService =
+        new AgentService(
+            new ProfileRegistry(Map.of("ops-agent", boundedProfile)),
+            reActLoop,
+            sessionManager,
+            mock(io.oryxos.core.memory.MemoryService.class));
+    Session latest = new Session("s-1", "ops-agent");
+    latest.appendUser("问题1");
+    latest.appendUser("问题2");
+    latest.appendUser("问题3");
+    List<Message> baseline = latest.messages();
+    when(sessionManager.get("s-1")).thenReturn(Optional.of(latest));
+    when(reActLoop.run(any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              invocation.<Session>getArgument(0).appendUser("问题4");
+              return "ok";
+            });
+
+    boundedService.process(new Session("s-1", "ops-agent"), "问题4");
+
+    assertEquals(List.of("问题3", "问题4"), latest.messages().stream().map(Message::content).toList());
+    verify(sessionManager).saveIfUnchanged(latest, baseline);
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/ToolExecutorTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/ToolExecutorTest.java
@@ -3,6 +3,7 @@ package io.oryxos.core.agent;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -10,7 +11,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -57,6 +60,25 @@ class ToolExecutorTest {
             eq(true),
             isNull(),
             anyLong());
+  }
+
+  @Test
+  @DisplayName("审计失败向上抛出且不重试工具或审计")
+  void auditFailurePropagatesWithoutRetry() {
+    when(httpGet.execute(any())).thenReturn(ToolResult.ok("ok"));
+    doThrow(new IllegalStateException("audit unavailable"))
+        .when(auditor)
+        .record(eq("s-1"), eq("http_get"), anyString(), eq("ok"), eq(true), isNull(), anyLong());
+
+    IllegalStateException error =
+        assertThrows(
+            IllegalStateException.class,
+            () -> executor.execute("s-1", "agent-x", new ToolCallRequest("http_get", "{}")));
+
+    assertEquals("audit unavailable", error.getMessage());
+    verify(httpGet, times(1)).execute(any());
+    verify(auditor, times(1))
+        .record(eq("s-1"), eq("http_get"), anyString(), eq("ok"), eq(true), isNull(), anyLong());
   }
 
   @Test

--- a/oryxos-core/src/test/java/io/oryxos/core/session/SessionTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/session/SessionTest.java
@@ -1,0 +1,27 @@
+package io.oryxos.core.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.oryxos.core.provider.ProviderResponse;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SessionTest {
+
+  @Test
+  @DisplayName("持久历史按用户轮次截断且不撕裂轮内消息")
+  void retainingRecentTurnsKeepsWholeLatestTurns() {
+    Session session = new Session("s-1", "ops-agent");
+    for (int turn = 1; turn <= 3; turn++) {
+      session.appendUser("问题" + turn);
+      session.appendAssistant(new ProviderResponse("回答" + turn, List.of(), null));
+    }
+
+    session.retainRecentTurns(2);
+
+    assertEquals(
+        List.of("问题2", "回答2", "问题3", "回答3"),
+        session.messages().stream().map(Message::content).toList());
+  }
+}

--- a/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
@@ -65,30 +65,37 @@ public class SpringAiProviderServiceImpl implements ProviderService {
     ChatModel model = resolveModel(def);
     Prompt prompt = buildPrompt(profile, request);
     long startedAt = System.currentTimeMillis();
+    ProviderResponse result;
     try {
       ChatResponse response = model.call(prompt);
-      ProviderResponse result = toProviderResponse(response);
-      audit.record(
-          sessionId,
-          providerName,
-          profile.provider().model(),
-          result.usage(),
-          true,
-          null,
-          System.currentTimeMillis() - startedAt);
-      return result;
+      result = toProviderResponse(response);
     } catch (RuntimeException e) {
       // 失败也留痕（宪法 V）：先落审计再上抛——只记成功不记失败，一次真实事故就没有痕迹
-      audit.record(
-          sessionId,
-          providerName,
-          profile.provider().model(),
-          null,
-          false,
-          e.getMessage(),
-          System.currentTimeMillis() - startedAt);
+      try {
+        audit.record(
+            sessionId,
+            providerName,
+            profile.provider().model(),
+            null,
+            false,
+            e.getMessage(),
+            System.currentTimeMillis() - startedAt);
+      } catch (RuntimeException auditFailure) {
+        auditFailure.addSuppressed(e);
+        throw auditFailure;
+      }
       throw e;
     }
+    // 成功审计放在模型异常边界之外，避免审计失败被误记成一次模型调用失败。
+    audit.record(
+        sessionId,
+        providerName,
+        profile.provider().model(),
+        result.usage(),
+        true,
+        null,
+        System.currentTimeMillis() - startedAt);
+    return result;
   }
 
   /** 按 name+key+url 缓存构建好的 ChatModel；参数变化即换缓存键、下次重建（provider CRUD 改了配置立即生效）。 */

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ProviderServiceTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ProviderServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -177,6 +178,24 @@ class ProviderServiceTest {
 
     verify(audit, times(1))
         .record(eq("s-1"), eq("deepseek"), eq("model-x"), any(), eq(true), isNull(), anyLong());
+  }
+
+  @Test
+  void 成功调用的审计失败_向上抛出且不伪装成模型失败() {
+    when(deepseek.call(any(Prompt.class))).thenReturn(textResponse("你好"));
+    doThrow(new IllegalStateException("audit unavailable"))
+        .when(audit)
+        .record(eq("s-1"), eq("deepseek"), eq("model-x"), any(), eq(true), isNull(), anyLong());
+
+    IllegalStateException error =
+        assertThrows(
+            IllegalStateException.class,
+            () -> service.chat("s-1", profileUsing("deepseek"), ProviderRequest.of("hi")));
+
+    assertEquals("audit unavailable", error.getMessage());
+    verify(deepseek, times(1)).call(any(Prompt.class));
+    verify(audit, never())
+        .record(eq("s-1"), eq("deepseek"), eq("model-x"), isNull(), eq(false), any(), anyLong());
   }
 
   @Test

--- a/oryxos-storage/src/main/java/io/oryxos/storage/JpaLlmCallAuditor.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/JpaLlmCallAuditor.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 /**
  * LlmCallAuditor 的 JPA 实现。
  *
- * <p>research D5：审计自身失败只记 ERROR、不上抛——可用性优先，审计故障不阻断模型调用主链路。
+ * <p>审计写入失败时 fail-closed：记录错误并抛出异常，防止主链路在没有审计记录的情况下返回成功。
  */
 public class JpaLlmCallAuditor implements LlmCallAuditor {
 
@@ -44,7 +44,8 @@ public class JpaLlmCallAuditor implements LlmCallAuditor {
       record.setDurationMs(durationMs);
       repository.save(record);
     } catch (RuntimeException e) {
-      LOG.error("llm_calls 审计写入失败（不阻断调用）: {}", sanitize(e.getMessage()));
+      LOG.error("llm_calls 审计写入失败: {}", sanitize(e.getMessage()));
+      throw new IllegalStateException("llm_calls 审计写入失败", e);
     }
   }
 

--- a/oryxos-storage/src/main/java/io/oryxos/storage/JpaSessionManager.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/JpaSessionManager.java
@@ -7,6 +7,7 @@ import io.oryxos.core.session.Message;
 import io.oryxos.core.session.SessionManager;
 import io.oryxos.core.session.SessionStats;
 import io.oryxos.core.session.SessionSummary;
+import io.oryxos.core.session.SessionUpdateConflictException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -61,6 +62,19 @@ public class JpaSessionManager implements SessionManager {
     entity.setMessagesJson(writeMessages(session.messages()));
     entity.setLastActiveAt(Instant.now());
     repository.save(entity);
+  }
+
+  @Override
+  public void saveIfUnchanged(
+      io.oryxos.core.session.Session session, List<Message> expectedMessages) {
+    String expectedJson = writeMessages(expectedMessages == null ? List.of() : expectedMessages);
+    String messagesJson = writeMessages(session.messages());
+    int updated =
+        repository.updateMessagesIfUnchanged(
+            session.sessionId(), expectedJson, messagesJson, Instant.now());
+    if (updated != 1) {
+      throw new SessionUpdateConflictException(safeId(session));
+    }
   }
 
   @Override

--- a/oryxos-storage/src/main/java/io/oryxos/storage/JpaToolInvocationAuditor.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/JpaToolInvocationAuditor.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 /**
  * ToolInvocationAuditor 的 JPA 实现。
  *
- * <p>审计自身失败只记 ERROR、不上抛——可用性优先，审计故障不阻断工具结果返回（口径同 16 节 D5）。
+ * <p>审计写入失败时 fail-closed：记录错误并抛出异常，防止主链路在没有审计记录的情况下返回工具结果。
  */
 public class JpaToolInvocationAuditor implements ToolInvocationAuditor {
 
@@ -39,7 +39,8 @@ public class JpaToolInvocationAuditor implements ToolInvocationAuditor {
       record.setDurationMs(durationMs);
       repository.save(record);
     } catch (RuntimeException e) {
-      LOG.error("tool_invocations 审计写入失败（不阻断工具结果返回）: {}", sanitize(e.getMessage()));
+      LOG.error("tool_invocations 审计写入失败: {}", sanitize(e.getMessage()));
+      throw new IllegalStateException("tool_invocations 审计写入失败", e);
     }
   }
 

--- a/oryxos-storage/src/main/java/io/oryxos/storage/SessionRepository.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/SessionRepository.java
@@ -1,7 +1,12 @@
 package io.oryxos.storage;
 
+import java.time.Instant;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 /** sessions 的读写通道；按 profile 查询供 session list 与后续 Web 端点使用。 */
 public interface SessionRepository extends JpaRepository<Session, String> {
@@ -9,4 +14,20 @@ public interface SessionRepository extends JpaRepository<Session, String> {
   List<Session> findByProfileName(String profileName);
 
   long countByStatus(String status);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Transactional(rollbackFor = Exception.class)
+  @Query(
+      """
+      UPDATE Session s
+         SET s.messagesJson = :messagesJson, s.lastActiveAt = :lastActiveAt
+       WHERE s.sessionId = :sessionId
+         AND (s.messagesJson = :expectedMessagesJson
+              OR (s.messagesJson IS NULL AND :expectedMessagesJson = '[]'))
+      """)
+  int updateMessagesIfUnchanged(
+      @Param("sessionId") String sessionId,
+      @Param("expectedMessagesJson") String expectedMessagesJson,
+      @Param("messagesJson") String messagesJson,
+      @Param("lastActiveAt") Instant lastActiveAt);
 }

--- a/oryxos-storage/src/test/java/io/oryxos/storage/LlmCallRepositoryTest.java
+++ b/oryxos-storage/src/test/java/io/oryxos/storage/LlmCallRepositoryTest.java
@@ -1,8 +1,8 @@
 package io.oryxos.storage;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -76,13 +76,16 @@ class LlmCallRepositoryTest {
   }
 
   @Test
-  void 审计实现自吞异常_不阻断主链路() {
+  void 审计写入失败_必须阻断主链路() {
     LlmCallRepository broken = mock(LlmCallRepository.class);
     when(broken.save(any())).thenThrow(new RuntimeException("db locked"));
     JpaLlmCallAuditor auditor = new JpaLlmCallAuditor(broken);
 
-    // research D5：审计自身失败只记 ERROR，不上抛
-    assertDoesNotThrow(
-        () -> auditor.record("s-3", "deepseek", "m", null, true, null, List.of().size()));
+    IllegalStateException error =
+        assertThrows(
+            IllegalStateException.class,
+            () -> auditor.record("s-3", "deepseek", "m", null, true, null, List.of().size()));
+    assertTrue(error.getMessage().contains("llm_calls"));
+    assertEquals("db locked", error.getCause().getMessage());
   }
 }

--- a/oryxos-storage/src/test/java/io/oryxos/storage/SessionRepositoryTest.java
+++ b/oryxos-storage/src/test/java/io/oryxos/storage/SessionRepositoryTest.java
@@ -1,7 +1,9 @@
 package io.oryxos.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.oryxos.core.ToolResult;
@@ -113,5 +115,27 @@ class SessionRepositoryTest {
     Session entity = repository.findById("cli:wang:weather").orElseThrow();
     assertNotNull(entity.getLastActiveAt());
     assertTrue(!entity.getLastActiveAt().isBefore(beforeSave.minusSeconds(5)));
+  }
+
+  @Test
+  @DisplayName("两个旧快照依次保存_第二个被拒绝而不是覆盖第一条消息")
+  void staleSnapshotCannotOverwriteNewerConversation() {
+    JpaSessionManager manager = new JpaSessionManager(repository);
+    var first = manager.getOrCreate("web", "default", "ops");
+    var stale = manager.getOrCreate("web", "default", "ops");
+    List<Message> firstBaseline = first.messages();
+    List<Message> staleBaseline = stale.messages();
+
+    first.appendUser("先到的消息");
+    manager.saveIfUnchanged(first, firstBaseline);
+    stale.appendUser("后到但基于旧快照的消息");
+
+    assertThrows(
+        io.oryxos.core.session.SessionUpdateConflictException.class,
+        () -> manager.saveIfUnchanged(stale, staleBaseline));
+
+    List<Message> persisted = manager.get("web:default:ops").orElseThrow().messages();
+    assertTrue(persisted.stream().anyMatch(m -> "先到的消息".equals(m.content())));
+    assertFalse(persisted.stream().anyMatch(m -> "后到但基于旧快照的消息".equals(m.content())));
   }
 }

--- a/oryxos-storage/src/test/java/io/oryxos/storage/ToolInvocationRepositoryTest.java
+++ b/oryxos-storage/src/test/java/io/oryxos/storage/ToolInvocationRepositoryTest.java
@@ -1,9 +1,9 @@
 package io.oryxos.storage;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -77,13 +77,17 @@ class ToolInvocationRepositoryTest {
   }
 
   @Test
-  @DisplayName("审计实现自吞异常_不阻断工具结果返回")
-  void auditorSwallowsItsOwnFailureWithoutBreakingMainPath() {
+  @DisplayName("审计写入失败_必须阻断工具结果返回")
+  void auditFailureStopsToolResultFromReturning() {
     ToolInvocationRepository broken = mock(ToolInvocationRepository.class);
     when(broken.save(any())).thenThrow(new RuntimeException("db locked"));
     JpaToolInvocationAuditor auditor = new JpaToolInvocationAuditor(broken);
 
-    // 口径同 16 节 D5：审计自身失败只记 ERROR，不上抛
-    assertDoesNotThrow(() -> auditor.record("s-3", "http_get", "{}", null, true, null, 1L));
+    IllegalStateException error =
+        assertThrows(
+            IllegalStateException.class,
+            () -> auditor.record("s-3", "http_get", "{}", null, true, null, 1L));
+    assertTrue(error.getMessage().contains("tool_invocations"));
+    assertEquals("db locked", error.getCause().getMessage());
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/GlobalExceptionHandler.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package io.oryxos.web;
 
 import io.oryxos.core.profile.ProfileValidationException;
+import io.oryxos.core.session.SessionUpdateConflictException;
 import io.oryxos.core.skill.SkillReferencedException;
 import io.oryxos.web.common.ApiResponse;
 import io.oryxos.web.controller.dto.SkillReferenceConflictView;
@@ -65,6 +66,15 @@ public class GlobalExceptionHandler {
         SkillReferenceConflictView.from(ex.skillName(), ex.references());
     return ResponseEntity.status(HttpStatus.CONFLICT)
         .body(new ApiResponse<>(HttpStatus.CONFLICT.value(), ex.getMessage(), data));
+  }
+
+  /** 409 — 会话在执行期间已被另一请求更新，拒绝旧快照覆盖新历史。 */
+  @ExceptionHandler(SessionUpdateConflictException.class)
+  public ResponseEntity<ApiResponse<Void>> handleSessionUpdateConflict(
+      SessionUpdateConflictException ex) {
+    LOG.warn("Session update conflict: {}", sanitize(ex.getMessage()));
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(ApiResponse.error(HttpStatus.CONFLICT.value(), ex.getMessage()));
   }
 
   /** 504 — Agent 调用超过 60 秒上限。 */

--- a/oryxos-web/src/test/java/io/oryxos/web/GlobalExceptionHandlerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/GlobalExceptionHandlerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import io.oryxos.core.session.SessionUpdateConflictException;
 import io.oryxos.web.error.AgentTimeoutException;
 import io.oryxos.web.error.ProviderUnavailableException;
 import io.oryxos.web.error.ResourceNotFoundException;
@@ -73,6 +74,15 @@ class GlobalExceptionHandlerTest {
   }
 
   @Test
+  @DisplayName("会话旧快照冲突_映射409并提示重新获取")
+  void sessionUpdateConflictMaps409() throws Exception {
+    mvc.perform(MockMvcRequestBuilders.get("/throw/session-conflict"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value(409))
+        .andExpect(jsonPath("$.message").value(containsString("重新获取")));
+  }
+
+  @Test
   @DisplayName("内部异常细节_绝不能出现在500响应里")
   void internalDetailsNeverLeakIn500() throws Exception {
     mvc.perform(MockMvcRequestBuilders.get("/throw/internal"))
@@ -108,6 +118,11 @@ class GlobalExceptionHandlerTest {
     @GetMapping("/throw/timeout")
     void timeout() {
       throw new AgentTimeoutException("Agent 调用超过 60 秒");
+    }
+
+    @GetMapping("/throw/session-conflict")
+    void sessionConflict() {
+      throw new SessionUpdateConflictException("s-x");
     }
 
     @GetMapping("/throw/internal")


### PR DESCRIPTION
## Summary

- reload the latest session after acquiring the per-session lock, then use a compare-and-swap JSON update so stale cross-process snapshots return HTTP 409 instead of overwriting newer history
- enable SQLite WAL and a 5-second `busy_timeout` for Hikari connections, and add the timeout to the standalone `session list` connection
- make LLM/tool audit writes fail closed, while keeping audit failures outside the model/tool execution exception boundary to avoid retries or false failure records
- trim persisted messages to `max_history_turns` using the same whole-turn boundary as prompt construction

## Verification

- `mvn clean verify`
- all 10 reactor modules passed, including unit/integration tests, Spotless, Checkstyle, PMD, and SpotBugs
- added regression coverage for stale snapshot conflicts, HTTP 409 mapping, whole-turn history retention, audit failure propagation, and live SQLite PRAGMA values (`journal_mode=wal`, `busy_timeout=5000`)

Closes #43
