### PR TITLE
fix(tool): delete_file must not follow symlinks for directory check

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -221,7 +221,8 @@ public class FileTools {
   public String deleteFile(@ToolParam(description = "要删除的文件路径") String path) {
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     Path file = Path.of(path);
-    if (Files.isDirectory(file)) {
+    // NOFOLLOW_LINKS：只拦真实目录；指向目录的 symlink（如 Agent Skill 绑定）应删链接本身，不跟随目标
+    if (Files.isDirectory(file, LinkOption.NOFOLLOW_LINKS)) {
       throw new IllegalArgumentException("拒绝删除目录（本工具只删文件）: " + path);
     }
     try {

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -58,6 +59,27 @@ class FileToolsTest {
   @DisplayName("delete_file 拒绝删除目录")
   void deleteRejectsDirectory() {
     assertThrows(IllegalArgumentException.class, () -> tools.deleteFile(dir.toString()));
+  }
+
+  @Test
+  @DisplayName("delete_file 可删指向目录的 symlink（不跟随目标）")
+  void deleteRemovesSymlinkToDirectoryWithoutRemovingTarget() throws IOException {
+    Path targetDir = dir.resolve("skill-body");
+    Files.createDirectories(targetDir);
+    Files.writeString(targetDir.resolve("SKILL.md"), "keep");
+    Path link = dir.resolve("skill-link");
+    try {
+      Files.createSymbolicLink(link, targetDir);
+    } catch (IOException | UnsupportedOperationException e) {
+      Assumptions.assumeTrue(false, "本机无法创建符号链接，跳过: " + e.getMessage());
+    }
+
+    String result = tools.deleteFile(link.toString());
+
+    assertTrue(result.contains("已删除"));
+    assertFalse(Files.exists(link), "应删除链接本身");
+    assertTrue(Files.isDirectory(targetDir), "目标目录不得被删");
+    assertTrue(Files.exists(targetDir.resolve("SKILL.md")));
   }
 
   @Test


### PR DESCRIPTION
NOFOLLOW_LINKS so Agent Skill-style directory symlinks can be unlinked without removing the target directory.

Fixes #145

## Summary
- Use LinkOption.NOFOLLOW_LINKS in delete_file directory check
- Allow deleting Agent Skill-style directory symlinks without removing the target

## Test plan
- [x] FileToolsTest.deleteRejectsDirectory
- [x] FileToolsTest.deleteRemovesSymlinkToDirectoryWithoutRemovingTarget