### PR TITLE
fix(tool): block web_search redirect SSRF via NEVER + endpoint HTTP_READ

### DIFF
--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -478,7 +478,7 @@ public class OryxOsRuntime {
         new HttpTools(sandbox, restClient)); // + http_request/fetch_webpage/download_file
     registry.registerAnnotated(new UtilTools()); // current_time / json_extract（纯计算，无沙箱）
     registry.registerAnnotated(
-        new WebSearchTools(sandbox, new DuckDuckGoSearchProvider(restClient)));
+        new WebSearchTools(sandbox, new DuckDuckGoSearchProvider(restClient, sandbox)));
     // chat → ConsoleUserInteraction；serve/gateway → UnsupportedUserInteraction（见 userInteraction
     // bean）
     registry.registerAnnotated(new InteractionTools(userInteraction));

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/WebSearchTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/WebSearchTools.java
@@ -12,8 +12,9 @@ import org.springframework.ai.tool.annotation.ToolParam;
 /**
  * 内置网页搜索工具：web_search——日报/调研类 Agent 的第一入口。
  *
- * <p>搜索走网络，同 http_get 一样是只读涉外请求（HTTP_READ：默认放行 + 内网黑名单）；具体引擎由 {@link SearchProvider}
- * 决定，本工具只负责把结果渲染成模型好读的文本。
+ * <p>搜索走网络，同 http_get 一样是只读涉外请求（HTTP_READ：默认放行 + 内网黑名单）。工具层用 {@code web_search:query}
+ * 伪目标记账；具体引擎（{@link SearchProvider}）还须对<strong>真实 endpoint</strong>再过 HTTP_READ，且禁自动重定向（与 HttpTools
+ * 读路径同策略）。本工具负责把结果渲染成模型好读的文本。
  */
 public class WebSearchTools {
 
@@ -29,7 +30,7 @@ public class WebSearchTools {
 
   @Tool(name = "web_search", description = "用搜索引擎检索网页，返回标题、链接和摘要列表")
   public String webSearch(@ToolParam(description = "搜索关键词") String query) {
-    // 搜索是一次只读涉外请求，与 http_get 同走 HTTP_READ；用 web_search: 伪目标（唯一允许的无主机读目标）
+    // 伪目标：无主机、供审计/策略标签；真实出网 SSRF 由 SearchProvider 对 endpoint 复检
     sandbox.enforce(new SandboxAction(ActionType.HTTP_READ, "web_search:" + query));
     List<SearchProvider.SearchResult> results = provider.search(query);
     if (results.isEmpty()) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/web/DuckDuckGoSearchProvider.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/web/DuckDuckGoSearchProvider.java
@@ -2,41 +2,71 @@ package io.oryxos.tool.web;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.tool.sandbox.ActionType;
+import io.oryxos.tool.sandbox.Sandbox;
+import io.oryxos.tool.sandbox.SandboxAction;
+import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 /**
  * 核心阶段唯一搜索实现：DuckDuckGo Instant Answer API（无需 API key，返回 JSON）。
  *
  * <p>端点由构造传入（默认公网），便于测试指向假服务；抓取 RelatedTopics 里的 Text/FirstURL 作为结果条目。搜不到即空列表——由上层工具决定怎么表达"没搜到"。
+ *
+ * <p>出网策略与 {@code HttpTools} 读路径对齐：对<strong>真实 endpoint</strong>过 {@code HTTP_READ}（SSRF
+ * 兜底），且<strong>禁自动重定向</strong>——Instant Answer 无需跟跳；避免共用 RestClient 默认跟随把公网入口 302 到内网/元数据。
  */
 public class DuckDuckGoSearchProvider implements SearchProvider {
 
   private static final String DEFAULT_ENDPOINT = "https://api.duckduckgo.com/";
   private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(20);
 
-  private final RestClient restClient;
+  /** 禁自动重定向的专用客户端；不沿用注入 RestClient 的跟随策略。 */
+  private final RestClient hopClient;
+
   private final String endpoint;
+  private final Sandbox sandbox;
 
-  public DuckDuckGoSearchProvider(RestClient restClient) {
-    this(restClient, DEFAULT_ENDPOINT);
+  public DuckDuckGoSearchProvider(RestClient restClient, Sandbox sandbox) {
+    this(restClient, DEFAULT_ENDPOINT, sandbox);
   }
 
-  public DuckDuckGoSearchProvider(RestClient restClient, String endpoint) {
-    this.restClient = restClient.mutate().build();
-    this.endpoint = endpoint;
+  public DuckDuckGoSearchProvider(RestClient restClient, String endpoint, Sandbox sandbox) {
+    Objects.requireNonNull(restClient, "restClient 不能为空"); // 保留签名，供 Spring 装配
+    this.sandbox = Objects.requireNonNull(sandbox, "sandbox 不能为空");
+    this.endpoint = Objects.requireNonNull(endpoint, "endpoint 不能为空");
+    JdkClientHttpRequestFactory hopFactory =
+        new JdkClientHttpRequestFactory(
+            HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build());
+    hopFactory.setReadTimeout(READ_TIMEOUT);
+    this.hopClient = RestClient.builder().requestFactory(hopFactory).build();
   }
 
   @Override
   public List<SearchResult> search(String query) {
-    String body =
-        restClient
+    // 伪目标 web_search:query 只做工具层标签；真实出网 URL 必须再过 HTTP_READ / SSRF
+    sandbox.enforce(new SandboxAction(ActionType.HTTP_READ, endpoint));
+    ResponseEntity<String> resp =
+        hopClient
             .get()
             .uri(endpoint + "?q={q}&format=json&no_html=1", query)
             .retrieve()
-            .body(String.class);
-    return parse(body);
+            .toEntity(String.class);
+    if (resp.getStatusCode().is3xxRedirection()) {
+      throw new IllegalStateException("搜索端点返回重定向，拒绝跟随: " + endpoint);
+    }
+    return parse(resp.getBody());
   }
 
   private static List<SearchResult> parse(String body) {

--- a/oryxos-tool/src/test/java/io/oryxos/tool/OryxToolContractTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/OryxToolContractTest.java
@@ -35,7 +35,8 @@ class OryxToolContractTest {
     registry.registerAnnotated(new HttpTools(sandbox, RestClient.create()));
     registry.registerAnnotated(
         new io.oryxos.tool.builtin.WebSearchTools(
-            sandbox, new io.oryxos.tool.web.DuckDuckGoSearchProvider(RestClient.create())));
+            sandbox,
+            new io.oryxos.tool.web.DuckDuckGoSearchProvider(RestClient.create(), sandbox)));
     registry.registerAnnotated(
         new io.oryxos.tool.builtin.InteractionTools(
             new io.oryxos.tool.interaction.UnsupportedUserInteraction()));

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/WebSearchToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/WebSearchToolsTest.java
@@ -8,15 +8,20 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 import com.sun.net.httpserver.HttpServer;
+import io.oryxos.tool.sandbox.FileSandboxProperties;
+import io.oryxos.tool.sandbox.HttpSandboxProperties;
 import io.oryxos.tool.sandbox.PermissiveSandbox;
 import io.oryxos.tool.sandbox.Sandbox;
 import io.oryxos.tool.sandbox.SandboxViolationException;
+import io.oryxos.tool.sandbox.ShellSandboxProperties;
+import io.oryxos.tool.sandbox.WhitelistSandbox;
 import io.oryxos.tool.web.DuckDuckGoSearchProvider;
 import io.oryxos.tool.web.SearchProvider;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -58,8 +63,10 @@ class WebSearchToolsTest {
   @Test
   @DisplayName("web_search 渲染标题/链接/摘要")
   void webSearchRendersResults() {
-    SearchProvider provider = new DuckDuckGoSearchProvider(RestClient.create(), endpoint());
-    WebSearchTools tools = new WebSearchTools(new PermissiveSandbox(), provider);
+    Sandbox sandbox = new PermissiveSandbox();
+    SearchProvider provider =
+        new DuckDuckGoSearchProvider(RestClient.create(), endpoint(), sandbox);
+    WebSearchTools tools = new WebSearchTools(sandbox, provider);
 
     String result = tools.webSearch("oryxos");
 
@@ -70,8 +77,7 @@ class WebSearchToolsTest {
   @Test
   @DisplayName("无结果时返回明确提示")
   void webSearchNoResult() {
-    SearchProvider empty = query -> List.of();
-    WebSearchTools tools = new WebSearchTools(new PermissiveSandbox(), empty);
+    WebSearchTools tools = new WebSearchTools(new PermissiveSandbox(), query -> List.of());
 
     assertEquals("（未搜到相关结果）", tools.webSearch("zzz"));
   }
@@ -85,5 +91,71 @@ class WebSearchToolsTest {
     WebSearchTools tools = new WebSearchTools(denying, provider);
 
     assertThrows(SandboxViolationException.class, () -> tools.webSearch("x"));
+  }
+
+  @Test
+  @DisplayName("搜索端点 302 不跟随：sink 零命中（禁自动重定向）")
+  void searchDoesNotFollowRedirect() throws IOException {
+    HttpServer entry = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    HttpServer sink = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    AtomicInteger sinkHits = new AtomicInteger();
+    try {
+      sink.createContext(
+          "/",
+          exchange -> {
+            sinkHits.incrementAndGet();
+            byte[] body = "leaked".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+          });
+      String sinkUrl = "http://127.0.0.1:" + sink.getAddress().getPort() + "/sink";
+      entry.createContext(
+          "/",
+          exchange -> {
+            exchange.getResponseHeaders().add("Location", sinkUrl);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+          });
+      entry.start();
+      sink.start();
+
+      Sandbox sandbox = new PermissiveSandbox();
+      String start = "http://127.0.0.1:" + entry.getAddress().getPort() + "/";
+      // RestClient.create() 默认会跟随；provider 必须自建 NEVER，否则 sink 会被打到
+      SearchProvider provider = new DuckDuckGoSearchProvider(RestClient.create(), start, sandbox);
+
+      assertThrows(IllegalStateException.class, () -> provider.search("oryxos"));
+      assertEquals(0, sinkHits.get(), "搜索端点 302 不得自动跟随到 sink");
+    } finally {
+      entry.stop(0);
+      sink.stop(0);
+    }
+  }
+
+  @Test
+  @DisplayName("真实 endpoint 过 HTTP_READ：回环地址被 SSRF 拦下且零请求")
+  void realEndpointSsrfBlocked() {
+    AtomicInteger hits = new AtomicInteger();
+    // 复用 @BeforeEach 的 server：WhitelistSandbox 对 127.0.0.1 走 SSRF 黑名单
+    server.removeContext("/");
+    server.createContext(
+        "/",
+        exchange -> {
+          hits.incrementAndGet();
+          exchange.sendResponseHeaders(200, 0);
+          exchange.close();
+        });
+
+    Sandbox whitelist =
+        new WhitelistSandbox(
+            new FileSandboxProperties(List.of()),
+            new ShellSandboxProperties(List.of()),
+            new HttpSandboxProperties(List.of()));
+    SearchProvider provider =
+        new DuckDuckGoSearchProvider(RestClient.create(), endpoint(), whitelist);
+
+    assertThrows(SandboxViolationException.class, () -> provider.search("x"));
+    assertEquals(0, hits.get(), "endpoint SSRF 校验不过，请求不该发出");
   }
 }


### PR DESCRIPTION
## Summary
- `DuckDuckGoSearchProvider` uses `Redirect.NEVER` and refuses 3xx instead of inheriting RestClient auto-follow
- Enforces `HTTP_READ` on the real search endpoint (not only `web_search:query`)
- Adds redirect + SSRF regression tests in `WebSearchToolsTest`

Fixes #155

## Test plan
- [ ] `WebSearchToolsTest.searchDoesNotFollowRedirect`
- [ ] `WebSearchToolsTest.realEndpointSsrfBlocked`
- [ ] `WebSearchToolsTest.webSearchRendersResults` still green
- [ ] CI Build & quality gate green