### PR TITLE
fix(tool): recheck notify whitelist on each redirect hop

### DIFF
--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -83,6 +83,7 @@ import io.oryxos.tool.mcp.McpConfigLoader;
 import io.oryxos.tool.notify.DingTalkNotifyAdapter;
 import io.oryxos.tool.notify.FeishuNotifyAdapter;
 import io.oryxos.tool.notify.NotifyChannelAdapter;
+import io.oryxos.tool.notify.NotifyPoster;
 import io.oryxos.tool.notify.WeComNotifyAdapter;
 import io.oryxos.tool.notify.WebhookNotifyAdapter;
 import io.oryxos.tool.sandbox.FileSandboxProperties;
@@ -425,13 +426,14 @@ public class OryxOsRuntime {
         new WebSearchTools(sandbox, new DuckDuckGoSearchProvider(restClient)));
     // chat 是交互终端，ask_user 读控制台；serve/gateway 无人值守时应换 UnsupportedUserInteraction
     registry.registerAnnotated(new InteractionTools(new ConsoleUserInteraction()));
-    // notify（19 节 OryxTool 形态）直接注册——渠道实现按 channelType 路由
+    // notify（19 节 OryxTool 形态）直接注册——渠道实现按 channelType 路由；出网经 NotifyPoster 逐跳复检白名单
+    NotifyPoster notifyPoster = new NotifyPoster(sandbox);
     Map<String, NotifyChannelAdapter> notifyAdapters =
         Map.of(
-            "webhook", new WebhookNotifyAdapter(restClient),
-            "wecom", new WeComNotifyAdapter(restClient),
-            "feishu", new FeishuNotifyAdapter(restClient),
-            "dingtalk", new DingTalkNotifyAdapter(restClient));
+            "webhook", new WebhookNotifyAdapter(notifyPoster),
+            "wecom", new WeComNotifyAdapter(notifyPoster),
+            "feishu", new FeishuNotifyAdapter(notifyPoster),
+            "dingtalk", new DingTalkNotifyAdapter(notifyPoster));
     registry.register(new NotifyTools(notifyAdapters, sandbox, notifyChannelRegistry));
     // 记忆工具：save_memory / recall_memory（补齐 20 节预留的两工具面），只认门面对后端无感
     registry.registerAnnotated(new MemoryTools(memoryService));

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
@@ -52,14 +52,6 @@ public class ShellTools {
     this.processStarter = Objects.requireNonNull(processStarter, "processStarter 不能为空");
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "COMMAND_INJECTION",
-      justification =
-          "ProcessBuilder 以 argv 列表启动，不经 shell；可执行文件在 shell() 内经 Sandbox 精确白名单校验后再 start")
-  private static Process startProcess(List<String> command) throws IOException {
-    return new ProcessBuilder(command).start();
-  }
-
   @Tool(name = "shell", description = "执行一个已获许可的可执行文件，返回标准输出")
   public String shell(
       @ToolParam(description = "要执行的、已在白名单中的可执行文件") String executable,

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/DingTalkNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/DingTalkNotifyAdapter.java
@@ -7,8 +7,6 @@ import java.util.Base64;
 import java.util.Map;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import org.springframework.http.MediaType;
-import org.springframework.web.client.RestClient;
 
 /**
  * 钉钉自定义机器人（type: dingtalk）。
@@ -16,13 +14,15 @@ import org.springframework.web.client.RestClient;
  * <p>body 格式：{@code {"msgtype":"text","text":{"content":"..."}}}。钉钉机器人必须启用一种安全设置：
  * "自定义关键词"最省事（把关键词写进 Skill 输出要求即可，本实现零处理）；若群里开的是"加签"， 在 config 里配 {@code secret}（走 ${ENV}
  * 占位），发送时按官方算法拼 timestamp+sign 到 URL。
+ *
+ * <p>出网经 {@link NotifyPoster}：禁自动重定向并每跳复检域名白名单。
  */
 public class DingTalkNotifyAdapter implements NotifyChannelAdapter {
 
-  private final RestClient restClient;
+  private final NotifyPoster poster;
 
-  public DingTalkNotifyAdapter(RestClient restClient) {
-    this.restClient = restClient.mutate().build();
+  public DingTalkNotifyAdapter(NotifyPoster poster) {
+    this.poster = poster;
   }
 
   @Override
@@ -35,13 +35,7 @@ public class DingTalkNotifyAdapter implements NotifyChannelAdapter {
     if (secret != null && !secret.isBlank()) {
       url = appendSignature(url, secret);
     }
-    restClient
-        .post()
-        .uri(url)
-        .contentType(MediaType.APPLICATION_JSON)
-        .body(Map.of("msgtype", "text", "text", Map.of("content", content)))
-        .retrieve()
-        .toBodilessEntity();
+    poster.postJson(url, Map.of("msgtype", "text", "text", Map.of("content", content)));
   }
 
   /** 钉钉"加签"安全设置：sign = urlEncode(base64(HmacSHA256(timestamp + "\n" + secret, secret)))。 */

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/FeishuNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/FeishuNotifyAdapter.java
@@ -1,21 +1,21 @@
 package io.oryxos.tool.notify;
 
 import java.util.Map;
-import org.springframework.http.MediaType;
-import org.springframework.web.client.RestClient;
 
 /**
  * 飞书 / Lark 自定义机器人（type: feishu）。
  *
  * <p>二者协议相同、仅域名不同（open.feishu.cn / open.larksuite.com），URL 来自配置故一个实现覆盖两者。 body 格式：{@code
  * {"msg_type":"text","content":{"text":"..."}}}；签名校验为可选项，未开启时拿 URL 即可推。
+ *
+ * <p>出网经 {@link NotifyPoster}：禁自动重定向并每跳复检域名白名单。
  */
 public class FeishuNotifyAdapter implements NotifyChannelAdapter {
 
-  private final RestClient restClient;
+  private final NotifyPoster poster;
 
-  public FeishuNotifyAdapter(RestClient restClient) {
-    this.restClient = restClient.mutate().build();
+  public FeishuNotifyAdapter(NotifyPoster poster) {
+    this.poster = poster;
   }
 
   @Override
@@ -24,12 +24,6 @@ public class FeishuNotifyAdapter implements NotifyChannelAdapter {
     if (url == null || url.isBlank()) {
       throw new IllegalArgumentException("feishu 渠道缺少 url 配置（notify_channels 条目需要 url 键）");
     }
-    restClient
-        .post()
-        .uri(url)
-        .contentType(MediaType.APPLICATION_JSON)
-        .body(Map.of("msg_type", "text", "content", Map.of("text", content)))
-        .retrieve()
-        .toBodilessEntity();
+    poster.postJson(url, Map.of("msg_type", "text", "content", Map.of("text", content)));
   }
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyPoster.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyPoster.java
@@ -1,0 +1,65 @@
+package io.oryxos.tool.notify;
+
+import io.oryxos.tool.sandbox.ActionType;
+import io.oryxos.tool.sandbox.Sandbox;
+import io.oryxos.tool.sandbox.SandboxAction;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.Objects;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+/**
+ * 通知推送共用 HTTP 出口：禁自动重定向，手动逐跳跟随并对<strong>每一跳</strong>过 {@code HTTP_REQUEST} 域名白名单——杜绝「白名单内 webhook
+ * 入口 302 到白名单外 / 内网」的绕过（与 {@code HttpTools} 写路径同策略）。
+ */
+public final class NotifyPoster {
+
+  private static final int MAX_REDIRECTS = 5;
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(20);
+
+  private final Sandbox sandbox;
+  private final RestClient hopClient;
+
+  public NotifyPoster(Sandbox sandbox) {
+    this.sandbox = Objects.requireNonNull(sandbox, "sandbox 不能为空");
+    JdkClientHttpRequestFactory hopFactory =
+        new JdkClientHttpRequestFactory(
+            HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build());
+    hopFactory.setReadTimeout(READ_TIMEOUT);
+    this.hopClient = RestClient.builder().requestFactory(hopFactory).build();
+  }
+
+  /** POST JSON body 到 url；3xx 时跟随 Location，每跳先过沙箱。 */
+  public void postJson(String url, Object body) {
+    String current = url;
+    for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, current));
+      ResponseEntity<Void> resp =
+          hopClient
+              .post()
+              .uri(current)
+              .contentType(MediaType.APPLICATION_JSON)
+              .body(body)
+              .retrieve()
+              .toBodilessEntity();
+      if (resp.getStatusCode().is3xxRedirection()) {
+        String location = resp.getHeaders().getFirst("Location");
+        if (location == null || location.isBlank()) {
+          return;
+        }
+        current = URI.create(current).resolve(location).toString();
+        continue;
+      }
+      return;
+    }
+    throw new IllegalStateException("通知推送重定向次数过多，拒绝: " + url);
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/WeComNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/WeComNotifyAdapter.java
@@ -1,21 +1,21 @@
 package io.oryxos.tool.notify;
 
 import java.util.Map;
-import org.springframework.http.MediaType;
-import org.springframework.web.client.RestClient;
 
 /**
  * 企业微信群机器人（type: wecom）。
  *
  * <p>webhook 形态与通用档相同，仅 body 格式不同：{@code {"msgtype":"text","text":{"content":"..."}}}。
  * 注意这是"群机器人"档——"应用消息"（corpid/corpsecret 换 AccessToken）属扩展阶段，不在此。
+ *
+ * <p>出网经 {@link NotifyPoster}：禁自动重定向并每跳复检域名白名单。
  */
 public class WeComNotifyAdapter implements NotifyChannelAdapter {
 
-  private final RestClient restClient;
+  private final NotifyPoster poster;
 
-  public WeComNotifyAdapter(RestClient restClient) {
-    this.restClient = restClient.mutate().build();
+  public WeComNotifyAdapter(NotifyPoster poster) {
+    this.poster = poster;
   }
 
   @Override
@@ -24,12 +24,6 @@ public class WeComNotifyAdapter implements NotifyChannelAdapter {
     if (url == null || url.isBlank()) {
       throw new IllegalArgumentException("wecom 渠道缺少 url 配置（notify_channels 条目需要 url 键）");
     }
-    restClient
-        .post()
-        .uri(url)
-        .contentType(MediaType.APPLICATION_JSON)
-        .body(Map.of("msgtype", "text", "text", Map.of("content", content)))
-        .retrieve()
-        .toBodilessEntity();
+    poster.postJson(url, Map.of("msgtype", "text", "text", Map.of("content", content)));
   }
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/WebhookNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/WebhookNotifyAdapter.java
@@ -1,21 +1,20 @@
 package io.oryxos.tool.notify;
 
 import java.util.Map;
-import org.springframework.http.MediaType;
-import org.springframework.web.client.RestClient;
 
 /**
  * 核心阶段唯一实现：通用 webhook——企业微信/飞书/钉钉的群机器人都收 webhook， 一档覆盖大部分场景，不逐家接签名算法与 AccessToken 刷新（留扩展阶段）。
  *
  * <p>失败口径（research D2）：对端非 2xx 走 RestClient 默认异常上抛、连接失败同样上抛—— "发出去没送到"与"没发出去"对 Agent 是同一件事，绝不静默吞掉。
+ *
+ * <p>出网经 {@link NotifyPoster}：禁自动重定向并每跳复检域名白名单。
  */
 public class WebhookNotifyAdapter implements NotifyChannelAdapter {
 
-  private final RestClient restClient;
+  private final NotifyPoster poster;
 
-  public WebhookNotifyAdapter(RestClient restClient) {
-    // 防御性副本：不持有调用方可继续改动的实例（SpotBugs EI_EXPOSE_REP2）
-    this.restClient = restClient.mutate().build();
+  public WebhookNotifyAdapter(NotifyPoster poster) {
+    this.poster = poster;
   }
 
   @Override
@@ -24,12 +23,6 @@ public class WebhookNotifyAdapter implements NotifyChannelAdapter {
     if (url == null || url.isBlank()) {
       throw new IllegalArgumentException("webhook 渠道缺少 url 配置（notify_channels 条目需要 url 键）");
     }
-    restClient
-        .post()
-        .uri(url)
-        .contentType(MediaType.APPLICATION_JSON)
-        .body(Map.of("content", content))
-        .retrieve()
-        .toBodilessEntity();
+    poster.postJson(url, Map.of("content", content));
   }
 }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
+import io.oryxos.tool.sandbox.PermissiveSandbox;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
@@ -18,7 +19,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
 /**
@@ -35,6 +35,7 @@ class VendorNotifyAdapterTest {
   private HttpServer server;
   private final List<ReceivedRequest> received = new ArrayList<>();
   private volatile int responseStatus = 200;
+  private NotifyPoster poster;
 
   @BeforeEach
   void startFakeWebhook() throws IOException {
@@ -45,6 +46,7 @@ class VendorNotifyAdapterTest {
           record(exchange);
         });
     server.start();
+    poster = new NotifyPoster(new PermissiveSandbox());
   }
 
   @AfterEach
@@ -70,8 +72,7 @@ class VendorNotifyAdapterTest {
   @Test
   @DisplayName("企业微信：msgtype/text.content 格式")
   void wecomBodyMatchesVendorContract() throws IOException {
-    new WeComNotifyAdapter(RestClient.create())
-        .send(new NotifyTarget("wecom", Map.of("url", url())), "日报来了");
+    new WeComNotifyAdapter(poster).send(new NotifyTarget("wecom", Map.of("url", url())), "日报来了");
 
     JsonNode body = lastBody();
     assertEquals("text", body.get("msgtype").asText());
@@ -81,8 +82,7 @@ class VendorNotifyAdapterTest {
   @Test
   @DisplayName("飞书/Lark：msg_type/content.text 格式")
   void feishuBodyMatchesVendorContract() throws IOException {
-    new FeishuNotifyAdapter(RestClient.create())
-        .send(new NotifyTarget("feishu", Map.of("url", url())), "日报来了");
+    new FeishuNotifyAdapter(poster).send(new NotifyTarget("feishu", Map.of("url", url())), "日报来了");
 
     JsonNode body = lastBody();
     assertEquals("text", body.get("msg_type").asText());
@@ -92,7 +92,7 @@ class VendorNotifyAdapterTest {
   @Test
   @DisplayName("钉钉：msgtype/text.content 格式（关键词模式，无签名参数）")
   void dingTalkBodyMatchesVendorContract() throws IOException {
-    new DingTalkNotifyAdapter(RestClient.create())
+    new DingTalkNotifyAdapter(poster)
         .send(new NotifyTarget("dingtalk", Map.of("url", url())), "OryxOS日报来了");
 
     JsonNode body = lastBody();
@@ -104,7 +104,7 @@ class VendorNotifyAdapterTest {
   @Test
   @DisplayName("钉钉加签：config 含 secret 时 URL 拼 timestamp+sign")
   void dingTalkSignedUrlCarriesTimestampAndSign() {
-    new DingTalkNotifyAdapter(RestClient.create())
+    new DingTalkNotifyAdapter(poster)
         .send(new NotifyTarget("dingtalk", Map.of("url", url(), "secret", "test-secret")), "hi");
 
     String query = received.get(0).query();
@@ -119,8 +119,7 @@ class VendorNotifyAdapterTest {
     NotifyTarget target = new NotifyTarget("wecom", Map.of("url", url()));
 
     assertThrows(
-        RestClientResponseException.class,
-        () -> new WeComNotifyAdapter(RestClient.create()).send(target, "hi"));
+        RestClientResponseException.class, () -> new WeComNotifyAdapter(poster).send(target, "hi"));
   }
 
   @Test
@@ -128,9 +127,7 @@ class VendorNotifyAdapterTest {
   void vendorAdaptersFailFastOnMissingUrl() {
     assertThrows(
         IllegalArgumentException.class,
-        () ->
-            new FeishuNotifyAdapter(RestClient.create())
-                .send(new NotifyTarget("feishu", Map.of()), "hi"));
+        () -> new FeishuNotifyAdapter(poster).send(new NotifyTarget("feishu", Map.of()), "hi"));
     assertEquals(0, received.size());
   }
 }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/notify/WebhookNotifyAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/notify/WebhookNotifyAdapterTest.java
@@ -6,17 +6,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
+import io.oryxos.tool.sandbox.FileSandboxProperties;
+import io.oryxos.tool.sandbox.HttpSandboxProperties;
+import io.oryxos.tool.sandbox.PermissiveSandbox;
+import io.oryxos.tool.sandbox.SandboxViolationException;
+import io.oryxos.tool.sandbox.ShellSandboxProperties;
+import io.oryxos.tool.sandbox.WhitelistSandbox;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
 /**
@@ -40,7 +46,7 @@ class WebhookNotifyAdapterTest {
     server = HttpServer.create(new InetSocketAddress(0), 0);
     server.createContext("/", this::record);
     server.start();
-    adapter = new WebhookNotifyAdapter(RestClient.create());
+    adapter = new WebhookNotifyAdapter(new NotifyPoster(new PermissiveSandbox()));
   }
 
   @AfterEach
@@ -107,5 +113,48 @@ class WebhookNotifyAdapterTest {
 
     assertTrue(ex.getMessage().contains("url"), "报错点名缺失的配置键");
     assertEquals(0, received.size(), "零请求发出");
+  }
+
+  @Test
+  @DisplayName("白名单内入口 302 到白名单外应被拦下（通知推送逐跳复检）")
+  void redirectOutsideWhitelistIsBlocked() throws IOException {
+    HttpServer entry = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    HttpServer sink = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    AtomicInteger sinkHits = new AtomicInteger();
+    try {
+      sink.createContext(
+          "/",
+          exchange -> {
+            sinkHits.incrementAndGet();
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+          });
+      String sinkUrl = "http://127.0.0.1:" + sink.getAddress().getPort() + "/sink";
+      entry.createContext(
+          "/",
+          exchange -> {
+            exchange.getResponseHeaders().add("Location", sinkUrl);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+          });
+      entry.start();
+      sink.start();
+
+      WebhookNotifyAdapter guarded =
+          new WebhookNotifyAdapter(
+              new NotifyPoster(
+                  new WhitelistSandbox(
+                      new FileSandboxProperties(List.of()),
+                      new ShellSandboxProperties(List.of()),
+                      new HttpSandboxProperties(List.of("localhost")))));
+      String start = "http://localhost:" + entry.getAddress().getPort() + "/";
+
+      assertThrows(
+          SandboxViolationException.class, () -> guarded.send(webhookTarget(start), "leaked"));
+      assertEquals(0, sinkHits.get(), "重定向目标不在白名单，请求不该到达 sink");
+    } finally {
+      entry.stop(0);
+      sink.stop(0);
+    }
   }
 }


### PR DESCRIPTION
Notify adapters used RestClient auto-follow after a single HTTP_REQUEST check on the configured URL. Route POSTs through NotifyPoster (NEVER + per-hop enforce). Also drop duplicate startProcess left on main.

Fixes #116

## Summary
- Route notify POSTs through NotifyPoster: Redirect.NEVER + per-hop HTTP_REQUEST enforce
- Regression: whitelist localhost → 302 → 127.0.0.1 sink blocked
- Remove duplicate startProcess on main (#108/#115 merge residue)

## Test plan
- [x] WebhookNotifyAdapterTest / VendorNotifyAdapterTest / NotifyToolsTest