### PR TITLE
docs: unify allowlist → whitelist in English docs

### DIFF
--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -645,7 +645,7 @@ Returns all tools registered in the `ToolRegistry` — built-in tools plus any t
 // data — ToolView[]
 [
   { "name": "read_file", "description": "Read a file from the filesystem (path whitelist enforced)" },
-  { "name": "shell",     "description": "Execute a shell command (allowlist and metacharacter checks enforced)" },
+  { "name": "shell",     "description": "Execute a shell command (command whitelist and metacharacter checks enforced)" },
   { "name": "notify",    "description": "Push a message to a registered notify channel by name" }
 ]
 ```

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -108,7 +108,7 @@ Modules communicate through interfaces. Adding a new Channel or Tool implementat
 | 3 | Execution model | Synchronous blocking with Java 21 virtual threads | Straightforward code, high concurrency without reactive programming complexity |
 | 4 | Provider resolution | Dynamic `provider name → ChatModel` map backed by a SQLite registry, cached by `(name\|apiKey\|baseUrl)` | Explicit mapping (never Bean-type scanning) but runtime-mutable, so providers can be added or edited without a restart |
 | 5 | HTTP service layer | Spring MVC + Java 21 virtual threads | Sync-style code, thousands of concurrent requests per node; `SseEmitter` available for streaming in extension phase |
-| 6 | Sandbox strategy | Path/pattern allowlists at the application layer, runtime-manageable | `SecurityManager` is deprecated since JDK 17 and unavailable on JDK 21; full container-level sandbox is extension-phase work |
+| 6 | Sandbox strategy | Path/pattern whitelists at the application layer, runtime-manageable | `SecurityManager` is deprecated since JDK 17 and unavailable on JDK 21; full container-level sandbox is extension-phase work |
 | 7 | Persistence | SQLite + Spring Data JPA for relational data; per-agent `MEMORY.md` for long-term memory | Single binary, no external database process required; audit tables written from day one so auditability is never retrofitted |
 
 ## Tech Stack

--- a/website/docs/what.md
+++ b/website/docs/what.md
@@ -55,7 +55,7 @@ Two layers today. Session memory holds the conversation history, persisted and r
 
 ### Tool System
 
-**24 built-in tools** cover the baseline: file operations (read / write / list / append / move / copy / delete / mkdir), shell, HTTP (get / post / arbitrary request / fetch-webpage / download), time and JSON utilities, memory, and `notify`. All execute under sandbox enforcement — path allowlist for files, command allowlist for shell, domain allowlist for HTTP — with every invocation audited. The `notify` tool pushes to named channels (Feishu / WeCom / DingTalk / generic webhook), themselves a dynamic registry with full CRUD.
+**24 built-in tools** cover the baseline: file operations (read / write / list / append / move / copy / delete / mkdir), shell, HTTP (get / post / arbitrary request / fetch-webpage / download), time and JSON utilities, memory, and `notify`. All execute under sandbox enforcement — path whitelist for files, command whitelist for shell, domain whitelist for HTTP — with every invocation audited. The `notify` tool pushes to named channels (Feishu / WeCom / DingTalk / generic webhook), themselves a dynamic registry with full CRUD.
 
 Extension follows three tiers, ordered by effort:
 
@@ -80,5 +80,5 @@ On top of it sits a web console at `/admin/`: an overview dashboard, agent manag
 - **One directory = one Agent** — an agent is defined by a directory of markdown, not by code
 - **Open standards** — MCP for tools, A2A for agent-to-agent collaboration, open formats for skills
 - **Stateless instances, externalized state** — the prerequisite for going distributed without an architectural rewrite
-- **Security as foundation, not afterthought** — least privilege, mandatory sandbox allowlists, credentials via environment variables, full audit trail persisted from day one
+- **Security as foundation, not afterthought** — least privilege, mandatory sandbox whitelists, credentials via environment variables, full audit trail persisted from day one
 - **Phased and disciplined** — build the minimal complete runtime kernel first; governance and distributed infrastructure come next, proven by real usage

--- a/website/docs/why.md
+++ b/website/docs/why.md
@@ -10,7 +10,7 @@ Why? Four barriers, none of which is the model:
 
 **The data has to leave.** Cloud agent platforms solve infrastructure by taking your data with it. For any company with data-residency, network-perimeter, or audit obligations, that's a non-starter.
 
-**It's a black box.** An agent that can run shell commands, write files, and call external APIs — with no record of what it did, no allowlist on what it *can* do, and no one approving the dangerous steps — is not something an enterprise can put into production.
+**It's a black box.** An agent that can run shell commands, write files, and call external APIs — with no record of what it did, no whitelist on what it *can* do, and no one approving the dangerous steps — is not something an enterprise can put into production.
 
 **One agent is easy. A fleet is not.** A single wrapped LLM loop is a script. Running dozens of agents — with shared providers, shared tools, schedules, lifecycle, and governance — is an operating-systems problem, and almost nobody hands you that layer.
 
@@ -22,7 +22,7 @@ OryxOS removes all four barriers at once:
 
 - **Plain language instead of code.** One sentence — or one markdown directory — defines an agent. The OS supplies everything else: memory, 24 built-in tools, MCP connectors, skills, notifications, scheduling. The cost of defining an agent trends toward zero.
 - **Your infrastructure, your data.** One self-hosted binary on your own servers or K8s. No managed service, no telemetry, no cloud lock-in.
-- **Glass box, not black box.** Every tool call and every LLM call is persisted to the audit tables from day one — what was invoked, with what arguments, what came back, how long it took. Sandbox allowlists gate files, shell, and HTTP. Governance is the foundation, not a bolt-on.
+- **Glass box, not black box.** Every tool call and every LLM call is persisted to the audit tables from day one — what was invoked, with what arguments, what came back, how long it took. Sandbox whitelists gate files, shell, and HTTP. Governance is the foundation, not a bolt-on.
 - **An OS for the fleet.** Agents are processes; OryxOS is the operating system — lifecycle, routing, shared registries, scheduling, console, and API for all of them at once.
 
 **So every company can run its own agents — in plain language.**
@@ -39,7 +39,7 @@ The industry has proven the pattern works (planner–worker–reviewer crews, ag
 
 ## Why an OS, not another framework
 
-The common assumption is that better agents need better models. In production, the bottleneck is the **harness** — the scaffolding between the model and the real world: the right context assembled before every call, tools that are allowlisted rather than open-ended, execution that is isolated and audited, and messages that reliably reach their destination.
+The common assumption is that better agents need better models. In production, the bottleneck is the **harness** — the scaffolding between the model and the real world: the right context assembled before every call, tools that are whitelisted rather than open-ended, execution that is isolated and audited, and messages that reliably reach their destination.
 
 A framework gives you one harness inside your own code. OryxOS ships the harness *as infrastructure* and runs a fleet on top of it — which is what changes who can use it: with a framework, engineers build agents; with an OS, **anyone who can describe the work** runs agents.
 


### PR DESCRIPTION
## What
统一英文文档中的术语：将 `allowlist` → `whitelist`，与代码库命名约定对齐。

## Why
代码统一使用 "whitelist"（API 路径 `/api/v1/sandbox/whitelist`、类名 `WhitelistSandbox`、配置键 `allowed_paths` / `allowed_commands` / `allowed_domains`），但几处文档写了 `allowlist`，甚至 `api.md` 同一张表里上一行写 `whitelist`、下一行写 `allowlist`，自相矛盾。

## Changed
- `website/docs/why.md` — 3 处
- `website/docs/what.md` — 4 处
- `website/docs/architecture.md` — 1 处
- `website/docs/api.md` — 1 处

纯文档措辞统一，不涉及代码逻辑。

---
