### PR TITLE
fix(web): block IPv6 ULA in skill import SSRF guard

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
@@ -52,14 +52,6 @@ public class ShellTools {
     this.processStarter = Objects.requireNonNull(processStarter, "processStarter 不能为空");
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "COMMAND_INJECTION",
-      justification =
-          "ProcessBuilder 以 argv 列表启动，不经 shell；可执行文件在 shell() 内经 Sandbox 精确白名单校验后再 start")
-  private static Process startProcess(List<String> command) throws IOException {
-    return new ProcessBuilder(command).start();
-  }
-
   @Tool(name = "shell", description = "执行一个已获许可的可执行文件，返回标准输出")
   public String shell(
       @ToolParam(description = "要执行的、已在白名单中的可执行文件") String executable,

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
@@ -180,8 +180,8 @@ public class SkillApiController {
   }
 
   /**
-   * SSRF 防护：拒绝主机解析到回环/任意本地/链路本地(含 169.254.169.254)/站点内网/组播/CGNAT/IPv6 ULA
-   * （fc00::/7），以及 localhost、*.internal、云元数据主机名。与工具层 {@code WhitelistSandbox} 内网口径对齐。
+   * SSRF 防护：拒绝主机解析到回环/任意本地/链路本地(含 169.254.169.254)/站点内网/组播/CGNAT/IPv6 ULA （fc00::/7），以及
+   * localhost、*.internal、云元数据主机名。与工具层 {@code WhitelistSandbox} 内网口径对齐。
    */
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
@@ -49,7 +49,7 @@ import org.springframework.web.bind.annotation.RestController;
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = {"SPRING_ENDPOINT", "EI_EXPOSE_REP2", "URLCONNECTION_SSRF_FD", "IMPROPER_UNICODE"},
     justification =
-        "core-stage web API is unauthenticated by design (internal network + gateway); auth is extension-phase. 协作者是 Spring 注入的共享单例，构造注入共享同一引用正是意图。/import 拉取运营者给定的 URL（等同安装插件），已做 SSRF 防护：限 http/https + 超时 + 大小上限 + 禁自动重定向、每跳校验目标主机非回环/内网/链路本地(含云元数据 169.254.169.254)/CGNAT。")
+        "core-stage web API is unauthenticated by design (internal network + gateway); auth is extension-phase. 协作者是 Spring 注入的共享单例，构造注入共享同一引用正是意图。/import 拉取运营者给定的 URL（等同安装插件），已做 SSRF 防护：限 http/https + 超时 + 大小上限 + 禁自动重定向、每跳校验目标主机非回环/内网/链路本地(含云元数据 169.254.169.254)/CGNAT/IPv6 ULA。")
 @RestController
 @RequestMapping("/api/v1/skills")
 public class SkillApiController {
@@ -180,13 +180,14 @@ public class SkillApiController {
   }
 
   /**
-   * SSRF 防护：拒绝主机解析到回环/任意本地/链路本地(含 169.254.169.254)/站点内网/组播/CGNAT，以及 localhost、*.internal、云元数据主机名。
+   * SSRF 防护：拒绝主机解析到回环/任意本地/链路本地(含 169.254.169.254)/站点内网/组播/CGNAT/IPv6 ULA
+   * （fc00::/7），以及 localhost、*.internal、云元数据主机名。与工具层 {@code WhitelistSandbox} 内网口径对齐。
    */
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",
       justification =
           "IDN.toASCII canonicalizes the complete DNS host before security checks; no substring is transformed independently.")
-  private static void guardPublicHost(URI uri) {
+  static void guardPublicHost(URI uri) {
     String host = uri.getHost();
     if (host == null || host.isBlank()) {
       throw new IllegalArgumentException("URL 缺少主机名: " + uri);
@@ -200,9 +201,14 @@ public class SkillApiController {
     if (isInternalName(asciiHost)) {
       throw new IllegalArgumentException("拒绝访问内网 / 元数据主机: " + host);
     }
+    // IPv6 字面量偶发带方括号；剥掉后再解析，ULA/回环判断才生效（与 WhitelistSandbox 一致）
+    String lookup =
+        asciiHost.startsWith("[") && asciiHost.endsWith("]")
+            ? asciiHost.substring(1, asciiHost.length() - 1)
+            : asciiHost;
     InetAddress[] addresses;
     try {
-      addresses = InetAddress.getAllByName(asciiHost);
+      addresses = InetAddress.getAllByName(lookup);
     } catch (UnknownHostException e) {
       throw new IllegalArgumentException("无法解析主机: " + host);
     }
@@ -212,7 +218,8 @@ public class SkillApiController {
           || addr.isLinkLocalAddress()
           || addr.isSiteLocalAddress()
           || addr.isMulticastAddress()
-          || isCarrierGradeNat(addr)) {
+          || isCarrierGradeNat(addr)
+          || isIpv6UniqueLocal(addr)) {
         throw new IllegalArgumentException(
             "拒绝访问内网 / 保留地址: " + host + " → " + addr.getHostAddress());
       }
@@ -237,6 +244,12 @@ public class SkillApiController {
   private static boolean isCarrierGradeNat(InetAddress addr) {
     byte[] b = addr.getAddress();
     return b.length == 4 && (b[0] & 0xFF) == 100 && (b[1] & 0xC0) == 0x40;
+  }
+
+  /** IPv6 ULA fc00::/7（唯一本地地址，isSiteLocalAddress 对 IPv6 不覆盖——否则 [fd00::1] 可绕过）。 */
+  private static boolean isIpv6UniqueLocal(InetAddress addr) {
+    byte[] b = addr.getAddress();
+    return b.length == 16 && (b[0] & 0xFE) == 0xFC;
   }
 
   @PutMapping("/{name}")

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/SkillApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/SkillApiControllerTest.java
@@ -118,14 +118,13 @@ class SkillApiControllerTest {
   }
 
   @Test
-  @DisplayName("import 指向回环/内网/云元数据地址 → 400（SSRF 防护）")
-  void import_ssrf_blocked() throws Exception {
+  @DisplayName("import 非 GitHub tree URL → 400（含回环地址，先被 GitHub URL 规则拒绝）")
+  void import_nonGithubUrl_returns400() throws Exception {
     for (String url :
         new String[] {
           "http://127.0.0.1:8080/x/SKILL.md",
           "http://localhost/x/SKILL.md",
-          "http://169.254.169.254/latest/meta-data/",
-          "http://10.0.0.5/SKILL.md"
+          "http://example.com/SKILL.md"
         }) {
       mvc.perform(
               post("/api/v1/skills/import")

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/SkillImportSsrfGuardTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/SkillImportSsrfGuardTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * 直接覆盖 {@link SkillApiController#guardPublicHost(URI)}：/import 虽只接受 GitHub tree URL，但
- * fetch 跟随重定向时仍依赖本方法挡内网（含 IPv6 ULA）。
+ * 直接覆盖 {@link SkillApiController#guardPublicHost(URI)}：/import 虽只接受 GitHub tree URL，但 fetch
+ * 跟随重定向时仍依赖本方法挡内网（含 IPv6 ULA）。
  */
 class SkillImportSsrfGuardTest {
 

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/SkillImportSsrfGuardTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/SkillImportSsrfGuardTest.java
@@ -1,0 +1,51 @@
+package io.oryxos.web.controller;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 直接覆盖 {@link SkillApiController#guardPublicHost(URI)}：/import 虽只接受 GitHub tree URL，但
+ * fetch 跟随重定向时仍依赖本方法挡内网（含 IPv6 ULA）。
+ */
+class SkillImportSsrfGuardTest {
+
+  @Test
+  @DisplayName("IPv6 ULA fc00::/7 被拒绝（isSiteLocalAddress 不覆盖）")
+  void ipv6UniqueLocalBlocked() {
+    for (String url : new String[] {"http://[fd00::1]/SKILL.md", "http://[fc00::abcd]/x"}) {
+      IllegalArgumentException ex =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> SkillApiController.guardPublicHost(URI.create(url)));
+      assertTrue(ex.getMessage().contains("拒绝访问"));
+    }
+  }
+
+  @Test
+  @DisplayName("回环 / 站点内网 / 链路本地 / CGNAT 仍被拒绝")
+  void classicPrivateRangesStillBlocked() {
+    for (String url :
+        new String[] {
+          "http://127.0.0.1/x",
+          "http://10.0.0.5/x",
+          "http://169.254.169.254/latest/meta-data/",
+          "http://100.64.1.2/x"
+        }) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> SkillApiController.guardPublicHost(URI.create(url)));
+    }
+  }
+
+  @Test
+  @DisplayName("公网字面量地址放行（解析层不抛）")
+  void publicLiteralAllowed() {
+    // 8.8.8.8 为公网 DNS；不发起真实 HTTP，只校验主机守卫
+    assertDoesNotThrow(() -> SkillApiController.guardPublicHost(URI.create("https://8.8.8.8/x")));
+  }
+}


### PR DESCRIPTION
WhitelistSandbox already rejects fc00::/7; SkillApiController.guardPublicHost did not, so a redirect target like [fd00::1] could bypass import SSRF checks. Align with tool sandbox and add direct unit coverage.

## Summary
Align skill-import SSRF with WhitelistSandbox by blocking IPv6 ULA (fc00::/7). Redirects/literal hosts like [fd00::1] were previously allowed.

## Test plan
- [x] `mvn -pl oryxos-web -am test -Dtest=SkillImportSsrfGuardTest`

Fixes #109