### PR TITLE
fix(provider): bound ChatModel cache by provider name

### DIFF
--- a/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
@@ -39,8 +39,12 @@ public class SpringAiProviderServiceImpl implements ProviderService {
   private final Function<ProviderDef, ChatModel> chatModelBuilder;
   private final ToolSchemaAdapter adapter;
   private final LlmCallAuditor audit;
-  // 已建的 ChatModel 缓存：key = name|apiKey|baseUrl；provider 改了 key/url（缓存键变）→ 下次自动重建（31 节动态 provider）
-  private final Map<String, ChatModel> cache = new ConcurrentHashMap<>();
+  // 已建的 ChatModel 缓存：key = provider name，值携带配置指纹（apiKey|baseUrl）。指纹变了原地替换旧条目——
+  // 缓存大小恒等于 provider 数，反复改 key/url 不再累积不可回收的旧实例（31 节动态 provider）。
+  private final Map<String, CachedModel> cache = new ConcurrentHashMap<>();
+
+  /** 缓存条目：配置指纹 + 已建实例，指纹不变则复用。 */
+  private record CachedModel(String fingerprint, ChatModel model) {}
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "EI_EXPOSE_REP2",
@@ -98,10 +102,17 @@ public class SpringAiProviderServiceImpl implements ProviderService {
     return result;
   }
 
-  /** 按 name+key+url 缓存构建好的 ChatModel；参数变化即换缓存键、下次重建（provider CRUD 改了配置立即生效）。 */
+  /** 按 provider 名缓存已建的 ChatModel；同名下 key/url 变化即原地重建替换（provider CRUD 改了配置立即生效，旧实例可回收）。 */
   private ChatModel resolveModel(ProviderDef def) {
-    String cacheKey = def.name() + "|" + def.apiKey() + "|" + def.baseUrl();
-    return cache.computeIfAbsent(cacheKey, k -> chatModelBuilder.apply(def));
+    String fingerprint = def.apiKey() + "|" + def.baseUrl();
+    return cache
+        .compute(
+            def.name(),
+            (name, cached) ->
+                cached != null && cached.fingerprint().equals(fingerprint)
+                    ? cached
+                    : new CachedModel(fingerprint, chatModelBuilder.apply(def)))
+        .model();
   }
 
   private Prompt buildPrompt(Profile profile, ProviderRequest request) {

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ProviderServiceTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ProviderServiceTest.java
@@ -220,4 +220,39 @@ class ProviderServiceTest {
     assertEquals("http_get", response.toolCalls().get(0).name());
     assertEquals("{\"url\":\"x\"}", response.toolCalls().get(0).argumentsJson()); // 原样，未执行
   }
+
+  @Test
+  void provider配置变更_ChatModel缓存原地替换不累积() {
+    io.oryxos.core.provider.ProviderRegistry registry =
+        mock(io.oryxos.core.provider.ProviderRegistry.class);
+    java.util.concurrent.atomic.AtomicReference<io.oryxos.core.provider.ProviderDef> current =
+        new java.util.concurrent.atomic.AtomicReference<>(
+            new io.oryxos.core.provider.ProviderDef("deepseek", "key-1", "https://a", null));
+    when(registry.find("deepseek")).thenAnswer(inv -> java.util.Optional.of(current.get()));
+    java.util.concurrent.atomic.AtomicInteger builds =
+        new java.util.concurrent.atomic.AtomicInteger();
+    ChatModel model = mock(ChatModel.class);
+    when(model.call(any(Prompt.class))).thenReturn(textResponse("ok"));
+    ProviderService cachedService =
+        new SpringAiProviderServiceImpl(
+            registry,
+            def -> {
+              builds.incrementAndGet();
+              return model;
+            },
+            new ToolSchemaAdapter(),
+            audit);
+
+    cachedService.chat("s-1", profileUsing("deepseek"), ProviderRequest.of("hi"));
+    cachedService.chat("s-1", profileUsing("deepseek"), ProviderRequest.of("hi"));
+    assertEquals(1, builds.get()); // 同配置复用，不重建
+
+    current.set(new io.oryxos.core.provider.ProviderDef("deepseek", "key-2", "https://b", null));
+    cachedService.chat("s-1", profileUsing("deepseek"), ProviderRequest.of("hi"));
+    assertEquals(2, builds.get()); // 改了 key/url → 重建
+
+    current.set(new io.oryxos.core.provider.ProviderDef("deepseek", "key-1", "https://a", null));
+    cachedService.chat("s-1", profileUsing("deepseek"), ProviderRequest.of("hi"));
+    assertEquals(3, builds.get()); // 换回旧配置也重建——旧条目已被替换而非累积保留
+  }
 }


### PR DESCRIPTION
## What

Rework the `ChatModel` cache in `SpringAiProviderServiceImpl`:

- **Before**: `Map<String, ChatModel>` keyed by `name|apiKey|baseUrl` — every config change adds a new entry, old ones are never removed.
- **After**: `Map<String, CachedModel>` keyed by **provider name**; each entry is a small record carrying a config fingerprint (`apiKey|baseUrl`) plus the built model. `resolveModel` uses `ConcurrentHashMap.compute`: same fingerprint → reuse, changed fingerprint → rebuild and replace in place.

Cache size is now bounded by the number of registered providers, regardless of how often keys/URLs are rotated.

## Why

On a long-running instance with the dynamic provider CRUD, every key rotation or base-URL switch leaked a stale `ChatModel` (plus its HTTP client) into the cache forever, and kept rotated API keys reachable in memory. See #83.

Runtime behavior is unchanged: config edits still take effect on the next call, same-config calls still hit the cached instance.

## How to verify

```bash
mvn -pl oryxos-provider -am clean verify
```

New regression test `ProviderServiceTest#provider配置变更_ChatModel缓存原地替换不累积`:

1. two calls with the same config → builder invoked once (reuse path intact);
2. config change → rebuilt (builds = 2);
3. switching **back** to the original config → rebuilt again (builds = 3), proving the old entry was replaced rather than silently retained.

All 9 tests in `ProviderServiceTest` pass.

## Notes

- No interface change; `ProviderService` and `ProviderChatModelFactory` untouched.
- Concurrency: `compute` gives per-key atomicity — two threads racing on the same provider build at most once per fingerprint, same guarantee as the previous `computeIfAbsent`.

Closes #83
