### PR TITLE
fix(web): scroll chat to bottom after new reply

### DIFF
--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, reactive, computed } from 'vue'
+import { ref, reactive, computed, nextTick } from 'vue'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import logoUrl from './assets/logo.svg'
@@ -871,6 +871,7 @@ const renderedMd = computed(() =>
 )
 // 会话：每个 Agent 一个固定 session，直接作为对话展示（不再是会话列表）
 const chat = reactive({ sessionId: null, messages: [], loading: false, error: null, input: '', sending: false })
+const chatScrollEl = ref(null) // 会话列表滚动容器：回复/重载后自动滚到底部（最新一条）
 
 const CHAT_SEND_MODE_KEY = 'oryxos.admin.chatSendMode'
 const CHAT_SEND_MODES = ['enter', 'modifier']
@@ -1118,6 +1119,15 @@ function resetChat() {
   chat.sending = false
 }
 
+// 会话列表自动滚到底部：新消息到达/历史重载后，把 .chat 容器推到最新一条。
+// nextTick 确保 chatTurns 渲染完再读 scrollHeight，否则还是旧值、滚不到底。
+function scrollChatToBottom() {
+  nextTick(() => {
+    const el = chatScrollEl.value
+    if (el) el.scrollTop = el.scrollHeight
+  })
+}
+
 async function loadChat() {
   chat.loading = true; chat.error = null
   try {
@@ -1128,6 +1138,7 @@ async function loadChat() {
     chat.sessionId = body.data.sessionId
     chat.messages = body.data.messages || []
   } catch (e) { chat.error = e.message } finally { chat.loading = false }
+  scrollChatToBottom() // 初次进会话看历史、发消息后重载 都走这里，一次覆盖
 }
 
 async function sendChat() {
@@ -1738,7 +1749,7 @@ const outputRows = computed(() =>
                 <p v-else-if="chat.error" class="error">出错：{{ chat.error }}</p>
                 <template v-else>
                   <p v-if="!chat.messages.length" class="empty">（还没有对话，在下面发一条消息开始）</p>
-                  <div v-else class="chat">
+                  <div v-else class="chat" ref="chatScrollEl">
                     <div v-for="(t, i) in chatTurns" :key="i" class="turn">
                       <!-- 用户提问 -->
                       <div v-if="t.user" class="msg user">


### PR DESCRIPTION
## Problem
Web 管理台会话页，Agent 每次回复完成后，消息列表会跳回顶部，用户需要手动往下翻才能看到最新回答，影响日常使用体验。

## Root Cause
`sendChat()` 发送消息后调用 `loadChat()` 整体重载 `chat.messages`，Vue 重新渲染 `.chat` 容器时浏览器把 `scrollTop` 重置为 0；而前端全程没有任何 auto-scroll逻辑，所以每次回复后视图都停在顶部。

## Fix
- 新增 template ref `chatScrollEl`，挂在会话消息列表容器 `.chat` 上
- 新增 `scrollChatToBottom()`，在 `nextTick` 内将 `scrollTop` 设为 `scrollHeight`（等 `chatTurns` 渲染完，否则 `scrollHeight` 还是旧值，滚不到底）
- 在 `loadChat()` 末尾调用一次，同时覆盖「初次进入会话看历史」和「发消息后重载」两种场景

## Files Changed
- `oryxos-web/src/main/frontend/src/App.vue`（纯前端，4 处小改）

## Impact
仅前端交互，不涉及后端 / 数据 / ReAct 逻辑，不改变 token 消耗或调用次数。

## Verification
- [x] `npm run build` + 重打 fat jar + 重启 serve
- [x] 发送消息收到回复后，列表自动停在底部（最新回答处）
- [x] 打开已有历史的会话，也自动滚到底