### PR TITLE
fix(tool): recheck FILE_WRITE before write_file/append_file/edit_file

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -64,6 +64,8 @@ public class FileTools {
       if (parent != null) {
         Files.createDirectories(parent);
       }
+      // 写前复检：与 download_file / grep 同款——防首次校验到 writeString 间路径被换成外向软链
+      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
       Files.writeString(file, content);
       return "已写入: " + path;
     } catch (IOException e) {
@@ -108,6 +110,7 @@ public class FileTools {
         // 多处匹配会改错地方——要求唯一，逼调用方给足上下文（Claude Code/Cursor 同款约束）
         throw new IllegalArgumentException("原文本在文件中出现多次，无法定位唯一编辑点: " + path);
       }
+      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
       Files.writeString(file, content.replace(oldString, newString));
       return "已编辑: " + path;
     } catch (IOException e) {
@@ -226,6 +229,7 @@ public class FileTools {
   public String makeDir(@ToolParam(description = "要创建的目录路径") String path) {
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     try {
+      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
       Files.createDirectories(Path.of(path));
       return "已创建目录: " + path;
     } catch (IOException e) {
@@ -244,6 +248,7 @@ public class FileTools {
       if (parent != null) {
         Files.createDirectories(parent);
       }
+      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
       Files.writeString(file, content, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
       return "已追加到: " + path;
     } catch (IOException e) {

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
+import io.oryxos.tool.sandbox.ActionType;
 import io.oryxos.tool.sandbox.FileSandboxProperties;
 import io.oryxos.tool.sandbox.HttpSandboxProperties;
 import io.oryxos.tool.sandbox.PermissiveSandbox;
@@ -19,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -176,6 +178,64 @@ class FileToolsTest {
     tools.writeFile(dir.resolve("out/b.txt").toString(), "written");
 
     assertEquals("written", Files.readString(dir.resolve("out/b.txt")));
+  }
+
+  @Test
+  @DisplayName("write_file 落盘前复检 FILE_WRITE（防校验窗口内路径逃逸）")
+  void writeFileRechecksPathBeforeWrite() {
+    AtomicInteger fileWrites = new AtomicInteger();
+    Sandbox sandbox =
+        action -> {
+          if (action.type() == ActionType.FILE_WRITE && fileWrites.incrementAndGet() >= 2) {
+            throw new SandboxViolationException("复检拒绝: " + action.target());
+          }
+        };
+    Path target = dir.resolve("escape.txt");
+    FileTools guarded = new FileTools(sandbox);
+
+    assertThrows(
+        SandboxViolationException.class, () -> guarded.writeFile(target.toString(), "secret"));
+    assertEquals(2, fileWrites.get(), "应在写前后各 enforce 一次 FILE_WRITE");
+    assertTrue(Files.notExists(target), "复检拒绝后不得落盘");
+  }
+
+  @Test
+  @DisplayName("append_file 落盘前复检 FILE_WRITE")
+  void appendFileRechecksPathBeforeWrite() {
+    AtomicInteger fileWrites = new AtomicInteger();
+    Sandbox sandbox =
+        action -> {
+          if (action.type() == ActionType.FILE_WRITE && fileWrites.incrementAndGet() >= 2) {
+            throw new SandboxViolationException("复检拒绝: " + action.target());
+          }
+        };
+    Path target = dir.resolve("append-escape.txt");
+    FileTools guarded = new FileTools(sandbox);
+
+    assertThrows(SandboxViolationException.class, () -> guarded.appendFile(target.toString(), "x"));
+    assertEquals(2, fileWrites.get());
+    assertTrue(Files.notExists(target));
+  }
+
+  @Test
+  @DisplayName("edit_file 写回前复检 FILE_WRITE")
+  void editFileRechecksPathBeforeWrite() throws IOException {
+    Path target = dir.resolve("edit.txt");
+    Files.writeString(target, "hello");
+    AtomicInteger fileWrites = new AtomicInteger();
+    Sandbox sandbox =
+        action -> {
+          if (action.type() == ActionType.FILE_WRITE && fileWrites.incrementAndGet() >= 2) {
+            throw new SandboxViolationException("复检拒绝: " + action.target());
+          }
+        };
+    FileTools guarded = new FileTools(sandbox);
+
+    assertThrows(
+        SandboxViolationException.class,
+        () -> guarded.editFile(target.toString(), "hello", "world"));
+    assertEquals(2, fileWrites.get());
+    assertEquals("hello", Files.readString(target), "复检拒绝后不得改写");
   }
 
   @Test


### PR DESCRIPTION
Same TOCTOU class as download_file: path can be swapped for an outbound symlink between the first sandbox check and Files.writeString. Recheck immediately before mutating the filesystem.

## Summary
- Second `FILE_WRITE` enforce before write/create in `write_file`, `append_file`, `edit_file`, `make_dir`
- Adds regression coverage in `FileToolsTest`

Fixes #165

## Test plan
- [ ] `FileToolsTest.writeFileRechecksPathBeforeWrite`
- [ ] `FileToolsTest.appendFileRechecksPathBeforeWrite`
- [ ] `FileToolsTest.editFileRechecksPathBeforeWrite`
- [ ] Existing FileTools tests still green
- [ ] CI Build & quality gate green