### PR TITLE
fix(tool): resolve directory symlinks before grep/glob walk

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -30,6 +30,9 @@ public class FileTools {
   /** grep / glob 单次返回上限，防超大目录撑爆上下文。 */
   private static final int MAX_MATCHES = 200;
 
+  /** glob 递归前缀；Java PathMatcher 对根下单段路径需去掉后再匹配。 */
+  private static final String GLOB_RECURSIVE_PREFIX = "**/";
+
   private final Sandbox sandbox;
 
   public FileTools(Sandbox sandbox) {
@@ -190,8 +193,10 @@ public class FileTools {
     if (matcher.matches(relative)) {
       return true;
     }
-    if (pattern.startsWith("**/") && relative.getNameCount() == 1) {
-      PathMatcher rest = FileSystems.getDefault().getPathMatcher("glob:" + pattern.substring(3));
+    if (pattern.startsWith(GLOB_RECURSIVE_PREFIX) && relative.getNameCount() == 1) {
+      PathMatcher rest =
+          FileSystems.getDefault()
+              .getPathMatcher("glob:" + pattern.substring(GLOB_RECURSIVE_PREFIX.length()));
       return rest.matches(relative);
     }
     return false;

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -123,16 +123,19 @@ public class FileTools {
     }
     Pattern regex = Pattern.compile(pattern);
     List<String> matches = new ArrayList<>();
-    try (Stream<Path> files = Files.walk(root)) {
-      // NOFOLLOW_LINKS：白名单根内被植入指向外部的软链接时，链接项不算普通文件，内容不外泄
-      for (Path file : (Iterable<Path>) files.filter(FileTools::isRealRegularFile)::iterator) {
-        if (matches.size() >= MAX_MATCHES) {
-          matches.add("...（已达 " + MAX_MATCHES + " 条上限，结果截断）");
-          break;
+    try {
+      // Skill 绑定等「目录软链」：walk 默认不跟随，需先解析到真实目录；嵌套文件软链仍靠 NOFOLLOW 跳过
+      Path walkRoot = resolveDirectorySymlink(root);
+      try (Stream<Path> files = Files.walk(walkRoot)) {
+        for (Path file : (Iterable<Path>) files.filter(FileTools::isRealRegularFile)::iterator) {
+          if (matches.size() >= MAX_MATCHES) {
+            matches.add("...（已达 " + MAX_MATCHES + " 条上限，结果截断）");
+            break;
+          }
+          // 纵深防御：每个实际读取的文件再过一次文件白名单（防根校验到读取间符号链接被替换）
+          sandbox.enforce(new SandboxAction(ActionType.FILE_READ, file.toString()));
+          appendMatches(file, regex, matches);
         }
-        // 纵深防御：每个实际读取的文件再过一次文件白名单（防根校验到读取间符号链接被替换）
-        sandbox.enforce(new SandboxAction(ActionType.FILE_READ, file.toString()));
-        appendMatches(file, regex, matches);
       }
     } catch (IOException e) {
       throw new UncheckedIOException("搜索失败: " + path, e);
@@ -151,21 +154,32 @@ public class FileTools {
     }
     PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pattern);
     List<String> hits = new ArrayList<>();
-    try (Stream<Path> files = Files.walk(root)) {
-      files
-          .filter(FileTools::isRealRegularFile)
-          .filter(p -> matcher.matches(root.relativize(p)))
-          .limit(MAX_MATCHES)
-          // 每个命中路径再过一次文件白名单（与 grep 同款纵深防御）
-          .forEach(
-              p -> {
-                sandbox.enforce(new SandboxAction(ActionType.FILE_READ, p.toString()));
-                hits.add(p.toString());
-              });
+    try {
+      Path walkRoot = resolveDirectorySymlink(root);
+      try (Stream<Path> files = Files.walk(walkRoot)) {
+        files
+            .filter(FileTools::isRealRegularFile)
+            .filter(p -> matcher.matches(walkRoot.relativize(p)))
+            .limit(MAX_MATCHES)
+            // 每个命中路径再过一次文件白名单（与 grep 同款纵深防御）
+            .forEach(
+                p -> {
+                  sandbox.enforce(new SandboxAction(ActionType.FILE_READ, p.toString()));
+                  hits.add(p.toString());
+                });
+      }
     } catch (IOException e) {
       throw new UncheckedIOException("查找失败: " + path, e);
     }
     return hits.isEmpty() ? "（无匹配）" : String.join("\n", hits);
+  }
+
+  /** 若根是指向目录的软链（Skill 绑定），解析到真实目录再 walk；否则原样返回。 */
+  private static Path resolveDirectorySymlink(Path root) throws IOException {
+    if (Files.isSymbolicLink(root) && Files.isDirectory(root)) {
+      return root.toRealPath();
+    }
+    return root;
   }
 
   /** 普通文件判定不跟随符号链接：链接项（无论指向内部还是外部）都不作为可读文件参与搜索。 */

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -159,7 +159,7 @@ public class FileTools {
       try (Stream<Path> files = Files.walk(walkRoot)) {
         files
             .filter(FileTools::isRealRegularFile)
-            .filter(p -> matcher.matches(walkRoot.relativize(p)))
+            .filter(p -> globMatches(matcher, pattern, walkRoot.relativize(p)))
             .limit(MAX_MATCHES)
             // 每个命中路径再过一次文件白名单（与 grep 同款纵深防御）
             .forEach(
@@ -180,6 +180,21 @@ public class FileTools {
       return root.toRealPath();
     }
     return root;
+  }
+
+  /**
+   * Java {@code PathMatcher} 对 {@code **}{@code /} 前缀不匹配 walk 根下的单段相对路径（如 {@code SKILL.md}），对 Skill
+   * 根目录文件补一次去掉该前缀后的匹配。
+   */
+  private static boolean globMatches(PathMatcher matcher, String pattern, Path relative) {
+    if (matcher.matches(relative)) {
+      return true;
+    }
+    if (pattern.startsWith("**/") && relative.getNameCount() == 1) {
+      PathMatcher rest = FileSystems.getDefault().getPathMatcher("glob:" + pattern.substring(3));
+      return rest.matches(relative);
+    }
+    return false;
   }
 
   /** 普通文件判定不跟随符号链接：链接项（无论指向内部还是外部）都不作为可读文件参与搜索。 */

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -263,6 +263,31 @@ class FileToolsTest {
   }
 
   @Test
+  @DisplayName("grep/glob 能搜到目录软链目标（Skill 绑定形态）")
+  void grepAndGlobFollowDirectorySymlinkRoot() throws IOException {
+    Path realSkill = dir.resolve("skills/report");
+    Files.createDirectories(realSkill);
+    Files.writeString(realSkill.resolve("SKILL.md"), "title: needle-report\n");
+    Path link = dir.resolve("agents/ops/skills/report");
+    Files.createDirectories(link.getParent());
+    try {
+      Files.createSymbolicLink(link, realSkill);
+    } catch (IOException | UnsupportedOperationException e) {
+      Assumptions.assumeTrue(false, "本机无法创建符号链接，跳过: " + e.getMessage());
+    }
+
+    String listing = tools.listDir(link.toString());
+    assertTrue(listing.contains("SKILL.md"), "list_dir 应能列出软链目录");
+
+    String grepped = tools.grep("needle-report", link.toString());
+    assertTrue(grepped.contains("SKILL.md"), grepped);
+    assertTrue(grepped.contains("needle-report"), grepped);
+
+    String globbed = tools.glob("**/*.md", link.toString());
+    assertTrue(globbed.contains("SKILL.md"), globbed);
+  }
+
+  @Test
   @DisplayName("越界会被拦：edit/grep/glob 校验不过零动作")
   void sandboxRejectionBlocksSearchAndEdit() throws IOException {
     Sandbox denying = mock(Sandbox.class);


### PR DESCRIPTION
Skill bindings are directory symlinks; Files.walk does not follow them, so grep/glob returned empty while list_dir worked. Resolve the root with toRealPath when it is a directory symlink.

Fixes #149

## Summary
- Resolve directory-symlink roots with toRealPath before Files.walk in grep/glob
- Keep NOFOLLOW on nested file symlinks and per-hit sandbox rechecks

## Test plan
- [x] FileToolsTest.grepAndGlobFollowDirectorySymlinkRoot
- [x] Existing grep/glob cases still pass