### PR TITLE
fix(tool): recheck sandbox before copy_file and move_file

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -292,6 +292,9 @@ public class FileTools {
       if (parent != null) {
         Files.createDirectories(parent);
       }
+      // 变更前复检：与 write_file 同款——防 createDirectories 窗口内目标父路径被换成外向软链
+      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, from));
+      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, to));
       Files.move(src, dst, StandardCopyOption.REPLACE_EXISTING);
       return "已移动: " + from + " -> " + to;
     } catch (IOException e) {
@@ -321,6 +324,9 @@ public class FileTools {
       if (parent != null) {
         Files.createDirectories(parent);
       }
+      // 变更前复检：与 write_file 同款——防校验到 copy 间路径被换成外向软链
+      sandbox.enforce(new SandboxAction(ActionType.FILE_READ, from));
+      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, to));
       Files.copy(src, dst, StandardCopyOption.REPLACE_EXISTING);
       return "已复制: " + from + " -> " + to;
     } catch (IOException e) {

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -239,6 +239,54 @@ class FileToolsTest {
   }
 
   @Test
+  @DisplayName("copy_file 落盘前复检 FILE_WRITE（防校验窗口内路径逃逸）")
+  void copyFileRechecksPathBeforeCopy() throws IOException {
+    Path src = dir.resolve("src.txt");
+    Files.writeString(src, "payload");
+    Path dst = dir.resolve("nested/out.txt");
+    AtomicInteger destWrites = new AtomicInteger();
+    Sandbox sandbox =
+        action -> {
+          if (action.type() == ActionType.FILE_WRITE
+              && action.target().equals(dst.toString())
+              && destWrites.incrementAndGet() >= 2) {
+            throw new SandboxViolationException("复检拒绝: " + action.target());
+          }
+        };
+    FileTools guarded = new FileTools(sandbox);
+
+    assertThrows(
+        SandboxViolationException.class, () -> guarded.copyFile(src.toString(), dst.toString()));
+    assertEquals(2, destWrites.get(), "目标应在 copy 前后各 enforce 一次 FILE_WRITE");
+    assertTrue(Files.notExists(dst), "复检拒绝后不得复制落盘");
+    assertTrue(Files.exists(src), "源应保留");
+  }
+
+  @Test
+  @DisplayName("move_file 落盘前复检 FILE_WRITE")
+  void moveFileRechecksPathBeforeMove() throws IOException {
+    Path src = dir.resolve("move-src.txt");
+    Files.writeString(src, "payload");
+    Path dst = dir.resolve("nested/moved.txt");
+    AtomicInteger destWrites = new AtomicInteger();
+    Sandbox sandbox =
+        action -> {
+          if (action.type() == ActionType.FILE_WRITE
+              && action.target().equals(dst.toString())
+              && destWrites.incrementAndGet() >= 2) {
+            throw new SandboxViolationException("复检拒绝: " + action.target());
+          }
+        };
+    FileTools guarded = new FileTools(sandbox);
+
+    assertThrows(
+        SandboxViolationException.class, () -> guarded.moveFile(src.toString(), dst.toString()));
+    assertEquals(2, destWrites.get());
+    assertTrue(Files.notExists(dst), "复检拒绝后不得移动落盘");
+    assertTrue(Files.exists(src), "源应保留");
+  }
+
+  @Test
   @DisplayName("list_dir 列出目录条目")
   void listDirShowsEntries() throws IOException {
     Files.writeString(dir.resolve("x.txt"), "");


### PR DESCRIPTION
Same TOCTOU class as write_file: destination parent can become an outbound symlink between the first enforce and Files.copy/move. Recheck source and destination immediately before the filesystem change.

## Summary
- `copy_file`: recheck `FILE_READ(from)` + `FILE_WRITE(to)` before `Files.copy`
- `move_file`: recheck `FILE_WRITE(from)` + `FILE_WRITE(to)` before `Files.move`
- Adds regression coverage in `FileToolsTest`

Fixes #167

## Test plan
- [ ] `FileToolsTest.copyFileRechecksPathBeforeCopy`
- [ ] `FileToolsTest.moveFileRechecksPathBeforeMove`
- [ ] Existing copy/move directory rejection tests still green
- [ ] CI Build & quality gate green