### PR TITLE
fix(tool): reject directory destinations in copy_file and move_file

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -281,6 +281,8 @@ public class FileTools {
     }
     try {
       Path dst = Path.of(to);
+      // 跟随链接：真实目录与 symlink→dir（Skill 绑定）都拒——REPLACE_EXISTING 会删链接假成功
+      rejectDirectoryDestination(dst, to);
       Path parent = dst.getParent();
       if (parent != null) {
         Files.createDirectories(parent);
@@ -308,6 +310,8 @@ public class FileTools {
     }
     try {
       Path dst = Path.of(to);
+      // 跟随链接：真实目录与 symlink→dir（Skill 绑定）都拒——REPLACE_EXISTING 会删链接假成功
+      rejectDirectoryDestination(dst, to);
       Path parent = dst.getParent();
       if (parent != null) {
         Files.createDirectories(parent);
@@ -316,6 +320,13 @@ public class FileTools {
       return "已复制: " + from + " -> " + to;
     } catch (IOException e) {
       throw new UncheckedIOException("复制文件失败: " + from, e);
+    }
+  }
+
+  /** 目标若为目录（含跟随后的目录软链），拒绝覆盖——否则 REPLACE_EXISTING 会毁掉 Skill 绑定链接并假成功。 */
+  private static void rejectDirectoryDestination(Path dst, String to) {
+    if (Files.isDirectory(dst)) {
+      throw new IllegalArgumentException("拒绝覆盖目录目标（本工具只写文件）: " + to);
     }
   }
 }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -98,6 +98,44 @@ class FileToolsTest {
   }
 
   @Test
+  @DisplayName("copy_file / move_file 拒绝覆盖目录目标（含 symlink→dir Skill 绑定）")
+  void copyAndMoveRejectDirectoryDestination() throws IOException {
+    Files.writeString(dir.resolve("payload.txt"), "x");
+    Path destDir = dir.resolve("dest-dir");
+    Files.createDirectories(destDir);
+    Files.writeString(destDir.resolve("keep.txt"), "stay");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> tools.copyFile(dir.resolve("payload.txt").toString(), destDir.toString()));
+    assertTrue(Files.isDirectory(destDir));
+    assertEquals("stay", Files.readString(destDir.resolve("keep.txt")));
+
+    Path skillBody = dir.resolve("skill-body-dst");
+    Files.createDirectories(skillBody);
+    Files.writeString(skillBody.resolve("SKILL.md"), "bound");
+    Path skillLink = dir.resolve("agents/ops/skills/report");
+    Files.createDirectories(skillLink.getParent());
+    try {
+      Files.createSymbolicLink(skillLink, skillBody);
+    } catch (IOException | UnsupportedOperationException e) {
+      Assumptions.assumeTrue(false, "本机无法创建符号链接，跳过: " + e.getMessage());
+    }
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> tools.copyFile(dir.resolve("payload.txt").toString(), skillLink.toString()));
+    assertTrue(Files.isSymbolicLink(skillLink), "Skill 绑定链接不得被 REPLACE 毁掉");
+    assertEquals("bound", Files.readString(skillBody.resolve("SKILL.md")));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> tools.moveFile(dir.resolve("payload.txt").toString(), skillLink.toString()));
+    assertTrue(Files.isSymbolicLink(skillLink));
+    assertTrue(Files.exists(dir.resolve("payload.txt")), "拒绝后源文件应仍在");
+  }
+
+  @Test
   @DisplayName("delete_file 拒绝删除目录")
   void deleteRejectsDirectory() {
     assertThrows(IllegalArgumentException.class, () -> tools.deleteFile(dir.toString()));


### PR DESCRIPTION
REPLACE_EXISTING on a symlink-to-directory target replaces the Skill binding link and reports success. Follow links when checking the destination and refuse directories.

## Summary
- `copy_file` / `move_file` reject directory destinations (including symlink→dir Skill bindings)
- Prevents `REPLACE_EXISTING` from destroying the binding link while reporting success
- Adds regression coverage in `FileToolsTest`

Fixes #158

## Test plan
- [ ] `FileToolsTest.copyAndMoveRejectDirectoryDestination`
- [ ] Existing copy/move source-directory tests still green
- [ ] CI Build & quality gate green