### PR TITLE
fix(tool): reject directories in copy_file and move_file

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -237,13 +237,21 @@ public class FileTools {
       @ToolParam(description = "源路径") String from, @ToolParam(description = "目标路径") String to) {
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, from));
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, to));
+    Path src = Path.of(from);
+    // NOFOLLOW：只拒真实目录；指向目录的 symlink（如 Skill 绑定）可移动链接本身
+    if (Files.isDirectory(src, LinkOption.NOFOLLOW_LINKS)) {
+      throw new IllegalArgumentException("拒绝移动目录（本工具只移动文件）: " + from);
+    }
+    if (!Files.exists(src, LinkOption.NOFOLLOW_LINKS)) {
+      throw new IllegalArgumentException("源不存在: " + from);
+    }
     try {
       Path dst = Path.of(to);
       Path parent = dst.getParent();
       if (parent != null) {
         Files.createDirectories(parent);
       }
-      Files.move(Path.of(from), dst, StandardCopyOption.REPLACE_EXISTING);
+      Files.move(src, dst, StandardCopyOption.REPLACE_EXISTING);
       return "已移动: " + from + " -> " + to;
     } catch (IOException e) {
       throw new UncheckedIOException("移动文件失败: " + from, e);
@@ -255,13 +263,22 @@ public class FileTools {
       @ToolParam(description = "源路径") String from, @ToolParam(description = "目标路径") String to) {
     sandbox.enforce(new SandboxAction(ActionType.FILE_READ, from));
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, to));
+    Path src = Path.of(from);
+    // 真实目录：拒绝（Files.copy 对目录会“成功”但只建空目录，造成假成功）
+    if (Files.isDirectory(src, LinkOption.NOFOLLOW_LINKS)) {
+      throw new IllegalArgumentException("拒绝复制目录（本工具只复制文件）: " + from);
+    }
+    // 跟随后须为普通文件：symlink→file 可复制内容；symlink→dir / 缺失 → 拒绝
+    if (!Files.isRegularFile(src)) {
+      throw new IllegalArgumentException("源不存在或不是普通文件: " + from);
+    }
     try {
       Path dst = Path.of(to);
       Path parent = dst.getParent();
       if (parent != null) {
         Files.createDirectories(parent);
       }
-      Files.copy(Path.of(from), dst, StandardCopyOption.REPLACE_EXISTING);
+      Files.copy(src, dst, StandardCopyOption.REPLACE_EXISTING);
       return "已复制: " + from + " -> " + to;
     } catch (IOException e) {
       throw new UncheckedIOException("复制文件失败: " + from, e);

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -56,6 +56,48 @@ class FileToolsTest {
   }
 
   @Test
+  @DisplayName("copy_file / move_file 拒绝真实目录（避免假成功空目录）")
+  void copyAndMoveRejectRealDirectories() throws IOException {
+    Path srcDir = dir.resolve("srcdir");
+    Files.createDirectories(srcDir);
+    Files.writeString(srcDir.resolve("keep.txt"), "data");
+    Path copyDest = dir.resolve("copied-dir");
+    Path moveDest = dir.resolve("moved-dir");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> tools.copyFile(srcDir.toString(), copyDest.toString()));
+    assertFalse(Files.exists(copyDest), "拒绝对目录复制后不得留下空目录");
+    assertTrue(Files.exists(srcDir.resolve("keep.txt")));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> tools.moveFile(srcDir.toString(), moveDest.toString()));
+    assertTrue(Files.isDirectory(srcDir), "真实目录不得被挪走");
+    assertFalse(Files.exists(moveDest));
+  }
+
+  @Test
+  @DisplayName("copy_file 拒绝指向目录的 symlink（不建空目录）")
+  void copyRejectsSymlinkToDirectory() throws IOException {
+    Path targetDir = dir.resolve("skill-body");
+    Files.createDirectories(targetDir);
+    Files.writeString(targetDir.resolve("SKILL.md"), "keep");
+    Path link = dir.resolve("skill-link");
+    try {
+      Files.createSymbolicLink(link, targetDir);
+    } catch (IOException | UnsupportedOperationException e) {
+      Assumptions.assumeTrue(false, "本机无法创建符号链接，跳过: " + e.getMessage());
+    }
+    Path dest = dir.resolve("out-copy");
+
+    assertThrows(
+        IllegalArgumentException.class, () -> tools.copyFile(link.toString(), dest.toString()));
+    assertFalse(Files.exists(dest), "不得留下假成功的空目录");
+    assertTrue(Files.exists(targetDir.resolve("SKILL.md")));
+  }
+
+  @Test
   @DisplayName("delete_file 拒绝删除目录")
   void deleteRejectsDirectory() {
     assertThrows(IllegalArgumentException.class, () -> tools.deleteFile(dir.toString()));


### PR DESCRIPTION
Files.copy on a directory silently creates an empty dest; reject real dirs and symlink-to-dir for copy, and real dirs for move, so tools match their file-only contract.

Fixes #147

## Summary
- Reject real directories (and symlink-to-dir) in copy_file so Files.copy cannot false-succeed as an empty dir
- Reject real directories in move_file; still allow moving symlink links themselves

## Test plan
- [x] FileToolsTest.copyAndMoveRejectRealDirectories
- [x] FileToolsTest.copyRejectsSymlinkToDirectory
- [x] FileToolsTest.copyThenMove