### PR TITLE
chore(ci): fast-fail spotless check + deploy-pages timeouts

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: website
@@ -43,6 +44,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,9 @@
                     </configuration>
                     <executions>
                         <execution>
+                            <!-- Fast-fail: run the format check before compile/test
+                                 (spotless:check defaults to the verify phase). -->
+                            <phase>validate</phase>
                             <goals>
                                 <goal>check</goal>
                             </goals>


### PR DESCRIPTION
## 概述

对 CI / 构建做两处小加固，来自一轮 GitHub Actions 工作流评审。

## 改动

1. **`spotless:check` 提前到 `validate` 阶段**（`pom.xml`）
   - 之前 `spotless:check` 默认绑在 `verify`，跑完单测之后才查格式，格式违规要等测试跑完才暴露。
   - 现在绑到 `validate`，格式检查先于编译/测试失败，零额外开销（`checkstyle` 早已在 `validate` 阶段）。

2. **`deploy-pages` 补超时**（`.github/workflows/deploy-pages.yml`）
   - `build`（10min）、`deploy`（15min）原来没有 `timeout-minutes`，卡死会占满 runner 直到默认上限。
   - 对齐 `ci.yml`（25/30）与 `docs.yml`（10）的基线。

## 影响面

- 不改 CI 语义，仅改变失败时序（格式检查更早失败）+ 加超时护栏。
- `pom.xml` 那处会影响本地 `mvn verify`：格式问题现在会在编译前就报错，属于更早的反馈，无副作用。

## 验证

- `mvn verify` 全绿即通过（spotless 现在在 validate 阶段先跑）。
- `deploy-pages` 超时在 GitHub Actions 触发时生效。
