### PR TITLE
fix(tool): drain shell stdout/stderr before waitFor

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
@@ -21,8 +21,8 @@ import org.springframework.ai.tool.annotation.ToolParam;
 /**
  * 内置命令工具：直接执行获准的可执行文件，带超时兜底——命令挂死不能拖死整个 ReAct 循环。
  *
- * <p>白名单校验可执行文件名（SHELL_COMMAND 检查位已过 enforce）；参数作为 argv 直接传给进程，不经 Shell 解释。超时默认 30
- * 秒。两个运维细节： (1) stdout/stderr 在 {@code waitFor} 前就并发排空——否则输出超过管道缓冲（~64KB）的命令会写阻塞、被误判超时；(2)
+ * <p>白名单校验可执行文件名（SHELL_COMMAND 检查位已过 enforce）；参数作为 argv 直接传给进程，不经 Shell 解释。超时默认 30 秒。两个运维细节： (1)
+ * stdout/stderr 在 {@code waitFor} 前就并发排空——否则输出超过管道缓冲（~64KB）的命令会写阻塞、被误判超时；(2)
  * 超时后递归杀进程树——子进程不在父进程组内时，只杀父进程会留孤儿继续跑。
  */
 public class ShellTools {
@@ -42,6 +42,10 @@ public class ShellTools {
     this(sandbox, DEFAULT_TIMEOUT);
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "COMMAND_INJECTION",
+      justification =
+          "ProcessBuilder 以 argv 列表启动，不经 shell；可执行文件在 shell() 内经 Sandbox 精确白名单校验后再 start")
   ShellTools(Sandbox sandbox, Duration timeout) {
     this(sandbox, timeout, command -> new ProcessBuilder(command).start());
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
@@ -42,12 +42,8 @@ public class ShellTools {
     this(sandbox, DEFAULT_TIMEOUT);
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "COMMAND_INJECTION",
-      justification =
-          "ProcessBuilder 以 argv 列表启动，不经 shell；可执行文件在 shell() 内经 Sandbox 精确白名单校验后再 start")
   ShellTools(Sandbox sandbox, Duration timeout) {
-    this(sandbox, timeout, command -> new ProcessBuilder(command).start());
+    this(sandbox, timeout, ShellTools::startProcess);
   }
 
   ShellTools(Sandbox sandbox, Duration timeout, ProcessStarter processStarter) {
@@ -56,10 +52,15 @@ public class ShellTools {
     this.processStarter = Objects.requireNonNull(processStarter, "processStarter 不能为空");
   }
 
-  @Tool(name = "shell", description = "执行一个已获许可的可执行文件，返回标准输出")
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "COMMAND_INJECTION",
-      justification = "参数以 ProcessBuilder 的 argv 直接执行，不经 shell 解释；可执行文件在启动前经 Sandbox 精确白名单校验")
+      justification =
+          "ProcessBuilder 以 argv 列表启动，不经 shell；可执行文件在 shell() 内经 Sandbox 精确白名单校验后再 start")
+  private static Process startProcess(List<String> command) throws IOException {
+    return new ProcessBuilder(command).start();
+  }
+
+  @Tool(name = "shell", description = "执行一个已获许可的可执行文件，返回标准输出")
   public String shell(
       @ToolParam(description = "要执行的、已在白名单中的可执行文件") String executable,
       @ToolParam(description = "传给可执行文件的独立参数数组，不支持 shell 语法") List<String> arguments) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
@@ -10,8 +10,10 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -19,7 +21,9 @@ import org.springframework.ai.tool.annotation.ToolParam;
 /**
  * 内置命令工具：直接执行获准的可执行文件，带超时兜底——命令挂死不能拖死整个 ReAct 循环。
  *
- * <p>白名单校验可执行文件名（SHELL_COMMAND 检查位已过 enforce）；参数作为 argv 直接传给进程，不经 Shell 解释。超时默认 30 秒。
+ * <p>白名单校验可执行文件名（SHELL_COMMAND 检查位已过 enforce）；参数作为 argv 直接传给进程，不经 Shell 解释。超时默认 30
+ * 秒。两个运维细节： (1) stdout/stderr 在 {@code waitFor} 前就并发排空——否则输出超过管道缓冲（~64KB）的命令会写阻塞、被误判超时；(2)
+ * 超时后递归杀进程树——子进程不在父进程组内时，只杀父进程会留孤儿继续跑。
  */
 public class ShellTools {
 
@@ -60,23 +64,36 @@ public class ShellTools {
     sandbox.enforce(new SandboxAction(ActionType.SHELL_COMMAND, commandExecutable));
     try {
       Process process = processStarter.start(command);
-      boolean finished = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
+      // 先起并发排空再 waitFor：管道不被写满阻塞，waitFor 只在「命令真没跑完」时超时
+      Future<byte[]> stdout = DRAINER.submit(() -> process.getInputStream().readAllBytes());
+      Future<byte[]> stderr = DRAINER.submit(() -> process.getErrorStream().readAllBytes());
+      boolean finished;
+      try {
+        finished = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        killTree(process);
+        throw new IllegalStateException("命令执行被中断: " + commandExecutable, e);
+      }
       if (!finished) {
-        process.destroyForcibly();
+        killTree(process);
         throw new IllegalStateException(
             "命令超时（" + timeout.toSeconds() + "s）被终止: " + commandExecutable);
       }
-      String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-      if (process.exitValue() != 0) {
-        String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
-        throw new IllegalStateException("命令退出码 " + process.exitValue() + ": " + stderr.trim());
+      try {
+        if (process.exitValue() != 0) {
+          String err = new String(stderr.get(), StandardCharsets.UTF_8);
+          throw new IllegalStateException("命令退出码 " + process.exitValue() + ": " + err.trim());
+        }
+        return new String(stdout.get(), StandardCharsets.UTF_8);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("命令执行被中断: " + commandExecutable, e);
+      } catch (ExecutionException e) {
+        throw new IllegalStateException("命令输出读取失败: " + commandExecutable, e.getCause());
       }
-      return stdout;
     } catch (IOException e) {
       throw new UncheckedIOException("命令启动失败: " + commandExecutable, e);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new IllegalStateException("命令执行被中断: " + commandExecutable, e);
     }
   }
 
@@ -106,9 +123,13 @@ public class ShellTools {
     Process start(List<String> command) throws IOException;
   }
 
-  /** 先递归杀 bash 派生的子孙进程，再杀 bash 本身（只 destroyForcibly(bash) 会留孤儿继续执行）。 */
+  /** 先递归杀子孙进程，再杀父进程（只 destroyForcibly(父) 会留孤儿继续执行）。 */
   private static void killTree(Process process) {
-    process.toHandle().descendants().forEach(ProcessHandle::destroyForcibly);
+    try {
+      process.toHandle().descendants().forEach(ProcessHandle::destroyForcibly);
+    } catch (UnsupportedOperationException | IllegalStateException ignored) {
+      // 测试替身或已退出的进程可能没有 ProcessHandle
+    }
     process.destroyForcibly();
   }
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -68,8 +68,10 @@ public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
    * 写穿到库、重启保留。启动播种（把配置文件的白名单插进来）由装配层调用 {@code add} 完成——{@code add} 会算好规范形并幂等落库。
    */
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "EI_EXPOSE_REP2",
-      justification = "store 是 Spring 注入的共享单例仓库，构造注入共享同一引用正是意图")
+      value = {"EI_EXPOSE_REP2", "CT_CONSTRUCTOR_THROW"},
+      justification =
+          "store 是 Spring 注入的共享单例仓库，构造注入共享同一引用正是意图；"
+              + "构造期 applyToMemory 校验失败应失败关闭，不保留半初始化实例供 finalize 攻击")
   public WhitelistSandbox(SandboxWhitelistStore store) {
     this.store = store;
     for (SandboxWhitelistStore.Entry entry : store.loadAll()) {

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/ShellToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/ShellToolsTest.java
@@ -187,9 +187,7 @@ class ShellToolsTest {
     }
   }
 
-  /**
-   * waitFor 仅在 stdout/stderr 都被开始读取后才返回 true——用来锁死「先排空再 waitFor」的顺序。
-   */
+  /** waitFor 仅在 stdout/stderr 都被开始读取后才返回 true——用来锁死「先排空再 waitFor」的顺序。 */
   private static final class DrainOrderProcess extends Process {
     private final byte[] stdout;
     private final CountDownLatch drainsStarted = new CountDownLatch(2);

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/ShellToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/ShellToolsTest.java
@@ -12,17 +12,19 @@ import io.oryxos.tool.sandbox.SandboxViolationException;
 import io.oryxos.tool.sandbox.ShellSandboxProperties;
 import io.oryxos.tool.sandbox.WhitelistSandbox;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-/** ShellTools 的回归测试：覆盖结构化 argv、Sandbox 拦截、退出码与超时行为。 */
+/** ShellTools 的回归测试：覆盖结构化 argv、Sandbox 拦截、退出码、超时与管道排空顺序。 */
 class ShellToolsTest {
 
   @Test
@@ -66,6 +68,19 @@ class ShellToolsTest {
 
     assertTrue(ex.getMessage().contains("超时"));
     assertTrue(process.wasForciblyDestroyed());
+  }
+
+  @Test
+  @DisplayName("waitFor 前并发排空 stdout/stderr_否则大输出会假超时")
+  void drainsStdoutAndStderrBeforeWaitFor() {
+    // 模拟管道背压：进程在 stdout/stderr 被开始读取之前不能「结束」；
+    // 若实现先 waitFor 再读流，waitFor 会拖到超时。
+    DrainOrderProcess process = new DrainOrderProcess("big-output");
+    ShellTools tools =
+        new ShellTools(new PermissiveSandbox(), Duration.ofSeconds(2), command -> process);
+
+    assertEquals("big-output", tools.shell("echo", List.of("big-output")));
+    assertTrue(process.drainsStartedBeforeWaitForReturned());
   }
 
   @Test
@@ -169,6 +184,99 @@ class ShellToolsTest {
 
     private boolean wasForciblyDestroyed() {
       return forciblyDestroyed;
+    }
+  }
+
+  /**
+   * waitFor 仅在 stdout/stderr 都被开始读取后才返回 true——用来锁死「先排空再 waitFor」的顺序。
+   */
+  private static final class DrainOrderProcess extends Process {
+    private final byte[] stdout;
+    private final CountDownLatch drainsStarted = new CountDownLatch(2);
+    private volatile boolean waitForReturnedAfterDrains;
+
+    private DrainOrderProcess(String stdout) {
+      this.stdout = stdout.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+      return OutputStream.nullOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return new SignalingInputStream(stdout, drainsStarted);
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+      return new SignalingInputStream(new byte[0], drainsStarted);
+    }
+
+    @Override
+    public int waitFor() {
+      return 0;
+    }
+
+    @Override
+    public boolean waitFor(long timeout, TimeUnit unit) throws InterruptedException {
+      boolean ok = drainsStarted.await(timeout, unit);
+      waitForReturnedAfterDrains = ok;
+      return ok;
+    }
+
+    @Override
+    public int exitValue() {
+      return 0;
+    }
+
+    @Override
+    public void destroy() {}
+
+    @Override
+    public Process destroyForcibly() {
+      return this;
+    }
+
+    private boolean drainsStartedBeforeWaitForReturned() {
+      return waitForReturnedAfterDrains;
+    }
+  }
+
+  private static final class SignalingInputStream extends InputStream {
+    private final ByteArrayInputStream delegate;
+    private final CountDownLatch started;
+    private boolean signaled;
+
+    private SignalingInputStream(byte[] data, CountDownLatch started) {
+      this.delegate = new ByteArrayInputStream(data);
+      this.started = started;
+    }
+
+    private void signalOnce() {
+      if (!signaled) {
+        signaled = true;
+        started.countDown();
+      }
+    }
+
+    @Override
+    public int read() throws IOException {
+      signalOnce();
+      return delegate.read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      signalOnce();
+      return delegate.read(b, off, len);
+    }
+
+    @Override
+    public byte[] readAllBytes() throws IOException {
+      signalOnce();
+      return delegate.readAllBytes();
     }
   }
 }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxMutationTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxMutationTest.java
@@ -72,8 +72,7 @@ class WhitelistSandboxMutationTest {
 
     assertTrue(sb.add(Category.SHELL, "python3"));
     assertTrue(sb.list(Category.SHELL).contains("python3"));
-    assertDoesNotThrow(
-        () -> sb.enforce(new SandboxAction(ActionType.SHELL_COMMAND, "python3")));
+    assertDoesNotThrow(() -> sb.enforce(new SandboxAction(ActionType.SHELL_COMMAND, "python3")));
   }
 
   @Test


### PR DESCRIPTION
#98 left DRAINER/killTree unused and read streams after waitFor, so large output could block on a full pipe and look like a timeout. Restore concurrent drain, kill the process tree on timeout, and lock the order with a regression test.

## Summary
Restore concurrent stdout/stderr drain before waitFor and kill the process tree on timeout. Regression from #98 left DRAINER/killTree unused, so large output could false-timeout.

## Test plan
- [x] `mvn -pl oryxos-tool -am test -Dtest=ShellToolsTest`

Fixes #107