### PR TITLE
fix(tool): default notify channel from global registry

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
@@ -19,10 +19,10 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
- * 内置工具 notify：把一条消息推送到当前 Agent 配置好的通知渠道。
+ * 内置工具 notify：把一条消息推送到通知渠道。
  *
- * <p>OryxTool 形态（research D3）：@Tool 注册机制归 20 节，本形态可直接被 17 节 ToolExecutor 执行与审计（tool_invocations
- * 走既有路径，不新增审计逻辑）。渠道来源是当前 Profile 的 notify_channels——webhook 地址是运行时配置，不是模型需要知道的信息（FR-005）。
+ * <p>31 节起优先按<strong>全局注册表渠道名</strong>解析；缺省 / {@code default} 取注册表第一个。仍兼容 Profile 内联 {@code
+ * notify_channels}（按 type 匹配）的老模型。
  */
 public class NotifyTools implements OryxTool {
 
@@ -35,7 +35,7 @@ public class NotifyTools implements OryxTool {
   /** 推送前过 HTTP 域名白名单（宪法 VI）——与 http_post 共享同一份 http.allowed_domains（24 节接线）。 */
   private final Sandbox sandbox;
 
-  /** 全局通知渠道注册表（31 节）：channel 传渠道名时按它解析成 {type,url}，不再依赖 AGENT.md 内联。 */
+  /** 全局通知渠道注册表（31 节）：按名解析成 {type,url}。 */
   private final NotifyChannelRegistry channelRegistry;
 
   @SuppressFBWarnings(
@@ -74,7 +74,7 @@ public class NotifyTools implements OryxTool {
           "type": "object",
           "properties": {
             "content": {"type": "string", "description": "要推送的内容"},
-            "channel": {"type": "string", "description": "渠道类型；缺省用第一个配置的渠道"}
+            "channel": {"type": "string", "description": "渠道名（全局 Notify 注册表中的 name）；缺省或 default 用注册表第一个渠道"}
           },
           "required": ["content"]
         }""";
@@ -86,37 +86,36 @@ public class NotifyTools implements OryxTool {
     if (contentNode == null || contentNode.asText().isEmpty()) {
       return ToolResult.error("notify 缺少必填参数 content", false);
     }
+    String content = contentNode.asText();
     String channel = input.hasNonNull("channel") ? input.get("channel").asText() : null;
+    boolean useDefault = channel == null || channel.isBlank() || DEFAULT_CHANNEL.equals(channel);
 
-    // 新模型（31 节）：channel 是全局注册表里的渠道名 → 按名解析成 {type,url}，与 Agent 内联配置无关。
-    // Agent 正文用自然语言指定"发到 <渠道名>"，模型把名字传进来即可。
-    if (channel != null && !channel.isBlank()) {
+    // 新模型（31 节）：注册表优先——缺省取第一个；显式名则 find
+    if (useDefault) {
+      List<NotifyChannelDef> registered = channelRegistry.list();
+      if (!registered.isEmpty()) {
+        return sendRegistered(registered.get(0), content);
+      }
+    } else {
       Optional<NotifyChannelDef> registered = channelRegistry.find(channel);
       if (registered.isPresent()) {
-        NotifyChannelDef def = registered.get();
-        NotifyChannelAdapter adapter = adapters.get(def.type());
-        if (adapter == null) {
-          return ToolResult.error(
-              "渠道 " + def.name() + " 的类型 " + def.type() + " 没有对应实现（已装配: " + adapters.keySet() + "）",
-              false);
-        }
-        // 校验先于发送（宪法 VI）：推送地址过 HTTP 域名白名单，与 http_post 共享 http.allowed_domains。
-        sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, def.url()));
-        adapter.send(new NotifyTarget(def.type(), Map.of("url", def.url())), contentNode.asText());
-        return ToolResult.ok("已推送");
+        return sendRegistered(registered.get(), content);
       }
-      // channel 给了名字但注册表没有 → 落到下面的兼容路径（按 type 匹配 Agent 内联渠道）
+      // 名字不在注册表 → 落到下面的兼容路径（按 type 匹配 Agent 内联渠道）
     }
 
-    // 兼容老模型：从当前 Profile 的内联 notify_channels 解析（channel 为空或按 type 匹配）
+    // 兼容老模型：从当前 Profile 的内联 notify_channels 解析
     Profile profile = ProfileContext.current();
     if (profile == null) {
-      return ToolResult.error("当前无 Agent 上下文，无法解析通知渠道", false);
+      return ToolResult.error("当前无已注册通知渠道，且无 Agent 上下文可解析内联 notify_channels", false);
     }
     List<Profile.NotifyChannel> channels = profile.notifyChannels();
     if (channels.isEmpty()) {
-      // 明确报错而非静默失败——Agent 不能以为发出去了（课件守点）
-      return ToolResult.error("Profile " + profile.name() + " 未配置 notify_channels，无处可推", false);
+      return ToolResult.error(
+          "无已注册通知渠道，且 Profile "
+              + profile.name()
+              + " 未配置 notify_channels——去管理台「Notify 渠道」新建，或配置内联渠道",
+          false);
     }
     Profile.NotifyChannel resolved = resolveChannel(channels, channel);
     if (resolved == null) {
@@ -128,11 +127,20 @@ public class NotifyTools implements OryxTool {
           "渠道类型 " + resolved.type() + " 没有对应的通知实现（已装配: " + adapters.keySet() + "）", false);
     }
     NotifyTarget target = new NotifyTarget(resolved.type(), resolved.config());
-    // 校验必须先于发送（宪法 VI）：推送地址过 HTTP 域名白名单，与 http_post 共享同一份 http.allowed_domains。
-    // enforce 不过抛 SandboxViolationException 不 catch——上抛至 ToolExecutor 走既有失败审计（success=false），
-    // 与 FileTools/HttpTools 同一路径，不为校验单独新增审计逻辑。
     sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, resolved.config().get("url")));
-    adapter.send(target, contentNode.asText());
+    adapter.send(target, content);
+    return ToolResult.ok("已推送");
+  }
+
+  private ToolResult sendRegistered(NotifyChannelDef def, String content) {
+    NotifyChannelAdapter adapter = adapters.get(def.type());
+    if (adapter == null) {
+      return ToolResult.error(
+          "渠道 " + def.name() + " 的类型 " + def.type() + " 没有对应实现（已装配: " + adapters.keySet() + "）",
+          false);
+    }
+    sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, def.url()));
+    adapter.send(new NotifyTarget(def.type(), Map.of("url", def.url())), content);
     return ToolResult.ok("已推送");
   }
 

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/NotifyToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/NotifyToolsTest.java
@@ -99,6 +99,53 @@ class NotifyToolsTest {
             eq("今日北京天气 + 穿搭建议"));
   }
 
+  @Test
+  @DisplayName("channel 缺省且注册表非空_取注册表第一个（不依赖 Profile 内联）")
+  void omittedChannelUsesFirstRegistryEntry() {
+    NotifyChannelRegistry registry = mock(NotifyChannelRegistry.class);
+    when(registry.list())
+        .thenReturn(
+            List.of(
+                new NotifyChannelDef("team-lark", "feishu", "https://open.feishu.cn/hook/x", "团队群"),
+                new NotifyChannelDef("ops-hook", "webhook", "https://hooks.example.com/a", null)));
+    when(registry.find(any())).thenReturn(java.util.Optional.empty());
+    NotifyTools tools =
+        new NotifyTools(
+            Map.of("feishu", adapter, "webhook", adapter), new PermissiveSandbox(), registry);
+    var input = MAPPER.createObjectNode();
+    input.put("content", "hello");
+
+    ToolResult result = tools.execute(input);
+
+    assertTrue(result.success(), "缺省应落到注册表第一个渠道");
+    verify(adapter)
+        .send(
+            argThat(
+                t ->
+                    "feishu".equals(t.channelType())
+                        && "https://open.feishu.cn/hook/x".equals(t.config().get("url"))),
+            eq("hello"));
+  }
+
+  @Test
+  @DisplayName("channel 传 default 且注册表非空_等同缺省取注册表第一个")
+  void defaultLiteralUsesFirstRegistryEntry() {
+    NotifyChannelRegistry registry = mock(NotifyChannelRegistry.class);
+    when(registry.list())
+        .thenReturn(
+            List.of(
+                new NotifyChannelDef(
+                    "team-lark", "feishu", "https://open.feishu.cn/hook/x", null)));
+    NotifyTools tools =
+        new NotifyTools(Map.of("feishu", adapter), new PermissiveSandbox(), registry);
+    var input = MAPPER.createObjectNode();
+    input.put("content", "hello");
+    input.put("channel", "default");
+
+    assertTrue(tools.execute(input).success());
+    verify(adapter).send(argThat(t -> "feishu".equals(t.channelType())), eq("hello"));
+  }
+
   private static Profile profileWith(List<Profile.NotifyChannel> channels) {
     return new Profile(
         "ops-agent",


### PR DESCRIPTION
Omit/default previously skipped the registry and required Profile inline notify_channels. Prefer registry.list().get(0); keep inline as fallback.

Fixes #122

## Summary
- Omit/`default` uses first registered notify channel
- Fall back to Profile inline notify_channels only if registry empty
- Align schema: 渠道名 + registry default

## Test plan
- [x] NotifyToolsTest (omittedChannelUsesFirstRegistryEntry / defaultLiteralUsesFirstRegistryEntry)