### PR TITLE
fix(tool): recheck sandbox before read_file and delete_file

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -47,6 +47,8 @@ public class FileTools {
       throw new IllegalArgumentException("文件不存在或不是普通文件: " + path);
     }
     try {
+      // 读前复检：与 write_file 同款——防首次校验到 readString 间路径被换成外向软链
+      sandbox.enforce(new SandboxAction(ActionType.FILE_READ, path));
       return Files.readString(file);
     } catch (IOException e) {
       throw new UncheckedIOException("读取文件失败: " + path, e);
@@ -265,6 +267,8 @@ public class FileTools {
       throw new IllegalArgumentException("拒绝删除目录（本工具只删文件）: " + path);
     }
     try {
+      // 删前复检：防首次校验到 delete 间路径/父目录被换成外向软链
+      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
       return Files.deleteIfExists(file) ? "已删除: " + path : "文件不存在: " + path;
     } catch (IOException e) {
       throw new UncheckedIOException("删除文件失败: " + path, e);

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -200,6 +200,45 @@ class FileToolsTest {
   }
 
   @Test
+  @DisplayName("read_file 读取前复检 FILE_READ")
+  void readFileRechecksPathBeforeRead() throws IOException {
+    Path target = dir.resolve("secret.txt");
+    Files.writeString(target, "classified");
+    AtomicInteger fileReads = new AtomicInteger();
+    Sandbox sandbox =
+        action -> {
+          if (action.type() == ActionType.FILE_READ && fileReads.incrementAndGet() >= 2) {
+            throw new SandboxViolationException("复检拒绝: " + action.target());
+          }
+        };
+    FileTools guarded = new FileTools(sandbox);
+
+    assertThrows(SandboxViolationException.class, () -> guarded.readFile(target.toString()));
+    assertEquals(2, fileReads.get(), "应在读前后各 enforce 一次 FILE_READ");
+    assertEquals("classified", Files.readString(target), "复检拒绝后文件仍在");
+  }
+
+  @Test
+  @DisplayName("delete_file 删除前复检 FILE_WRITE")
+  void deleteFileRechecksPathBeforeDelete() throws IOException {
+    Path target = dir.resolve("keep.txt");
+    Files.writeString(target, "keep-me");
+    AtomicInteger fileWrites = new AtomicInteger();
+    Sandbox sandbox =
+        action -> {
+          if (action.type() == ActionType.FILE_WRITE && fileWrites.incrementAndGet() >= 2) {
+            throw new SandboxViolationException("复检拒绝: " + action.target());
+          }
+        };
+    FileTools guarded = new FileTools(sandbox);
+
+    assertThrows(SandboxViolationException.class, () -> guarded.deleteFile(target.toString()));
+    assertEquals(2, fileWrites.get());
+    assertTrue(Files.exists(target), "复检拒绝后不得删除");
+    assertEquals("keep-me", Files.readString(target));
+  }
+
+  @Test
   @DisplayName("append_file 落盘前复检 FILE_WRITE")
   void appendFileRechecksPathBeforeWrite() {
     AtomicInteger fileWrites = new AtomicInteger();


### PR DESCRIPTION
Same TOCTOU class as write_file: path can be swapped for an outbound symlink between the first enforce and Files.readString/deleteIfExists. Recheck immediately before IO.

## Summary
- `read_file`: second `FILE_READ` enforce before `Files.readString`
- `delete_file`: second `FILE_WRITE` enforce before `Files.deleteIfExists`
- Adds regression coverage in `FileToolsTest`

Fixes #169

## Test plan
- [ ] `FileToolsTest.readFileRechecksPathBeforeRead`
- [ ] `FileToolsTest.deleteFileRechecksPathBeforeDelete`
- [ ] Existing read/delete / symlink-directory tests still green
- [ ] CI Build & quality gate green