### PR TITLE
feat(provider): add connect/read timeouts to LLM HTTP calls

### DIFF
--- a/oryxos-provider/src/main/java/io/oryxos/provider/ProviderChatModelFactory.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ProviderChatModelFactory.java
@@ -1,10 +1,14 @@
 package io.oryxos.provider;
 
+import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
 
 /**
  * 按全局配置逐条手工构造 ChatModel，产出显式 name→ChatModel 映射表（宪法 III）。
@@ -19,6 +23,15 @@ public class ProviderChatModelFactory {
 
   private static final String SLASH = "/";
   private static final String PATH_V1 = "/v1";
+
+  /** 连接超时（秒）的系统属性名：默认 10，{@code -Doryxos.llm.connect-timeout-seconds=N} 覆盖。 */
+  static final String CONNECT_TIMEOUT_PROP = "oryxos.llm.connect-timeout-seconds";
+
+  /** 读取超时（秒）的系统属性名：默认 120（推理模型长回答留足余量），{@code -Doryxos.llm.read-timeout-seconds=N} 覆盖。 */
+  static final String READ_TIMEOUT_PROP = "oryxos.llm.read-timeout-seconds";
+
+  private static final long DEFAULT_CONNECT_TIMEOUT_SECONDS = 10;
+  private static final long DEFAULT_READ_TIMEOUT_SECONDS = 120;
 
   /** 末尾版本段（如 GLM 的 /api/paas/v4）：此类端点版本在 baseUrl 里，不能再补 /v1。 */
   private static final java.util.regex.Pattern TRAILING_VERSION =
@@ -40,12 +53,29 @@ public class ProviderChatModelFactory {
     }
     // baseUrl 约定不含 /v1：OpenAiApi 内部会追加 /v1/chat/completions；用户填带 /v1 则先剥离，避免双 /v1（fix-issue-47）
     String base = stripTrailingV1(baseUrl);
-    OpenAiApi.Builder api = OpenAiApi.builder().baseUrl(base).apiKey(apiKey);
+    OpenAiApi.Builder api =
+        OpenAiApi.builder()
+            .baseUrl(base)
+            .apiKey(apiKey)
+            .restClientBuilder(RestClient.builder().requestFactory(timeoutFactory()));
     if (TRAILING_VERSION.matcher(base).matches()) {
       // 端点版本在 baseUrl 里（如 GLM 的 /api/paas/v4），改补无版本的 /chat/completions
       api.completionsPath("/chat/completions");
     }
     return OpenAiChatModel.builder().openAiApi(api.build()).build();
+  }
+
+  /** 带连接/读取超时的请求工厂：默认 RestClient 无超时，端点挂死会把同步 ReAct 循环连带会话永久卡住。构建时读属性，不在类加载期固化。 */
+  static JdkClientHttpRequestFactory timeoutFactory() {
+    Duration connectTimeout =
+        Duration.ofSeconds(Long.getLong(CONNECT_TIMEOUT_PROP, DEFAULT_CONNECT_TIMEOUT_SECONDS));
+    Duration readTimeout =
+        Duration.ofSeconds(Long.getLong(READ_TIMEOUT_PROP, DEFAULT_READ_TIMEOUT_SECONDS));
+    JdkClientHttpRequestFactory factory =
+        new JdkClientHttpRequestFactory(
+            HttpClient.newBuilder().connectTimeout(connectTimeout).build());
+    factory.setReadTimeout(readTimeout);
+    return factory;
   }
 
   /**

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ProviderChatModelFactoryTimeoutTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ProviderChatModelFactoryTimeoutTest.java
@@ -1,0 +1,69 @@
+package io.oryxos.provider;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import com.sun.net.httpserver.HttpServer;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+/**
+ * 超时回归：LLM 端点挂死时，单次 HTTP 调用必须在读取超时内失败，不能无限阻塞。
+ *
+ * <p>直接测 {@link ProviderChatModelFactory#timeoutFactory()} 装配出的客户端（buildOne 传给 OpenAiApi 的就是它）：走
+ * ChatModel.call 会叠加 Spring AI 默认 RetryTemplate（对 ResourceAccessException 重试 10 次、 指数退避至
+ * 180s），无法在单测时间预算内断言。
+ */
+class ProviderChatModelFactoryTimeoutTest {
+
+  private HttpServer hangingServer;
+  private final CountDownLatch release = new CountDownLatch(1);
+
+  @BeforeEach
+  void startHangingServer() throws Exception {
+    hangingServer = HttpServer.create(new InetSocketAddress(0), 0);
+    hangingServer.createContext(
+        "/",
+        exchange -> {
+          try {
+            release.await(30, TimeUnit.SECONDS); // 收到请求后既不响应也不断连——模拟挂死端点
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+          exchange.close();
+        });
+    hangingServer.start();
+  }
+
+  @AfterEach
+  void stopServer() {
+    release.countDown(); // 放行 handler，避免 stop 等待
+    hangingServer.stop(0);
+    System.clearProperty(ProviderChatModelFactory.READ_TIMEOUT_PROP);
+  }
+
+  @Test
+  @DisplayName("端点收到请求后挂死_单次调用在读取超时内失败而非永久阻塞")
+  void hangingEndpointFailsWithinReadTimeout() {
+    System.setProperty(ProviderChatModelFactory.READ_TIMEOUT_PROP, "1");
+    String baseUrl = "http://127.0.0.1:" + hangingServer.getAddress().getPort();
+    RestClient client =
+        RestClient.builder().requestFactory(ProviderChatModelFactory.timeoutFactory()).build();
+
+    // 修复前：默认请求工厂无读取超时，这里会永久阻塞（preemptive 兜底 10 秒防测试挂死）
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(10),
+        () ->
+            assertThrows(
+                ResourceAccessException.class,
+                () -> client.get().uri(baseUrl).retrieve().toEntity(String.class)));
+  }
+}


### PR DESCRIPTION
## What

`ProviderChatModelFactory.buildOne()` now injects a `RestClient.Builder` backed by a `JdkClientHttpRequestFactory` with explicit timeouts into `OpenAiApi`:

- **connect timeout**: 10s default, override with `-Doryxos.llm.connect-timeout-seconds=N`
- **read timeout**: 120s default (headroom for reasoning models / long answers), override with `-Doryxos.llm.read-timeout-seconds=N`

Properties are read when the model is built (not at class-load), so overrides also apply to dynamically (re)built providers. The `mock` provider path and the `/v1`-stripping / `completionsPath` logic are untouched.

## Why

The default `RestClient` has no connect or read timeout. A provider endpoint that accepts the request and then never responds blocked the synchronous `chat()` call — and with it the session's ReAct loop — forever; scheduled tasks hitting a hung provider never completed. The built-in `HttpTools` already bounds its outbound calls (10s/20s); the LLM path was the last unbounded outbound I/O. See #87.

## How to verify

```bash
mvn -pl oryxos-provider -am clean verify
```

New regression test `ProviderChatModelFactoryTimeoutTest#端点收到请求后挂死_单次调用在读取超时内失败而非永久阻塞`:

- starts a local `HttpServer` that accepts the request and then hangs (no response, no close);
- sets read timeout to 1s via the system property;
- asserts the call fails with `ResourceAccessException` within a 10s preemptive budget. Before the fix this blocks indefinitely.

The test targets the request factory directly rather than `ChatModel.call`, because Spring AI's default `RetryTemplate` retries `ResourceAccessException` 10 times with exponential backoff (up to 180s per wait) — see Notes.

## Notes

- **Interaction with Spring AI retry**: the default `RetryTemplate` (unchanged by this PR) retries timeouts. Net behavior after this PR: a hung endpoint degrades from *infinite hang* to *bounded retried failure*. If maintainers prefer fewer/faster retries for interactive sessions, that's a separate discussion — kept out of scope here to avoid changing failure semantics for 429/5xx.
- Streaming (`webClientBuilder`) is untouched; OryxOS only uses the sync `call` path.

Closes #87
