### PR TITLE
fix(tool): describe notify channel as registry name in schema

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
@@ -74,7 +74,7 @@ public class NotifyTools implements OryxTool {
           "type": "object",
           "properties": {
             "content": {"type": "string", "description": "要推送的内容"},
-            "channel": {"type": "string", "description": "渠道类型；缺省用第一个配置的渠道"}
+            "channel": {"type": "string", "description": "渠道名（全局 Notify 注册表中的 name）；缺省或 default 用第一个配置的渠道"}
           },
           "required": ["content"]
         }""";

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
@@ -52,14 +52,6 @@ public class ShellTools {
     this.processStarter = Objects.requireNonNull(processStarter, "processStarter 不能为空");
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "COMMAND_INJECTION",
-      justification =
-          "ProcessBuilder 以 argv 列表启动，不经 shell；可执行文件在 shell() 内经 Sandbox 精确白名单校验后再 start")
-  private static Process startProcess(List<String> command) throws IOException {
-    return new ProcessBuilder(command).start();
-  }
-
   @Tool(name = "shell", description = "执行一个已获许可的可执行文件，返回标准输出")
   public String shell(
       @ToolParam(description = "要执行的、已在白名单中的可执行文件") String executable,

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/NotifyToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/NotifyToolsTest.java
@@ -99,6 +99,25 @@ class NotifyToolsTest {
             eq("今日北京天气 + 穿搭建议"));
   }
 
+  @Test
+  @DisplayName("inputSchema 的 channel 描述应为渠道名（与 getDescription / 注册表按名解析一致）")
+  void inputSchemaDescribesChannelAsNameNotType() {
+    NotifyChannelRegistry registry = mock(NotifyChannelRegistry.class);
+    when(registry.list())
+        .thenReturn(
+            List.of(new NotifyChannelDef("team-lark", "feishu", "https://open.feishu.cn/x", null)));
+    NotifyTools tools =
+        new NotifyTools(Map.of("feishu", adapter), new PermissiveSandbox(), registry);
+
+    String schema = tools.getInputSchema();
+    String description = tools.getDescription();
+
+    assertTrue(schema.contains("渠道名"), "schema 应写渠道名，避免模型传 feishu/webhook 类型串: " + schema);
+    assertFalse(schema.contains("渠道类型"), "schema 不应再写渠道类型（与 31 节按名引用矛盾）: " + schema);
+    assertTrue(description.contains("渠道名"), description);
+    assertTrue(description.contains("team-lark"), description);
+  }
+
   private static Profile profileWith(List<Profile.NotifyChannel> channels) {
     return new Profile(
         "ops-agent",


### PR DESCRIPTION
Fixes #113

## Summary
- Align `notify` inputSchema: `channel` is 渠道名 (registry name), not 渠道类型
- Regression test in `NotifyToolsTest`
- Include inherited SpotBugs/spotless CI unblocks (same as #108/#110) until those land on main

## Test plan
- [x] `NotifyToolsTest` (incl. inputSchemaDescribesChannelAsNameNotType)