### PR TITLE
fix(sandbox): require http(s) host for HTTP_READ

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/WebSearchTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/WebSearchTools.java
@@ -29,7 +29,7 @@ public class WebSearchTools {
 
   @Tool(name = "web_search", description = "用搜索引擎检索网页，返回标题、链接和摘要列表")
   public String webSearch(@ToolParam(description = "搜索关键词") String query) {
-    // 搜索是一次只读涉外请求，与 http_get 同走 HTTP_READ（默认放行 + 内网黑名单；伪目标无主机=放行）
+    // 搜索是一次只读涉外请求，与 http_get 同走 HTTP_READ；用 web_search: 伪目标（唯一允许的无主机读目标）
     sandbox.enforce(new SandboxAction(ActionType.HTTP_READ, "web_search:" + query));
     List<SearchProvider.SearchResult> results = provider.search(query);
     if (results.isEmpty()) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -48,6 +48,12 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   private static final String HTTP_SCHEME = "http";
   private static final String HTTPS_SCHEME = "https";
 
+  /** IPv6 地址字节长度；IPv4-mapped / NAT64 展开前需先确认。 */
+  private static final int IPV6_ADDRESS_LENGTH = 16;
+
+  /** {@code ::ffff:0:0/96} 前缀中必须为 0 的前缀字节数（随后两字节为 0xff）。 */
+  private static final int IPV4_MAPPED_ZERO_PREFIX_LENGTH = 10;
+
   // 具体类型 CopyOnWriteArrayList（而非 List 接口）：需要 addIfAbsent 的原子"不存在才加"语义
   private final CopyOnWriteArrayList<Path> allowedRoots = new CopyOnWriteArrayList<>();
   private final Set<String> allowedCommands = ConcurrentHashMap.newKeySet();
@@ -271,7 +277,7 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
    */
   private static InetAddress unwrapEmbeddedIpv4(InetAddress addr) {
     byte[] b = addr.getAddress();
-    if (b.length != 16 || (!isIpv4MappedPrefix(b) && !isNat64WellKnownPrefix(b))) {
+    if (!isEmbeddedIpv4Candidate(b)) {
       return addr;
     }
     try {
@@ -281,9 +287,14 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
     }
   }
 
+  /** 16 字节且带 IPv4-mapped 或 NAT64 知名前缀时，才做末 32 位展开。 */
+  private static boolean isEmbeddedIpv4Candidate(byte[] b) {
+    return b.length == IPV6_ADDRESS_LENGTH && (isIpv4MappedPrefix(b) || isNat64WellKnownPrefix(b));
+  }
+
   /** {@code ::ffff:0:0/96}——前 10 字节为 0，第 11–12 字节为 {@code 0xff}。 */
   private static boolean isIpv4MappedPrefix(byte[] b) {
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < IPV4_MAPPED_ZERO_PREFIX_LENGTH; i++) {
       if (b[i] != 0) {
         return false;
       }
@@ -330,7 +341,7 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   /** IPv6 ULA fc00::/7（唯一本地地址，isSiteLocalAddress 对 IPv6 不覆盖，单独判——否则 [fd00::1] 可绕过）。 */
   private static boolean isIpv6UniqueLocal(InetAddress addr) {
     byte[] b = addr.getAddress();
-    return b.length == 16 && (b[0] & 0xFE) == 0xFC;
+    return b.length == IPV6_ADDRESS_LENGTH && (b[0] & 0xFE) == 0xFC;
   }
 
   private String firstAllowedRoot() {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -266,8 +266,8 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   }
 
   /**
-   * 若为 IPv4-mapped 或 NAT64 well-known prefix，返回嵌入的 IPv4；否则原样返回。JDK 常把 mapped 字面量直接解成
-   * {@link java.net.Inet4Address}，此展开主要兜住仍以 16 字节返回的形态与 NAT64。
+   * 若为 IPv4-mapped 或 NAT64 well-known prefix，返回嵌入的 IPv4；否则原样返回。JDK 常把 mapped 字面量直接解成 {@link
+   * java.net.Inet4Address}，此展开主要兜住仍以 16 字节返回的形态与 NAT64。
    */
   private static InetAddress unwrapEmbeddedIpv4(InetAddress addr) {
     byte[] b = addr.getAddress();

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -42,6 +42,12 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   private static final String GOOGLE_METADATA_HOST = "metadata.google.internal";
   private static final String INTERNAL_DOMAIN_SUFFIX = ".internal";
 
+  /** {@link io.oryxos.tool.builtin.WebSearchTools} 用的伪目标前缀；无真实主机，读路径放行。 */
+  private static final String WEB_SEARCH_TARGET_PREFIX = "web_search:";
+
+  private static final String HTTP_SCHEME = "http";
+  private static final String HTTPS_SCHEME = "https";
+
   // 具体类型 CopyOnWriteArrayList（而非 List 接口）：需要 addIfAbsent 的原子"不存在才加"语义
   private final CopyOnWriteArrayList<Path> allowedRoots = new CopyOnWriteArrayList<>();
   private final Set<String> allowedCommands = ConcurrentHashMap.newKeySet();
@@ -157,11 +163,28 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
     }
   }
 
-  /** HTTP 读（GET 类）：默认放行，只挡内网/回环/云元数据等 SSRF 目标。无主机的伪目标（如 web_search）放行。 */
+  /**
+   * HTTP 读（GET 类）：默认放行，只挡内网/回环/云元数据等 SSRF 目标。仅 {@code web_search:} 伪目标可无主机；其余必须是 http/https
+   * 且带主机名——否则 {@code file://}/{@code data:} 等会因 host==null 被误放行。
+   */
   private void checkHttpRead(String url) {
-    String host = hostOf(url);
-    if (host == null) {
+    if (url != null && url.startsWith(WEB_SEARCH_TARGET_PREFIX)) {
       return;
+    }
+    URI uri;
+    try {
+      uri = URI.create(url);
+    } catch (RuntimeException e) {
+      throw new SandboxViolationException("非法 URL: " + url);
+    }
+    String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+    if (!HTTP_SCHEME.equals(scheme) && !HTTPS_SCHEME.equals(scheme)) {
+      throw new SandboxViolationException(
+          "读请求仅支持 http/https（伪目标 web_search: 除外）: " + url + "。这是安全策略，请勿重试。");
+    }
+    String host = uri.getHost();
+    if (host == null || host.isBlank()) {
+      throw new SandboxViolationException("读请求缺少主机名，拒绝: " + url);
     }
     assertNotInternalHost(host);
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -173,6 +173,10 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
    * HTTP 读（GET 类）：默认放行，只挡内网/回环/云元数据等 SSRF 目标。仅 {@code web_search:} 伪目标可无主机；其余必须是 http/https
    * 且带主机名——否则 {@code file://}/{@code data:} 等会因 host==null 被误放行。
    */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "URI scheme tokens are ASCII; Locale.ROOT lowercasing is the correct case-fold for http/https comparison.")
   private void checkHttpRead(String url) {
     if (url != null && url.startsWith(WEB_SEARCH_TARGET_PREFIX)) {
       return;

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
@@ -247,10 +247,29 @@ class WhitelistSandboxTest {
     }
 
     @Test
-    @DisplayName("无主机的伪目标（web_search）放行")
-    void hostlessReadAllowed() {
+    @DisplayName("web_search 伪目标放行")
+    void webSearchPseudoTargetAllowed() {
       assertDoesNotThrow(
           () -> sb.enforce(new SandboxAction(ActionType.HTTP_READ, "web_search:foo")));
+    }
+
+    @Test
+    @DisplayName("非 http(s) 或无主机名拒绝（不再把 host==null 一律放行）")
+    void nonHttpOrHostlessReadBlocked() {
+      for (String url :
+          new String[] {
+            "file:///etc/passwd",
+            "file:///C:/Windows/win.ini",
+            "data:text/plain,hi",
+            "ftp://example.com/x",
+            "http:///no-host",
+            "https:"
+          }) {
+        assertThrows(
+            SandboxViolationException.class,
+            () -> sb.enforce(new SandboxAction(ActionType.HTTP_READ, url)),
+            () -> url);
+      }
     }
 
     @Test

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
@@ -65,6 +65,12 @@ public class SkillApiController {
   private static final String VISIBILITY_PUBLIC = "public";
   private static final String VISIBILITY_PRIVATE = "private";
 
+  /** IPv6 地址字节长度；IPv4-mapped / NAT64 展开前需先确认。 */
+  private static final int IPV6_ADDRESS_LENGTH = 16;
+
+  /** {@code ::ffff:0:0/96} 前缀中必须为 0 的前缀字节数（随后两字节为 0xff）。 */
+  private static final int IPV4_MAPPED_ZERO_PREFIX_LENGTH = 10;
+
   private final SkillService skills;
   private final SkillCatalog catalog;
   private final AgentSkillBindingService bindings;
@@ -237,7 +243,7 @@ public class SkillApiController {
 
   private static InetAddress unwrapEmbeddedIpv4(InetAddress addr) {
     byte[] b = addr.getAddress();
-    if (b.length != 16 || (!isIpv4MappedPrefix(b) && !isNat64WellKnownPrefix(b))) {
+    if (!isEmbeddedIpv4Candidate(b)) {
       return addr;
     }
     try {
@@ -247,8 +253,13 @@ public class SkillApiController {
     }
   }
 
+  /** 16 字节且带 IPv4-mapped 或 NAT64 知名前缀时，才做末 32 位展开。 */
+  private static boolean isEmbeddedIpv4Candidate(byte[] b) {
+    return b.length == IPV6_ADDRESS_LENGTH && (isIpv4MappedPrefix(b) || isNat64WellKnownPrefix(b));
+  }
+
   private static boolean isIpv4MappedPrefix(byte[] b) {
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < IPV4_MAPPED_ZERO_PREFIX_LENGTH; i++) {
       if (b[i] != 0) {
         return false;
       }
@@ -294,7 +305,7 @@ public class SkillApiController {
   /** IPv6 ULA fc00::/7（唯一本地地址，isSiteLocalAddress 对 IPv6 不覆盖——否则 [fd00::1] 可绕过）。 */
   private static boolean isIpv6UniqueLocal(InetAddress addr) {
     byte[] b = addr.getAddress();
-    return b.length == 16 && (b[0] & 0xFE) == 0xFC;
+    return b.length == IPV6_ADDRESS_LENGTH && (b[0] & 0xFE) == 0xFC;
   }
 
   @PutMapping("/{name}")


### PR DESCRIPTION
Only web_search: remains a hostless exception; reject file/data/ftp and other hostless URLs so redirects cannot bypass SSRF via non-http Locations.

Fixes #130

## Summary
- Require http/https + non-blank host for HTTP_READ
- Keep only web_search: as the hostless pseudo-target exception
- Reject file://, data:, ftp:, and other hostless URLs at the sandbox

## Test plan
- [x] WhitelistSandboxTest$HttpReadDefaultAllow (web_search allowed; file/data/ftp blocked)