### PR TITLE
fix(deps): update security baseline and dependency scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,7 @@ jobs:
           distribution: temurin
           java-version: '21'
           cache: maven
-      # Enabled via -Dowasp.skip=false. NVD_API_KEY (repo secret) makes the NVD
-      # download fast and avoids rate limiting; the scan still works without it, slowly.
+      # Enabled via -Dowasp.skip=false. The Maven configuration uses
+      # Dependency-Check's nightly NVD cache, which is available to fork PRs.
       - name: mvn verify with dependency-check
-        run: mvn -B clean verify -DskipTests -Dowasp.skip=false -DnvdApiKey="${NVD_API_KEY}"
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: mvn -B clean verify -DskipTests -Dowasp.skip=false

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ All endpoints are prefixed with `/api/v1` and every response is wrapped in a uni
 | --- | --- |
 | Language / Runtime | Java 21 (virtual threads) |
 | Framework | Spring Boot 3.x |
-| LLM Integration | Spring AI Alibaba (protocol translation + `@Tool` schema only) |
+| LLM Integration | Spring AI (OpenAI-compatible protocol translation + `@Tool` schema only) |
 | CLI | Picocli |
 | Config | SnakeYAML |
 | Persistence | SQLite + Spring Data JPA |

--- a/config/dependency-check-suppressions.xml
+++ b/config/dependency-check-suppressions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.4.xsd">
+    <suppress>
+        <notes><![CDATA[
+        CVE-2023-39022 affects opensymphony:oscore through 2.2.6.
+        io.oryxos:oryxos-core is an unrelated first-party artifact that Dependency-Check
+        matched only because its artifact name is similar to "oscore".
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.oryxos/oryxos-core@.*$</packageUrl>
+        <cve>CVE-2023-39022</cve>
+    </suppress>
+</suppressions>

--- a/oryxos-boot/src/main/resources/application.yml
+++ b/oryxos-boot/src/main/resources/application.yml
@@ -6,7 +6,6 @@ spring:
   # auto-instantiated at startup (which would also demand API keys before any agent runs).
   autoconfigure:
     exclude:
-      - com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeAutoConfiguration
       # 宪法 II：禁用 Spring AI eager 模型自动装配。deepseek 走 spring-ai-openai starter，
       # OpenAiAutoConfiguration 会急切建 OpenAiChatModel 并索要 spring.ai.openai.api-key；
       # OryxOS 不用它（Provider 由 ProviderChatModelFactory 显式构造），排掉后 serve 只需 DEEPSEEK_API_KEY。
@@ -84,13 +83,6 @@ management:
     web:
       exposure:
         include: health,info,prometheus,metrics
-  health:
-    # Nacos is pulled in transitively by the Spring AI Alibaba starter but OryxOS does not
-    # use it; its health indicator would otherwise report DOWN (no Nacos server).
-    nacos-config:
-      enabled: false
-    nacos-discovery:
-      enabled: false
   endpoint:
     health:
       probes:

--- a/oryxos-memory/pom.xml
+++ b/oryxos-memory/pom.xml
@@ -30,7 +30,7 @@
         <!-- @Tool 注解（MemoryTools 走 20 节同款注解管道，schema 自动生成） -->
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-core</artifactId>
+            <artifactId>spring-ai-model</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/oryxos-provider/pom.xml
+++ b/oryxos-provider/pom.xml
@@ -12,16 +12,12 @@
 
     <artifactId>oryxos-provider</artifactId>
     <name>OryxOS Provider</name>
-    <description>LLM provider integration with Spring AI Alibaba</description>
+    <description>LLM provider integration with Spring AI</description>
 
     <dependencies>
         <dependency>
             <groupId>io.oryxos</groupId>
             <artifactId>oryxos-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.alibaba.cloud.ai</groupId>
-            <artifactId>spring-ai-alibaba-starter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>

--- a/oryxos-provider/src/main/java/io/oryxos/provider/MockChatModel.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/MockChatModel.java
@@ -42,7 +42,12 @@ public class MockChatModel implements ChatModel {
             "function",
             "save_memory",
             "{\"content\":" + jsonString(fact) + ",\"scope\":\"archival\"}");
-    return single(new AssistantMessage("", Map.of(), List.of(toolCall)));
+    return single(
+        AssistantMessage.builder()
+            .content("")
+            .properties(Map.of())
+            .toolCalls(List.of(toolCall))
+            .build());
   }
 
   private static ChatResponse single(AssistantMessage message) {
@@ -54,7 +59,7 @@ public class MockChatModel implements ChatModel {
     for (int i = messages.size() - 1; i >= 0; i--) {
       if (messages.get(i) instanceof UserMessage) {
         String text = ((UserMessage) messages.get(i)).getText();
-        return text == null || text.isBlank() ? "（空消息）" : text;
+        return text.isBlank() ? "（空消息）" : text;
       }
     }
     return "（无用户消息）";

--- a/oryxos-provider/src/main/java/io/oryxos/provider/ProviderChatModelFactory.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ProviderChatModelFactory.java
@@ -45,7 +45,7 @@ public class ProviderChatModelFactory {
       // 端点版本在 baseUrl 里（如 GLM 的 /api/paas/v4），改补无版本的 /chat/completions
       api.completionsPath("/chat/completions");
     }
-    return new OpenAiChatModel(api.build());
+    return OpenAiChatModel.builder().openAiApi(api.build()).build();
   }
 
   /**

--- a/oryxos-provider/src/main/java/io/oryxos/provider/ProviderModule.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ProviderModule.java
@@ -1,6 +1,6 @@
 package io.oryxos.provider;
 
-// ProviderModule: LLM provider integration using Spring AI Alibaba.
+// ProviderModule: LLM provider integration using Spring AI.
 // Provides ProviderService with explicit provider name -> ChatModel mapping.
 // See CLAUDE.md: Principle 3 — explicit provider mapping, no bean type scanning.
 public class ProviderModule {}

--- a/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
@@ -23,15 +23,15 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.ai.model.function.FunctionCallback;
 import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.tool.ToolCallback;
 
 /**
  * Provider 前台（core {@link ProviderService} 契约的 Spring AI 实现）：按 Profile 显式路由到对应
  * ChatModel，完成一次调用并落审计。
  *
- * <p>宪法 II/III：显式 name→ChatModel 映射、调用方式 {@code chatModel.call(new Prompt(...))}、
- * proxyToolCalls=true 关闭框架自动工具执行——工具 schema 只翻译、tool call 原样透传。
+ * <p>宪法 II/III：显式 name→ChatModel 映射、调用方式 {@code chatModel.call(new Prompt(...))}、 {@code
+ * internalToolExecutionEnabled=false} 关闭框架自动工具执行——工具 schema 只翻译、tool call 原样透传。
  */
 public class SpringAiProviderServiceImpl implements ProviderService {
 
@@ -101,11 +101,11 @@ public class SpringAiProviderServiceImpl implements ProviderService {
     OpenAiChatOptions.Builder options =
         OpenAiChatOptions.builder()
             .model(profile.provider().model())
-            .proxyToolCalls(Boolean.TRUE); // 关闭自动执行：执行权只在 ToolExecutor（17 节）
+            .internalToolExecutionEnabled(Boolean.FALSE); // 执行权只在 ToolExecutor（17 节）
     if (profile.provider().temperature() != null) {
       options.temperature(profile.provider().temperature());
     }
-    List<FunctionCallback> callbacks = adapter.toSpringAiTools(request.availableTools());
+    List<ToolCallback> callbacks = adapter.toSpringAiTools(request.availableTools());
     if (!callbacks.isEmpty()) {
       options.toolCallbacks(callbacks);
     }
@@ -132,8 +132,11 @@ public class SpringAiProviderServiceImpl implements ProviderService {
       if (id == null || id.isBlank()) {
         return new UserMessage("[工具 " + message.toolName() + " 返回] " + message.content());
       }
-      return new ToolResponseMessage(
-          List.of(new ToolResponseMessage.ToolResponse(id, message.toolName(), message.content())));
+      return ToolResponseMessage.builder()
+          .responses(
+              List.of(
+                  new ToolResponseMessage.ToolResponse(id, message.toolName(), message.content())))
+          .build();
     }
     // assistant：带 tool_calls（含 id）才能让下一轮的 tool 结果配上对
     if (message.toolCalls().isEmpty()) {
@@ -146,26 +149,26 @@ public class SpringAiProviderServiceImpl implements ProviderService {
                     new AssistantMessage.ToolCall(
                         tc.id() == null ? "" : tc.id(), "function", tc.name(), tc.argumentsJson()))
             .toList();
-    return new AssistantMessage(message.content(), Map.of(), toolCalls);
+    return AssistantMessage.builder()
+        .content(message.content())
+        .properties(Map.of())
+        .toolCalls(toolCalls)
+        .build();
   }
 
   private static ProviderResponse toProviderResponse(ChatResponse response) {
     Generation generation = response.getResult();
-    String text = null;
-    List<ToolCallRequest> toolCalls = List.of();
-    if (generation != null) {
-      AssistantMessage output = generation.getOutput();
-      text = output.getText();
-      toolCalls =
-          output.getToolCalls().stream()
-              .map(call -> new ToolCallRequest(call.id(), call.name(), call.arguments()))
-              .toList();
-    }
+    AssistantMessage output = generation.getOutput();
+    String text = output.getText();
+    List<ToolCallRequest> toolCalls =
+        output.getToolCalls().stream()
+            .map(call -> new ToolCallRequest(call.id(), call.name(), call.arguments()))
+            .toList();
     return new ProviderResponse(text, toolCalls, extractUsage(response));
   }
 
   private static Usage extractUsage(ChatResponse response) {
-    if (response.getMetadata() == null || response.getMetadata().getUsage() == null) {
+    if (response.getMetadata().getUsage() == null) {
       return null;
     }
     org.springframework.ai.chat.metadata.Usage usage = response.getMetadata().getUsage();

--- a/oryxos-provider/src/main/java/io/oryxos/provider/ToolSchemaAdapter.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ToolSchemaAdapter.java
@@ -2,53 +2,45 @@ package io.oryxos.provider;
 
 import io.oryxos.core.OryxTool;
 import java.util.List;
-import org.springframework.ai.model.function.FunctionCallback;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
 
 /**
  * 把 OryxTool 的三要素（name/description/inputSchema）翻译成 Spring AI 的工具描述。
  *
- * <p>只翻译、不执行（宪法 II）：产物的 call() 永远抛异常——proxyToolCalls 模式下框架不会调用它， 抛出是"绝不执行"的第二道保险。
+ * <p>只翻译、不执行（宪法 II）：产物的 call() 永远抛异常——关闭框架内部工具执行后不会调用它， 抛出是"绝不执行"的第二道保险。
  */
 public class ToolSchemaAdapter {
 
-  public List<FunctionCallback> toSpringAiTools(List<OryxTool> tools) {
+  public List<ToolCallback> toSpringAiTools(List<OryxTool> tools) {
     if (tools == null || tools.isEmpty()) {
       return List.of();
     }
-    return tools.stream().map(SchemaOnlyCallback::new).map(FunctionCallback.class::cast).toList();
+    return tools.stream().map(SchemaOnlyCallback::new).map(ToolCallback.class::cast).toList();
   }
 
   /** 纯 schema 描述载体：不携带任何可执行逻辑。 */
-  static final class SchemaOnlyCallback implements FunctionCallback {
+  static final class SchemaOnlyCallback implements ToolCallback {
 
-    private final String name;
-    private final String description;
-    private final String inputSchema;
+    private final ToolDefinition toolDefinition;
 
     SchemaOnlyCallback(OryxTool tool) {
-      this.name = tool.getName();
-      this.description = tool.getDescription();
-      this.inputSchema = tool.getInputSchema();
+      this.toolDefinition =
+          ToolDefinition.builder()
+              .name(tool.getName())
+              .description(tool.getDescription())
+              .inputSchema(tool.getInputSchema())
+              .build();
     }
 
     @Override
-    public String getName() {
-      return name;
-    }
-
-    @Override
-    public String getDescription() {
-      return description;
-    }
-
-    @Override
-    public String getInputTypeSchema() {
-      return inputSchema;
+    public ToolDefinition getToolDefinition() {
+      return toolDefinition;
     }
 
     @Override
     public String call(String functionInput) {
-      throw new IllegalStateException("Provider 只翻译工具、不执行工具: " + name);
+      throw new IllegalStateException("Provider 只翻译工具、不执行工具: " + toolDefinition.name());
     }
   }
 }

--- a/oryxos-provider/src/test/java/io/oryxos/provider/MockChatModelTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/MockChatModelTest.java
@@ -40,9 +40,11 @@ class MockChatModelTest {
             new Prompt(
                 List.of(
                     new UserMessage("记住：我在北京"),
-                    new ToolResponseMessage(
-                        List.of(
-                            new ToolResponseMessage.ToolResponse("id-1", "save_memory", "已记住"))))));
+                    ToolResponseMessage.builder()
+                        .responses(
+                            List.of(
+                                new ToolResponseMessage.ToolResponse("id-1", "save_memory", "已记住")))
+                        .build())));
 
     AssistantMessage out = resp.getResult().getOutput();
     assertFalse(out.hasToolCalls(), "第二轮不应再调工具");

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ProviderServiceTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ProviderServiceTest.java
@@ -116,9 +116,9 @@ class ProviderServiceTest {
     ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
     verify(deepseek).call(captor.capture());
     OpenAiChatOptions options = (OpenAiChatOptions) captor.getValue().getOptions();
-    assertTrue(options.getProxyToolCalls()); // 坑二的回归：一旦有人改回自动执行，这里立刻红
+    assertFalse(options.getInternalToolExecutionEnabled()); // 坑二的回归：一旦有人改回自动执行，这里立刻红
     assertFalse(options.getToolCallbacks().isEmpty()); // 翻译过的 schema 确实带上了
-    assertEquals("http_get", options.getToolCallbacks().get(0).getName());
+    assertEquals("http_get", options.getToolCallbacks().get(0).getToolDefinition().name());
   }
 
   @Test
@@ -182,11 +182,14 @@ class ProviderServiceTest {
   @Test
   void 模型想调工具_请求被原样透传_本模块零执行() {
     AssistantMessage withToolCall =
-        new AssistantMessage(
-            "",
-            Map.of(),
-            List.of(
-                new AssistantMessage.ToolCall("id-1", "function", "http_get", "{\"url\":\"x\"}")));
+        AssistantMessage.builder()
+            .content("")
+            .properties(Map.of())
+            .toolCalls(
+                List.of(
+                    new AssistantMessage.ToolCall(
+                        "id-1", "function", "http_get", "{\"url\":\"x\"}")))
+            .build();
     when(deepseek.call(any(Prompt.class)))
         .thenReturn(new ChatResponse(List.of(new Generation(withToolCall))));
 

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ToolSchemaAdapterTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ToolSchemaAdapterTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.when;
 import io.oryxos.core.OryxTool;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.springframework.ai.model.function.FunctionCallback;
+import org.springframework.ai.tool.ToolCallback;
 
 /** 课件《第16节》验收 harness：ToolSchemaAdapterTest——只翻译、不执行。 */
 class ToolSchemaAdapterTest {
@@ -27,20 +27,20 @@ class ToolSchemaAdapterTest {
 
   @Test
   void 翻译后_三要素与OryxTool一一对齐() {
-    List<FunctionCallback> callbacks = adapter.toSpringAiTools(List.of(httpGetTool()));
+    List<ToolCallback> callbacks = adapter.toSpringAiTools(List.of(httpGetTool()));
 
     assertEquals(1, callbacks.size());
-    FunctionCallback callback = callbacks.get(0);
-    assertEquals("http_get", callback.getName());
-    assertEquals("发起一个 HTTP GET 请求", callback.getDescription());
-    assertTrue(callback.getInputTypeSchema().contains("\"url\""));
+    ToolCallback callback = callbacks.get(0);
+    assertEquals("http_get", callback.getToolDefinition().name());
+    assertEquals("发起一个 HTTP GET 请求", callback.getToolDefinition().description());
+    assertTrue(callback.getToolDefinition().inputSchema().contains("\"url\""));
   }
 
   @Test
   void 翻译产物是纯描述_被调用执行时必须抛异常() {
-    FunctionCallback callback = adapter.toSpringAiTools(List.of(httpGetTool())).get(0);
+    ToolCallback callback = adapter.toSpringAiTools(List.of(httpGetTool())).get(0);
 
-    // 第二道保险：即使有人绕过 proxyToolCalls，执行也走不通
+    // 第二道保险：即使有人绕过 internalToolExecutionEnabled=false，执行也走不通
     assertThrows(IllegalStateException.class, () -> callback.call("{\"url\":\"https://x\"}"));
   }
 

--- a/oryxos-tool/pom.xml
+++ b/oryxos-tool/pom.xml
@@ -22,7 +22,7 @@
         <!-- @Tool schema 生成管道（宪法 II 第二件事）与 MCP 协议接入——版本由 Spring AI BOM 管理 -->
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-core</artifactId>
+            <artifactId>spring-ai-model</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>

--- a/oryxos-tool/src/main/java/io/oryxos/tool/ToolRegistry.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/ToolRegistry.java
@@ -7,8 +7,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.springframework.ai.support.ToolCallbacks;
 import org.springframework.ai.tool.ToolCallback;
-import org.springframework.ai.tool.ToolCallbacks;
 
 /**
  * 工具注册表：所有来源（内置 @Tool、方式三 @Tool、MCP、直接实现）统一成 {@link OryxTool} 在此汇总， ReAct 循环与 ToolExecutor

--- a/oryxos-tool/src/main/java/io/oryxos/tool/mcp/McpClientService.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/mcp/McpClientService.java
@@ -5,6 +5,7 @@ import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.client.transport.StdioClientTransport;
+import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.oryxos.core.mcp.McpServerConfig;
 import io.oryxos.core.mcp.McpServerStatus;
 import io.oryxos.tool.ToolRegistry;
@@ -23,8 +24,7 @@ import org.slf4j.LoggerFactory;
  * 循环由此对来源无感知）。管理台 CRUD（31 节）新增/删除一个 server 也走同一段 {@link #connect}/{@link #disconnect}，不需要重启。
  *
  * <p>失联的 server 只 WARN 跳过——外部依赖的可用性不是自己的可用性，不能变成自己的启动故障。 连接工厂构造可注入（测试替身），生产默认按 transport 分派：{@code
- * stdio} 起本地子进程，{@code http} 连远程 server（当前 SDK 版本的 SSE 客户端不支持自定义请求头， 需要 Authorization 头鉴权的远程 server
- * 暂时连不上鉴权网关——见 {@link #connectHttp}）。其余 transport 一律跳过。
+ * stdio} 起本地子进程，{@code http} 连远程 SSE server，并透传配置的请求头。其余 transport 一律跳过。
  */
 public class McpClientService {
 
@@ -70,11 +70,6 @@ public class McpClientService {
       LOG.warn("MCP server {} 的 {}，跳过", s(config.name()), s(msg));
       lastErrors.put(config.name(), msg);
       return;
-    }
-    if (McpServerConfig.TRANSPORT_HTTP.equals(config.transport()) && !config.headers().isEmpty()) {
-      LOG.warn(
-          "MCP server {} 配置了 headers，但当前 SDK 版本的远程传输不支持自定义请求头，将忽略 headers 尝试匿名连接",
-          s(config.name()));
     }
     try {
       McpSyncClient client = clientFactory.apply(config);
@@ -137,19 +132,20 @@ public class McpClientService {
             .args(java.util.Arrays.copyOfRange(parts, 1, parts.length))
             .env(config.env())
             .build();
-    return McpClient.sync(new StdioClientTransport(params)).requestTimeout(REQUEST_TIMEOUT).build();
-  }
-
-  /**
-   * 远程 http server：用 SDK 自带的 SSE 客户端传输连接 {@code url}。已知限制——这版 SDK （{@code
-   * io.modelcontextprotocol.sdk:mcp:0.7.0}）的 {@code HttpClientSseClientTransport} 不支持挂自定义请求头， 所以
-   * {@code config.headers()} 里配的 Authorization 之类目前不会真正发出去；需要鉴权的远程 server 要嘛换成 无需请求头鉴权的方式（如 URL
-   * 自带签名），要嘛等 SDK 升级后再补上请求头透传。
-   */
-  private static McpSyncClient connectHttp(McpServerConfig config) {
-    return McpClient.sync(new HttpClientSseClientTransport(config.url()))
+    return McpClient.sync(new StdioClientTransport(params, McpJsonDefaults.getMapper()))
         .requestTimeout(REQUEST_TIMEOUT)
         .build();
+  }
+
+  /** 远程 http server：用 SDK 自带的 SSE 客户端连接 {@code url}，并把配置请求头应用到每次请求。 */
+  private static McpSyncClient connectHttp(McpServerConfig config) {
+    HttpClientSseClientTransport.Builder transport =
+        HttpClientSseClientTransport.builder(config.url());
+    if (!config.headers().isEmpty()) {
+      transport.httpRequestCustomizer(
+          (request, method, uri, body, context) -> config.headers().forEach(request::header));
+    }
+    return McpClient.sync(transport.build()).requestTimeout(REQUEST_TIMEOUT).build();
   }
 
   private static String s(String value) {

--- a/oryxos-tool/src/test/java/io/oryxos/tool/ToolRegistryTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/ToolRegistryTest.java
@@ -56,7 +56,13 @@ class ToolRegistryTest {
 
   private static McpToolAdapter mcpTool(String name) {
     McpSyncClient client = mock(McpSyncClient.class);
-    return new McpToolAdapter(client, new McpSchema.Tool(name, name + " mcp", "{}"));
+    McpSchema.Tool tool =
+        McpSchema.Tool.builder()
+            .name(name)
+            .description(name + " mcp")
+            .inputSchema(io.modelcontextprotocol.json.McpJsonDefaults.getMapper(), "{}")
+            .build();
+    return new McpToolAdapter(client, tool);
   }
 
   @Test

--- a/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpClientServiceTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpClientServiceTest.java
@@ -33,10 +33,16 @@ class McpClientServiceTest {
   private static McpSyncClient goodClient() {
     McpSyncClient client = mock(McpSyncClient.class);
     when(client.listTools())
-        .thenReturn(
-            new McpSchema.ListToolsResult(
-                List.of(new McpSchema.Tool("good_mcp_tool", "好工具", "{}")), null));
+        .thenReturn(new McpSchema.ListToolsResult(List.of(mcpTool("good_mcp_tool", "好工具")), null));
     return client;
+  }
+
+  private static McpSchema.Tool mcpTool(String name, String description) {
+    return McpSchema.Tool.builder()
+        .name(name)
+        .description(description)
+        .inputSchema(io.modelcontextprotocol.json.McpJsonDefaults.getMapper(), "{}")
+        .build();
   }
 
   @Test
@@ -76,10 +82,7 @@ class McpClientServiceTest {
     when(client.listTools())
         .thenReturn(
             new McpSchema.ListToolsResult(
-                List.of(
-                    new McpSchema.Tool("tool_a", "a", "{}"),
-                    new McpSchema.Tool("tool_b", "b", "{}")),
-                null));
+                List.of(mcpTool("tool_a", "a"), mcpTool("tool_b", "b")), null));
     McpConfigLoader loader =
         loaderWith("servers:\n  - name: s\n    transport: stdio\n    command: c\n");
     ToolRegistry registry = new ToolRegistry();

--- a/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpServerAdminServiceTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpServerAdminServiceTest.java
@@ -36,7 +36,12 @@ class McpServerAdminServiceTest {
     org.mockito.Mockito.when(client.listTools())
         .thenReturn(
             new io.modelcontextprotocol.spec.McpSchema.ListToolsResult(
-                List.of(new io.modelcontextprotocol.spec.McpSchema.Tool("demo_tool", "demo", "{}")),
+                List.of(
+                    io.modelcontextprotocol.spec.McpSchema.Tool.builder()
+                        .name("demo_tool")
+                        .description("demo")
+                        .inputSchema(io.modelcontextprotocol.json.McpJsonDefaults.getMapper(), "{}")
+                        .build()),
                 null));
     return client;
   }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpToolAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpToolAdapterTest.java
@@ -31,7 +31,14 @@ class McpToolAdapterTest {
     client = mock(McpSyncClient.class);
     adapter =
         new McpToolAdapter(
-            client, new McpSchema.Tool("github_search", "搜 GitHub", "{\"type\":\"object\"}"));
+            client,
+            McpSchema.Tool.builder()
+                .name("github_search")
+                .description("搜 GitHub")
+                .inputSchema(
+                    io.modelcontextprotocol.json.McpJsonDefaults.getMapper(),
+                    "{\"type\":\"object\"}")
+                .build());
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.5</version>
+        <version>3.5.16</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <java.version>21</java.version>
         <spring-ai.version>1.1.8</spring-ai.version>
         <picocli.version>4.7.6</picocli.version>
-        <sqlite-jdbc.version>3.46.1.0</sqlite-jdbc.version>
+        <sqlite-jdbc.version>3.53.2.1</sqlite-jdbc.version>
 
         <!-- Infrastructure libraries -->
         <jackson-bom.version>2.21.5</jackson-bom.version>
@@ -318,7 +318,7 @@
                         <skip>${owasp.skip}</skip>
                         <failBuildOnCVSS>8</failBuildOnCVSS>
                         <!-- Fork PRs do not receive OSS Index credentials; NVD and CISA remain enabled. -->
-                        <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
+                        <ossIndexAnalyzerEnabled>false</ossIndexAnalyzerEnabled>
                         <suppressionFile>${maven.multiModuleProjectDirectory}/config/dependency-check-suppressions.xml</suppressionFile>
                         <formats>
                             <format>HTML</format>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <!-- Infrastructure libraries -->
         <jackson-bom.version>2.21.5</jackson-bom.version>
         <log4j2.version>2.25.5</log4j2.version>
+        <tomcat.version>10.1.57</tomcat.version>
         <logstash-logback.version>7.4</logstash-logback.version>
         <springdoc.version>2.6.0</springdoc.version>
 
@@ -42,9 +43,9 @@
         <spotbugs.version>4.8.6</spotbugs.version>
         <findsecbugs.version>1.13.0</findsecbugs.version>
         <dependency-check.version>12.2.2</dependency-check.version>
+        <nvd.datafeed.url>https://dependency-check.github.io/DependencyCheck_Builder/nvd_cache/</nvd.datafeed.url>
 
-        <!-- OWASP Dependency-Check is slow (downloads the NVD) and benefits from an API key;
-             skipped by default for fast local builds, enabled in CI with -Dowasp.skip=false. -->
+        <!-- OWASP Dependency-Check is skipped by default for fast local builds and enabled in CI. -->
         <owasp.skip>true</owasp.skip>
     </properties>
 
@@ -317,6 +318,8 @@
                     <configuration>
                         <skip>${owasp.skip}</skip>
                         <failBuildOnCVSS>8</failBuildOnCVSS>
+                        <!-- Use Dependency-Check's nightly NVD cache so fork PRs do not require an NVD API key. -->
+                        <nvdDatafeedUrl>${nvd.datafeed.url}</nvdDatafeedUrl>
                         <!-- Fork PRs do not receive OSS Index credentials; NVD and CISA remain enabled. -->
                         <ossIndexAnalyzerEnabled>false</ossIndexAnalyzerEnabled>
                         <suppressionFile>${maven.multiModuleProjectDirectory}/config/dependency-check-suppressions.xml</suppressionFile>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
         <sqlite-jdbc.version>3.46.1.0</sqlite-jdbc.version>
 
         <!-- Infrastructure libraries -->
+        <jackson-bom.version>2.21.5</jackson-bom.version>
+        <log4j2.version>2.25.5</log4j2.version>
         <logstash-logback.version>7.4</logstash-logback.version>
         <springdoc.version>2.6.0</springdoc.version>
 
@@ -40,7 +42,7 @@
         <spotbugs-maven-plugin.version>4.8.6.4</spotbugs-maven-plugin.version>
         <spotbugs.version>4.8.6</spotbugs.version>
         <findsecbugs.version>1.13.0</findsecbugs.version>
-        <dependency-check.version>10.0.4</dependency-check.version>
+        <dependency-check.version>12.2.2</dependency-check.version>
 
         <!-- OWASP Dependency-Check is slow (downloads the NVD) and benefits from an API key;
              skipped by default for fast local builds, enabled in CI with -Dowasp.skip=false. -->
@@ -323,6 +325,8 @@
                     <configuration>
                         <skip>${owasp.skip}</skip>
                         <failBuildOnCVSS>8</failBuildOnCVSS>
+                        <!-- Fork PRs do not receive OSS Index credentials; NVD and CISA remain enabled. -->
+                        <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
                         <formats>
                             <format>HTML</format>
                             <format>JSON</format>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,7 @@
 
     <properties>
         <java.version>21</java.version>
-        <spring-ai.version>1.0.0-M6</spring-ai.version>
-        <spring-ai-alibaba.version>1.0.0-M6.1</spring-ai-alibaba.version>
+        <spring-ai.version>1.1.8</spring-ai.version>
         <picocli.version>4.7.6</picocli.version>
         <sqlite-jdbc.version>3.46.1.0</sqlite-jdbc.version>
 
@@ -134,13 +133,6 @@
                 <artifactId>spotbugs-annotations</artifactId>
                 <version>4.8.6</version>
                 <scope>provided</scope>
-            </dependency>
-
-            <!-- Spring AI Alibaba -->
-            <dependency>
-                <groupId>com.alibaba.cloud.ai</groupId>
-                <artifactId>spring-ai-alibaba-starter</artifactId>
-                <version>${spring-ai-alibaba.version}</version>
             </dependency>
 
             <!-- Structured logging: JSON encoder for Logback -->
@@ -327,6 +319,7 @@
                         <failBuildOnCVSS>8</failBuildOnCVSS>
                         <!-- Fork PRs do not receive OSS Index credentials; NVD and CISA remain enabled. -->
                         <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
+                        <suppressionFile>${maven.multiModuleProjectDirectory}/config/dependency-check-suppressions.xml</suppressionFile>
                         <formats>
                             <format>HTML</format>
                             <format>JSON</format>

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -2,7 +2,7 @@
 
 OryxOS is a Spring Boot 3.x single-binary application running on JDK 21. The entire system — LLM routing, reasoning loop, memory, tools, REST API, and the web admin console — ships as one fat JAR. No external dependencies are required beyond a JVM and the LLM provider credentials you configure. State is stored in SQLite and on the local filesystem under the workspace directory (`.oryxos/` by default, configurable — see below).
 
-The reasoning engine is a self-implemented ReAct loop. Spring AI Alibaba handles LLM protocol translation; OryxOS owns the loop, the context assembly, the tool dispatch, and the audit records.
+The reasoning engine is a self-implemented ReAct loop. Spring AI's OpenAI connector handles OpenAI-compatible LLM protocol translation; OryxOS owns the loop, the context assembly, the tool dispatch, and the audit records.
 
 ## Architecture Diagram
 
@@ -117,7 +117,7 @@ Modules communicate through interfaces. Adding a new Channel or Tool implementat
 | --- | --- |
 | Language / runtime | Java 21 (required; virtual threads, no SecurityManager) |
 | Framework | Spring Boot 3.x |
-| LLM integration | Spring AI + Spring AI Alibaba (protocol translation and `@Tool` schema generation only) |
+| LLM integration | Spring AI (OpenAI-compatible protocol translation and `@Tool` schema generation only) |
 | HTTP service | Spring MVC with Java 21 virtual threads |
 | Admin console | Vue 3 + Vite (served at `/admin/`) |
 | CLI | Picocli |

--- a/website/docs/provider.md
+++ b/website/docs/provider.md
@@ -1,6 +1,6 @@
 # Provider
 
-OryxOS uses Spring AI Alibaba as a thin protocol adapter layer — it handles the per-vendor wire format differences (OpenAI, Anthropic, Gemini, etc.) so OryxOS does not have to. On top of that, `ProviderService` owns routing, auditing, and the explicit name-to-model mapping that makes multi-provider setups reliable.
+OryxOS uses Spring AI's OpenAI connector as a thin protocol adapter for OpenAI-compatible endpoints. On top of that, `ProviderService` owns routing, auditing, and the explicit name-to-model mapping that makes multi-provider setups reliable.
 
 ## Providers are dynamic
 

--- a/website/zh/docs/architecture.md
+++ b/website/zh/docs/architecture.md
@@ -2,7 +2,7 @@
 
 OryxOS 是一个 Spring Boot 3.x 单体应用，运行在 JDK 21 上，整个系统——LLM 路由、推理循环、记忆系统、工具体系、REST API 以及 Web 管理台——打包在一个 fat JAR 里交付。除了 JVM 和你配置的 LLM Provider 凭证，不需要任何外部依赖。状态存储在 SQLite 和工作区目录下的本地文件系统中（默认 `.oryxos/`，可配置——见下文）。
 
-推理引擎是自实现的 ReAct Loop。Spring AI Alibaba 负责 LLM 协议转换；循环本身、上下文组装、工具调度和审计记录，都由 OryxOS 自己掌控。
+推理引擎是自实现的 ReAct Loop。Spring AI 的 OpenAI connector 负责 OpenAI 兼容 LLM 协议转换；循环本身、上下文组装、工具调度和审计记录，都由 OryxOS 自己掌控。
 
 ## 架构图
 
@@ -117,7 +117,7 @@ Provider 和通知渠道不再是静态配置——两者都存储在 SQLite 中
 | --- | --- |
 | 语言 / 运行时 | Java 21（必须；虚拟线程，无 SecurityManager） |
 | 框架 | Spring Boot 3.x |
-| LLM 集成 | Spring AI + Spring AI Alibaba（仅用于协议转换和 `@Tool` Schema 生成） |
+| LLM 集成 | Spring AI（仅用于 OpenAI 兼容协议转换和 `@Tool` Schema 生成） |
 | HTTP 服务 | Spring MVC + Java 21 虚拟线程 |
 | 管理台 | Vue 3 + Vite（通过 `/admin/` 提供） |
 | 命令行 | Picocli |

--- a/website/zh/docs/provider.md
+++ b/website/zh/docs/provider.md
@@ -1,6 +1,6 @@
 # Provider
 
-OryxOS 把 Spring AI Alibaba 用作薄薄的协议适配层——它处理各厂商的 wire format 差异（OpenAI、Anthropic、Gemini 等），OryxOS 本身不需要关心这些。在此之上，`ProviderService` 负责路由、审计，以及让多 Provider 可靠运行的显式名称到模型的映射。
+OryxOS 使用 Spring AI 的 OpenAI connector 作为薄协议适配层，接入 OpenAI 兼容端点。在此之上，`ProviderService` 负责路由、审计，以及让多 Provider 可靠运行的显式名称到模型的映射。
 
 ## Provider 是动态的
 


### PR DESCRIPTION
## Summary

- upgrade the Spring Boot parent from 3.3.5 to 3.5.16, refreshing Spring Framework to 6.2.19
- override the managed Jackson BOM to 2.21.5 and Log4j to 2.25.5
- upgrade OWASP Dependency-Check from 10.0.4 to 12.2.2
- use Dependency-Check's official nightly NVD data feed so fork PRs do not depend on an `NVD_API_KEY` secret
- upgrade Spring AI from 1.0.0-M6 to 1.1.8 and migrate the provider/tool APIs
- remove the unused Spring AI Alibaba starter and its vulnerable Nacos, Kotlin, OpenNLP, and Protobuf dependency chain
- upgrade SQLite JDBC from 3.46.1.0 to 3.53.2.1, embedding SQLite 3.53.2
- override Spring Boot's managed Tomcat 10.1.55 to 10.1.57
- disable the OSS Index analyzer for fork-safe CI while retaining the NVD/CISA-backed scan
- keep `failBuildOnCVSS` at 8 and add one package-scoped suppression for the false match between first-party `io.oryxos:oryxos-core` and the unrelated OpenSymphony `oscore` project

## Why

The first CI run exposed two scan-infrastructure blockers after the Spring Boot upgrade:

1. OWASP Dependency-Check 10.0.4 could not persist newer CVE reference URLs longer than its 1000-character database column.
2. The OSS Index analyzer returned `401 Invalid credentials`; fork pull requests cannot depend on repository credentials being available.

After those were fixed, the next scan identified a separate dependency issue in `oryxos-provider`. The unused `spring-ai-alibaba-starter:1.0.0-M6.1` pulled in vulnerable Nacos, Kotlin, OpenNLP, and Protobuf artifacts. OryxOS does not import Alibaba or DashScope APIs; its provider factory explicitly builds Spring AI's OpenAI connector for OpenAI-compatible endpoints. Removing the unused starter eliminates that dependency chain instead of suppressing real findings.

The following scan reached `oryxos-storage` and failed on `sqlite-jdbc:3.46.1.0`, including CVE-2026-11822 and CVE-2026-11824 at CVSS 8.5. Both affect SQLite versions before 3.53.2. Upgrading SQLite JDBC to 3.53.2.1 embeds SQLite 3.53.2 and fixes the dependency rather than suppressing the findings. The Dependency-Check parameter is also updated from the deprecated `ossindexAnalyzerEnabled` spelling to `ossIndexAnalyzerEnabled`.

The next fork CI run was blocked before analysis because the unauthenticated NVD API returned HTTP 429, leaving Dependency-Check's local database transaction in a failed state. The Maven configuration now consumes the [official Dependency-Check nightly NVD cache](https://github.com/dependency-check/DependencyCheck_Builder), and the workflow no longer passes an empty secret for fork PRs.

Once that cache initialized successfully, the scan identified four CVSS 9.1 findings in Spring Boot's managed `tomcat-embed-core:10.1.55`: CVE-2026-55276, CVE-2026-53434, CVE-2026-59083, and CVE-2026-59084. Apache's [Tomcat 10 security advisories](https://tomcat.apache.org/security-10.html) show these are fixed across 10.1.56 and 10.1.57, so the Boot-compatible Tomcat line is overridden to 10.1.57 rather than suppressing them.

The remaining `CVE-2023-39022` match is a name-based false positive: the CVE applies to `opensymphony:oscore` through 2.2.6, while the flagged artifact is OryxOS's own `io.oryxos:oryxos-core`. The suppression is therefore limited to that exact Maven package URL and CVE.

Keeping these changes in the standalone baseline PR lets PRs #68 and #69 synchronize with one shared dependency fix after it is merged. PR #70 has already been merged into `main`.

## Verification

- `mvn clean verify` with Java 21: all 10 reactor modules succeeded; tests, Spotless, PMD, Checkstyle, and SpotBugs passed
- a fresh Dependency-Check database initialized from the official nightly NVD cache without an API key; after the Tomcat upgrade, `mvn -B clean verify -DskipTests -Dowasp.skip=false` succeeded for all 10 modules with `failBuildOnCVSS=8`
- filtered Tomcat dependency trees resolve `tomcat-embed-core`, `tomcat-embed-el`, and `tomcat-embed-websocket` to 10.1.57 in both `oryxos-web` and `oryxos-boot`
- filtered SQLite dependency tree resolves `org.xerial:sqlite-jdbc:3.53.2.1` in both `oryxos-storage` and `oryxos-cli`
- storage and boot integration logs report SQLite database version 3.53.2
- filtered Provider dependency tree contains only Spring AI 1.1.8 artifacts; no Alibaba, Nacos, Kotlin, OpenNLP, or Protobuf entries remain
- `config/dependency-check-suppressions.xml` validates against Dependency-Check 12.2.2's bundled `dependency-suppression.1.4.xsd`
- `npm ci --no-audit --no-fund && npm run docs:build` in `website/`
- `git diff --check`
- updated GitHub Actions run for the current PR head is pending

## Scope

This does not lower the OWASP failure threshold or broadly suppress third-party vulnerabilities. The full NVD/CISA-backed Dependency-Check scan remains in GitHub Actions and now uses the official nightly NVD data feed so fork pull requests do not require repository secrets.
