### PR TITLE
docs: align HTTP whitelist docs with HTTP_READ vs HTTP_REQUEST split

### DIFF
--- a/website/docs/profile.md
+++ b/website/docs/profile.md
@@ -144,7 +144,7 @@ Built-in tool names:
 | `write_file` | Write a file (path whitelist enforced) |
 | `list_dir` | List directory contents (path whitelist enforced) |
 | `shell` | Execute a shell command (command whitelist enforced) |
-| `http_get` | HTTP GET request (domain whitelist enforced) |
+| `http_get` | HTTP GET request (default allow + SSRF blocklist) |
 | `http_post` | HTTP POST request (domain whitelist enforced) |
 | `save_memory` | Append a note to `MEMORY.md` |
 | `recall_memory` | Keyword search over `MEMORY.md` |

--- a/website/docs/tool.md
+++ b/website/docs/tool.md
@@ -46,11 +46,11 @@ About two dozen tools ship with OryxOS core — a set of **universal primitives*
 | `copy_file` | `FileTools` | Copy a file | Path whitelist (source + target) |
 | `delete_file` | `FileTools` | Delete a file (never a directory) | Path whitelist |
 | `shell` | `ShellTools` | Execute a shell command | Command whitelist + metacharacter scan + timeout |
-| `http_get` / `http_post` | `HttpTools` | HTTP GET / POST | Domain wildcard whitelist |
-| `http_request` | `HttpTools` | HTTP with any method (GET/POST/PUT/PATCH/DELETE) + headers | Domain wildcard whitelist |
-| `fetch_webpage` | `HttpTools` | Fetch a URL and extract readable text (strip HTML) | Domain wildcard whitelist |
-| `download_file` | `HttpTools` | Download a URL to a local file | Domain + path whitelist |
-| `web_search` | `WebSearchTools` | Search the web | Domain wildcard whitelist |
+| `http_get` / `http_post` | `HttpTools` | HTTP GET / POST | GET: default allow + SSRF blocklist; POST: domain wildcard whitelist |
+| `http_request` | `HttpTools` | HTTP with any method (GET/POST/PUT/PATCH/DELETE) + headers | GET: default allow + SSRF; write methods: domain wildcard whitelist |
+| `fetch_webpage` | `HttpTools` | Fetch a URL and extract readable text (strip HTML) | Default allow + SSRF blocklist |
+| `download_file` | `HttpTools` | Download a URL to a local file | URL: default allow + SSRF; local path: path whitelist |
+| `web_search` | `WebSearchTools` | Search the web | Default allow + SSRF blocklist |
 | `current_time` | `UtilTools` | Current date/time in a timezone | None (pure) |
 | `json_extract` | `UtilTools` | Extract a value from JSON text by path | None (pure) |
 | `save_memory` | `MemoryTools` | Append text to `MEMORY.md` | None (always allowed) |
@@ -154,7 +154,10 @@ shell:
 
 The shell whitelist is an independent capability boundary. Adding an interpreter or shell such as `python`, `python3`, `sh`, or `bash` grants the agent the capabilities of that executable and can bypass the file and HTTP tool policies. They are deliberately excluded from the default configuration. Add such entries only for trusted scripts and only when that broader authority is intentional.
 
-**HTTP domain whitelist** — applies to `http_get` and `http_post`. Supports `*` as a prefix wildcard.
+**HTTP sandbox (read/write split)** — since section 32, read and write requests use different policies:
+
+- **Read** (`http_get`, GET via `http_request`, `fetch_webpage`, `web_search`, download URLs): **allow by default**, with an SSRF blocklist for private/loopback/cloud-metadata targets. An empty `http.allowed_domains` does **not** block public GETs.
+- **Write** (`http_post`, non-GET `http_request`): `http.allowed_domains` domain wildcard whitelist. An empty list means deny-all for writes. Supports `*` as a prefix wildcard.
 
 ```yaml
 http:

--- a/website/zh/docs/profile.md
+++ b/website/zh/docs/profile.md
@@ -143,7 +143,7 @@ export DEEPSEEK_API_KEY=sk-...
 | `write_file` | 写文件（路径白名单） |
 | `list_dir` | 列目录（路径白名单） |
 | `shell` | 执行 shell 命令（命令白名单） |
-| `http_get` | HTTP GET（域名白名单） |
+| `http_get` | HTTP GET（默认放行 + SSRF 黑名单） |
 | `http_post` | HTTP POST（域名白名单） |
 | `save_memory` | 向 `MEMORY.md` 追加记忆 |
 | `recall_memory` | 关键词检索 `MEMORY.md` |

--- a/website/zh/docs/tool.md
+++ b/website/zh/docs/tool.md
@@ -46,11 +46,11 @@ OryxOS 核心内置约两打工具——一组精心挑选的**通用原语**，
 | `copy_file` | `FileTools` | 复制文件 | 路径白名单（源 + 目标） |
 | `delete_file` | `FileTools` | 删除文件（拒绝删目录） | 路径白名单 |
 | `shell` | `ShellTools` | 执行 Shell 命令 | 命令白名单 + 元字符扫描 + 超时 |
-| `http_get` / `http_post` | `HttpTools` | HTTP GET / POST | 域名通配符白名单 |
-| `http_request` | `HttpTools` | 任意方法 HTTP（GET/POST/PUT/PATCH/DELETE）+ 请求头 | 域名通配符白名单 |
-| `fetch_webpage` | `HttpTools` | 抓取网页并抽取可读正文（去 HTML） | 域名通配符白名单 |
-| `download_file` | `HttpTools` | 下载 URL 到本地文件 | 域名 + 路径白名单 |
-| `web_search` | `WebSearchTools` | 网络搜索 | 域名通配符白名单 |
+| `http_get` / `http_post` | `HttpTools` | HTTP GET / POST | GET：默认放行 + SSRF 黑名单；POST：域名通配符白名单 |
+| `http_request` | `HttpTools` | 任意方法 HTTP（GET/POST/PUT/PATCH/DELETE）+ 请求头 | GET：默认放行 + SSRF；写方法：域名通配符白名单 |
+| `fetch_webpage` | `HttpTools` | 抓取网页并抽取可读正文（去 HTML） | 默认放行 + SSRF 黑名单 |
+| `download_file` | `HttpTools` | 下载 URL 到本地文件 | URL：默认放行 + SSRF；本地路径：路径白名单 |
+| `web_search` | `WebSearchTools` | 网络搜索 | 默认放行 + SSRF 黑名单 |
 | `current_time` | `UtilTools` | 返回指定时区的当前时间 | 无（纯计算） |
 | `json_extract` | `UtilTools` | 从 JSON 文本按路径取值 | 无（纯计算） |
 | `save_memory` | `MemoryTools` | 向 `MEMORY.md` 追加文本 | 无（始终允许） |
@@ -154,7 +154,10 @@ shell:
 
 Shell 白名单是一条独立的能力边界。加入 `python`、`python3`、`sh`、`bash` 等解释器或 Shell，等于授予 Agent 该可执行文件的完整能力，并可能绕过文件与 HTTP 工具策略。因此默认配置刻意不包含它们；只有在脚本可信且确实需要扩大权限时才应显式加入。
 
-**HTTP 域名白名单** — 作用于 `http_get` 和 `http_post`。支持 `*` 作为前缀通配符。
+**HTTP 沙箱（读写分治）** — 自第 32 节起，读请求与写请求策略不同：
+
+- **读**（`http_get`、`http_request` 的 GET、`fetch_webpage`、`web_search`、下载 URL）：**默认放行**，仅用 SSRF 黑名单拦截内网 / 回环 / 云元数据等目标。空的 `http.allowed_domains` **不会**禁止公网 GET。
+- **写**（`http_post`、`http_request` 的非 GET）：走 `http.allowed_domains` 域名通配符白名单。空列表表示写请求 deny-all。支持 `*` 作为前缀通配符。
 
 ```yaml
 http:


### PR DESCRIPTION
Docs incorrectly said domain whitelist applies to http_get and other read tools. Runtime (section 32) allow-by-default reads with SSRF blocklist; only writes use http.allowed_domains.

Fixes #103