### PR TITLE
fix(web): encode GitHub skill path spaces as %20

### DIFF
--- a/oryxos-web/src/main/java/io/oryxos/web/skill/GithubFolderFetcher.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/skill/GithubFolderFetcher.java
@@ -3,6 +3,8 @@ package io.oryxos.web.skill;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -75,7 +77,11 @@ public class GithubFolderFetcher {
   private void fetchDir(Target target, String dirPath, Map<String, String> out, long[] totalBytes) {
     String api =
         "https://api.github.com/repos/%s/%s/contents/%s?ref=%s"
-            .formatted(target.owner(), target.repo(), encodePath(dirPath), target.branch());
+            .formatted(
+                target.owner(),
+                target.repo(),
+                encodePath(dirPath),
+                URLEncoder.encode(target.branch(), StandardCharsets.UTF_8));
     JsonNode entries = parseJson(httpGet.apply(URI.create(api)));
     if (!entries.isArray()) {
       throw new IllegalArgumentException("GitHub 返回的不是一个目录: " + dirPath);
@@ -110,14 +116,19 @@ public class GithubFolderFetcher {
     }
   }
 
+  /**
+   * Contents API 的 path 段允许 {@code '/'}，逐段编码后再拼回去。{@link URLEncoder} 是
+   * application/x-www-form-urlencoded（空格 → {@code +}），GitHub path 需要 URI 百分号编码（空格 → {@code
+   * %20}），否则带空格的目录 会 404。
+   */
   private static String encodePath(String path) {
-    // Contents API 的 path 段允许 '/'，逐段做 URL 编码后再拼回去
     StringBuilder sb = new StringBuilder();
     for (String seg : path.split(PATH_SEPARATOR)) {
       if (!sb.isEmpty()) {
         sb.append('/');
       }
-      sb.append(java.net.URLEncoder.encode(seg, java.nio.charset.StandardCharsets.UTF_8));
+      sb.append(
+          URLEncoder.encode(seg, StandardCharsets.UTF_8).replace("+", "%20").replace("%7E", "~"));
     }
     return sb.toString();
   }

--- a/oryxos-web/src/test/java/io/oryxos/web/skill/GithubFolderFetcherTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/skill/GithubFolderFetcherTest.java
@@ -1,11 +1,13 @@
 package io.oryxos.web.skill;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -97,6 +99,26 @@ class GithubFolderFetcherTest {
         GithubFolderFetcher.parseTreeUrl("https://github.com/a/b/tree/main/x");
 
     assertThrows(IllegalArgumentException.class, () -> fetcher.fetchFolder(target));
+  }
+
+  @Test
+  @DisplayName("fetchFolder：路径空格编成 %20 而非 form 的 +（否则 GitHub Contents 404）")
+  void fetchFolder_encodesPathSpacesAsPercent20() {
+    AtomicReference<String> seen = new AtomicReference<>();
+    GithubFolderFetcher fetcher =
+        new GithubFolderFetcher(
+            uri -> {
+              seen.set(uri.toString());
+              return "[]";
+            });
+    GithubFolderFetcher.Target target =
+        new GithubFolderFetcher.Target("o", "r", "main", "skills/my skill");
+
+    assertThrows(IllegalArgumentException.class, () -> fetcher.fetchFolder(target));
+
+    String api = seen.get();
+    assertTrue(api.contains("skills/my%20skill"), api);
+    assertFalse(api.contains("my+skill"), api);
   }
 
   @Test


### PR DESCRIPTION
URLEncoder form-encoding turned spaces into +, which GitHub Contents API treats literally and 404s. Also encode the ref query parameter.

Fixes #141

## Summary
- Encode GitHub Contents path spaces as %20 (not form-urlencoded +)
- URL-encode the ref query parameter
- Regression: skills/my skill → my%20skill in request URI

## Test plan
- [x] GithubFolderFetcherTest (incl. fetchFolder_encodesPathSpacesAsPercent20)