### PR TITLE
fix(sandbox): block NAT64/IPv4-mapped embeds in SSRF guard

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -220,17 +220,68 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
       throw new SandboxViolationException("无法解析主机: " + host + "。请检查地址是否正确，勿反复重试。");
     }
     for (InetAddress addr : addresses) {
-      if (addr.isLoopbackAddress()
-          || addr.isAnyLocalAddress()
-          || addr.isLinkLocalAddress()
-          || addr.isSiteLocalAddress()
-          || addr.isMulticastAddress()
-          || isCarrierGradeNat(addr)
-          || isIpv6UniqueLocal(addr)) {
+      if (isBlockedSsrfAddress(addr)) {
         throw new SandboxViolationException(
             "拒绝访问内网 / 保留地址（SSRF 防护）: " + host + " → " + addr.getHostAddress() + "。这是安全策略，请勿重试。");
       }
     }
+  }
+
+  /**
+   * 对解析结果做 SSRF 分类。IPv4-mapped（{@code ::ffff:0:0/96}）与 NAT64 知名前缀（{@code 64:ff9b::/96}）先展开末 32 位
+   * IPv4，再套用回环/链路本地/站点内网/CGNAT 等判定——否则 {@code [64:ff9b::169.254.169.254]} 会以「公网 IPv6」放行。
+   */
+  private static boolean isBlockedSsrfAddress(InetAddress addr) {
+    InetAddress effective = unwrapEmbeddedIpv4(addr);
+    return effective.isLoopbackAddress()
+        || effective.isAnyLocalAddress()
+        || effective.isLinkLocalAddress()
+        || effective.isSiteLocalAddress()
+        || effective.isMulticastAddress()
+        || isCarrierGradeNat(effective)
+        || isIpv6UniqueLocal(addr);
+  }
+
+  /**
+   * 若为 IPv4-mapped 或 NAT64 well-known prefix，返回嵌入的 IPv4；否则原样返回。JDK 常把 mapped 字面量直接解成
+   * {@link java.net.Inet4Address}，此展开主要兜住仍以 16 字节返回的形态与 NAT64。
+   */
+  private static InetAddress unwrapEmbeddedIpv4(InetAddress addr) {
+    byte[] b = addr.getAddress();
+    if (b.length != 16 || (!isIpv4MappedPrefix(b) && !isNat64WellKnownPrefix(b))) {
+      return addr;
+    }
+    try {
+      return InetAddress.getByAddress(new byte[] {b[12], b[13], b[14], b[15]});
+    } catch (UnknownHostException e) {
+      return addr; // 4 字节形式不会失败；保底不改变判定输入
+    }
+  }
+
+  /** {@code ::ffff:0:0/96}——前 10 字节为 0，第 11–12 字节为 {@code 0xff}。 */
+  private static boolean isIpv4MappedPrefix(byte[] b) {
+    for (int i = 0; i < 10; i++) {
+      if (b[i] != 0) {
+        return false;
+      }
+    }
+    return (b[10] & 0xFF) == 0xFF && (b[11] & 0xFF) == 0xFF;
+  }
+
+  /** NAT64 知名前缀 {@code 64:ff9b::/96}（RFC 6052）。 */
+  private static boolean isNat64WellKnownPrefix(byte[] b) {
+    return (b[0] & 0xFF) == 0x00
+        && (b[1] & 0xFF) == 0x64
+        && (b[2] & 0xFF) == 0xFF
+        && (b[3] & 0xFF) == 0x9B
+        && b[4] == 0
+        && b[5] == 0
+        && b[6] == 0
+        && b[7] == 0
+        && b[8] == 0
+        && b[9] == 0
+        && b[10] == 0
+        && b[11] == 0;
   }
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
@@ -264,12 +264,22 @@ class WhitelistSandboxTest {
             "http://169.254.1.1/x",
             "http://[::1]/x", // IPv6 回环
             "http://[fd00::1]/x", // IPv6 ULA fc00::/7
+            "http://[::ffff:169.254.169.254]/x", // IPv4-mapped 云元数据
+            "http://[64:ff9b::a9fe:a9fe]/x", // NAT64 well-known → 169.254.169.254
+            "http://[64:ff9b::100.64.1.1]/x", // NAT64 → CGNAT
             "http://localhost/x"
           }) {
         assertThrows(
             SandboxViolationException.class,
             () -> sb.enforce(new SandboxAction(ActionType.HTTP_READ, url)));
       }
+    }
+
+    @Test
+    @DisplayName("NAT64 嵌入公网 IPv4 仍放行")
+    void nat64PublicIpv4Allowed() {
+      assertDoesNotThrow(
+          () -> sb.enforce(new SandboxAction(ActionType.HTTP_READ, "http://[64:ff9b::8.8.8.8]/x")));
     }
   }
 

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
@@ -213,17 +213,62 @@ public class SkillApiController {
       throw new IllegalArgumentException("无法解析主机: " + host);
     }
     for (InetAddress addr : addresses) {
-      if (addr.isLoopbackAddress()
-          || addr.isAnyLocalAddress()
-          || addr.isLinkLocalAddress()
-          || addr.isSiteLocalAddress()
-          || addr.isMulticastAddress()
-          || isCarrierGradeNat(addr)
-          || isIpv6UniqueLocal(addr)) {
+      if (isBlockedSsrfAddress(addr)) {
         throw new IllegalArgumentException(
             "拒绝访问内网 / 保留地址: " + host + " → " + addr.getHostAddress());
       }
     }
+  }
+
+  /**
+   * IPv4-mapped（{@code ::ffff:0:0/96}）与 NAT64 知名前缀（{@code 64:ff9b::/96}）先展开末 32 位 IPv4，再套用内网/元数据判定；
+   * 与 {@code WhitelistSandbox} 读路径 SSRF 兜底对齐。
+   */
+  private static boolean isBlockedSsrfAddress(InetAddress addr) {
+    InetAddress effective = unwrapEmbeddedIpv4(addr);
+    return effective.isLoopbackAddress()
+        || effective.isAnyLocalAddress()
+        || effective.isLinkLocalAddress()
+        || effective.isSiteLocalAddress()
+        || effective.isMulticastAddress()
+        || isCarrierGradeNat(effective)
+        || isIpv6UniqueLocal(addr);
+  }
+
+  private static InetAddress unwrapEmbeddedIpv4(InetAddress addr) {
+    byte[] b = addr.getAddress();
+    if (b.length != 16 || (!isIpv4MappedPrefix(b) && !isNat64WellKnownPrefix(b))) {
+      return addr;
+    }
+    try {
+      return InetAddress.getByAddress(new byte[] {b[12], b[13], b[14], b[15]});
+    } catch (UnknownHostException e) {
+      return addr;
+    }
+  }
+
+  private static boolean isIpv4MappedPrefix(byte[] b) {
+    for (int i = 0; i < 10; i++) {
+      if (b[i] != 0) {
+        return false;
+      }
+    }
+    return (b[10] & 0xFF) == 0xFF && (b[11] & 0xFF) == 0xFF;
+  }
+
+  private static boolean isNat64WellKnownPrefix(byte[] b) {
+    return (b[0] & 0xFF) == 0x00
+        && (b[1] & 0xFF) == 0x64
+        && (b[2] & 0xFF) == 0xFF
+        && (b[3] & 0xFF) == 0x9B
+        && b[4] == 0
+        && b[5] == 0
+        && b[6] == 0
+        && b[7] == 0
+        && b[8] == 0
+        && b[9] == 0
+        && b[10] == 0
+        && b[11] == 0;
   }
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/SkillImportSsrfGuardTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/SkillImportSsrfGuardTest.java
@@ -48,4 +48,26 @@ class SkillImportSsrfGuardTest {
     // 8.8.8.8 为公网 DNS；不发起真实 HTTP，只校验主机守卫
     assertDoesNotThrow(() -> SkillApiController.guardPublicHost(URI.create("https://8.8.8.8/x")));
   }
+
+  @Test
+  @DisplayName("IPv4-mapped / NAT64 嵌入内网或元数据地址被拒绝")
+  void nat64AndMappedPrivateBlocked() {
+    for (String url :
+        new String[] {
+          "http://[::ffff:169.254.169.254]/latest/meta-data/",
+          "http://[64:ff9b::a9fe:a9fe]/latest/meta-data/",
+          "http://[64:ff9b::100.64.1.1]/x"
+        }) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> SkillApiController.guardPublicHost(URI.create(url)));
+    }
+  }
+
+  @Test
+  @DisplayName("NAT64 嵌入公网 IPv4 仍放行")
+  void nat64PublicIpv4Allowed() {
+    assertDoesNotThrow(
+        () -> SkillApiController.guardPublicHost(URI.create("http://[64:ff9b::8.8.8.8]/x")));
+  }
 }


### PR DESCRIPTION
Unwrap 64:ff9b::/96 and ::ffff:0:0/96 before loopback/link/site/CGNAT checks so http_get cannot reach cloud metadata via NAT64. Align SkillApiController fetch guard; drop duplicate startProcess on main.

Fixes #126

## Summary
- Unwrap NAT64 well-known prefix (64:ff9b::/96) and IPv4-mapped (::ffff:0:0/96) before SSRF checks
- Block embedded cloud-metadata / private / CGNAT on HTTP_READ and skill-import fetch hops
- Remove duplicate startProcess on main

## Test plan
- [x] WhitelistSandboxTest$HttpReadDefaultAllow (NAT64 metadata/CGNAT blocked; public embed allowed)
- [x] SkillApiControllerTest import SSRF cases extended