### PR TITLE
release: 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 本文件记录 OryxOS 的版本变更。格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
-## [0.1.2-RELEASE] - 2026-08-06
+## [0.1.2-RELEASE] - 2026-08-10
 
 ### Added
 - 管理台概览页接入实时数据源，新增会话统计端点（`feat(web/api)`）。
@@ -12,6 +12,9 @@
 - 渐进式 Agent Skill 加载（`feat`）。
 
 ### Fixed
+- `/api/v1/agents/{name}/invoke` 改为无状态调用：每次用独立内存会话，不再泄漏隐藏会话（#68，Closes #49）。
+- 会话并发写入丢消息修复：进锁重读 + CAS 条件更新（冲突返回 409）、SQLite WAL + `busy_timeout`、审计 fail-closed、持久历史按整轮截断（#69，Closes #43）。
+- 更新安全基线与依赖扫描，处理传递依赖 CVE 门禁（#71）。
 - `WorkspaceWatcher` 递归监听 Agent 子目录，修复 `AGENT.md` 变更漏检（#63，Closes #61）。
 - 恢复 `main` 分支 CI 绿：spotless 格式、P3C 误报/魔法值、掩码测试对齐（#64）。
 - 修复七项高风险安全与并发问题（#58）。
@@ -27,10 +30,14 @@
 - 复用 `requireAgent` 收敛重复的存在性检查（#65）。
 - Skill 页面简化为纯 CRUD（`refactor(web)`）。
 
+### Security
+- 明确 shell 沙箱边界：默认命令白名单移除 `python3`，锁定为 `ls`/`cat`/`echo`/`grep` 最小权限，并补文档警示解释器会放大 Agent 权限（#70，Closes #41）。
+
 ### Docs
 - 新增根 `CONTRIBUTING.md` 并链接贡献指南（#60）；澄清 Agent 目录相关措辞（#59）。
 - 对齐 notify channel 文档与当前实现；修正 `serve` 命令过时的帮助文本（#62）。
 - 修复 OryxOS 概览 logo 链接失效（#55）。
+- README 版本徽章升级至 0.1.2（#72）。
 
 ## [0.1.1-RELEASE] - 2026-07-23
 


### PR DESCRIPTION
## 触发 0.1.2 发布

0.1.2 此前从未成功发布——`release: 0.1.2`（#66）合并时的 Release workflow 因 fork PR 的 `GITHUB_TOKEN` 被降级为只读，在创建 Release 步骤 403 失败。此后 main 又合入了 #68/#69/#70/#71/#72（均仍标 `0.1.2-RELEASE`）。

本 PR 由**仓库内分支**发起（非 fork），合并后 Release workflow 的 token 可写，自 main 当前顶端发布 `v0.1.2-RELEASE`。

### 变更
- 补全 `CHANGELOG.md` 的 0.1.2 段，纳入 #68/#69/#70/#71/#72，发布日期更新为 2026-08-10。
- 无代码改动，`pom.xml` 已是 `0.1.2-RELEASE`。

### 合并后自动化（`.github/workflows/release.yml`）
标题 `release:` 前缀 → 合并到 main 触发：解析版本 `0.1.2-RELEASE` → 打 tag `v0.1.2-RELEASE` → `make release` 产出 `dist/oryxos-0.1.2-RELEASE.tar.gz` → 创建 GitHub Release（`--generate-notes` 自动汇总自 v0.1.1 起的 PR）。

Made with [Cursor](https://cursor.com)