### PR TITLE
chore(scripts): read deploy target from env instead of hardcoded host

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 # Package OryxOS changed files into a tar.gz and sync to remote server.
 # Usage: ./scripts/package.sh [output_dir]
+#
+# Deploy target is read from the environment (never hardcode server
+# addresses / credentials in version control):
+#   ORYXOS_DEPLOY_HOST  (required) SSH target, e.g. "deploy@example.com" or an ssh-config alias
+#   ORYXOS_DEPLOY_DIR   (optional) remote checkout directory, default "/opt/oryxos"
 
 set -euo pipefail
 
 # ── Configuration ─────────────────────────────────────────────────────────────
-REMOTE_HOST="root@117.72.92.117"
-REMOTE_DIR="/root/oryxos"
+REMOTE_HOST="${ORYXOS_DEPLOY_HOST:-}"
+REMOTE_DIR="${ORYXOS_DEPLOY_DIR:-/opt/oryxos}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -16,6 +21,15 @@ OUTPUT_DIR="${1:-$PROJECT_ROOT}"
 info()  { echo "[INFO]  $*"; }
 warn()  { echo "[WARN]  $*" >&2; }
 error() { echo "[ERROR] $*" >&2; }
+
+# ── Validate deploy target ───────────────────────────────────────────────────────
+if [[ -z "$REMOTE_HOST" ]]; then
+  error "ORYXOS_DEPLOY_HOST is not set."
+  error "Set the deploy target first, e.g.:"
+  error "  export ORYXOS_DEPLOY_HOST=deploy@your-server"
+  error "  export ORYXOS_DEPLOY_DIR=/opt/oryxos   # optional, this is the default"
+  exit 1
+fi
 
 # ── Commit message builder ──────────────────────────────────────────────────────
 # Derive a meaningful commit message from the changed / deleted file lists:


### PR DESCRIPTION
## What

`scripts/package.sh` now reads the deploy target from the environment instead of hardcoding a personal server address:

- `ORYXOS_DEPLOY_HOST` (required) — SSH target, e.g. `deploy@example.com` or an ssh-config alias
- `ORYXOS_DEPLOY_DIR` (optional) — remote checkout dir, default `/opt/oryxos`

When `ORYXOS_DEPLOY_HOST` is unset, the script fails fast with a clear error and usage hint (consistent with the script's existing `set -euo pipefail` / logging style).

## Why

A real server IP with `root` login (`root@117.72.92.117`) was committed to a public repository — see #81. Sensitive deployment configuration must come from the environment, matching the project rule that credentials are never committed in plaintext.

## How to verify

```bash
bash -n scripts/package.sh                 # syntax OK
unset ORYXOS_DEPLOY_HOST
./scripts/package.sh                       # → [ERROR] ORYXOS_DEPLOY_HOST is not set. (exit 1)
export ORYXOS_DEPLOY_HOST=user@your-server
./scripts/package.sh                       # behaves as before
```

No Java code touched; `mvn verify` unaffected.

## Notes

The old IP remains in git history — recommend rotating that server's SSH credentials (noted in #81).

Closes #81
