### PR TITLE
fix: 默认模型从已废弃的 deepseek-chat 改为 deepseek-v4-flash

### DIFF
--- a/oryxos-boot/src/main/resources/application.yml
+++ b/oryxos-boot/src/main/resources/application.yml
@@ -72,7 +72,7 @@ oryxos:
   # model 留空则生成端点返回可读的 503（不向 OpenAI 兼容端点发 model=null）。
   author:
     provider: deepseek
-    model: deepseek-chat
+    model: deepseek-v4-flash
   # 管理台 Basic Auth（012-web-auth）。默认关=假设内网现状不变（SC-001）；
   # 开启后 /admin/** 需账密，/api/v1/** 不受影响（REST 不做 Basic Auth）。
   # 开启前先 oryxos user add <username> 建账号，否则启动阻断（FR-006）。

--- a/oryxos-cli/src/main/java/io/oryxos/cli/command/ProfileCommand.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/command/ProfileCommand.java
@@ -85,7 +85,7 @@ public class ProfileCommand implements Runnable {
             prompt: 你是一个乐于助人的助手。
           provider:
             name: deepseek
-            model: deepseek-chat
+            model: deepseek-v4-flash
           tools: []
           bootstrap:
             - AGENTS.md

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
@@ -151,7 +151,7 @@ public class AgentLifecycleService {
         prompt: 你是一个天气播报助手，简洁给出天气与穿搭提示。
       provider:
         name: deepseek
-        model: deepseek-chat
+        model: deepseek-v4-flash
       tools:
         - http_get
         - notify


### PR DESCRIPTION
Closes #79

## 问题

`config/application.yml.example` 已注明 `deepseek-chat` 被 DeepSeek 官方废弃，但三处用户可触达的默认模型仍是 `deepseek-chat`，导致新用户按默认流程 `profile create` 创建 Agent 后首次对话即报 `Model Not Exist` 失败（实际跑通 quick-start 时踩中）。

## 改动（3 行，仅字符串常量）

| 位置 | 影响面 |
|---|---|
| `oryxos-cli/.../ProfileCommand.java` | `profile create` 生成的 AGENT.md 模板 |
| `oryxos-core/.../AgentLifecycleService.java` | 「一句话生成 Agent」few-shot 示例（AUTHOR_EXAMPLE） |
| `oryxos-boot/.../application.yml` | 作者模型 `oryxos.author.model` 缺省值 |

统一改为 example 配置推荐的 `deepseek-v4-flash`。

## 验证

- `mvn -pl oryxos-cli,oryxos-core -am test`：BUILD SUCCESS，全部测试通过（core 141 + tool 141 + cli 相关，0 失败）
- 端到端实测：用新构建的包执行 `profile create verify-agent`，生成的 AGENT.md 中 `model: deepseek-v4-flash` ✅

## 未改动（有意保留）

- 测试 fixture 中的 `deepseek-chat`：仅为字符串样本，不影响行为
- 文档/网站中的 `deepseek-chat` 示例（README、website/docs 等）：如需一并更新可另开 docs PR