### PR TITLE
fix(tool): recheck HTTP write whitelist on each redirect hop

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -22,7 +23,8 @@ import org.springframework.web.client.RestClient;
 
 /**
  * 内置 HTTP 工具：http_get / http_post / http_request（任意方法）/ fetch_webpage（抓网页抽正文）/
- * download_file（下载到文件）。域名白名单检查位第一行——不过校验请求根本不发出。
+ * download_file（下载到文件）。读请求走 {@code HTTP_READ}（默认放行 + SSRF）；写请求走 {@code HTTP_REQUEST}（域名白名单）。
+ * 读写都禁自动重定向，由本类手动逐跳跟随并每跳重过沙箱校验。
  */
 public class HttpTools {
 
@@ -31,10 +33,10 @@ public class HttpTools {
 
   private static final String DEFAULT_METHOD = "GET";
 
-  /** 读请求手动跟随重定向的最大跳数（每跳都重新过 SSRF 校验，防公网 302→内网）。 */
+  /** 手动跟随重定向的最大跳数（每跳都重新过沙箱校验，防公网 302→白名单外 / 内网）。 */
   private static final int MAX_REDIRECTS = 5;
 
-  /** 读请求连接 / 读取超时——外网慢站点不能拖死同步的 ReAct 触发（否则浏览器 Failed to fetch）。 */
+  /** 连接 / 读取超时——外网慢站点不能拖死同步的 ReAct 触发。 */
   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
 
   private static final Duration READ_TIMEOUT = Duration.ofSeconds(20);
@@ -47,21 +49,23 @@ public class HttpTools {
   private static final Pattern HEADER_LINE_SEP = Pattern.compile("\\R");
 
   private final Sandbox sandbox;
-  private final RestClient restClient;
-  // 读专用客户端：**禁自动重定向**，由本类手动逐跳跟随并每跳重过 SSRF 校验（防公网 302 → 内网绕过）。
-  private final RestClient readClient;
+  /**
+   * 读写共用：**禁自动重定向**，由本类手动逐跳跟随并每跳重过沙箱校验。不使用注入的 RestClient
+   * 默认跟随行为（否则写请求会在首跳过白名单后跟到任意 Location）。
+   */
+  private final RestClient hopClient;
 
   public HttpTools(Sandbox sandbox, RestClient restClient) {
     this.sandbox = sandbox;
-    this.restClient = restClient.mutate().build();
-    JdkClientHttpRequestFactory readFactory =
+    Objects.requireNonNull(restClient, "restClient 不能为空"); // 保留构造签名，供 Spring 装配
+    JdkClientHttpRequestFactory hopFactory =
         new JdkClientHttpRequestFactory(
             HttpClient.newBuilder()
                 .connectTimeout(CONNECT_TIMEOUT)
                 .followRedirects(HttpClient.Redirect.NEVER)
                 .build());
-    readFactory.setReadTimeout(READ_TIMEOUT);
-    this.readClient = RestClient.builder().requestFactory(readFactory).build();
+    hopFactory.setReadTimeout(READ_TIMEOUT);
+    this.hopClient = RestClient.builder().requestFactory(hopFactory).build();
   }
 
   /**
@@ -72,11 +76,47 @@ public class HttpTools {
     String current = url;
     for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
       sandbox.enforce(new SandboxAction(ActionType.HTTP_READ, current)); // 每跳校验
-      ResponseEntity<T> resp = readClient.get().uri(current).retrieve().toEntity(type);
+      ResponseEntity<T> resp = hopClient.get().uri(current).retrieve().toEntity(type);
       if (resp.getStatusCode().is3xxRedirection()) {
         String location = resp.getHeaders().getFirst("Location");
         if (location == null || location.isBlank()) {
           return resp.getBody(); // 3xx 但无 Location：返回现有响应体
+        }
+        current = URI.create(current).resolve(location).toString();
+        continue;
+      }
+      return resp.getBody();
+    }
+    throw new IllegalStateException("重定向次数过多，拒绝: " + url);
+  }
+
+  /**
+   * 写请求（POST/PUT/…）：手动跟随重定向，**每跳都重过 {@code HTTP_REQUEST} 域名白名单**——杜绝"白名单内入口 302 跳白名单外"。
+   */
+  private String write(HttpMethod method, String url, String headers, String body, boolean jsonBody) {
+    String current = url;
+    for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, current)); // 每跳校验
+      RestClient.RequestBodySpec spec = hopClient.method(method).uri(current);
+      if (headers != null && !headers.isBlank()) {
+        for (String line : HEADER_LINE_SEP.split(headers)) {
+          int colon = line.indexOf(':');
+          if (colon > 0) {
+            spec.header(line.substring(0, colon).strip(), line.substring(colon + 1).strip());
+          }
+        }
+      }
+      if (body != null && !body.isBlank()) {
+        if (jsonBody) {
+          spec.contentType(MediaType.APPLICATION_JSON);
+        }
+        spec.body(body);
+      }
+      ResponseEntity<String> resp = spec.retrieve().toEntity(String.class);
+      if (resp.getStatusCode().is3xxRedirection()) {
+        String location = resp.getHeaders().getFirst("Location");
+        if (location == null || location.isBlank()) {
+          return resp.getBody();
         }
         current = URI.create(current).resolve(location).toString();
         continue;
@@ -95,14 +135,7 @@ public class HttpTools {
   public String httpPost(
       @ToolParam(description = "要请求的完整 URL") String url,
       @ToolParam(description = "JSON 请求体") String body) {
-    sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, url));
-    return restClient
-        .post()
-        .uri(url)
-        .contentType(MediaType.APPLICATION_JSON)
-        .body(body)
-        .retrieve()
-        .body(String.class);
+    return write(HttpMethod.POST, url, null, body, true);
   }
 
   @Tool(
@@ -118,24 +151,11 @@ public class HttpTools {
       @ToolParam(required = false, description = "可选请求体（如 JSON 文本）") String body) {
     String verb = (method == null || method.isBlank()) ? DEFAULT_METHOD : method.strip();
     HttpMethod httpMethod = HttpMethod.valueOf(verb.toUpperCase(Locale.ROOT));
-    // 按方法分级：GET 走读路径（放行 + 内网黑名单 + 逐跳重定向重校验），其余写方法走域名白名单
+    // 按方法分级：GET 走读路径（放行 + 内网黑名单 + 逐跳重定向重校验），其余写方法走域名白名单 + 逐跳重定向重校验
     if (HttpMethod.GET.equals(httpMethod)) {
       return read(url, String.class);
     }
-    sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, url));
-    RestClient.RequestBodySpec spec = restClient.method(httpMethod).uri(url);
-    if (headers != null && !headers.isBlank()) {
-      for (String line : HEADER_LINE_SEP.split(headers)) {
-        int colon = line.indexOf(':');
-        if (colon > 0) {
-          spec.header(line.substring(0, colon).strip(), line.substring(colon + 1).strip());
-        }
-      }
-    }
-    if (body != null && !body.isBlank()) {
-      spec.body(body);
-    }
-    return spec.retrieve().body(String.class);
+    return write(httpMethod, url, headers, body, false);
   }
 
   @Tool(name = "fetch_webpage", description = "抓取一个网页并抽取可读正文（去掉 HTML 标签/脚本/样式），适合让模型阅读网页内容")
@@ -144,7 +164,9 @@ public class HttpTools {
     return htmlToText(html);
   }
 
-  @Tool(name = "download_file", description = "下载一个 URL 的内容到指定本地文件路径（域名 + 路径都过白名单）")
+  @Tool(
+      name = "download_file",
+      description = "下载一个 URL 的内容到指定本地文件路径（URL：默认放行 + SSRF；本地路径：文件白名单）")
   public String downloadFile(
       @ToolParam(description = "要下载的 URL") String url,
       @ToolParam(description = "保存到的本地文件路径") String path) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -49,10 +49,8 @@ public class HttpTools {
   private static final Pattern HEADER_LINE_SEP = Pattern.compile("\\R");
 
   private final Sandbox sandbox;
-  /**
-   * 读写共用：**禁自动重定向**，由本类手动逐跳跟随并每跳重过沙箱校验。不使用注入的 RestClient
-   * 默认跟随行为（否则写请求会在首跳过白名单后跟到任意 Location）。
-   */
+
+  /** 读写共用：**禁自动重定向**，由本类手动逐跳跟随并每跳重过沙箱校验。不使用注入的 RestClient 默认跟随行为（否则写请求会在首跳过白名单后跟到任意 Location）。 */
   private final RestClient hopClient;
 
   public HttpTools(Sandbox sandbox, RestClient restClient) {
@@ -90,10 +88,9 @@ public class HttpTools {
     throw new IllegalStateException("重定向次数过多，拒绝: " + url);
   }
 
-  /**
-   * 写请求（POST/PUT/…）：手动跟随重定向，**每跳都重过 {@code HTTP_REQUEST} 域名白名单**——杜绝"白名单内入口 302 跳白名单外"。
-   */
-  private String write(HttpMethod method, String url, String headers, String body, boolean jsonBody) {
+  /** 写请求（POST/PUT/…）：手动跟随重定向，**每跳都重过 {@code HTTP_REQUEST} 域名白名单**——杜绝"白名单内入口 302 跳白名单外"。 */
+  private String write(
+      HttpMethod method, String url, String headers, String body, boolean jsonBody) {
     String current = url;
     for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
       sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, current)); // 每跳校验
@@ -164,9 +161,7 @@ public class HttpTools {
     return htmlToText(html);
   }
 
-  @Tool(
-      name = "download_file",
-      description = "下载一个 URL 的内容到指定本地文件路径（URL：默认放行 + SSRF；本地路径：文件白名单）")
+  @Tool(name = "download_file", description = "下载一个 URL 的内容到指定本地文件路径（URL：默认放行 + SSRF；本地路径：文件白名单）")
   public String downloadFile(
       @ToolParam(description = "要下载的 URL") String url,
       @ToolParam(description = "保存到的本地文件路径") String path) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
@@ -52,14 +52,6 @@ public class ShellTools {
     this.processStarter = Objects.requireNonNull(processStarter, "processStarter 不能为空");
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "COMMAND_INJECTION",
-      justification =
-          "ProcessBuilder 以 argv 列表启动，不经 shell；可执行文件在 shell() 内经 Sandbox 精确白名单校验后再 start")
-  private static Process startProcess(List<String> command) throws IOException {
-    return new ProcessBuilder(command).start();
-  }
-
   @Tool(name = "shell", description = "执行一个已获许可的可执行文件，返回标准输出")
   public String shell(
       @ToolParam(description = "要执行的、已在白名单中的可执行文件") String executable,

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
@@ -20,6 +20,7 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -102,5 +103,50 @@ class HttpToolsTest {
 
     assertThrows(SandboxViolationException.class, () -> guarded.httpGet(url()));
     assertEquals(0, receivedBodies.size(), "白名单外域名，请求根本不该到达服务");
+  }
+
+  @Test
+  @DisplayName("http_post 白名单内入口 302 到白名单外应被拦下（写路径逐跳复检）")
+  void httpPostRedirectOutsideWhitelistIsBlocked() throws IOException {
+    // 入口用 localhost（在白名单），Location 跳到 127.0.0.1（同机不同主机名、不在白名单）。
+    // 修复前：写路径只校验首跳、RestClient 自动跟随 → 会打到外站；修复后：每跳 HTTP_REQUEST 复检。
+    HttpServer entry = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    HttpServer sink = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    AtomicInteger sinkHits = new AtomicInteger();
+    try {
+      sink.createContext(
+          "/",
+          exchange -> {
+            sinkHits.incrementAndGet();
+            byte[] response = "leaked".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+          });
+      String sinkUrl = "http://127.0.0.1:" + sink.getAddress().getPort() + "/sink";
+      entry.createContext(
+          "/",
+          exchange -> {
+            exchange.getResponseHeaders().add("Location", sinkUrl);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+          });
+      entry.start();
+      sink.start();
+
+      Sandbox whitelist =
+          new WhitelistSandbox(
+              new FileSandboxProperties(List.of()),
+              new ShellSandboxProperties(List.of()),
+              new HttpSandboxProperties(List.of("localhost")));
+      HttpTools guarded = new HttpTools(whitelist, RestClient.create());
+      String start = "http://localhost:" + entry.getAddress().getPort() + "/";
+
+      assertThrows(SandboxViolationException.class, () -> guarded.httpPost(start, "{\"x\":1}"));
+      assertEquals(0, sinkHits.get(), "重定向目标不在白名单，请求不该到达 sink");
+    } finally {
+      entry.stop(0);
+      sink.stop(0);
+    }
   }
 }


### PR DESCRIPTION
Write path previously only enforced HTTP_REQUEST on the first URL then auto-followed redirects, which could land outside the whitelist.

Fixes #111

## Summary
- Write path (`http_post` / non-GET `http_request`) previously only enforced `HTTP_REQUEST` on the first URL, then RestClient auto-followed redirects.
- Mirror the read path: hop client with `Redirect.NEVER`, re-enforce whitelist on every hop.

## Test plan
- [x] `HttpToolsTest` — `httpPostRedirectOutsideWhitelistIsBlocked` (localhost → 302 → 127.0.0.1 sink blocked)
- [x] Existing `HttpToolsTest` cases still pass