### PR TITLE
fix(sandbox): remove duplicate HTTP_SCHEME constants

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -47,9 +47,6 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   /** {@link io.oryxos.tool.builtin.WebSearchTools} 用的伪目标前缀；无真实主机，读路径放行。 */
   private static final String WEB_SEARCH_TARGET_PREFIX = "web_search:";
 
-  private static final String HTTP_SCHEME = "http";
-  private static final String HTTPS_SCHEME = "https";
-
   /** IPv6 地址字节长度；IPv4-mapped / NAT64 展开前需先确认。 */
   private static final int IPV6_ADDRESS_LENGTH = 16;
 


### PR DESCRIPTION
## Summary
- #131 and #136 both introduced `HTTP_SCHEME`/`HTTPS_SCHEME`; merge left duplicates and broke `main` compile.

## Test plan
- [x] `mvn -pl oryxos-tool -am compile`

Made with [Cursor](https://cursor.com)