### PR TITLE
docs(security): clarify shell sandbox boundaries

### DIFF
--- a/oryxos-boot/src/test/java/io/oryxos/boot/SandboxDefaultsConfigTest.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/SandboxDefaultsConfigTest.java
@@ -1,0 +1,34 @@
+package io.oryxos.boot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import io.oryxos.tool.sandbox.ShellSandboxProperties;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+/** 锁定内置 application.yml 的最小 shell 权限，防止解释器再次进入默认白名单。 */
+class SandboxDefaultsConfigTest {
+
+  @Test
+  void defaultShellWhitelistExcludesInterpreters() {
+    new ApplicationContextRunner()
+        .withInitializer(new ConfigDataApplicationContextInitializer())
+        .withUserConfiguration(ShellPropertiesConfiguration.class)
+        .run(
+            context -> {
+              ShellSandboxProperties properties = context.getBean(ShellSandboxProperties.class);
+              assertEquals(List.of("ls", "cat", "echo", "grep"), properties.allowedCommands());
+              assertFalse(properties.allowedCommands().contains("python"));
+              assertFalse(properties.allowedCommands().contains("python3"));
+            });
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  @EnableConfigurationProperties(ShellSandboxProperties.class)
+  static class ShellPropertiesConfiguration {}
+}

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -645,7 +645,7 @@ Returns all tools registered in the `ToolRegistry` — built-in tools plus any t
 // data — ToolView[]
 [
   { "name": "read_file", "description": "Read a file from the filesystem (path whitelist enforced)" },
-  { "name": "shell",     "description": "Execute a shell command (command whitelist enforced)" },
+  { "name": "shell",     "description": "Execute a shell command (allowlist and metacharacter checks enforced)" },
   { "name": "notify",    "description": "Push a message to a registered notify channel by name" }
 ]
 ```
@@ -666,7 +666,7 @@ Returns all three categories at once.
 // data
 {
   "file": ["/home/user/project/.oryxos"],
-  "shell": ["ls", "cat", "python3"],
+  "shell": ["ls", "cat", "echo", "grep"],
   "http": ["*.open-meteo.com", "hn.algolia.com"]
 }
 ```

--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -86,9 +86,11 @@ OryxOS ships with three demo agents under `.oryxos/agents/` that show the model 
 | --- | --- |
 | `weather-daily` | Fetches Beijing weather from open-meteo and pushes a dressing tip via `notify` |
 | `daily-tech-digest` | Pulls headlines from `hn.algolia.com`, reads an on-demand skill file, and notifies a digest |
-| `github-daily` | Runs `python3 scripts/github_trending.py` via `shell` and notifies a GitHub trending report |
+| `github-daily` | Runs a trusted local Python script via `shell` and notifies a GitHub trending report (requires explicitly allowing `python3`) |
 
 All three use provider `deepseek` / `deepseek-chat` and reference a notify channel by name.
+
+> `github-daily` is an opt-in trusted-script demo. `python3` is deliberately absent from the default shell whitelist because an interpreter grants arbitrary code execution. Review the script before explicitly adding `python3`; do not enable it for untrusted agent input.
 
 ## Start chatting
 

--- a/website/docs/tool.md
+++ b/website/docs/tool.md
@@ -45,7 +45,7 @@ About two dozen tools ship with OryxOS core — a set of **universal primitives*
 | `move_file` | `FileTools` | Move / rename a file | Path whitelist (source + target) |
 | `copy_file` | `FileTools` | Copy a file | Path whitelist (source + target) |
 | `delete_file` | `FileTools` | Delete a file (never a directory) | Path whitelist |
-| `shell` | `ShellTools` | Execute a shell command | Command first-token whitelist + timeout |
+| `shell` | `ShellTools` | Execute a shell command | Command whitelist + metacharacter scan + timeout |
 | `http_get` / `http_post` | `HttpTools` | HTTP GET / POST | Domain wildcard whitelist |
 | `http_request` | `HttpTools` | HTTP with any method (GET/POST/PUT/PATCH/DELETE) + headers | Domain wildcard whitelist |
 | `fetch_webpage` | `HttpTools` | Fetch a URL and extract readable text (strip HTML) | Domain wildcard whitelist |
@@ -132,7 +132,7 @@ Each entry carries comments on prerequisites (Node.js/`npx` or `uv`/`uvx` on the
 
 `SandboxChecker` runs before every tool invocation. It enforces three independent whitelists configured as top-level keys in `application.yml`. An empty list means **deny-all** — the sandbox is closed by default and you widen it explicitly, following least privilege. The configured workspace root is added to the file whitelist automatically at runtime.
 
-**File path whitelist** — applies to `read_file`, `write_file`, `list_dir`. The requested path must match at least one entry.
+**File path whitelist** — applies to `read_file`, `write_file`, `list_dir`. The requested path's real target must remain under at least one entry; symlinks cannot escape an allowed root.
 
 ```yaml
 file:
@@ -141,17 +141,18 @@ file:
     - /tmp/oryxos
 ```
 
-**Shell command whitelist** — applies to `shell`. Only the first token of the command is checked (the executable name). Arguments are not restricted by the whitelist.
+**Shell command whitelist** — applies to `shell`. The executable (first token) must be listed, and shell control, substitution, and redirection metacharacters such as `;`, `&&`, `|`, `$()`, backticks, newlines, and `>` are rejected. Quoted literal punctuation remains valid. Arguments are not independently restricted.
 
 ```yaml
 shell:
   allowed_commands:
     - ls
     - cat
+    - echo
     - grep
-    - python3
-  timeout_seconds: 30
 ```
+
+The shell whitelist is an independent capability boundary. Adding an interpreter or shell such as `python`, `python3`, `sh`, or `bash` grants the agent the capabilities of that executable and can bypass the file and HTTP tool policies. They are deliberately excluded from the default configuration. Add such entries only for trusted scripts and only when that broader authority is intentional.
 
 **HTTP domain whitelist** — applies to `http_get` and `http_post`. Supports `*` as a prefix wildcard.
 

--- a/website/zh/docs/api.md
+++ b/website/zh/docs/api.md
@@ -645,7 +645,7 @@ null
 // data —— ToolView[]
 [
   { "name": "read_file", "description": "读取文件内容，路径受白名单限制" },
-  { "name": "shell",     "description": "执行 shell 命令，命令首 token 受白名单限制" },
+  { "name": "shell",     "description": "执行 shell 命令，受命令白名单与元字符校验限制" },
   { "name": "notify",    "description": "按名字把消息推送到已注册的通知渠道" }
 ]
 ```
@@ -666,7 +666,7 @@ Sandbox 白名单分三类——`FILE`（允许路径）、`SHELL`（允许命�
 // data
 {
   "file": ["/home/user/project/.oryxos"],
-  "shell": ["ls", "cat", "python3"],
+  "shell": ["ls", "cat", "echo", "grep"],
   "http": ["*.open-meteo.com", "hn.algolia.com"]
 }
 ```

--- a/website/zh/docs/quick-start.md
+++ b/website/zh/docs/quick-start.md
@@ -86,9 +86,11 @@ OryxOS 在 `.oryxos/agents/` 下自带三个 Demo Agent 演示这套模型：
 | --- | --- |
 | `weather-daily` | 从 open-meteo 拿北京天气，通过 `notify` 推送穿搭建议 |
 | `daily-tech-digest` | 从 `hn.algolia.com` 拉头条，按需读取 skill 文件，推送科技日报 |
-| `github-daily` | 用 `shell` 跑 `python3 scripts/github_trending.py`，推送 GitHub 热门日报 |
+| `github-daily` | 用 `shell` 跑受信任的本地 Python 脚本，推送 GitHub 热门日报（需显式允许 `python3`） |
 
 三者都用 Provider `deepseek` / `deepseek-chat`，并按名引用通知渠道。
+
+> `github-daily` 是需要主动启用的受信任脚本 Demo。默认 shell 白名单刻意不包含 `python3`，因为解释器等同于任意代码执行能力。显式加入前请先审查脚本，不要对不受信任的 Agent 输入开放。
 
 ## 开始对话
 

--- a/website/zh/docs/tool.md
+++ b/website/zh/docs/tool.md
@@ -45,7 +45,7 @@ OryxOS 核心内置约两打工具——一组精心挑选的**通用原语**，
 | `move_file` | `FileTools` | 移动 / 重命名文件 | 路径白名单（源 + 目标） |
 | `copy_file` | `FileTools` | 复制文件 | 路径白名单（源 + 目标） |
 | `delete_file` | `FileTools` | 删除文件（拒绝删目录） | 路径白名单 |
-| `shell` | `ShellTools` | 执行 Shell 命令 | 命令首 token 白名单 + 超时 |
+| `shell` | `ShellTools` | 执行 Shell 命令 | 命令白名单 + 元字符扫描 + 超时 |
 | `http_get` / `http_post` | `HttpTools` | HTTP GET / POST | 域名通配符白名单 |
 | `http_request` | `HttpTools` | 任意方法 HTTP（GET/POST/PUT/PATCH/DELETE）+ 请求头 | 域名通配符白名单 |
 | `fetch_webpage` | `HttpTools` | 抓取网页并抽取可读正文（去 HTML） | 域名通配符白名单 |
@@ -132,7 +132,7 @@ OryxOS 刻意让内置工具保持精简。内置工具是**通用原语**——
 
 `SandboxChecker` 在每次工具调用前运行，执行在 `application.yml` 里以顶层键配置的三个独立白名单。空列表表示 **deny-all**——沙箱默认关闭，需按最小权限显式放开。配置的工作区根目录会在运行期自动纳入文件白名单。
 
-**文件路径白名单** — 作用于 `read_file`、`write_file`、`list_dir`。请求的路径必须匹配至少一条白名单项。
+**文件路径白名单** — 作用于 `read_file`、`write_file`、`list_dir`。请求路径的真实目标必须位于至少一条白名单项之下；符号链接不能逃逸到允许根目录之外。
 
 ```yaml
 file:
@@ -141,17 +141,18 @@ file:
     - /tmp/oryxos
 ```
 
-**Shell 命令白名单** — 作用于 `shell`。只检查命令的第一个 token（可执行文件名），参数不受白名单限制。
+**Shell 命令白名单** — 作用于 `shell`。可执行文件（第一个 token）必须在白名单中，同时拒绝 `;`、`&&`、`|`、`$()`、反引号、换行、`>` 等控制、替换和重定向元字符；引号内的字面标点仍可使用。参数不会被单独限制。
 
 ```yaml
 shell:
   allowed_commands:
     - ls
     - cat
+    - echo
     - grep
-    - python3
-  timeout_seconds: 30
 ```
+
+Shell 白名单是一条独立的能力边界。加入 `python`、`python3`、`sh`、`bash` 等解释器或 Shell，等于授予 Agent 该可执行文件的完整能力，并可能绕过文件与 HTTP 工具策略。因此默认配置刻意不包含它们；只有在脚本可信且确实需要扩大权限时才应显式加入。
 
 **HTTP 域名白名单** — 作用于 `http_get` 和 `http_post`。支持 `*` 作为前缀通配符。
 


### PR DESCRIPTION
## Summary

- document the shell sandbox behavior already implemented by #58
- remove `python3` from public allowlist and API examples, and warn that interpreters broaden agent authority
- clarify real-path/symlink enforcement and the trusted-script requirements of the `github-daily` demo
- add a configuration regression test that locks the default allowlist to `ls`, `cat`, `echo`, and `grep`

## Security assessment

The vulnerable source-to-sink path reported in #41 was already fixed by #58. This PR closes the remaining documentation and configuration-guidance gap that could lead operators to re-enable an interpreter and recreate the unsafe boundary.

## Verification

- `mvn clean verify`
- `mvn test -pl oryxos-tool,oryxos-boot -am -Dtest='WhitelistSandboxTest,ShellToolsTest,FileToolsTest,SandboxDefaultsConfigTest' -Dsurefire.failIfNoSpecifiedTests=false`
- `cd website && npm ci && npm run docs:build`

Closes #41
