### PR TITLE
fix(sandbox): remove unused hostOf after HTTP scheme checks

### DIFF
--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -102,8 +102,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -111,6 +109,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -387,8 +386,8 @@ public class OryxOsRuntime {
   /**
    * 工具 HTTP 请求工厂：连接/读取超时可经系统属性覆盖，防止远端挂死时永久阻塞 Agent 调用。
    *
-   * <p>提取为 static 方法便于单测直接验证超时行为（无需启 Spring 容器），模式同
-   * {@code ProviderChatModelFactory.timeoutFactory()}。
+   * <p>提取为 static 方法便于单测直接验证超时行为（无需启 Spring 容器），模式同 {@code
+   * ProviderChatModelFactory.timeoutFactory()}。
    */
   static JdkClientHttpRequestFactory toolHttpRequestFactory() {
     Duration connectTimeout =

--- a/oryxos-cli/src/test/java/io/oryxos/cli/OryxOsRuntimeTimeoutTest.java
+++ b/oryxos-cli/src/test/java/io/oryxos/cli/OryxOsRuntimeTimeoutTest.java
@@ -16,8 +16,7 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
 /**
- * 工具 HTTP 超时回归：远端挂死时，{@code OryxOsRuntime.restClient()} 装配的客户端必须在读取超时内失败，
- * 不能无限阻塞 Agent 调用。
+ * 工具 HTTP 超时回归：远端挂死时，{@code OryxOsRuntime.restClient()} 装配的客户端必须在读取超时内失败， 不能无限阻塞 Agent 调用。
  *
  * <p>模式与 {@code ProviderChatModelFactoryTimeoutTest} 完全一致——挂死 HttpServer + CountDownLatch
  * 模拟「收到请求后永不响应」，通过系统属性把超时压到 1s 保证单测快速反馈。
@@ -59,9 +58,7 @@ class OryxOsRuntimeTimeoutTest {
     System.setProperty(OryxOsRuntime.TOOL_HTTP_READ_TIMEOUT_PROP, "1");
 
     RestClient client =
-        RestClient.builder()
-            .requestFactory(OryxOsRuntime.toolHttpRequestFactory())
-            .build();
+        RestClient.builder().requestFactory(OryxOsRuntime.toolHttpRequestFactory()).build();
 
     String url = "http://127.0.0.1:" + hangingServer.getAddress().getPort() + "/api";
 

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -232,14 +232,6 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
     }
   }
 
-  private static String hostOf(String url) {
-    try {
-      return URI.create(url).getHost();
-    } catch (RuntimeException e) {
-      return null;
-    }
-  }
-
   /** SSRF 兜底：拒绝主机解析到回环/任意本地/链路本地(含云元数据 169.254.169.254)/站点内网/组播/CGNAT，及 localhost、*.internal。 */
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",


### PR DESCRIPTION
## Summary
- Delete dead `WhitelistSandbox.hostOf()` left after #131/#136 switched read/write checks to `URI.create`
- Clears SpotBugs `UPM_UNCALLED_PRIVATE_METHOD` that is currently failing main CI

## Test plan
- [x] `mvn -pl oryxos-tool -am verify -DskipTests`

Made with [Cursor](https://cursor.com)