### PR TITLE
fix(tool): restore main quality gate (spotless violation + 3 SpotBugs bugs from #98)

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
@@ -38,6 +38,10 @@ public class ShellTools {
     this(sandbox, DEFAULT_TIMEOUT);
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "COMMAND_INJECTION",
+      justification =
+          "默认 ProcessStarter 以 argv 直接执行、不经 shell 解释；可执行文件在 shell() 启动前经 Sandbox 精确白名单校验")
   ShellTools(Sandbox sandbox, Duration timeout) {
     this(sandbox, timeout, command -> new ProcessBuilder(command).start());
   }
@@ -62,7 +66,7 @@ public class ShellTools {
       Process process = processStarter.start(command);
       boolean finished = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
       if (!finished) {
-        process.destroyForcibly();
+        killTree(process);
         throw new IllegalStateException(
             "命令超时（" + timeout.toSeconds() + "s）被终止: " + commandExecutable);
       }
@@ -106,9 +110,9 @@ public class ShellTools {
     Process start(List<String> command) throws IOException;
   }
 
-  /** 先递归杀 bash 派生的子孙进程，再杀 bash 本身（只 destroyForcibly(bash) 会留孤儿继续执行）。 */
+  /** 先递归杀命令派生的子孙进程，再杀命令本身（只 destroyForcibly 主进程会留孤儿继续执行）。 */
   private static void killTree(Process process) {
-    process.toHandle().descendants().forEach(ProcessHandle::destroyForcibly);
+    process.descendants().forEach(ProcessHandle::destroyForcibly);
     process.destroyForcibly();
   }
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
@@ -38,12 +38,8 @@ public class ShellTools {
     this(sandbox, DEFAULT_TIMEOUT);
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "COMMAND_INJECTION",
-      justification =
-          "默认 ProcessStarter 以 argv 直接执行、不经 shell 解释；可执行文件在 shell() 启动前经 Sandbox 精确白名单校验")
   ShellTools(Sandbox sandbox, Duration timeout) {
-    this(sandbox, timeout, command -> new ProcessBuilder(command).start());
+    this(sandbox, timeout, ShellTools::startProcess);
   }
 
   ShellTools(Sandbox sandbox, Duration timeout, ProcessStarter processStarter) {
@@ -82,6 +78,17 @@ public class ShellTools {
       Thread.currentThread().interrupt();
       throw new IllegalStateException("命令执行被中断: " + commandExecutable, e);
     }
+  }
+
+  /**
+   * 默认 ProcessStarter：命名方法而非 lambda，让 SuppressFBWarnings 能落在告警位置上（lambda 编译成 synthetic
+   * 方法，构造器上的注解盖不住）。
+   */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "COMMAND_INJECTION",
+      justification = "以 argv 直接执行、不经 shell 解释；可执行文件在 shell() 启动前经 Sandbox 精确白名单校验")
+  private static Process startProcess(List<String> command) throws IOException {
+    return new ProcessBuilder(command).start();
   }
 
   private static String requireExecutable(String executable) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -30,7 +30,8 @@ import org.slf4j.LoggerFactory;
  * <p>三个 {@code check*} 与 {@code matchesDomain} 均 {@code private}——对外只暴露 {@code enforce} 与管理三方法。 若把
  * check* public 暴露到 {@code Sandbox} 接口上，接口就被这一档实现带偏了。
  */
-public class WhitelistSandbox implements Sandbox, SandboxWhitelist {
+// final：构造器会因非法配置抛异常（normalizeRoot/requireNonBlank），禁止子类化以杜绝 finalizer attack（CT_CONSTRUCTOR_THROW）
+public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
 
   private static final Logger LOG = LoggerFactory.getLogger(WhitelistSandbox.class);
 

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/ShellToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/ShellToolsTest.java
@@ -167,6 +167,11 @@ class ShellToolsTest {
       return this;
     }
 
+    @Override
+    public java.util.stream.Stream<ProcessHandle> descendants() {
+      return java.util.stream.Stream.empty(); // 替身无真实 OS 进程，killTree 无子孙可杀
+    }
+
     private boolean wasForciblyDestroyed() {
       return forciblyDestroyed;
     }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxMutationTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxMutationTest.java
@@ -72,8 +72,7 @@ class WhitelistSandboxMutationTest {
 
     assertTrue(sb.add(Category.SHELL, "python3"));
     assertTrue(sb.list(Category.SHELL).contains("python3"));
-    assertDoesNotThrow(
-        () -> sb.enforce(new SandboxAction(ActionType.SHELL_COMMAND, "python3")));
+    assertDoesNotThrow(() -> sb.enforce(new SandboxAction(ActionType.SHELL_COMMAND, "python3")));
   }
 
   @Test


### PR DESCRIPTION
## 背景

main 的质量门禁目前是红的：#98 合入时带着一处 spotless 格式违规进了主干（当时 CI 恰好没拦住），它 fail-fast 挡住了全仓构建；修掉它之后又暴露出 oryxos-tool 的 3 个 SpotBugs bug（同样来自 #98 的 ShellTools 重写）。因为所有 PR 的 CI 都以 merge-with-main 运行，主干这几处问题正在把 #86、#92、#95 等全部 open PR 的 CI 一起挡红。

这些修复此前混在 #95 里（并已在那边验证 CI 转绿），按 [#95 评论](https://github.com/oryx-labs/oryxos/pull/95#issuecomment-5281416658)中的提议拆成本独立 PR，只含"恢复 main 门禁"这一件事，合入后其余 PR re-run 即可解套。

## 修复内容（3 个 commit，全部 oryxos-tool）

1. **spotless 违规**：`WhitelistSandboxMutationTest.java` 一处 lambda 换行不符合 google-java-format，`spotless:apply` 修复。
2. **SpotBugs 3 个 bug**：
   - `COMMAND_INJECTION`（ShellTools）：以 argv 直接执行、不经 shell 解释，可执行文件在启动前经 Sandbox 白名单校验——属误报，按仓库惯例加方法级 `@SuppressFBWarnings` + justification。注意 lambda 编译成 synthetic 方法、注解盖不住，故把默认 ProcessStarter 抽成命名静态方法让注解落在告警位置上。
   - `UPM_UNCALLED_PRIVATE_METHOD`（ShellTools.killTree）：#98 重写后超时路径只 `destroyForcibly()` 主进程，killTree 成了死代码——这是真实行为回归（超时会留孤儿子进程继续执行）。恢复调用，并改用 `process.descendants()` 以便测试替身可覆写。
   - `CT_CONSTRUCTOR_THROW`（WhitelistSandbox）:构造器会因非法配置抛异常，类标 `final` 杜绝 finalizer attack（已确认无子类）。

## 验证

- 本地 `mvn verify` 全绿（oryxos-tool 18 个测试通过，含超时杀进程树的回归测试）。
- 同一组修复在 #95 分支上已被 CI（temurin 21 实跑 SpotBugs）验证通过：[run 31707111603](https://github.com/oryx-labs/oryxos/actions/runs/31707111603) 双 job SUCCESS。

## 合并后

- #95 会 rebase 掉与本 PR 重复的 commit，收窄回纯审计主题。
- #86 等其余 open PR re-run CI 即可转绿（如 #86，其自身问题已修复，目前只被主干挡着）。
