### PR TITLE
fix(cli): HttpTools注入的restClient未设置超时

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ logs/
 
 # Codex isolated worktrees
 .worktrees/
+
+# IDEA
+.idea/

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -94,12 +94,16 @@ import io.oryxos.tool.sandbox.Sandbox;
 import io.oryxos.tool.sandbox.ShellSandboxProperties;
 import io.oryxos.tool.sandbox.WhitelistSandbox;
 import io.oryxos.tool.web.DuckDuckGoSearchProvider;
+import java.net.http.HttpClient;
 import java.nio.file.Path;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -371,9 +375,39 @@ public class OryxOsRuntime {
     return list == null ? List.of() : list;
   }
 
+  /** 工具 HTTP 连接超时（秒）的系统属性名：默认 10，{@code -Doryxos.tool.http.connect-timeout-seconds=N} 覆盖。 */
+  static final String TOOL_HTTP_CONNECT_TIMEOUT_PROP = "oryxos.tool.http.connect-timeout-seconds";
+
+  /** 工具 HTTP 读取超时（秒）的系统属性名：默认 30，{@code -Doryxos.tool.http.read-timeout-seconds=N} 覆盖。 */
+  static final String TOOL_HTTP_READ_TIMEOUT_PROP = "oryxos.tool.http.read-timeout-seconds";
+
+  private static final long DEFAULT_TOOL_HTTP_CONNECT_TIMEOUT_SECONDS = 10;
+  private static final long DEFAULT_TOOL_HTTP_READ_TIMEOUT_SECONDS = 30;
+
+  /**
+   * 工具 HTTP 请求工厂：连接/读取超时可经系统属性覆盖，防止远端挂死时永久阻塞 Agent 调用。
+   *
+   * <p>提取为 static 方法便于单测直接验证超时行为（无需启 Spring 容器），模式同
+   * {@code ProviderChatModelFactory.timeoutFactory()}。
+   */
+  static JdkClientHttpRequestFactory toolHttpRequestFactory() {
+    Duration connectTimeout =
+        Duration.ofSeconds(
+            Long.getLong(
+                TOOL_HTTP_CONNECT_TIMEOUT_PROP, DEFAULT_TOOL_HTTP_CONNECT_TIMEOUT_SECONDS));
+    Duration readTimeout =
+        Duration.ofSeconds(
+            Long.getLong(TOOL_HTTP_READ_TIMEOUT_PROP, DEFAULT_TOOL_HTTP_READ_TIMEOUT_SECONDS));
+    JdkClientHttpRequestFactory factory =
+        new JdkClientHttpRequestFactory(
+            HttpClient.newBuilder().connectTimeout(connectTimeout).build());
+    factory.setReadTimeout(readTimeout);
+    return factory;
+  }
+
   @Bean
   RestClient restClient() {
-    return RestClient.create();
+    return RestClient.builder().requestFactory(toolHttpRequestFactory()).build();
   }
 
   /** 长期记忆后端：按 memory.backend 选一档（默认 markdown）——这是第 21/22 节"接口墙"的装配落点。 */

--- a/oryxos-cli/src/test/java/io/oryxos/cli/OryxOsRuntimeTimeoutTest.java
+++ b/oryxos-cli/src/test/java/io/oryxos/cli/OryxOsRuntimeTimeoutTest.java
@@ -1,0 +1,82 @@
+package io.oryxos.cli;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import com.sun.net.httpserver.HttpServer;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+/**
+ * 工具 HTTP 超时回归：远端挂死时，{@code OryxOsRuntime.restClient()} 装配的客户端必须在读取超时内失败，
+ * 不能无限阻塞 Agent 调用。
+ *
+ * <p>模式与 {@code ProviderChatModelFactoryTimeoutTest} 完全一致——挂死 HttpServer + CountDownLatch
+ * 模拟「收到请求后永不响应」，通过系统属性把超时压到 1s 保证单测快速反馈。
+ */
+class OryxOsRuntimeTimeoutTest {
+
+  private HttpServer hangingServer;
+  private final CountDownLatch release = new CountDownLatch(1);
+
+  @BeforeEach
+  void startHangingServer() throws Exception {
+    hangingServer = HttpServer.create(new InetSocketAddress(0), 0);
+    hangingServer.createContext(
+        "/",
+        exchange -> {
+          try {
+            release.await(30, TimeUnit.SECONDS); // 收到请求后挂死，不响应不断连
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+          exchange.close();
+        });
+    hangingServer.start();
+  }
+
+  @AfterEach
+  void stopServer() {
+    release.countDown(); // 放行 handler，避免 stop(0) 卡住
+    hangingServer.stop(0);
+    System.clearProperty(OryxOsRuntime.TOOL_HTTP_CONNECT_TIMEOUT_PROP);
+    System.clearProperty(OryxOsRuntime.TOOL_HTTP_READ_TIMEOUT_PROP);
+  }
+
+  @Test
+  @DisplayName("工具 RestClient 远端挂死时在读取超时内失败，不永久阻塞")
+  void toolRestClientFailsOnHangingEndpoint() {
+    // 系统属性压到 1s——跟 ProviderChatModelFactoryTimeoutTest 完全同模式
+    System.setProperty(OryxOsRuntime.TOOL_HTTP_CONNECT_TIMEOUT_PROP, "1");
+    System.setProperty(OryxOsRuntime.TOOL_HTTP_READ_TIMEOUT_PROP, "1");
+
+    RestClient client =
+        RestClient.builder()
+            .requestFactory(OryxOsRuntime.toolHttpRequestFactory())
+            .build();
+
+    String url = "http://127.0.0.1:" + hangingServer.getAddress().getPort() + "/api";
+
+    // 修复前：默认 RestClient.create() 无超时，这里会永久阻塞（preemptive 10s 兜底防测试挂死）
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(10),
+        () ->
+            assertThrows(
+                ResourceAccessException.class,
+                () ->
+                    client
+                        .post()
+                        .uri(url)
+                        .body("{\"city\":\"beijing\"}")
+                        .retrieve()
+                        .toEntity(String.class)));
+  }
+}


### PR DESCRIPTION
  ## 概述

  修复 `HttpTools` 注入的 `restClient` 无超时设置的问题（Closes #137）。

  修复前 `OryxOsRuntime.restClient()` 直接返回 `RestClient.create()`，未设置连接/读取超时。当
  `http_post`、非 GET 的 `http_request`，以及 `web_search` / notify 渠道 / mem0 后端请求到挂死的远端时，
  调用会无限期阻塞，卡死同步的 ReAct 循环。

  ## 变更内容

  - `OryxOsRuntime.restClient()`：从 `RestClient.create()` 改为经 `toolHttpRequestFactory()` 显式设置
    connect / read 超时。
  - 新增 `toolHttpRequestFactory()`（static）：用 `JdkClientHttpRequestFactory` 设置超时，缺省
    connect 10s / read 30s，支持系统属性覆盖：
    - `-Doryxos.tool.http.connect-timeout-seconds=N`
    - `-Doryxos.tool.http.read-timeout-seconds=N`
    - 提取为 static 方法，模式与 `ProviderChatModelFactory.timeoutFactory()` 一致，便于单测直接验证。
  - 新增 `OryxOsRuntimeTimeoutTest`：挂死 `HttpServer` + `CountDownLatch` 模拟「收到请求后永不响应」，
    通过系统属性把超时压到 1s，断言在读取超时内抛 `ResourceAccessException`、不永久阻塞。
  - `.gitignore`：忽略 IDEA 的 `.idea/` 目录。

  ## 影响范围

  同一 `restClient` bean 的消费方随修复一并获得超时保护：

  | 消费方 | 用途 |
  |--------|------|
  | `HttpTools` | `http_post` / 非 GET `http_request` 写路径 |
  | `DuckDuckGoSearchProvider` | `web_search` 工具 |
  | `WebhookNotifyAdapter` / `WeComNotifyAdapter` / `FeishuNotifyAdapter` / `DingTalkNotifyAdapter` | notify 通知渠道 |
  | `Mem0MemoryStore` | `memory.backend=mem0` 时的长期记忆后端 |

  > 读路径（`http_get` / `fetch_webpage` / `download_file` / GET 版 `http_request`）走
  > `HttpTools` 自建的 `readClient`，本身已有硬编码超时，不在本次修复范围。

  ## 测试

  - [ ] `mvn -pl oryxos-cli test` 全绿，`OryxOsRuntimeTimeoutTest` 通过

  ## 关联

  - 关联 issue：#137