### PR TITLE
chore(ci): harden workflows (OWASP split, concurrency, docs check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,36 +3,76 @@ name: CI
 on:
   push:
     branches: [main, 'week-*', 'dev-*']
+    paths-ignore:
+      - 'website/**'
+      - '**.md'
+      - 'docs/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'website/**'
+      - '**.md'
+      - 'docs/**'
+
+# Least privilege: this workflow only needs to read the repo.
+permissions:
+  contents: read
+
+# One run per PR / branch; cancel superseded pushes to save runners.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     name: Build & quality gate
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
           cache: maven
-      # Runs the full lifecycle: spotless:check (validate) → checkstyle → compile →
-      # test → pmd/p3c → spotbugs+findsecbugs (verify). Any violation fails the job.
+      # Full quality gate: spotless → checkstyle → compile → test → pmd/p3c →
+      # spotbugs+findsecbugs. Any violation fails the job.
       - name: mvn verify
         run: mvn -B clean verify
 
   dependency-check:
     name: OWASP Dependency-Check (CVE scan)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: write # upload-artifact
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
           cache: maven
-      # Enabled via -Dowasp.skip=false. The Maven configuration uses
-      # Dependency-Check's nightly NVD cache, which is available to fork PRs.
-      - name: mvn verify with dependency-check
-        run: mvn -B clean verify -DskipTests -Dowasp.skip=false
+      # Package only (skip quality plugins already covered by `build`), then run
+      # Dependency-Check aggregate. Avoids a second spotless/pmd/spotbugs pass
+      # that duplicated ~half the CI time and made CVE failures hard to spot.
+      # NVD feed uses Dependency-Check's nightly cache (no NVD API key for forks).
+      - name: package (skip quality plugins)
+        run: >-
+          mvn -B clean package -DskipTests
+          -Dspotless.check.skip=true
+          -Dcheckstyle.skip=true
+          -Dpmd.skip=true
+          -Dspotbugs.skip=true
+      - name: OWASP dependency-check aggregate
+        run: mvn -B -Dowasp.skip=false org.owasp:dependency-check-maven:aggregate
+      - name: Upload Dependency-Check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: |
+            target/dependency-check-report.html
+            target/dependency-check-report.json
+          if-no-files-found: ignore

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,8 +25,8 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Docs site
+
+# PR / push that only touch website get a build check (Java CI paths-ignores website/**).
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: VitePress build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build with VitePress
+        run: npm run docs:build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,16 @@ jobs:
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.title, 'release:')
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
       - name: Checkout main (含已合入代码)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
@@ -41,8 +42,11 @@ jobs:
       - name: Resolve version from pom.xml
         id: ver
         run: |
-          RAW=$(awk '/<artifactId>oryxos<\/artifactId>/{f=1} f&&/<version>/{gsub(/.*<version>|<\/version>.*/,"");gsub(/[[:space:]]/,"");print;exit}' pom.xml)
-          if [ -z "$RAW" ]; then echo "::error::无法从 pom.xml 解析版本号"; exit 1; fi
+          RAW=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)
+          if [ -z "$RAW" ] || [ "$RAW" = "null object or invalid expression" ]; then
+            echo "::error::无法从 pom.xml 解析版本号"
+            exit 1
+          fi
           # 剥离开发用 -SNAPSHOT 后缀；-RELEASE 等正式标签原样保留
           VERSION="${RAW%-SNAPSHOT}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
P1 CI/CD hardening:

1. **OWASP job** no longer re-runs spotless/pmd/spotbugs — `package` (quality plugins skipped) + `dependency-check:aggregate`; uploads report artifact
2. **concurrency** + **timeouts** + **`permissions: contents: read`**
3. **paths-ignore** for `website/**` / `**.md` / `docs/**` so docs-only changes skip Java CI
4. **`docs.yml`** — VitePress build for website-only PRs (closes the gap from paths-ignore)
5. **Action upgrades** — `checkout`/`setup-java`/`setup-node` → v5
6. **Release** — version via `mvn help:evaluate` (replace fragile awk)

## Out of scope (follow-ups)
- Branch protection required checks (repo settings)
- Release job running full `mvn verify` before `make release`

## Test plan
- [ ] This PR: Build & quality gate green
- [ ] This PR: OWASP job green and faster than before (no second SpotBugs)
- [ ] Artifact `dependency-check-report` present on OWASP job

Made with [Cursor](https://cursor.com)