### PR TITLE
fix(web): preserve chat position when reloading messages

### DIFF
--- a/oryxos-web/pom.xml
+++ b/oryxos-web/pom.xml
@@ -93,6 +93,14 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>npm-test</id>
+                        <goals><goal>npm</goal></goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <arguments>test</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>npm-build</id>
                         <goals><goal>npm</goal></goals>
                         <phase>generate-resources</phase>

--- a/oryxos-web/src/main/frontend/package.json
+++ b/oryxos-web/src/main/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "node --test src/chat-scroll.test.js",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -4,6 +4,7 @@ import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import logoUrl from './assets/logo.svg'
 import LoginView from './views/LoginView.vue'
+import { isNearBottom } from './chat-scroll.js'
 
 // —— 012-web-auth US3：登录守卫 —— 未登录先查 /api/v1/auth/me；登录页 LoginView 调 /auth/login
 const auth = reactive({ checking: true, enabled: true, username: null })
@@ -1119,9 +1120,10 @@ function resetChat() {
   chat.sending = false
 }
 
-// 会话列表自动滚到底部：新消息到达/历史重载后，把 .chat 容器推到最新一条。
+// 会话列表按需滚到底部：刷新前仍在底部附近才继续跟随，用户上翻历史时保留阅读位置。
 // nextTick 确保 chatTurns 渲染完再读 scrollHeight，否则还是旧值、滚不到底。
-function scrollChatToBottom() {
+function scrollChatToBottom(shouldScroll) {
+  if (!shouldScroll) return
   nextTick(() => {
     const el = chatScrollEl.value
     if (el) el.scrollTop = el.scrollHeight
@@ -1129,6 +1131,7 @@ function scrollChatToBottom() {
 }
 
 async function loadChat() {
+  const shouldScroll = isNearBottom(chatScrollEl.value)
   chat.loading = true; chat.error = null
   try {
     const name = agentDetail.value.name
@@ -1138,7 +1141,7 @@ async function loadChat() {
     chat.sessionId = body.data.sessionId
     chat.messages = body.data.messages || []
   } catch (e) { chat.error = e.message } finally { chat.loading = false }
-  scrollChatToBottom() // 初次进会话看历史、发消息后重载 都走这里，一次覆盖
+  scrollChatToBottom(shouldScroll)
 }
 
 async function sendChat() {
@@ -1745,7 +1748,7 @@ const outputRows = computed(() =>
               <!-- Tab 4：会话 —— 每个 Agent 一个固定 session，直接作为对话展示 -->
               <div v-else-if="agentDetail.tab === 'chat'">
                 <div class="sess-meta"><span class="mono">{{ chat.sessionId || '（会话尚未创建）' }}</span></div>
-                <p v-if="chat.loading" class="empty">加载中…</p>
+                <p v-if="chat.loading && !chat.messages.length" class="empty">加载中…</p>
                 <p v-else-if="chat.error" class="error">出错：{{ chat.error }}</p>
                 <template v-else>
                   <p v-if="!chat.messages.length" class="empty">（还没有对话，在下面发一条消息开始）</p>

--- a/oryxos-web/src/main/frontend/src/chat-scroll.js
+++ b/oryxos-web/src/main/frontend/src/chat-scroll.js
@@ -1,0 +1,9 @@
+export const CHAT_NEAR_BOTTOM_THRESHOLD_PX = 80
+
+export function isNearBottom(scrollContainer, threshold = CHAT_NEAR_BOTTOM_THRESHOLD_PX) {
+  if (!scrollContainer) return true
+
+  const distanceToBottom =
+    scrollContainer.scrollHeight - scrollContainer.scrollTop - scrollContainer.clientHeight
+  return distanceToBottom <= threshold
+}

--- a/oryxos-web/src/main/frontend/src/chat-scroll.test.js
+++ b/oryxos-web/src/main/frontend/src/chat-scroll.test.js
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { CHAT_NEAR_BOTTOM_THRESHOLD_PX, isNearBottom } from './chat-scroll.js'
+
+test('没有滚动容器时视为需要滚到底部', () => {
+  assert.equal(isNearBottom(null), true)
+})
+
+test('距离底部不超过阈值时允许自动滚动', () => {
+  const atThreshold = {
+    scrollHeight: 1000,
+    scrollTop: 720,
+    clientHeight: 200,
+  }
+
+  assert.equal(isNearBottom(atThreshold), true)
+  assert.equal(CHAT_NEAR_BOTTOM_THRESHOLD_PX, 80)
+})
+
+test('用户离开底部超过阈值时保留阅读位置', () => {
+  const aboveThreshold = {
+    scrollHeight: 1000,
+    scrollTop: 719,
+    clientHeight: 200,
+  }
+
+  assert.equal(isNearBottom(aboveThreshold), false)
+})


### PR DESCRIPTION
## Summary

- capture whether the Agent chat is near the bottom before reloading messages
- keep following the latest message only when the user was already near the bottom
- keep existing messages mounted while a reload is in progress; initial and empty-session loads still land on the latest message
- add focused 80 px threshold tests and run them through the Maven frontend lifecycle

## Scope

This is a frontend-only improvement for the current synchronous chat flow. It intentionally does not add SSE, image or ResizeObserver handling, or backend changes.

## Testing

- npm test
- npm run build
- mvn -pl oryxos-web -am -DskipTests generate-resources
- mvn clean verify
- git diff --check

Addresses #78