### PR TITLE
feat: add provider connectivity test

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -8,7 +8,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT" # 工作区（.oryxos/、oryxos.db、config/）都相对 CWD，必须在项目根跑
 
 PORT="${1:-8080}"
-JAR="$(find "$ROOT/oryxos-boot/target" -maxdepth 1 -name 'oryxos-boot-*.jar' 2>/dev/null | head -1 || true)"
+JAR="$(find "$ROOT/oryxos-boot/target" -maxdepth 1 -name 'oryxos-boot-*.jar' -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || true)"
 CONFIG="$ROOT/config/application.yml"
 PIDFILE="$ROOT/bin/oryxos.pid"
 LOG="$ROOT/logs/oryxos.log"

--- a/oryxos-cli/src/main/java/io/oryxos/cli/command/ServeCommand.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/command/ServeCommand.java
@@ -1,6 +1,7 @@
 package io.oryxos.cli.command;
 
 import io.oryxos.cli.OryxOsRuntime;
+import java.util.concurrent.CountDownLatch;
 import org.springframework.boot.SpringApplication;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -25,7 +26,7 @@ public class ServeCommand implements Runnable {
 
   static void keepAlive() {
     try {
-      Thread.currentThread().join(); // 常驻直到进程被终止
+      new CountDownLatch(1).await(); // 常驻直到进程被终止
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     }

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -606,6 +606,7 @@ async function deleteNotifyChannel(name) {
 
 // —— Provider 管理（CRUD /api/v1/providers）：命名的模型 Provider，apiKey 明文返回 ——
 const providers = ref({ loading: false, error: null, data: [] })
+const providerTests = ref({})
 async function loadProviders() {
   providers.value = { loading: true, error: null, data: [] }
   try {
@@ -615,6 +616,33 @@ async function loadProviders() {
     providers.value = { loading: false, error: null, data: body.data || [] }
   } catch (e) {
     providers.value = { loading: false, error: e.message, data: [] }
+  }
+}
+
+async function testProvider(name) {
+  providerTests.value = {
+    ...providerTests.value,
+    [name]: { loading: true, ok: null, message: '测试中…' },
+  }
+  try {
+    const res = await fetch(`/api/v1/providers/${encodeURIComponent(name)}/test`, { method: 'POST' })
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '连通测试失败')
+    const data = body.data || {}
+    const samples = (data.sampleModels || []).slice(0, 3).join('、')
+    providerTests.value = {
+      ...providerTests.value,
+      [name]: {
+        loading: false,
+        ok: true,
+        message: samples ? `可用 · ${data.modelCount || 0} 个模型 · ${samples}` : `可用 · ${data.modelCount || 0} 个模型`,
+      },
+    }
+  } catch (e) {
+    providerTests.value = {
+      ...providerTests.value,
+      [name]: { loading: false, ok: false, message: e.message || '连通测试失败' },
+    }
   }
 }
 
@@ -1966,15 +1994,24 @@ const outputRows = computed(() =>
             <p v-if="providers.loading" class="empty">加载中…</p>
             <p v-else-if="providers.error" class="error">出错：{{ providers.error }}</p>
             <table v-else>
-              <thead><tr><th>name</th><th>apiKey</th><th>baseUrl</th><th>description</th><th>操作</th></tr></thead>
+              <thead><tr><th>name</th><th>apiKey</th><th>baseUrl</th><th>description</th><th>连通性</th><th>操作</th></tr></thead>
               <tbody>
-                <tr v-if="!providers.data.length"><td colspan="5" class="empty">（暂无 Provider · 点上面「新建 Provider」）</td></tr>
+                <tr v-if="!providers.data.length"><td colspan="6" class="empty">（暂无 Provider · 点上面「新建 Provider」）</td></tr>
                 <tr v-for="p in providers.data" :key="p.name">
                   <td class="mono">{{ p.name }}</td>
                   <td class="mono">{{ p.apiKey || '—' }}</td>
                   <td class="mono">{{ p.baseUrl || '—' }}</td>
                   <td>{{ p.description || '—' }}</td>
+                  <td>
+                    <span v-if="providerTests[p.name]" :class="providerTests[p.name].ok === false ? 'error' : 'ok'">
+                      {{ providerTests[p.name].message }}
+                    </span>
+                    <span v-else class="empty">未测试</span>
+                  </td>
                   <td class="ops">
+                    <button class="btn" :disabled="providerTests[p.name]?.loading" @click="testProvider(p.name)">
+                      {{ providerTests[p.name]?.loading ? '测试中' : '测试连接' }}
+                    </button>
                     <button class="btn" @click="editProvider(p)">编辑</button>
                     <button class="btn" @click="deleteProvider(p.name)">删除</button>
                   </td>

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/ProviderApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/ProviderApiController.java
@@ -5,6 +5,7 @@ import io.oryxos.core.provider.ProviderDef;
 import io.oryxos.core.provider.ProviderRegistry;
 import io.oryxos.web.common.ApiResponse;
 import io.oryxos.web.controller.dto.CreateProviderRequest;
+import io.oryxos.web.controller.dto.ProviderConnectivityView;
 import io.oryxos.web.controller.dto.ProviderView;
 import io.oryxos.web.controller.dto.UpdateProviderRequest;
 import io.oryxos.web.error.ResourceNotFoundException;
@@ -97,6 +98,14 @@ public class ProviderApiController {
   @GetMapping("/{name}/models")
   public ApiResponse<List<String>> models(@PathVariable String name) {
     return ApiResponse.ok(modelsService.listModels(name));
+  }
+
+  /** 测试 provider 连通性：复用服务端 /models 探测，不把 api-key 暴露给浏览器。 */
+  @PostMapping("/{name}/test")
+  public ApiResponse<ProviderConnectivityView> test(@PathVariable String name) {
+    List<String> models = modelsService.listModels(name);
+    return ApiResponse.ok(
+        new ProviderConnectivityView(true, models.size(), models.stream().limit(5).toList()));
   }
 
   @DeleteMapping("/{name}")

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ProviderConnectivityView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ProviderConnectivityView.java
@@ -1,0 +1,11 @@
+package io.oryxos.web.controller.dto;
+
+import java.util.List;
+
+/** Provider 连通性测试结果。 */
+public record ProviderConnectivityView(boolean ok, int modelCount, List<String> sampleModels) {
+
+  public ProviderConnectivityView {
+    sampleModels = sampleModels == null ? List.of() : List.copyOf(sampleModels);
+  }
+}


### PR DESCRIPTION
## Summary
- Add provider connectivity test API
- Add "测试连接" button in Provider management UI
- Show success/failure state with model count and sample models

## Verification
- mvn package -DskipTests
- GET /api/v1/health
- POST /api/v1/providers/mock/test