### PR TITLE
docs: bump README version badge to 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/oryx-labs/oryxos/releases"><img src="https://img.shields.io/badge/version-0.1.1-orange?style=flat-square" alt="version"/></a>
+  <a href="https://github.com/oryx-labs/oryxos/releases"><img src="https://img.shields.io/badge/version-0.1.2-orange?style=flat-square" alt="version"/></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-native-8A2BE2?style=flat-square" alt="MCP native"/></a>
   <a href="https://www.apache.org/licenses/LICENSE-2.0"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0"/></a>
 </p>


### PR DESCRIPTION
## What
把 README 顶部版本徽章从 0.1.1 更新到 0.1.2。

## Why
0.1.2 已发布(CHANGELOG `[0.1.2-RELEASE] - 2026-08-06`,见 #66),但 README 徽章漏更新,访客看到的还是旧版本号。

## Verification
- 徽章现显示 0.1.2
- 与 CHANGELOG.md 顶部版本一致