### PR TITLE
fix(cli): decode console stdin with console/default charset

### DIFF
--- a/oryxos-channel-cli/src/main/java/io/oryxos/channel/cli/CliChannel.java
+++ b/oryxos-channel-cli/src/main/java/io/oryxos/channel/cli/CliChannel.java
@@ -4,17 +4,21 @@ import io.oryxos.core.agent.AgentService;
 import io.oryxos.core.session.Session;
 import io.oryxos.core.session.SessionManager;
 import java.io.BufferedReader;
+import java.io.Console;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 
 /**
  * chat 命令的交互通道：读 stdin、写 stdout，维护当前 Session，每行交给引擎，{@code /quit} 退出。
  *
  * <p>CLI 是消息进出的门，不是干活的人——本类没有任何 Agent 智能，就是读—转交—打印的壳（课件骨架）。 channel 字面量 "cli" 只作为三元组参数提供，session_id
  * 拼接在 SessionManager 内部（H4④）。
+ *
+ * <p>stdin 编码：有 {@link System#console()} 用 console reader；否则 {@link Charset#defaultCharset()}。不硬编码
+ * UTF-8。
  */
 public class CliChannel {
 
@@ -32,8 +36,7 @@ public class CliChannel {
     Session session = sessionManager.getOrCreate("cli", userId, profileName);
     PrintStream out = System.out;
     out.printf("已连接 Agent [%s]，输入 %s 退出。%n", profileName, QUIT);
-    BufferedReader in =
-        new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
+    BufferedReader in = stdinReader();
     while (true) {
       out.print("> ");
       String line = readLine(in);
@@ -48,6 +51,20 @@ public class CliChannel {
       String reply = agentService.process(session, line);
       out.println(reply);
     }
+  }
+
+  /** 可见给单测：解析 stdin 的 reader 选择策略。 */
+  static BufferedReader stdinReader() {
+    Console console = System.console();
+    if (console != null) {
+      return new BufferedReader(console.reader());
+    }
+    return new BufferedReader(new InputStreamReader(System.in, stdinFallbackCharset()));
+  }
+
+  /** 无 {@link System#console()} 时的回退编码——跟 JVM 默认，不写死 UTF-8。 */
+  static Charset stdinFallbackCharset() {
+    return Charset.defaultCharset();
   }
 
   private static String readLine(BufferedReader in) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/interaction/ConsoleUserInteraction.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/interaction/ConsoleUserInteraction.java
@@ -1,17 +1,21 @@
 package io.oryxos.tool.interaction;
 
 import java.io.BufferedReader;
+import java.io.Console;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 
 /**
  * CLI 场景的交互实现：把问题打到终端、读用户输入的一行。
  *
  * <p>与 chat 循环共用同一终端；因 ReAct 循环同步执行，ask_user 期间的读行不会与对话读行并发争抢。
+ *
+ * <p>读入编码：有 {@link System#console()} 时走 console reader（跟随控制台编码）；否则用 {@link
+ * Charset#defaultCharset()}（Windows 上多为 GBK/GB18030）。禁止再硬编码 UTF-8 解 {@code System.in}——会把本地中文打成乱码。
  */
 public class ConsoleUserInteraction implements UserInteraction {
 
@@ -19,15 +23,29 @@ public class ConsoleUserInteraction implements UserInteraction {
   private final PrintStream out;
 
   public ConsoleUserInteraction() {
-    this(System.in, System.out);
+    Console console = System.console();
+    if (console != null) {
+      this.in = new BufferedReader(console.reader());
+      this.out = System.out;
+    } else {
+      // IDE / 管道 / 无 console 时：跟 JVM 默认 charset（native.encoding），不是 UTF-8 常量
+      this.in = new BufferedReader(new InputStreamReader(System.in, Charset.defaultCharset()));
+      this.out = System.out;
+    }
   }
 
+  /** 测试 / 注入用：按指定 charset 解输入流（生产默认构造见无参）。 */
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "EI_EXPOSE_REP2",
       justification = "交互实现必须持有输出流引用向用户打印问题；流的生命周期由调用方（终端 / 测试）管理")
-  public ConsoleUserInteraction(InputStream in, PrintStream out) {
-    this.in = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+  public ConsoleUserInteraction(InputStream in, PrintStream out, Charset charset) {
+    this.in = new BufferedReader(new InputStreamReader(in, charset));
     this.out = out;
+  }
+
+  /** 注入流时跟 JVM 默认 charset（与无 console 的生产回退一致）。需要 UTF-8 fixture 请用三参构造。 */
+  public ConsoleUserInteraction(InputStream in, PrintStream out) {
+    this(in, out, Charset.defaultCharset());
   }
 
   @Override

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/InteractionToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/InteractionToolsTest.java
@@ -10,6 +10,7 @@ import io.oryxos.tool.interaction.UnsupportedUserInteraction;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,8 @@ class InteractionToolsTest {
     var out = new ByteArrayOutputStream();
     InteractionTools tools =
         new InteractionTools(
-            new ConsoleUserInteraction(in, new PrintStream(out, true, StandardCharsets.UTF_8)));
+            new ConsoleUserInteraction(
+                in, new PrintStream(out, true, StandardCharsets.UTF_8), StandardCharsets.UTF_8));
 
     String answer = tools.askUser("你希望什么时候开会？");
 
@@ -47,8 +49,21 @@ class InteractionToolsTest {
     var out = new ByteArrayOutputStream();
     InteractionTools tools =
         new InteractionTools(
-            new ConsoleUserInteraction(in, new PrintStream(out, true, StandardCharsets.UTF_8)));
+            new ConsoleUserInteraction(
+                in, new PrintStream(out, true, StandardCharsets.UTF_8), StandardCharsets.UTF_8));
 
     assertThrows(InteractionUnavailableException.class, () -> tools.askUser("在吗？"));
+  }
+
+  @Test
+  @DisplayName("按本地 charset（如 GBK）解码 stdin，中文不因硬编码 UTF-8 乱码")
+  void askUserDecodesWithExplicitLocalCharset() {
+    Charset gbk = Charset.forName("GBK");
+    var in = new ByteArrayInputStream("周三下午\n".getBytes(gbk));
+    var out = new ByteArrayOutputStream();
+    InteractionTools tools =
+        new InteractionTools(new ConsoleUserInteraction(in, new PrintStream(out, true, gbk), gbk));
+
+    assertEquals("周三下午", tools.askUser("时间？"));
   }
 }


### PR DESCRIPTION
Hard-coded UTF-8 on System.in garbles Chinese on GBK Windows consoles. Prefer System.console().reader(); otherwise Charset.defaultCharset().

Fixes #120

## Summary
- Prefer System.console().reader(); else Charset.defaultCharset() for stdin
- CliChannel + ConsoleUserInteraction
- GBK round-trip regression in InteractionToolsTest

## Test plan
- [x] InteractionToolsTest (incl. askUserDecodesWithExplicitLocalCharset)