### PR TITLE
docs: fix stale jar path and outdated docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ All endpoints are prefixed with `/api/v1` and every response is wrapped in a uni
 
 ## Contributing
 
-First PRs are welcome — see the [Contributing Guide](https://oryx-labs.github.io/oryxos/docs/contributing) and the [GitHub workflow primer](https://oryx-labs.github.io/oryxos/docs/github-workflow).
+First PRs are welcome — see the [Contributing Guide](https://oryxos.robustmq.com/docs/contributing) and the [GitHub workflow primer](https://oryxos.robustmq.com/docs/github-workflow).
 
 ## License
 

--- a/docs/CliGuide.md
+++ b/docs/CliGuide.md
@@ -13,7 +13,7 @@ OryxOS 打包为一个可执行 JAR，所有操作都通过 `oryxos` 命令的�
 mvn -pl oryxos-boot -am package -DskipTests
 
 # 运行（下文所有 oryxos 命令均指这个别名）
-alias oryxos='java -jar /path/to/oryxos/oryxos-boot/target/oryxos-boot-1.0.0-SNAPSHOT.jar'
+alias oryxos='java -jar /path/to/oryxos/oryxos-boot/target/oryxos-boot-*.jar'
 
 oryxos --help      # 总览
 oryxos --version   # 版本与 JVM/OS 信息


### PR DESCRIPTION
## What
修复两处文档中过时的引用：

- `docs/CliGuide.md`：jar 文件名仍是 `1.0.0-SNAPSHOT`，实际构建产物为 `0.1.2-RELEASE`，改为通配符 `oryxos-boot-*.jar`（与 README 一致）。
- `README.md`：Contributing 两处链接指向已迁移的 `oryx-labs.github.io` 域名，改为规范域名 `oryxos.robustmq.com`。

## Why
旧链接/路径会导致 404 或「文件不存在」。

## How verified
本地 `mvn clean verify` 编译 + 质量门禁（spotless/checkstyle/PMD/SpotBugs）BUILD SUCCESS。

## Notes
- 纯文档改动，不涉及代码逻辑。
