### PR TITLE
fix(web): honor X-Forwarded-Proto for Secure cookie and invalidate old session on login

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -15,6 +15,9 @@
 # ── 服务 ────────────────────────────────────────────────
 server:
   port: 8080                    # HTTP API / 管理台端口（oryxos serve --port 可临时覆盖）
+  # 反向代理（nginx/caddy 终止 TLS）下识别 X-Forwarded-Proto 等头，登录 cookie 才会带 Secure；
+  # 直连部署无副作用（无 X-Forwarded-* 头时行为不变）。从 jar 内置默认继承，列此便于按需关闭。
+  forward-headers-strategy: framework
 
 # ── 持久化 / 并发 ───────────────────────────────────────
 spring:

--- a/oryxos-boot/src/main/resources/application.yml
+++ b/oryxos-boot/src/main/resources/application.yml
@@ -32,6 +32,10 @@ spring:
 
 server:
   port: 8080
+  # 反向代理（nginx/caddy 终止 TLS）下识别 X-Forwarded-Proto/Host/Port：
+  # 没有它 request.isSecure() 恒为 false，登录 cookie 不会带 Secure 属性。
+  # 直连部署无副作用（无 X-Forwarded-* 头时行为不变）。
+  forward-headers-strategy: framework
 
 # Sandbox 白名单（第 24 节 WhitelistSandbox；宪法 VI 第一档：应用层校验）。
 # 三块各自独立；**空列表 = 该类什么都不允许（deny-all）**，绝非"不校验"——按最小权限收窄。

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/AuthApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/AuthApiController.java
@@ -54,7 +54,9 @@ public class AuthApiController {
     this.properties = properties;
   }
 
-  /** 登录：验账密 → 建 session → 设 cookie。失败 401（"Invalid username or password"，不区分原因防枚举）。 */
+  /**
+   * 登录：验账密 → 废旧 session → 建新 session → 设 cookie。失败 401（"Invalid username or password"，不区分原因防枚举）。
+   */
   @PostMapping("/login")
   public ApiResponse<AuthMeView> login(
       @RequestBody LoginRequest loginRequest,
@@ -73,6 +75,8 @@ public class AuthApiController {
       response.setStatus(HttpStatus.UNAUTHORIZED.value());
       return ApiResponse.error(HttpStatus.UNAUTHORIZED.value(), "Invalid username or password");
     }
+    // 重新登录废掉旧 session：旧 id 不能继续用，也不在库里堆孤儿行等自然过期。
+    findSessionId(request).ifPresent(sessionService::delete);
     WebSession session = sessionService.create(loginRequest.username());
     response.addHeader(
         HttpHeaders.SET_COOKIE, buildCookie(session.getSessionId(), -1, request.isSecure()));

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/AuthApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/AuthApiControllerTest.java
@@ -112,6 +112,47 @@ class AuthApiControllerTest {
   }
 
   @Test
+  @DisplayName("login_带旧cookie重新登录_旧session被废新session生效")
+  void login_withStaleCookie_deletesOldSession() throws Exception {
+    when(userService.verify("admin", "s3cret-pw")).thenReturn(true);
+    when(sessionService.create("admin")).thenReturn(newSession("admin", "sid-new"));
+
+    mvc.perform(
+            post("/api/v1/auth/login")
+                .cookie(new jakarta.servlet.http.Cookie("oryxos_session", "sid-old"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"admin\",\"password\":\"s3cret-pw\"}"))
+        .andExpect(status().isOk())
+        .andExpect(
+            header()
+                .string(
+                    "Set-Cookie", org.hamcrest.Matchers.containsString("oryxos_session=sid-new")));
+    verify(sessionService).delete("sid-old"); // 旧 session 废掉，不留孤儿行也不给旧 id 续命
+  }
+
+  @Test
+  @DisplayName("login_反代带X-Forwarded-Proto=https_ForwardedHeaderFilter下Set-Cookie含Secure")
+  void login_behindProxy_forwardedProtoYieldsSecureCookie() throws Exception {
+    when(userService.verify("admin", "s3cret-pw")).thenReturn(true);
+    when(sessionService.create("admin")).thenReturn(newSession("admin", "sid-123"));
+    // 镜像 server.forward-headers-strategy=framework 的装配：该策略就是注册 ForwardedHeaderFilter
+    MockMvc proxiedMvc =
+        MockMvcBuilders.standaloneSetup(
+                new AuthApiController(userService, sessionService, properties))
+            .addFilters(new org.springframework.web.filter.ForwardedHeaderFilter())
+            .build();
+
+    proxiedMvc
+        .perform(
+            post("/api/v1/auth/login")
+                .header("X-Forwarded-Proto", "https")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"admin\",\"password\":\"s3cret-pw\"}"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("Secure")));
+  }
+
+  @Test
   @DisplayName("login_缺字段_400")
   void login_missingFields_400() throws Exception {
     mvc.perform(


### PR DESCRIPTION
## What

1. **Honor `X-Forwarded-Proto` for the `Secure` cookie attribute** — add `server.forward-headers-strategy: framework` to the built-in `application.yml` (Spring Boot registers `ForwardedHeaderFilter`), and document the key in `config/application.yml.example`. `request.isSecure()` now reflects the original client protocol behind a TLS-terminating proxy, so the `oryxos_session` cookie gets `Secure` where it should.
2. **Invalidate the old session on re-login** — `login` now deletes the session referenced by the incoming cookie (if present) before creating the new one. Cookie construction itself (`HttpOnly` + `SameSite=Strict` + `Path=/`) is unchanged.

## Why

Behind nginx/caddy the connection to OryxOS is plain HTTP, so `isSecure()` was always `false` and the session cookie was issued without `Secure` even for HTTPS users — browsers would also send it over plain `http://` to the same host. Separately, re-login left the previous session id valid until natural TTL expiry (leaked ids survive a fresh login; orphan rows accumulate). See #89.

Direct deployments are unaffected: without `X-Forwarded-*` headers `ForwardedHeaderFilter` is a no-op, and login without a prior cookie behaves exactly as before.

## How to verify

```bash
mvn -pl oryxos-web -am clean verify
```

Two new tests in `AuthApiControllerTest` (12 total, all green):

- `login_反代带X-Forwarded-Proto=https_ForwardedHeaderFilter下Set-Cookie含Secure` — mirrors the `framework` strategy by adding `ForwardedHeaderFilter` to the standalone MockMvc, sends `X-Forwarded-Proto: https` over plain HTTP, asserts `Set-Cookie` contains `Secure`.
- `login_带旧cookie重新登录_旧session被废新session生效` — asserts the old session id is deleted and the new cookie is issued.

Existing tests pin the unchanged behavior: plain HTTP still gets no `Secure`; direct HTTPS still gets `Secure`.

## Notes

- `framework` strategy trusts `X-Forwarded-*` from any client connecting directly. That matches the current threat model (the port is either private or fronted by a proxy that overwrites these headers). If OryxOS ever documents an "exposed directly + proxy optional" topology, this should move to `native` + a trusted-proxy list — flagged in #89.
- Not a session-fixation fix (ids are random UUIDs, freshly generated per login); this is about not leaving stale-but-valid ids behind.

Closes #89
