### PR TITLE
fix(provider): force HTTP/1.1 for local vLLM/Ollama endpoints

### DIFF
--- a/oryxos-provider/src/main/java/io/oryxos/provider/ProviderChatModelFactory.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ProviderChatModelFactory.java
@@ -72,10 +72,20 @@ public class ProviderChatModelFactory {
     Duration readTimeout =
         Duration.ofSeconds(Long.getLong(READ_TIMEOUT_PROP, DEFAULT_READ_TIMEOUT_SECONDS));
     JdkClientHttpRequestFactory factory =
-        new JdkClientHttpRequestFactory(
-            HttpClient.newBuilder().connectTimeout(connectTimeout).build());
+        new JdkClientHttpRequestFactory(httpClient(connectTimeout));
     factory.setReadTimeout(readTimeout);
     return factory;
+  }
+
+  /**
+   * 构造带连接超时的 {@link HttpClient}，强制 HTTP/1.1：JDK 21 HttpClient 默认尝试 HTTP/2 升级（Upgrade: h2c +
+   * Transfer-Encoding: chunked），vLLM/Ollama（uvicorn）不认 h2c 升级，导致请求体丢失（'input': None）、服务端返回 400。
+   */
+  static HttpClient httpClient(Duration connectTimeout) {
+    return HttpClient.newBuilder()
+        .connectTimeout(connectTimeout)
+        .version(HttpClient.Version.HTTP_1_1)
+        .build();
   }
 
   /**

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ProviderChatModelFactoryHttpVersionTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ProviderChatModelFactoryHttpVersionTest.java
@@ -1,0 +1,22 @@
+package io.oryxos.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 本地推理端点回归：JDK 21 HttpClient 默认 HTTP/2，对明文 http:// 的 vLLM/Ollama（uvicorn）发 h2c 升级会 丢请求体（'input':
+ * None → 400）。工厂构造的 HttpClient 必须强制 HTTP/1.1。
+ */
+class ProviderChatModelFactoryHttpVersionTest {
+
+  @Test
+  @DisplayName("工厂构造的HttpClient强制HTTP1_1_避免对本地vLLM_Ollama的h2c升级丢请求体")
+  void httpClientForcesHttp11() {
+    HttpClient client = ProviderChatModelFactory.httpClient(Duration.ofSeconds(10));
+    assertEquals(HttpClient.Version.HTTP_1_1, client.version());
+  }
+}


### PR DESCRIPTION
Closes #132

## What & why

Provider calls to a local inference server (vLLM / Ollama / llama.cpp) over cleartext
http:// fail with HTTP 400 / 'input': None, because ProviderChatModelFactory builds the
JDK HttpClient without .version(), defaulting to HTTP/2. JDK 21 then sends an Upgrade: h2c
request against the HTTP/1.1-only server, which drops the body.

This PR forces HTTP/1.1 for provider (OpenAI-compatible) endpoints — one-shot JSON calls
where HTTP/2 offers no benefit and HTTP/1.1 is universally supported.

## Changes

- ProviderChatModelFactory: extract a httpClient(Duration) helper that sets
  .version(HttpClient.Version.HTTP_1_1); timeoutFactory() now delegates to it.
- Add ProviderChatModelFactoryHttpVersionTest asserting the factory's client is HTTP/1.1.

## Verification

- `mvn -pl oryxos-provider verify` → BUILD SUCCESS, 37 tests green
  (Spotless / PMD-P3C / SpotBugs all pass).
