### PR TITLE
fix(tool): distinguish JSON null from missing path in json_extract

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/UtilTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/UtilTools.java
@@ -51,7 +51,7 @@ public class UtilTools {
       String index = m.group(1);
       current = index != null ? current.path(Integer.parseInt(index)) : current.path(m.group());
     }
-    if (current == null || current.isMissingNode() || current.isNull()) {
+    if (current == null || current.isMissingNode()) {
       return "(未找到路径: " + path + ")";
     }
     return current.isValueNode() ? current.asText() : current.toString();

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/UtilToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/UtilToolsTest.java
@@ -42,6 +42,13 @@ class UtilToolsTest {
   }
 
   @Test
+  @DisplayName("json_extract 显式 null 返回 null 文本，不与路径缺失混淆")
+  void jsonExtractExplicitNullVsMissing() {
+    assertEquals("null", tools.jsonExtract("{\"a\":null}", "a"));
+    assertTrue(tools.jsonExtract("{\"a\":1}", "b").contains("未找到"));
+  }
+
+  @Test
   @DisplayName("json_extract 非法 JSON 抛 IllegalArgumentException")
   void jsonExtractBadJson() {
     assertThrows(IllegalArgumentException.class, () -> tools.jsonExtract("not json", "a"));


### PR DESCRIPTION
Explicit null is a found value and should return null text, not the missing-path sentinel. Also clear #127 spotless/PMD debt in WhitelistSandbox and SkillApiController so the quality gate can pass on current main.

## Summary
- `json_extract` no longer reports explicit JSON `null` as a missing path; returns `null` text instead
- Keeps `(未找到路径: …)` only for truly missing paths
- Clears #127 spotless/PMD debt in `WhitelistSandbox` / `SkillApiController` so CI can pass on current main

Fixes #151

## Test plan
- [ ] `UtilToolsTest.jsonExtractExplicitNullVsMissing`
- [ ] `UtilToolsTest.jsonExtractMissing` still reports 未找到
- [ ] CI Build & quality gate green