### PR TITLE
fix(scheduler): separate schedule runtime identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,9 @@ tools:
   - save_memory
   - recall_memory
 schedules:
-  - cron: "0 9 * * *"
+  - key: daily-brief
+    name: Daily brief
+    cron: "0 0 9 * * *"
 settings:
   max_iterations: 10
   max_history_turns: 20

--- a/docs/ScheduleIdentityMigration.md
+++ b/docs/ScheduleIdentityMigration.md
@@ -1,0 +1,21 @@
+# 定时任务身份分离与 SQLite 升级
+
+`AGENT.md` 中的 `schedules` 是定义源。每条任务必须包含 Agent 内唯一的 `key` 和展示用的 `name`；旧 `id` 仅在读取旧配置时兼容为 `key`，并以该值补足 `name`。
+
+运行态不再使用配置键：SQLite 为每个 `(profile_name, schedule_key)` 生成稳定、全局唯一的 UUID `schedule_id`。锁、启停、立即运行、任务状态和执行历史均按 `scheduleId` 工作。因此多个 Agent 可以同时使用 `key: daily`，互不覆盖也不互锁。配置删除或改名时，旧任务会标记为退役并从运行态列表隐藏；其状态和历史仍保留，重新使用同一 key 时会恢复原 ID。已知旧 `scheduleId` 仍可通过 v2 executions 端点回查退役任务的历史，但不能再运行或启停它。
+
+## SQLite 升级
+
+不使用 Flyway 或迁移版本表。启动时 `ScheduleSchemaUpgrade` 根据真实列和约束检测结构：
+
+- 新结构含 `schedule_id` 主键及 `(profile_name, schedule_key)` 唯一约束时，幂等跳过并补齐执行历史索引；
+- 识别到旧 `task_id` 双表时，在一个 `BEGIN IMMEDIATE … COMMIT` 内重建、复制并生成 UUID；
+- 任何混合或未知结构直接拒绝启动，避免猜测性处理数据。
+
+迁移前必须停止应用并复制数据库文件。旧执行历史保留 `legacy_task_key` 与 `legacy_migrated=true`；若历史无法关联现存旧任务，仍保留记录，`schedule_id` 为 `NULL`。
+
+## API
+
+新管理 API 位于 `/api/v2/schedules`，所有运行态路径参数都是 `scheduleId`。按配置精确定位可使用 `POST /api/v2/agents/{profileName}/schedules/{key}/run`。
+
+v1 仅用于过渡：路径参数作为旧 key 解析。唯一匹配时继续工作；多个 Agent 使用同 key 时返回 HTTP 409，绝不再静默选择第一条。

--- a/docs/TechnicalSolution.md
+++ b/docs/TechnicalSolution.md
@@ -520,9 +520,9 @@ Channel 是 Agent 对外的消息接入入口，主要解决"消息进来、响�
 
 **状态持久化与可管理（第 28 节补齐）。** 光"到点自动跑"还不够——运营方要能看见有哪些定时任务、跑过几次、上次成没成，也要能手动补跑一次、临时停掉一个任务。为此把任务状态和执行历史落 SQLite（重启不丢），并做成管理台的一等公民：
 
-- **两张表**（手工建表脚本，见 9.2）：`scheduled_tasks` 存任务登记信息与运行状态（`task_id` 主键、`profile_name`、`cron`、`zone`、`message`、`enabled`、`next_run_at`、`last_run_at`、`last_status`、`run_count`），`task_executions` 存每次执行的历史（成功失败都记：`task_id`、`session_id`、`started_at`、`success`、`error_message`、`duration_ms`）。定义来源仍是 skill/Profile 的 `schedules`——这两张表只存"状态 + 历史"，不作为定义源，重启时从文件重新注册。
-- **契约在 core、实现在 storage**（依赖倒置）：`ScheduledTaskStore` 接口（`register`/`recordExecution`/`isEnabled`/`setEnabled`/`list`/`executions`）放 `oryxos-core`，`AgentScheduler` 依赖它；JPA 实现 `JpaScheduledTaskStore` 放 `oryxos-storage`。`AgentScheduler` 启动扫描时顺带 `register` 登记，每次 `execute` 成功失败都 `recordExecution` 留痕（与宪法 V 审计同源）；`runOnce` 先看 `isEnabled`（停用则跳过、不记执行），管理台"立即执行"走 `runNow` 手动触发一次（无视启用状态）。
-- **四个管理端点**（`ScheduleApiController`，前缀 `/api/v1/schedules`）：`GET /schedules` 列任务与状态、`GET /schedules/{id}/executions` 查执行历史、`POST /schedules/{id}/run` 立即执行一次、`PUT /schedules/{id}` 启用/停用。管理台"定时任务"页调这四个端点，可查可管——这是第 28 节相对第 26 节"管理台只读"的一处明确扩展（仅限定时任务这一子系统的运行控制）。
+- **两张表**（手工建表脚本，见 9.2）：`scheduled_tasks` 存任务登记信息与运行状态（全局 `schedule_id` 主键、`profile_name`、Agent 内的 `schedule_key`、展示 `display_name`、`cron`、`zone`、`message` 与运行态字段）；`task_executions` 存每次执行的历史（`schedule_id`、`session_id`、`started_at`、`success`、`error_message`、`duration_ms`）。定义来源仍是 Agent 的 `schedules`——这两张表只存“状态 + 历史”，不作为定义源，重启时从文件重新协调。
+- **契约在 core、实现在 storage**（依赖倒置）：`ScheduledTaskStore` 接口（`reconcile`/`retire`/`recordExecution`/`isEnabled`/`setEnabled`/`list`/`executions`）放 `oryxos-core`，`AgentScheduler` 依赖它；JPA 实现 `JpaScheduledTaskStore` 放 `oryxos-storage`。`reconcile(profileName, key, ...)` 为同一配置任务复用稳定 `scheduleId`，调度锁、启停、立即执行和历史均使用该 ID；删改 key 时旧记录退役而不删历史。
+- **v2 管理端点**（前缀 `/api/v2`）：`GET /schedules`、`GET /schedules/{scheduleId}/executions`、`POST /schedules/{scheduleId}/run`、`PUT /schedules/{scheduleId}`，以及按定义精确定位的 `POST /agents/{profileName}/schedules/{key}/run`。管理台只调用 v2；v1 仍可按旧 key 兼容，但当多个 Agent 使用同一 key 时返回 HTTP 409，绝不再静默选择第一条。
 
 **核心阶段 vs 扩展阶段的边界。** 核心阶段的 `schedules` **定义**只能写在 `AGENT.md` frontmatter 里，跟着进程启动一起注册，改 cron / 新增任务要重启（或触发重新加载）才生效；第 28 节补齐的是任务的**状态持久化与运行控制**（查看 / 执行历史 / 立即执行 / 启用停用），不含通过 API 增删改 cron 定义。"业务方通过 Web Service 上传一个 Agent 目录（`AGENT.md` 带 `schedules` frontmatter）、由此定义一个新 Agent 并让它定时自动运行"这个完整闭环，依赖的是 7.3 里扩展阶段才补齐的两个能力——Agent 目录上传接口（含一句话生成）、`AgentScheduler` 的运行时增删接口——核心阶段这条链路要靠手动丢目录走通，扩展阶段补上后才是纯 API、免重启的闭环。
 
@@ -612,12 +612,15 @@ session list
 
 | 字段 | 说明 |
 |------|------|
-| `task_id` | 主键，schedule 的 id（Profile/Skill 的 `schedules` 里声明） |
+| `schedule_id` | 全局运行态主键；由 SQLite 为 `(profile_name, schedule_key)` 生成并保持稳定 |
 | `profile_name` | 归属 Profile |
+| `schedule_key` | Agent 内配置键；同一 Profile 内唯一 |
+| `display_name` | 展示名称，不参与运行态定位 |
 | `cron` | cron 表达式 |
 | `zone` | 时区 |
 | `message` | 到点发给 Agent 的消息 |
 | `enabled` | 是否启用（管理台开关，默认启用） |
+| `retired` | 配置被删除或改 key 后标记为退役；不参与调度和活动列表，但状态与历史保留 |
 | `next_run_at` | 下次触发时刻 |
 | `last_run_at` | 上次触发时刻 |
 | `last_status` | 上次结果 `success` / `failed` |
@@ -629,7 +632,7 @@ session list
 | 字段 | 说明 |
 |------|------|
 | `id` | 主键，自增 |
-| `task_id` | 关联 `scheduled_tasks` |
+| `schedule_id` | 关联 `scheduled_tasks`；迁移前无法可靠关联的历史可为空 |
 | `session_id` | 本次触发所用的钟推 Session |
 | `started_at` | 开始时间 |
 | `success` | 是否成功 |

--- a/oryxos-boot/src/test/java/io/oryxos/boot/RestartRecoveryIT.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/RestartRecoveryIT.java
@@ -29,7 +29,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 @Tag("integration")
 class RestartRecoveryIT {
 
-  private static final String TASK_ID = "restart-probe";
+  private static final String SCHEDULE_KEY = "restart-probe";
 
   @Test
   @DisplayName("任务状态与执行历史_跨进程重启仍在")
@@ -40,9 +40,9 @@ class RestartRecoveryIT {
     // —— 第一次启动：登记 + 执行一次，然后关闭（模拟停机）——
     try (ConfigurableApplicationContext ctx = boot(root, dbUrl)) {
       AgentScheduler scheduler = ctx.getBean(AgentScheduler.class);
-      scheduler.runNow(TASK_ID); // 手动触发一次真实 ReAct（mock provider）
-
       ScheduledTaskView task = findTask(ctx.getBean(ScheduledTaskStore.class).list());
+      scheduler.runNow(task.scheduleId()); // 手动触发一次真实 ReAct（mock provider）
+      task = findTask(ctx.getBean(ScheduledTaskStore.class).list());
       assertEquals(1, task.runCount(), "第一次运行后 run_count 应为 1");
     }
 
@@ -52,25 +52,25 @@ class RestartRecoveryIT {
       ScheduledTaskView task = findTask(store.list());
       assertEquals(1, task.runCount(), "重启后 run_count 仍应为 1（状态没随进程丢）");
       assertEquals("success", task.lastStatus(), "重启后 last_status 仍应为 success");
-      assertTrue(store.executions(TASK_ID, 10).size() >= 1, "重启后执行历史仍应查得到");
+      assertTrue(store.executions(task.scheduleId(), 10).size() >= 1, "重启后执行历史仍应查得到");
     }
   }
 
   private static ConfigurableApplicationContext boot(Path root, String dbUrl) {
     return new SpringApplicationBuilder(OryxOsRuntime.class)
-        .properties(
-            "oryxos.root=" + root,
-            "oryxos.providers[0].name=mock",
-            "spring.datasource.url=" + dbUrl,
-            "spring.main.web-application-type=none")
-        .run();
+        .run(
+            "--oryxos.root=" + root,
+            "--oryxos.providers[0].name=mock",
+            "--spring.datasource.url=" + dbUrl,
+            "--spring.lifecycle.timeout-per-shutdown-phase=100ms",
+            "--spring.main.web-application-type=none");
   }
 
   private static ScheduledTaskView findTask(List<ScheduledTaskView> list) {
     return list.stream()
-        .filter(t -> TASK_ID.equals(t.taskId()))
+        .filter(t -> SCHEDULE_KEY.equals(t.key()))
         .findFirst()
-        .orElseThrow(() -> new AssertionError("列表里应含任务 " + TASK_ID));
+        .orElseThrow(() -> new AssertionError("列表里应含任务 " + SCHEDULE_KEY));
   }
 
   private static Path seedWorkspace() throws IOException {
@@ -93,7 +93,8 @@ class RestartRecoveryIT {
           - save_memory
           - recall_memory
         schedules:
-          - id: restart-probe
+          - key: restart-probe
+            name: Restart probe
             cron: "0 0 0 1 1 *"
             zone: Asia/Shanghai
             message: 重启探针一次巡检

--- a/oryxos-boot/src/test/java/io/oryxos/boot/ScheduleSchemaUpgradeIntegrationTest.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/ScheduleSchemaUpgradeIntegrationTest.java
@@ -1,0 +1,200 @@
+package io.oryxos.boot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.oryxos.cli.OryxOsRuntime;
+import io.oryxos.core.agent.AgentScheduler;
+import io.oryxos.storage.ScheduleSchemaUpgrade;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/** Verifies that a real application start upgrades a recognized pre-scheduleId SQLite database. */
+class ScheduleSchemaUpgradeIntegrationTest {
+
+  @Test
+  @DisplayName("startup upgrades legacy schedule tables without losing task or execution rows")
+  void startupUpgradesLegacySchemaAndPreservesRows() throws Exception {
+    Path root = seedWorkspace();
+    Path database = root.resolve("legacy-schedules.db");
+    String dbUrl = "jdbc:sqlite:" + database;
+    createLegacyDatabase(dbUrl);
+
+    try (ConfigurableApplicationContext context = boot(root, dbUrl)) {
+      // The scheduler is an eager dependency of the normal web runtime; resolve it here because
+      // this fixture deliberately uses WebApplicationType.NONE to avoid binding a server port.
+      assertNotNull(context.getBean(AgentScheduler.class));
+      assertEquals(dbUrl, jdbcUrl(context.getBean(DataSource.class)));
+      context.getBean(ScheduleSchemaUpgrade.class).upgrade();
+      assertNewSchemaAndPreservedRows(dbUrl);
+    }
+
+    assertNewSchemaAndPreservedRows(dbUrl);
+  }
+
+  private static String jdbcUrl(DataSource dataSource) throws Exception {
+    try (Connection connection = dataSource.getConnection()) {
+      return connection.getMetaData().getURL();
+    }
+  }
+
+  private static ConfigurableApplicationContext boot(Path root, String dbUrl) {
+    return new SpringApplicationBuilder(OryxOsRuntime.class)
+        .run(
+            "--oryxos.root=" + root,
+            "--oryxos.providers[0].name=mock",
+            "--spring.datasource.url=" + dbUrl,
+            "--spring.lifecycle.timeout-per-shutdown-phase=100ms",
+            "--spring.main.web-application-type=none");
+  }
+
+  private static void createLegacyDatabase(String dbUrl) throws Exception {
+    try (Connection connection = DriverManager.getConnection(dbUrl);
+        Statement statement = connection.createStatement()) {
+      statement.execute(
+          """
+          CREATE TABLE scheduled_tasks (
+            task_id VARCHAR(255) PRIMARY KEY,
+            profile_name VARCHAR(255) NOT NULL,
+            cron VARCHAR(128) NOT NULL,
+            zone VARCHAR(64),
+            message TEXT,
+            enabled BOOLEAN NOT NULL DEFAULT 1,
+            next_run_at TIMESTAMP,
+            last_run_at TIMESTAMP,
+            last_status VARCHAR(16),
+            run_count INTEGER NOT NULL DEFAULT 0,
+            updated_at TIMESTAMP NOT NULL
+          )
+          """);
+      statement.execute(
+          """
+          CREATE TABLE task_executions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id VARCHAR(255) NOT NULL,
+            session_id VARCHAR(512),
+            started_at TIMESTAMP NOT NULL,
+            success BOOLEAN NOT NULL,
+            error_message TEXT,
+            duration_ms INTEGER NOT NULL
+          )
+          """);
+      statement.execute(
+          """
+          INSERT INTO scheduled_tasks (
+            task_id, profile_name, cron, zone, message, enabled, next_run_at, last_run_at,
+            last_status, run_count, updated_at)
+          VALUES (
+            'daily', 'legacy-agent', '0 0 0 1 1 *', 'Asia/Shanghai', 'legacy message', 0,
+            '2026-01-01T00:00:00Z', '2025-12-31T00:00:00Z', 'success', 7,
+            '2025-12-31T00:00:00Z')
+          """);
+      statement.execute(
+          """
+          INSERT INTO task_executions (
+            task_id, session_id, started_at, success, error_message, duration_ms)
+          VALUES ('daily', 'legacy-session', '2025-12-31T00:00:00Z', 1, NULL, 42)
+          """);
+    }
+  }
+
+  private static void assertNewSchemaAndPreservedRows(String dbUrl) throws Exception {
+    try (Connection connection = DriverManager.getConnection(dbUrl);
+        Statement statement = connection.createStatement()) {
+      assertFalse(columnExists(statement, "scheduled_tasks", "task_id"));
+      assertTrue(columnExists(statement, "scheduled_tasks", "schedule_id"));
+      assertTrue(columnExists(statement, "task_executions", "schedule_id"));
+      assertTrue(columnExists(statement, "task_executions", "legacy_task_key"));
+      assertTrue(columnExists(statement, "task_executions", "legacy_migrated"));
+      assertEquals(1, count(statement, "scheduled_tasks"));
+      assertEquals(1, count(statement, "task_executions"));
+
+      try (ResultSet task =
+          statement.executeQuery(
+              "SELECT schedule_id, profile_name, schedule_key, display_name, enabled, run_count"
+                  + " FROM scheduled_tasks")) {
+        assertTrue(task.next());
+        assertNotNull(task.getString("schedule_id"));
+        assertFalse(task.getString("schedule_id").isBlank());
+        assertEquals("legacy-agent", task.getString("profile_name"));
+        assertEquals("daily", task.getString("schedule_key"));
+        assertEquals("daily", task.getString("display_name"));
+        assertFalse(task.getBoolean("enabled"));
+        assertEquals(7, task.getInt("run_count"));
+      }
+
+      try (ResultSet execution =
+          statement.executeQuery(
+              "SELECT schedule_id, legacy_task_key, legacy_migrated FROM task_executions")) {
+        assertTrue(execution.next());
+        assertNotNull(execution.getString("schedule_id"));
+        assertEquals("daily", execution.getString("legacy_task_key"));
+        assertTrue(execution.getBoolean("legacy_migrated"));
+      }
+    }
+  }
+
+  private static boolean columnExists(Statement statement, String table, String column)
+      throws Exception {
+    try (ResultSet rows = statement.executeQuery("PRAGMA table_info(" + table + ")")) {
+      while (rows.next()) {
+        if (column.equals(rows.getString("name"))) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
+  private static long count(Statement statement, String table) throws Exception {
+    try (ResultSet rows = statement.executeQuery("SELECT COUNT(*) FROM " + table)) {
+      assertTrue(rows.next());
+      return rows.getLong(1);
+    }
+  }
+
+  private static Path seedWorkspace() throws IOException {
+    Path root = Files.createTempDirectory("oryxos-legacy-schedule-upgrade");
+    Files.createDirectories(root.resolve("memory"));
+    Files.createDirectories(root.resolve("agents").resolve("legacy-agent"));
+    Files.writeString(
+        root.resolve("agents/legacy-agent/AGENT.md"),
+        """
+        ---
+        name: legacy-agent
+        description: legacy upgrade fixture
+        identity:
+          agent_name: Legacy Agent
+          prompt: You are a test agent.
+        provider:
+          name: mock
+          model: mock-model
+        tools:
+          - save_memory
+        schedules:
+          - key: daily
+            name: Daily check
+            cron: "0 0 0 1 1 *"
+            zone: Asia/Shanghai
+            message: current message
+        settings:
+          max_iterations: 1
+          max_history_turns: 1
+        ---
+        Test fixture.
+        """);
+    return root;
+  }
+}

--- a/oryxos-boot/src/test/java/io/oryxos/boot/ScheduledTaskE2ETest.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/ScheduledTaskE2ETest.java
@@ -43,7 +43,7 @@ import org.springframework.test.context.DynamicPropertySource;
 class ScheduledTaskE2ETest {
 
   private static final Path ROOT = seedWorkspace();
-  private static final String TASK_ID = "daily-inspect";
+  private static final String SCHEDULE_KEY = "daily-inspect";
 
   private final ObjectMapper mapper = new ObjectMapper();
 
@@ -71,7 +71,8 @@ class ScheduledTaskE2ETest {
             - save_memory
             - recall_memory
           schedules:
-            - id: daily-inspect
+            - key: daily-inspect
+              name: Daily inspection
               cron: "0 0 0 1 1 *"
               zone: Asia/Shanghai
               message: 记录一次定时任务巡检
@@ -98,22 +99,23 @@ class ScheduledTaskE2ETest {
   void bootRegistersTask_runOnce_thenStateHistoryMemoryAllMatch_disableTakesEffect()
       throws Exception {
     // ① 启动即登记：列表里查得到该任务，初始启用、还没跑过
-    JsonNode before = findTask(getData("/api/v1/schedules"), TASK_ID);
+    JsonNode before = findTask(getData("/api/v2/schedules"), SCHEDULE_KEY);
     assertTrue(before.get("enabled").asBoolean(), "新任务应默认启用");
     assertEquals(0, before.get("runCount").asLong(), "还没触发过，run_count 应为 0");
 
     // ② 立即执行一次（手动触发一次真实 ReAct）
-    JsonNode execs = postData("/api/v1/schedules/" + TASK_ID + "/run");
+    String scheduleId = before.get("scheduleId").asText();
+    JsonNode execs = postData("/api/v2/schedules/" + scheduleId + "/run");
     assertFalse(execs.isEmpty(), "触发后应有一条执行历史");
     assertTrue(execs.get(0).get("success").asBoolean(), "本次执行应成功");
 
     // ③ 任务状态更新：run_count=1、last_status=success
-    JsonNode after = findTask(getData("/api/v1/schedules"), TASK_ID);
+    JsonNode after = findTask(getData("/api/v2/schedules"), SCHEDULE_KEY);
     assertEquals(1, after.get("runCount").asLong(), "触发一次后 run_count 应为 1");
     assertEquals("success", after.get("lastStatus").asText(), "last_status 应为 success");
 
     // ④ 执行历史端点查得到（成功、带 sessionId）
-    JsonNode history = getData("/api/v1/schedules/" + TASK_ID + "/executions");
+    JsonNode history = getData("/api/v2/schedules/" + scheduleId + "/executions");
     assertTrue(history.size() >= 1, "执行历史应查得到");
     assertFalse(history.get(0).get("sessionId").asText().isBlank(), "执行应关联到一个 session");
 
@@ -124,15 +126,15 @@ class ScheduledTaskE2ETest {
 
     // ⑥ 停用后列表里 enabled=false
     JsonNode afterDisable =
-        findTask(putData("/api/v1/schedules/" + TASK_ID, "{\"enabled\":false}"), TASK_ID);
+        findTask(putData("/api/v2/schedules/" + scheduleId, "{\"enabled\":false}"), SCHEDULE_KEY);
     assertFalse(afterDisable.get("enabled").asBoolean(), "停用后 enabled 应为 false");
   }
 
-  private static JsonNode findTask(JsonNode list, String taskId) {
+  private static JsonNode findTask(JsonNode list, String key) {
     return stream(list)
-        .filter(n -> taskId.equals(n.get("taskId").asText()))
+        .filter(n -> key.equals(n.get("key").asText()))
         .findFirst()
-        .orElseThrow(() -> new AssertionError("列表里应含任务 " + taskId));
+        .orElseThrow(() -> new AssertionError("列表里应含任务 " + key));
   }
 
   private JsonNode postData(String path) throws Exception {

--- a/oryxos-boot/src/test/java/io/oryxos/boot/SchedulerFlowIT.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/SchedulerFlowIT.java
@@ -43,7 +43,7 @@ import org.springframework.http.ResponseEntity;
 class SchedulerFlowIT {
 
   /** 与 `.oryxos/profiles/weather-daily.yaml` 里的 schedule id 对齐；换 Profile 时同步改这里。 */
-  private static final String TASK_ID = "weather-daily-morning";
+  private static final String SCHEDULE_KEY = "weather-daily-morning";
 
   private final ObjectMapper mapper = new ObjectMapper();
 
@@ -55,7 +55,8 @@ class SchedulerFlowIT {
   @DisplayName("钟推立即执行一次_状态历史入库且逐表对账")
   void runNowOnce_stateAndHistoryPersisted_andAuditReconciled() throws Exception {
     // 立即执行一次钟推（走 execute 同一路径，免等 cron 到点）
-    JsonNode execs = post("/api/v1/schedules/" + TASK_ID + "/run");
+    JsonNode task = findTask(get("/api/v2/schedules"), SCHEDULE_KEY);
+    JsonNode execs = post("/api/v2/schedules/" + task.get("scheduleId").asText() + "/run");
     assertFalse(execs.isEmpty(), "触发后应有执行历史");
     JsonNode latest = execs.get(0);
     assertTrue(latest.get("success").asBoolean(), "本次钟推应成功");
@@ -64,7 +65,7 @@ class SchedulerFlowIT {
     assertFalse(sid.isBlank(), "钟推应关联一个 session");
 
     // 任务状态更新入库
-    JsonNode task = findTask(get("/api/v1/schedules"), TASK_ID);
+    task = findTask(get("/api/v2/schedules"), SCHEDULE_KEY);
     assertTrue(task.get("runCount").asLong() >= 1, "run_count 应累加");
     assertEquals("success", task.get("lastStatus").asText(), "last_status 应为 success");
 
@@ -73,13 +74,13 @@ class SchedulerFlowIT {
     assertTrue(toolInvocations.findBySessionId(sid).size() >= 0, "钟推的工具调用（若有）应按 session 关联落审计");
   }
 
-  private static JsonNode findTask(JsonNode list, String taskId) {
+  private static JsonNode findTask(JsonNode list, String key) {
     for (JsonNode n : list) {
-      if (taskId.equals(n.get("taskId").asText())) {
+      if (key.equals(n.get("key").asText())) {
         return n;
       }
     }
-    throw new AssertionError("列表里应含任务 " + taskId + "（检查 .oryxos Profile 的 schedule id）");
+    throw new AssertionError("列表里应含任务 " + key + "（检查 .oryxos Profile 的 schedule key）");
   }
 
   private JsonNode post(String path) throws Exception {

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -567,7 +567,8 @@ public class OryxOsRuntime {
   /** 28 节：定时任务状态与执行历史落 SQLite（重启不丢），并支撑管理台的查看/立即执行/启用停用。 */
   /**
    * Runs after schema.sql and before any scheduler store or scheduler bean can observe the tables.
-   * The upgrader derives idempotence solely from the live SQLite columns; it has no migration table.
+   * The upgrader derives idempotence solely from the live SQLite columns; it has no migration
+   * table.
    */
   @Bean
   @DependsOn("dataSourceScriptDatabaseInitializer")

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -61,6 +61,7 @@ import io.oryxos.storage.LlmProviderRepository;
 import io.oryxos.storage.MemoryEntryRepository;
 import io.oryxos.storage.NotifyChannelRepository;
 import io.oryxos.storage.SandboxWhitelistRepository;
+import io.oryxos.storage.ScheduleSchemaUpgrade;
 import io.oryxos.storage.ScheduledTaskRepository;
 import io.oryxos.storage.SessionRepository;
 import io.oryxos.storage.TaskExecutionRepository;
@@ -100,12 +101,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -562,9 +565,22 @@ public class OryxOsRuntime {
   }
 
   /** 28 节：定时任务状态与执行历史落 SQLite（重启不丢），并支撑管理台的查看/立即执行/启用停用。 */
+  /**
+   * Runs after schema.sql and before any scheduler store or scheduler bean can observe the tables.
+   * The upgrader derives idempotence solely from the live SQLite columns; it has no migration table.
+   */
+  @Bean
+  @DependsOn("dataSourceScriptDatabaseInitializer")
+  ScheduleSchemaUpgrade scheduleSchemaUpgrade(DataSource dataSource) {
+    return new ScheduleSchemaUpgrade(dataSource);
+  }
+
   @Bean
   ScheduledTaskStore scheduledTaskStore(
-      ScheduledTaskRepository taskRepository, TaskExecutionRepository executionRepository) {
+      ScheduleSchemaUpgrade scheduleSchemaUpgrade,
+      ScheduledTaskRepository taskRepository,
+      TaskExecutionRepository executionRepository) {
+    scheduleSchemaUpgrade.upgrade();
     return new JpaScheduledTaskStore(taskRepository, executionRepository);
   }
 

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
@@ -111,8 +111,8 @@ public class AgentLifecycleService {
       2. name 必须是「{name}」；provider.name 必须是「{provider}」；model 必须是「{model}」（若该 provider 下没有这个 exact 模型名，就填该 provider 下合理的默认模型名）。
       3. tools 只能从下面【可用工具】里按需挑选，**绝不允许编造清单以外的工具名**。常见映射：查网页/接口数据用 http_get / http_post；\
       抓网页正文用 fetch_webpage；读写文件用 read_file / write_file；跑脚本用 shell。
-      4. schedules 每条的字段只有：id（任务标识）、cron（Spring 6 段 cron，如 "0 0 9 * * *" 表示每天 9 点）、zone（时区，如 Asia/Shanghai）、\
-      message（到点发给 Agent 的触发语）。**不要用 timezone、action 等清单外字段名。**
+      4. schedules 每条必须包含：key（Agent 内唯一的配置键）、name（展示名称）、cron（Spring 6 段 cron，如 "0 0 9 * * *" 表示每天 9 点）、\
+      zone（时区，如 Asia/Shanghai）、message（到点发给 Agent 的触发语）。不要输出 legacy id、timezone、action 等字段。
       5. 通知：{notify}
       6. MCP：如果任务需要用到下面【可用 MCP Server】里"已连接"的某个 server 提供的能力，把该 server 名加进 frontmatter 的 \
       mcp_servers 列表，**并且**把它提供的具体工具名也加进 tools 列表（两者都要写，只写一个不生效）；未连接 / 清单外的 server \
@@ -140,7 +140,7 @@ public class AgentLifecycleService {
       需求：
       """;
 
-  /** few-shot 范例：真实工具（http_get + notify）+ 正确 schedules 字段（id/cron/zone/message）。 */
+  /** few-shot 范例：真实工具（http_get + notify）+ 正确 schedules 字段（key/name/cron/zone/message）。 */
   private static final String AUTHOR_EXAMPLE =
       """
       ---
@@ -159,7 +159,8 @@ public class AgentLifecycleService {
         max_iterations: 10
         max_history_turns: 20
       schedules:
-        - id: morning-weather
+        - key: morning-weather
+          name: Morning weather
           cron: "0 0 9 * * *"
           zone: Asia/Shanghai
           message: 查询今天的天气并把穿搭提示发到团队群

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentScheduler.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentScheduler.java
@@ -139,7 +139,8 @@ public class AgentScheduler {
           taskStore.list().stream()
               .filter(
                   task ->
-                      task.profileName().equals(profile.name()) && task.key().equals(schedule.key()))
+                      task.profileName().equals(profile.name())
+                          && task.key().equals(schedule.key()))
               .map(ScheduledTaskView::scheduleId)
               .toList();
       for (String scheduleId : scheduleIds) {
@@ -165,14 +166,19 @@ public class AgentScheduler {
         taskStore.list().stream()
             .filter(candidate -> candidate.scheduleId().equals(scheduleId))
             .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("Schedule does not exist: " + scheduleId));
+            .orElseThrow(
+                () -> new IllegalArgumentException("Schedule does not exist: " + scheduleId));
     Profile profile =
         profileRegistry
             .get(task.profileName())
             .orElseThrow(
                 () ->
                     new IllegalArgumentException(
-                        "Schedule owner does not exist: " + task.profileName() + " (" + scheduleId + ")"));
+                        "Schedule owner does not exist: "
+                            + task.profileName()
+                            + " ("
+                            + scheduleId
+                            + ")"));
     ScheduleConfig schedule =
         profile.schedules().stream()
             .filter(candidate -> candidate.key().equals(task.key()))
@@ -198,7 +204,9 @@ public class AgentScheduler {
             .map(ScheduledTaskView::scheduleId)
             .findFirst()
             .orElseThrow(
-                () -> new IllegalArgumentException("Schedule does not exist: " + profileName + "/" + key));
+                () ->
+                    new IllegalArgumentException(
+                        "Schedule does not exist: " + profileName + "/" + key));
     runNow(scheduleId);
   }
 
@@ -327,7 +335,8 @@ public class AgentScheduler {
           System.currentTimeMillis() - start,
           nextExecution(schedule));
     } catch (RuntimeException exception) {
-      LOG.warn("Could not record execution for schedule {}: {}", scheduleId, exception.getMessage());
+      LOG.warn(
+          "Could not record execution for schedule {}: {}", scheduleId, exception.getMessage());
     }
   }
 

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentScheduler.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentScheduler.java
@@ -85,6 +85,10 @@ public class AgentScheduler {
    * Reconciles each configured task before its trigger is installed. Reconciliation preserves the
    * stable scheduleId for the same (profileName, key), including its enabled state and history.
    */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "CRLF_INJECTION_LOGS",
+      justification =
+          "Every dynamic log value is passed through sanitizeLogValue; SpotBugs does not track the sanitizer across method calls.")
   public void registerProfile(Profile profile) {
     for (ScheduleConfig schedule : profile.schedules()) {
       try {
@@ -116,13 +120,16 @@ public class AgentScheduler {
         }
         LOG.info(
             "Registered schedule {} (profile={} key={} cron={} zone={})",
-            scheduleId,
-            profile.name(),
-            schedule.key(),
-            schedule.cron(),
-            schedule.zone());
+            sanitizeLogValue(scheduleId),
+            sanitizeLogValue(profile.name()),
+            sanitizeLogValue(schedule.key()),
+            sanitizeLogValue(schedule.cron()),
+            sanitizeLogValue(schedule.zone()));
       } catch (RuntimeException exception) {
-        LOG.warn("Invalid schedule {} was skipped: {}", schedule.key(), exception.getMessage());
+        LOG.warn(
+            "Invalid schedule {} was skipped: {}",
+            sanitizeLogValue(schedule.key()),
+            sanitizeLogValue(exception.getMessage()));
       }
     }
   }
@@ -215,20 +222,25 @@ public class AgentScheduler {
     executeIfCurrent(profile, schedule, scheduleId, currentGeneration(scheduleId));
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "CRLF_INJECTION_LOGS",
+      justification = "The scheduleId is stripped of CR and LF before logging.")
   private void runOnce(
       Profile profile, ScheduleConfig schedule, String scheduleId, long capturedGeneration) {
     Lock lock = lockFor(scheduleId);
     if (!lock.tryLock()) {
-      LOG.info("Schedule {} is still running; skipping this trigger", scheduleId);
+      LOG.info("Schedule {} is still running; skipping this trigger", sanitizeLogValue(scheduleId));
       return;
     }
     try {
       if (!isCurrentGeneration(scheduleId, capturedGeneration)) {
-        LOG.debug("Schedule {} callback belongs to a retired configuration; skipping", scheduleId);
+        LOG.debug(
+            "Schedule {} callback belongs to a retired configuration; skipping",
+            sanitizeLogValue(scheduleId));
         return;
       }
       if (!taskStore.isEnabled(scheduleId)) {
-        LOG.info("Schedule {} is disabled; skipping this trigger", scheduleId);
+        LOG.info("Schedule {} is disabled; skipping this trigger", sanitizeLogValue(scheduleId));
         return;
       }
       executeLocked(profile, schedule, scheduleId);
@@ -237,16 +249,21 @@ public class AgentScheduler {
     }
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "CRLF_INJECTION_LOGS",
+      justification = "The scheduleId is stripped of CR and LF before logging.")
   private void executeIfCurrent(
       Profile profile, ScheduleConfig schedule, String scheduleId, long capturedGeneration) {
     Lock lock = lockFor(scheduleId);
     if (!lock.tryLock()) {
-      LOG.info("Schedule {} is still running; skipping this trigger", scheduleId);
+      LOG.info("Schedule {} is still running; skipping this trigger", sanitizeLogValue(scheduleId));
       return;
     }
     try {
       if (!isCurrentGeneration(scheduleId, capturedGeneration)) {
-        LOG.debug("Schedule {} changed while it was being started; skipping", scheduleId);
+        LOG.debug(
+            "Schedule {} changed while it was being started; skipping",
+            sanitizeLogValue(scheduleId));
         return;
       }
       executeLocked(profile, schedule, scheduleId);
@@ -255,6 +272,9 @@ public class AgentScheduler {
     }
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "CRLF_INJECTION_LOGS",
+      justification = "The scheduleId is stripped of CR and LF before logging.")
   private void executeLocked(Profile profile, ScheduleConfig schedule, String scheduleId) {
     Instant startedAt = Instant.now();
     long start = System.currentTimeMillis();
@@ -270,13 +290,16 @@ public class AgentScheduler {
       success = true;
     } catch (Exception exception) {
       error = exception.getMessage();
-      LOG.error("Schedule {} failed", scheduleId, exception);
+      LOG.error("Schedule {} failed", sanitizeLogValue(scheduleId), exception);
     } finally {
       recordExecution(schedule, scheduleId, sessionId, startedAt, success, error, start);
       finishAgentExecution(agentExecutionId, sessionId, success, error);
     }
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "CRLF_INJECTION_LOGS",
+      justification = "The scheduleId is stripped of CR and LF before logging.")
   private void retire(String scheduleId, String profileName, String key) {
     Lock lock = lockFor(scheduleId);
     lock.lock();
@@ -285,7 +308,7 @@ public class AgentScheduler {
       ScheduledFuture<?> future = scheduledTasks.remove(scheduleId);
       if (future != null) {
         future.cancel(false);
-        LOG.info("Unregistered schedule {}", scheduleId);
+        LOG.info("Unregistered schedule {}", sanitizeLogValue(scheduleId));
       }
       taskStore.retire(profileName, key);
     } finally {
@@ -305,6 +328,9 @@ public class AgentScheduler {
     return currentGeneration(scheduleId) == capturedGeneration;
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "CRLF_INJECTION_LOGS",
+      justification = "The exception message is stripped of CR and LF before logging.")
   private long startAgentExecution(Profile profile, Instant startedAt) {
     if (agentExecutionStore == null) {
       return -1;
@@ -312,11 +338,16 @@ public class AgentScheduler {
     try {
       return agentExecutionStore.start(profile.name(), "schedule", startedAt);
     } catch (RuntimeException exception) {
-      LOG.warn("Could not create Agent execution record: {}", exception.getMessage());
+      LOG.warn(
+          "Could not create Agent execution record: {}", sanitizeLogValue(exception.getMessage()));
       return -1;
     }
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "CRLF_INJECTION_LOGS",
+      justification =
+          "The scheduleId and exception message are stripped of CR and LF before logging.")
   private void recordExecution(
       ScheduleConfig schedule,
       String scheduleId,
@@ -336,10 +367,15 @@ public class AgentScheduler {
           nextExecution(schedule));
     } catch (RuntimeException exception) {
       LOG.warn(
-          "Could not record execution for schedule {}: {}", scheduleId, exception.getMessage());
+          "Could not record execution for schedule {}: {}",
+          sanitizeLogValue(scheduleId),
+          sanitizeLogValue(exception.getMessage()));
     }
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "CRLF_INJECTION_LOGS",
+      justification = "The exception message is stripped of CR and LF before logging.")
   private void finishAgentExecution(
       long agentExecutionId, String sessionId, boolean success, String error) {
     if (agentExecutionStore == null || agentExecutionId < 0) {
@@ -348,7 +384,8 @@ public class AgentScheduler {
     try {
       agentExecutionStore.finish(agentExecutionId, sessionId, success, error, Instant.now());
     } catch (RuntimeException exception) {
-      LOG.warn("Could not finish Agent execution record: {}", exception.getMessage());
+      LOG.warn(
+          "Could not finish Agent execution record: {}", sanitizeLogValue(exception.getMessage()));
     }
   }
 
@@ -368,5 +405,9 @@ public class AgentScheduler {
 
   private ZoneId resolveZone(String zone) {
     return zone == null || zone.isBlank() ? ZoneId.systemDefault() : ZoneId.of(zone);
+  }
+
+  static String sanitizeLogValue(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
   }
 }

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentScheduler.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentScheduler.java
@@ -7,6 +7,7 @@ import io.oryxos.core.session.Session;
 import io.oryxos.core.session.SessionManager;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -20,54 +21,34 @@ import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.scheduling.support.SimpleTriggerContext;
 
 /**
- * 定时任务这个第三触发源（"钟推"）。CLI/Web 是人推，本类到点自己拼一条消息交给 {@link AgentService#process}——
- * 走跟人推完全一样的入口，ReAct/Tool/Provider 一个字不用改（§8.5）。
- *
- * <p>只干一件事：到点了拼消息、交给编排入口。消息说什么是 Agent（AGENT.md）的事，交上去怎么处理是 ReActLoop 的事， 都不归本类管——职责划窄，不膨胀成工作流引擎。
- *
- * <p>四个坑的解法：坑一配置驱动（{@code TaskScheduler.schedule(...)} 动态注册，不用编译期写死的 {@code @Scheduled}）；
- * 坑二重叠跳过（按任务 id 的进程内 {@link ReentrantLock} + {@code tryLock}，核心阶段单实例，非分布式锁）； 坑三失败隔离（单次失败只记日志不外抛、审计走
- * {@code process} 既有链路、{@code finally} 必放锁）； 坑四时区显式（{@link CronTrigger} 带 {@link
- * ZoneId}，不由服务器系统时区替用户做主）。
- *
- * <p>纯 POJO：装配与启动注册由 {@code OryxOsRuntime} 显式做（{@code @Bean(initMethod="registerAll")}）， 不在 core
- * 类里放 Spring 注解（与 AgentService/ReActLoop 同构）。
+ * Delivers a configured scheduler message through the same AgentService entry point as interactive
+ * callers. Runtime identity is always the globally unique scheduleId; the profile key only locates
+ * the current configuration definition.
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",
-    justification = "taskStore 等协作者是 Spring 注入的单例服务，构造注入共享同一引用正是意图（无法也不应防御性拷贝）。")
+    justification = "Injected collaborators are shared Spring services by design.")
 public class AgentScheduler {
 
   private static final Logger LOG = LoggerFactory.getLogger(AgentScheduler.class);
-
-  /** 钟推的会话身份三元组固定值：同一 Profile 的历次定时触发复用同一 Session（§8.5、FR-006）。 */
   private static final String SCHEDULER_CHANNEL = "scheduler";
-
   private static final String SCHEDULER_USER = "scheduler";
-
-  /** 任务句柄复合键分隔符：schedule id 是 Agent 内的，跨 Agent 用 profileName@taskId 区分。 */
-  private static final String KEY_SEP = "@";
 
   private final TaskScheduler taskScheduler;
   private final ProfileRegistry profileRegistry;
   private final AgentService agentService;
   private final SessionManager sessionManager;
-
-  /** 28 节：任务状态 + 执行历史落 SQLite（重启不丢），并支持启用/停用。 */
   private final ScheduledTaskStore taskStore;
-
-  /** 32 节：定时触发也记进 Agent 维度执行历史（可空——旧调用方/测试不带）。 */
   private final AgentExecutionStore agentExecutionStore;
 
-  /** 任务 id → 锁：防同一任务重叠执行。进程内锁，核心阶段单实例足够（非分布式锁）。 */
+  /** scheduleId => in-process overlap lock. */
   private final ConcurrentMap<String, Lock> taskLocks = new ConcurrentHashMap<>();
 
-  /**
-   * 可注销句柄表（为 30 节运行时注销/更新 Agent 铺路）。 键是 {@code profileName@taskId} 复合（review 高危 7）：schedule id 只在
-   * 单个 Agent 内唯一，跨 Agent 撞 id 时若用裸 taskId 作键，后注册覆盖先注册的句柄（旧 future 泄漏、任务双跑）， 删除先注册的 Agent 还会 cancel
-   * 掉另一个 Agent 的任务。
-   */
+  /** scheduleId => cancellable future. */
   private final Map<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
+
+  /** scheduleId => configuration generation captured by each cron callback. */
+  private final ConcurrentMap<String, Long> scheduleGenerations = new ConcurrentHashMap<>();
 
   public AgentScheduler(
       TaskScheduler taskScheduler,
@@ -78,7 +59,6 @@ public class AgentScheduler {
     this(taskScheduler, profileRegistry, agentService, sessionManager, taskStore, null);
   }
 
-  /** 32 节：注入 {@link AgentExecutionStore}，定时触发也记 Agent 维度执行历史。 */
   public AgentScheduler(
       TaskScheduler taskScheduler,
       ProfileRegistry profileRegistry,
@@ -94,7 +74,7 @@ public class AgentScheduler {
     this.agentExecutionStore = agentExecutionStore;
   }
 
-  /** 启动时扫一遍所有 Agent 的 schedules，逐个 Profile 注册（配置驱动，坑一）。 */
+  /** Registers schedules for every currently loaded Agent. */
   public void registerAll() {
     for (Profile profile : profileRegistry.all()) {
       registerProfile(profile);
@@ -102,163 +82,281 @@ public class AgentScheduler {
   }
 
   /**
-   * 注册单个 Agent（Profile）的全部定时（29 节：从 {@link #registerAll} 循环体抽出，供 30 节运行时逐个 Agent
-   * 注册/注销）。每条定时留一个可注销句柄进 {@link #scheduledTasks}；单条 cron/时区非法只跳过这条、不拖垮其它（FR-007）。
+   * Reconciles each configured task before its trigger is installed. Reconciliation preserves the
+   * stable scheduleId for the same (profileName, key), including its enabled state and history.
    */
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "CRLF_INJECTION_LOGS",
-      justification = "日志里的 id/cron/zone 来自运营方手写的 AGENT.md 配置（非请求输入），仅用于启动诊断")
   public void registerProfile(Profile profile) {
-    for (ScheduleConfig sc : profile.schedules()) {
+    for (ScheduleConfig schedule : profile.schedules()) {
       try {
-        CronTrigger trigger = new CronTrigger(sc.cron(), resolveZone(sc.zone()));
-        ScheduledFuture<?> future = taskScheduler.schedule(() -> runOnce(profile, sc), trigger);
-        if (future != null) {
-          scheduledTasks.put(taskKey(sc.id(), profile.name()), future); // 留可注销句柄（30 节用）
+        CronTrigger trigger = new CronTrigger(schedule.cron(), resolveZone(schedule.zone()));
+        String scheduleId =
+            taskStore.reconcile(
+                profile.name(),
+                schedule.key(),
+                schedule.name(),
+                schedule.cron(),
+                schedule.zone(),
+                schedule.message(),
+                nextExecution(schedule));
+        Lock lock = lockFor(scheduleId);
+        lock.lock();
+        try {
+          long generation = nextGeneration(scheduleId);
+          ScheduledFuture<?> future =
+              taskScheduler.schedule(
+                  () -> runOnce(profile, schedule, scheduleId, generation), trigger);
+          if (future != null) {
+            ScheduledFuture<?> previous = scheduledTasks.put(scheduleId, future);
+            if (previous != null && previous != future) {
+              previous.cancel(false);
+            }
+          }
+        } finally {
+          lock.unlock();
         }
-        // 28 节：登记任务状态 + 下次触发到 SQLite（重启后可查；已存在则保留启用状态与运行次数）
-        taskStore.register(
-            sc.id(), profile.name(), sc.cron(), sc.zone(), sc.message(), nextExecution(sc));
-        LOG.info("已注册定时任务 {}（cron={} zone={}）", sc.id(), sc.cron(), sc.zone());
-      } catch (RuntimeException e) {
-        LOG.warn("定时任务 {} 配置非法，跳过：{}", sc.id(), e.getMessage());
+        LOG.info(
+            "Registered schedule {} (profile={} key={} cron={} zone={})",
+            scheduleId,
+            profile.name(),
+            schedule.key(),
+            schedule.cron(),
+            schedule.zone());
+      } catch (RuntimeException exception) {
+        LOG.warn("Invalid schedule {} was skipped: {}", schedule.key(), exception.getMessage());
       }
     }
   }
 
-  /** 某任务是否已留下可注销句柄（30 节注销前提；harness 守点）。键为复合键，按 taskId 前缀匹配。 */
-  public boolean hasScheduledTask(String taskId) {
-    String suffix = KEY_SEP + taskId;
-    return scheduledTasks.keySet().stream().anyMatch(key -> key.endsWith(suffix));
+  /** Returns whether the runtime handle for this scheduleId exists. */
+  public boolean hasScheduledTask(String scheduleId) {
+    return scheduledTasks.containsKey(scheduleId);
   }
 
-  /**
-   * 按 Agent 注销其全部定时（30 节：删除 / 改定时用）。遍历 {@code profile.schedules()}，从 {@link #scheduledTasks} 取句柄
-   * {@code cancel(false)}（不打断正在跑的一次，配合 taskLocks 的重叠保护）再移除句柄；不动 taskLocks、不动 taskStore。
-   */
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "CRLF_INJECTION_LOGS",
-      justification = "日志里的 sc.id() 来自运营方手写的 AGENT.md 配置（非请求输入），仅用于诊断")
+  /** Cancels the registered futures for all definitions belonging to a Profile. */
   public void unregisterProfile(Profile profile) {
-    for (ScheduleConfig sc : profile.schedules()) {
-      ScheduledFuture<?> future = scheduledTasks.remove(taskKey(sc.id(), profile.name()));
-      if (future != null) {
-        future.cancel(false);
-        LOG.info("已注销定时任务 {}", sc.id());
+    for (ScheduleConfig schedule : profile.schedules()) {
+      List<String> scheduleIds =
+          taskStore.list().stream()
+              .filter(
+                  task ->
+                      task.profileName().equals(profile.name()) && task.key().equals(schedule.key()))
+              .map(ScheduledTaskView::scheduleId)
+              .toList();
+      for (String scheduleId : scheduleIds) {
+        retire(scheduleId, profile.name(), schedule.key());
+      }
+      if (scheduleIds.isEmpty()) {
+        taskStore.retire(profile.name(), schedule.key());
       }
     }
   }
 
-  /** 定时触发入口：先看启用状态（停用则跳过、不记执行），启用才真正执行。 */
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "CRLF_INJECTION_LOGS",
-      justification = "日志里的 sc.id() 来自运营方手写的 Profile YAML 配置（非请求输入），仅用于诊断")
-  public void runOnce(Profile profile, ScheduleConfig sc) {
-    if (!taskStore.isEnabled(sc.id())) {
-      LOG.info("定时任务 {} 已停用，跳过本次触发", sc.id());
-      return;
-    }
-    execute(profile, sc);
-  }
-
-  /** 管理台"立即执行"：按 id 找到任务手动跑一次（无视启用状态，属显式手动触发）。找不到抛 IllegalArgumentException。 */
-  public void runNow(String taskId) {
-    for (Profile profile : profileRegistry.all()) {
-      for (ScheduleConfig sc : profile.schedules()) {
-        if (sc.id().equals(taskId)) {
-          execute(profile, sc);
-          return;
-        }
-      }
-    }
-    throw new IllegalArgumentException("定时任务不存在: " + taskId);
+  /** Runs a cron callback if its runtime task is enabled. */
+  public void runOnce(Profile profile, ScheduleConfig schedule, String scheduleId) {
+    runOnce(profile, schedule, scheduleId, currentGeneration(scheduleId));
   }
 
   /**
-   * 真正跑一次：拿锁 → 拼消息交给编排入口 → 成功失败都记 task_executions 并更新任务状态 → finally 放锁。 拿不到锁说明上一次还没跑完，直接跳过。public
-   * 为可测（harness 直接调、抓锁）。
+   * Manually runs exactly one persisted schedule. The persisted scheduleId identifies both the
+   * owning profile and the current configuration key.
    */
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "CRLF_INJECTION_LOGS",
-      justification = "日志里的 sc.id() 来自运营方手写的 Profile YAML 配置（非请求输入），仅用于诊断")
-  public void execute(Profile profile, ScheduleConfig sc) {
-    Lock lock = lockFor(sc.id());
+  public void runNow(String scheduleId) {
+    ScheduledTaskView task =
+        taskStore.list().stream()
+            .filter(candidate -> candidate.scheduleId().equals(scheduleId))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Schedule does not exist: " + scheduleId));
+    Profile profile =
+        profileRegistry
+            .get(task.profileName())
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "Schedule owner does not exist: " + task.profileName() + " (" + scheduleId + ")"));
+    ScheduleConfig schedule =
+        profile.schedules().stream()
+            .filter(candidate -> candidate.key().equals(task.key()))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "Schedule configuration does not exist: "
+                            + task.profileName()
+                            + "/"
+                            + task.key()
+                            + " ("
+                            + scheduleId
+                            + ")"));
+    executeIfCurrent(profile, schedule, scheduleId, currentGeneration(scheduleId));
+  }
+
+  /** Manually runs one schedule identified by its configuration location. */
+  public void runNow(String profileName, String key) {
+    String scheduleId =
+        taskStore.list().stream()
+            .filter(task -> task.profileName().equals(profileName) && task.key().equals(key))
+            .map(ScheduledTaskView::scheduleId)
+            .findFirst()
+            .orElseThrow(
+                () -> new IllegalArgumentException("Schedule does not exist: " + profileName + "/" + key));
+    runNow(scheduleId);
+  }
+
+  /** Executes and records one scheduler delivery under its global scheduleId. */
+  public void execute(Profile profile, ScheduleConfig schedule, String scheduleId) {
+    executeIfCurrent(profile, schedule, scheduleId, currentGeneration(scheduleId));
+  }
+
+  private void runOnce(
+      Profile profile, ScheduleConfig schedule, String scheduleId, long capturedGeneration) {
+    Lock lock = lockFor(scheduleId);
     if (!lock.tryLock()) {
-      LOG.info("定时任务 {} 上一次还在跑，跳过本次触发", sc.id()); // 坑二：不排队、不并行两份
+      LOG.info("Schedule {} is still running; skipping this trigger", scheduleId);
       return;
     }
+    try {
+      if (!isCurrentGeneration(scheduleId, capturedGeneration)) {
+        LOG.debug("Schedule {} callback belongs to a retired configuration; skipping", scheduleId);
+        return;
+      }
+      if (!taskStore.isEnabled(scheduleId)) {
+        LOG.info("Schedule {} is disabled; skipping this trigger", scheduleId);
+        return;
+      }
+      executeLocked(profile, schedule, scheduleId);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void executeIfCurrent(
+      Profile profile, ScheduleConfig schedule, String scheduleId, long capturedGeneration) {
+    Lock lock = lockFor(scheduleId);
+    if (!lock.tryLock()) {
+      LOG.info("Schedule {} is still running; skipping this trigger", scheduleId);
+      return;
+    }
+    try {
+      if (!isCurrentGeneration(scheduleId, capturedGeneration)) {
+        LOG.debug("Schedule {} changed while it was being started; skipping", scheduleId);
+        return;
+      }
+      executeLocked(profile, schedule, scheduleId);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void executeLocked(Profile profile, ScheduleConfig schedule, String scheduleId) {
     Instant startedAt = Instant.now();
     long start = System.currentTimeMillis();
     String sessionId = null;
     boolean success = false;
     String error = null;
-    // 32 节：Agent 维度执行记录（定时来源）；store 为空（旧装配/测试）则不记
-    long agentExecId = -1;
-    if (agentExecutionStore != null) {
-      try {
-        agentExecId = agentExecutionStore.start(profile.name(), "schedule", startedAt);
-      } catch (RuntimeException re) {
-        LOG.warn("Agent 执行记录落库失败（start）：{}", re.getMessage());
-      }
-    }
+    long agentExecutionId = startAgentExecution(profile, startedAt);
     try {
-      // channel/user 固定为 scheduler：同一 Profile 历次触发复用同一 Session，历史靠 max_history_turns 截断兜底。
-      // session_id 仍由 SessionManager 内部按三元组拼（本类不碰 session_id 生成）。
       Session session =
           sessionManager.getOrCreate(SCHEDULER_CHANNEL, SCHEDULER_USER, profile.name());
       sessionId = session.sessionId();
-      agentService.process(session, sc.message()); // 走跟 CLI/Web 完全一样的入口；审计在 process 内部
+      agentService.process(session, schedule.message());
       success = true;
-    } catch (Exception e) {
-      // 坑三：一次失败只记日志、不外抛，不把调度器搞挂、不影响其它任务的下次触发
-      error = e.getMessage();
-      LOG.error("定时任务 {} 执行失败", sc.id(), e);
+    } catch (Exception exception) {
+      error = exception.getMessage();
+      LOG.error("Schedule {} failed", scheduleId, exception);
     } finally {
-      lock.unlock(); // 成功失败都必须放锁，否则这个任务永远卡住
-      try {
-        // 宪法 V 同理：成功失败都留痕，重启后可回看
-        taskStore.recordExecution(
-            sc.id(),
-            sessionId,
-            startedAt,
-            success,
-            error,
-            System.currentTimeMillis() - start,
-            nextExecution(sc));
-      } catch (RuntimeException re) {
-        LOG.warn("定时任务 {} 执行记录落库失败：{}", sc.id(), re.getMessage());
-      }
-      if (agentExecutionStore != null && agentExecId >= 0) {
-        try {
-          agentExecutionStore.finish(agentExecId, sessionId, success, error, Instant.now());
-        } catch (RuntimeException re) {
-          LOG.warn("Agent 执行记录落库失败（finish）：{}", re.getMessage());
-        }
-      }
+      recordExecution(schedule, scheduleId, sessionId, startedAt, success, error, start);
+      finishAgentExecution(agentExecutionId, sessionId, success, error);
     }
   }
 
-  /** 按 cron/zone 算下次触发时刻；非法配置返回 null（不影响执行本身）。 */
-  private Instant nextExecution(ScheduleConfig sc) {
+  private void retire(String scheduleId, String profileName, String key) {
+    Lock lock = lockFor(scheduleId);
+    lock.lock();
     try {
-      CronTrigger trigger = new CronTrigger(sc.cron(), resolveZone(sc.zone()));
+      nextGeneration(scheduleId);
+      ScheduledFuture<?> future = scheduledTasks.remove(scheduleId);
+      if (future != null) {
+        future.cancel(false);
+        LOG.info("Unregistered schedule {}", scheduleId);
+      }
+      taskStore.retire(profileName, key);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private long nextGeneration(String scheduleId) {
+    return scheduleGenerations.merge(scheduleId, 1L, Long::sum);
+  }
+
+  private long currentGeneration(String scheduleId) {
+    return scheduleGenerations.getOrDefault(scheduleId, 0L);
+  }
+
+  private boolean isCurrentGeneration(String scheduleId, long capturedGeneration) {
+    return currentGeneration(scheduleId) == capturedGeneration;
+  }
+
+  private long startAgentExecution(Profile profile, Instant startedAt) {
+    if (agentExecutionStore == null) {
+      return -1;
+    }
+    try {
+      return agentExecutionStore.start(profile.name(), "schedule", startedAt);
+    } catch (RuntimeException exception) {
+      LOG.warn("Could not create Agent execution record: {}", exception.getMessage());
+      return -1;
+    }
+  }
+
+  private void recordExecution(
+      ScheduleConfig schedule,
+      String scheduleId,
+      String sessionId,
+      Instant startedAt,
+      boolean success,
+      String error,
+      long start) {
+    try {
+      taskStore.recordExecution(
+          scheduleId,
+          sessionId,
+          startedAt,
+          success,
+          error,
+          System.currentTimeMillis() - start,
+          nextExecution(schedule));
+    } catch (RuntimeException exception) {
+      LOG.warn("Could not record execution for schedule {}: {}", scheduleId, exception.getMessage());
+    }
+  }
+
+  private void finishAgentExecution(
+      long agentExecutionId, String sessionId, boolean success, String error) {
+    if (agentExecutionStore == null || agentExecutionId < 0) {
+      return;
+    }
+    try {
+      agentExecutionStore.finish(agentExecutionId, sessionId, success, error, Instant.now());
+    } catch (RuntimeException exception) {
+      LOG.warn("Could not finish Agent execution record: {}", exception.getMessage());
+    }
+  }
+
+  private Instant nextExecution(ScheduleConfig schedule) {
+    try {
+      CronTrigger trigger = new CronTrigger(schedule.cron(), resolveZone(schedule.zone()));
       return trigger.nextExecution(new SimpleTriggerContext());
-    } catch (RuntimeException e) {
+    } catch (RuntimeException exception) {
       return null;
     }
   }
 
-  /** 按任务 id 取同一把锁。public 为可测（harness 占锁模拟"上一次还在跑"）。 */
-  public Lock lockFor(String taskId) {
-    return taskLocks.computeIfAbsent(taskId, id -> new ReentrantLock());
+  /** Returns the in-process overlap lock associated with one globally unique scheduleId. */
+  public Lock lockFor(String scheduleId) {
+    return taskLocks.computeIfAbsent(scheduleId, ignored -> new ReentrantLock());
   }
 
-  /** 句柄表复合键：profileName@taskId。taskId 来自 AGENT.md，SAFE 名不含 @，不会与分隔符撞。 */
-  private static String taskKey(String taskId, String profileName) {
-    return profileName + KEY_SEP + taskId;
-  }
-
-  /** 时区显式（坑四）：空/blank 时才退回服务器系统时区，否则按配置解析。 */
   private ZoneId resolveZone(String zone) {
     return zone == null || zone.isBlank() ? ZoneId.systemDefault() : ZoneId.of(zone);
   }

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/ScheduledTaskStore.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/ScheduledTaskStore.java
@@ -4,25 +4,29 @@ import java.time.Instant;
 import java.util.List;
 
 /**
- * 定时任务的持久化契约（28 节）：把任务状态与执行历史落 SQLite，重启后仍在。
+ * Persistent runtime state and execution history for schedules defined by Agent profiles.
  *
- * <p>依赖倒置：接口在 core（{@link AgentScheduler} 用它），JPA 实现在 oryxos-storage。定义来源仍是 skill/Profile 的
- * schedules——本 store 只存"状态 + 历史"，不作为定义源（与 29 节 skill-centric 不冲突）。
+ * <p>Configuration belongs to AGENT.md. This store owns the stable runtime {@code scheduleId}
+ * generated for each profile/key pair.
  */
 public interface ScheduledTaskStore {
 
-  /** 注册/更新一条任务的登记信息与下次触发（启动扫描或运行时新增时调用）；新任务默认启用。 */
-  void register(
-      String taskId,
+  /**
+   * Reconcile the configuration with stored state and return its stable, globally unique schedule
+   * ID. A matching profile/key pair retains its enabled flag and execution history.
+   */
+  String reconcile(
       String profileName,
+      String key,
+      String name,
       String cron,
       String zone,
       String message,
       Instant nextRunAt);
 
-  /** 记录一次执行（成功失败都记），并更新任务的 last_run / last_status / run_count / next_run。 */
+  /** Record an execution and update the schedule's runtime state. */
   void recordExecution(
-      String taskId,
+      String scheduleId,
       String sessionId,
       Instant startedAt,
       boolean success,
@@ -30,15 +34,24 @@ public interface ScheduledTaskStore {
       long durationMs,
       Instant nextRunAt);
 
-  /** 任务是否启用（未登记的按启用处理，fail-open）。 */
-  boolean isEnabled(String taskId);
+  /** Return the enabled state for an existing schedule ID. */
+  boolean isEnabled(String scheduleId);
 
-  /** 启用/停用一条任务（管理台开关）。 */
-  void setEnabled(String taskId, boolean enabled);
+  /** Enable or disable an existing schedule ID. */
+  void setEnabled(String scheduleId, boolean enabled);
 
-  /** 列出全部定时任务的状态视图。 */
+  /** Retire a configuration definition while retaining its runtime state and history. */
+  void retire(String profileName, String key);
+
+  /** List currently configured, non-retired schedules. */
   List<ScheduledTaskView> list();
 
-  /** 某任务最近 {@code limit} 条执行历史（按开始时间倒序）。 */
-  List<TaskExecutionView> executions(String taskId, int limit);
+  /** Find all profile schedules sharing the supplied configuration key. */
+  List<ScheduledTaskView> findByKey(String key);
+
+  /** Whether a persisted schedule exists, including a retired one retained for history. */
+  boolean exists(String scheduleId);
+
+  /** Return the most recent execution history for a schedule ID, including a retired schedule. */
+  List<TaskExecutionView> executions(String scheduleId, int limit);
 }

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/ScheduledTaskView.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/ScheduledTaskView.java
@@ -8,8 +8,10 @@ import java.time.Instant;
  * <p>定义来源仍是 skill/Profile 的 schedules；本视图投影自 SQLite 里持久化的任务状态（重启后仍在）。
  */
 public record ScheduledTaskView(
-    String taskId,
+    String scheduleId,
     String profileName,
+    String key,
+    String name,
     String cron,
     String zone,
     String message,

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/TaskExecutionView.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/TaskExecutionView.java
@@ -4,7 +4,9 @@ import java.time.Instant;
 
 /** 定时任务一次执行的历史记录视图（成功失败都记）。供 GET /api/v1/schedules/{id}/executions。 */
 public record TaskExecutionView(
-    String taskId,
+    String scheduleId,
+    String legacyTaskKey,
+    boolean legacyMigrated,
     String sessionId,
     Instant startedAt,
     boolean success,

--- a/oryxos-core/src/main/java/io/oryxos/core/profile/Profile.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/Profile.java
@@ -3,11 +3,7 @@ package io.oryxos.core.profile;
 import java.util.List;
 import java.util.Map;
 
-/**
- * 一个 Agent 的完整配置载体（YAML 解析产物，不可变）。
- *
- * <p>第 16 节建全全部字段；本节只消费 provider 段，其余字段供后续各节取用。 集合字段一律防御性拷贝，杜绝外部可变引用。
- */
+/** Immutable configuration projection for one Agent profile. */
 public record Profile(
     String name,
     String description,
@@ -31,7 +27,7 @@ public record Profile(
     settings = settings == null ? Settings.defaults() : settings;
   }
 
-  /** 源码兼容旧 12 参调用点。{@code ignoredSkills} 不再进入 Profile，也不参与绑定；Agent Skill 的唯一真相源是目录软连接。 */
+  /** Compatibility constructor for callers that still pass ignoredSkills. */
   public Profile(
       String name,
       String description,
@@ -59,23 +55,19 @@ public record Profile(
         settings);
   }
 
-  /** 人格设定。 */
   public record Identity(String agentName, String prompt) {}
 
-  /** 模型选择：provider 名、model、温度（可空——缺省用 provider 侧默认，research D6）。 */
   public record ProviderRef(String name, String model, Double temperature) {}
 
-  /** 通知渠道（19 节 NotifyTools 消费）。 */
   public record NotifyChannel(String type, Map<String, String> config) {
     public NotifyChannel {
       config = config == null ? Map.of() : Map.copyOf(config);
     }
   }
 
-  /** 定时配置（25 节 AgentScheduler 消费）。 */
-  public record ScheduleConfig(String id, String cron, String zone, String message) {}
+  /** key locates a configuration within a Profile; name is for display only. */
+  public record ScheduleConfig(String key, String name, String cron, String zone, String message) {}
 
-  /** 循环参数。 */
   public record Settings(int maxIterations, int maxHistoryTurns) {
     private static final int DEFAULT_MAX_ITERATIONS = 10;
     private static final int DEFAULT_MAX_HISTORY_TURNS = 20;

--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -120,7 +120,7 @@ public class ProfileLoader {
         asStringList(map.get("mcp_servers")),
         asStringList(map.get("channels")),
         toNotifyChannels(asList(map.get("notify_channels"))),
-        toSchedules(asList(map.get("schedules"))),
+        toSchedules(asList(map.get("schedules")), source),
         asStringList(map.get("bootstrap")),
         toSettings(asMap(map.get("settings"))));
   }
@@ -180,19 +180,46 @@ public class ProfileLoader {
     return channels;
   }
 
-  private static List<Profile.ScheduleConfig> toSchedules(List<Object> list) {
+  private static List<Profile.ScheduleConfig> toSchedules(List<Object> list, String source) {
     if (list == null) {
       return List.of();
     }
     List<Profile.ScheduleConfig> schedules = new ArrayList<>();
+    Set<String> keys = new java.util.HashSet<>();
     for (Object item : list) {
       Map<String, Object> entry = asMap(item);
       if (entry == null) {
         continue;
       }
+      String legacyId = asString(entry.get("id"));
+      String configuredKey = asString(entry.get("key"));
+      if (configuredKey != null && configuredKey.isBlank()) {
+        throw new ProfileValidationException("Profile 定时配置 key 不能为空: " + source);
+      }
+      if (legacyId != null && legacyId.isBlank()) {
+        throw new ProfileValidationException("Profile 定时配置 id 不能为空: " + source);
+      }
+      if (configuredKey != null && legacyId != null && !configuredKey.equals(legacyId)) {
+        throw new ProfileValidationException(
+            "Profile 定时配置 id 与 key 必须相同: " + source);
+      }
+
+      String key = configuredKey != null ? configuredKey : legacyId;
+      if (key == null || key.isBlank()) {
+        throw new ProfileValidationException("Profile 定时配置缺少 key: " + source);
+      }
+      String configuredName = asString(entry.get("name"));
+      String name = configuredName != null ? configuredName : configuredKey == null ? legacyId : null;
+      if (name == null || name.isBlank()) {
+        throw new ProfileValidationException("Profile 定时配置缺少 name: " + source);
+      }
+      if (!keys.add(key)) {
+        throw new ProfileValidationException("Profile 定时配置 key 重复: " + key + " (" + source + ")");
+      }
       schedules.add(
           new Profile.ScheduleConfig(
-              asString(entry.get("id")),
+              key,
+              name,
               asString(entry.get("cron")),
               asString(entry.get("zone")),
               asString(entry.get("message"))));

--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -200,8 +200,7 @@ public class ProfileLoader {
         throw new ProfileValidationException("Profile 定时配置 id 不能为空: " + source);
       }
       if (configuredKey != null && legacyId != null && !configuredKey.equals(legacyId)) {
-        throw new ProfileValidationException(
-            "Profile 定时配置 id 与 key 必须相同: " + source);
+        throw new ProfileValidationException("Profile 定时配置 id 与 key 必须相同: " + source);
       }
 
       String key = configuredKey != null ? configuredKey : legacyId;
@@ -209,7 +208,8 @@ public class ProfileLoader {
         throw new ProfileValidationException("Profile 定时配置缺少 key: " + source);
       }
       String configuredName = asString(entry.get("name"));
-      String name = configuredName != null ? configuredName : configuredKey == null ? legacyId : null;
+      String name =
+          configuredName != null ? configuredName : configuredKey == null ? legacyId : null;
       if (name == null || name.isBlank()) {
         throw new ProfileValidationException("Profile 定时配置缺少 name: " + source);
       }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleServiceTest.java
@@ -147,7 +147,8 @@ class AgentLifecycleServiceTest {
   @DisplayName("update 改 schedules 先注销旧再注册新")
   void update_scheduleChanged_unregistersBeforeRegister() throws Exception {
     Profile old = profile("w", new ScheduleConfig("m", "m", "0 0 9 * * *", "Asia/Shanghai", "旧"));
-    Profile updated = profile("w", new ScheduleConfig("m", "m", "0 0 10 * * *", "Asia/Shanghai", "新"));
+    Profile updated =
+        profile("w", new ScheduleConfig("m", "m", "0 0 10 * * *", "Asia/Shanghai", "新"));
     when(profileRegistry.get("w")).thenReturn(Optional.of(old));
     Path dir = Path.of("agents", "w");
     when(agentStore.writeAll(eq("w"), any())).thenReturn(dir);

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleServiceTest.java
@@ -119,7 +119,7 @@ class AgentLifecycleServiceTest {
   @DisplayName("register 带 schedules 的 Agent 注册定时（三录入同一段代码）")
   void register_withSchedules_registersTimer() throws Exception {
     Path dir = Path.of("agents", "cron");
-    Profile p = profile("cron", new ScheduleConfig("m", "0 0 9 * * *", "Asia/Shanghai", "x"));
+    Profile p = profile("cron", new ScheduleConfig("m", "m", "0 0 9 * * *", "Asia/Shanghai", "x"));
     doReturn(p).when(agentLoader).deriveProfile(dir);
 
     service.register(dir);
@@ -132,7 +132,7 @@ class AgentLifecycleServiceTest {
   @DisplayName("删除必须先停定时_再动索引和目录")
   void delete_unregistersThenRemovesThenArchives() {
     Profile p =
-        profile("weather-daily", new ScheduleConfig("m", "0 0 9 * * *", "Asia/Shanghai", "x"));
+        profile("weather-daily", new ScheduleConfig("m", "m", "0 0 9 * * *", "Asia/Shanghai", "x"));
     when(profileRegistry.get("weather-daily")).thenReturn(Optional.of(p));
 
     service.delete("weather-daily");
@@ -146,8 +146,8 @@ class AgentLifecycleServiceTest {
   @Test
   @DisplayName("update 改 schedules 先注销旧再注册新")
   void update_scheduleChanged_unregistersBeforeRegister() throws Exception {
-    Profile old = profile("w", new ScheduleConfig("m", "0 0 9 * * *", "Asia/Shanghai", "旧"));
-    Profile updated = profile("w", new ScheduleConfig("m", "0 0 10 * * *", "Asia/Shanghai", "新"));
+    Profile old = profile("w", new ScheduleConfig("m", "m", "0 0 9 * * *", "Asia/Shanghai", "旧"));
+    Profile updated = profile("w", new ScheduleConfig("m", "m", "0 0 10 * * *", "Asia/Shanghai", "新"));
     when(profileRegistry.get("w")).thenReturn(Optional.of(old));
     Path dir = Path.of("agents", "w");
     when(agentStore.writeAll(eq("w"), any())).thenReturn(dir);

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentScanRegisterTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentScanRegisterTest.java
@@ -25,7 +25,9 @@ class AgentScanRegisterTest {
     fm.append("name: ").append(name).append('\n');
     fm.append("provider:\n  name: deepseek\n  model: deepseek-chat\n");
     if (withSchedule) {
-      fm.append("schedules:\n  - {cron: \"0 0 9 * * *\", zone: Asia/Shanghai, message: 到点}\n");
+      fm.append(
+          "schedules:\n"
+              + "  - {key: morning, name: Morning digest, cron: \"0 0 9 * * *\", zone: Asia/Shanghai, message: 到点}\n");
     }
     Files.writeString(dir.resolve("AGENT.md"), "---\n" + fm + "---\n正文");
   }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentSchedulerIdentityTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentSchedulerIdentityTest.java
@@ -1,0 +1,305 @@
+package io.oryxos.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.oryxos.core.profile.Profile;
+import io.oryxos.core.profile.Profile.ScheduleConfig;
+import io.oryxos.core.profile.ProfileRegistry;
+import io.oryxos.core.session.Session;
+import io.oryxos.core.session.SessionManager;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.Trigger;
+
+class AgentSchedulerIdentityTest {
+
+  private static final String CRON = "0 0 9 * * *";
+  private static final String ZONE = "Asia/Shanghai";
+
+  @Test
+  void sameScheduleKeyInDifferentProfilesKeepsIndependentScheduleIdsAndLocks() {
+    InMemoryTaskStore store = new InMemoryTaskStore();
+    Profile alpha = profile("alpha", schedule("daily", "Alpha daily", "alpha message"));
+    Profile beta = profile("beta", schedule("daily", "Beta daily", "beta message"));
+    AgentScheduler scheduler = scheduler(store, new ProfileRegistry(Map.of("alpha", alpha, "beta", beta)));
+
+    scheduler.registerAll();
+
+    String alphaId = store.scheduleId("alpha", "daily");
+    String betaId = store.scheduleId("beta", "daily");
+    assertNotEquals(alphaId, betaId);
+    assertNotSame(scheduler.lockFor(alphaId), scheduler.lockFor(betaId));
+  }
+
+  @Test
+  void reloadingSameProfileAndKeyKeepsIdEnabledStateAndHistoryWhenNameChanges() {
+    InMemoryTaskStore store = new InMemoryTaskStore();
+    Profile initial = profile("alpha", schedule("daily", "Original name", "first message"));
+    AgentScheduler scheduler = scheduler(store, new ProfileRegistry(Map.of("alpha", initial)));
+
+    scheduler.registerProfile(initial);
+    String scheduleId = store.scheduleId("alpha", "daily");
+    store.setEnabled(scheduleId, false);
+    store.recordExecution(scheduleId, "legacy-session", Instant.EPOCH, true, null, 1, Instant.EPOCH);
+
+    scheduler.unregisterProfile(initial);
+    Profile reloaded = profile("alpha", schedule("daily", "Renamed daily", "second message"));
+    scheduler.registerProfile(reloaded);
+
+    assertEquals(scheduleId, store.scheduleId("alpha", "daily"));
+    ScheduledTaskView task = store.onlyTask();
+    assertEquals("Renamed daily", task.name());
+    assertFalse(task.enabled());
+    assertEquals(1, store.executions(scheduleId, 10).size());
+  }
+
+  @Test
+  void changingKeyRetiresTheOldScheduleWithoutDiscardingItsHistory() {
+    InMemoryTaskStore store = new InMemoryTaskStore();
+    Profile original = profile("alpha", schedule("daily", "Daily", "daily message"));
+    AgentScheduler scheduler = scheduler(store, new ProfileRegistry(Map.of("alpha", original)));
+    scheduler.registerProfile(original);
+    String dailyId = store.scheduleId("alpha", "daily");
+    store.recordExecution(dailyId, "daily-session", Instant.EPOCH, true, null, 1, Instant.EPOCH);
+
+    scheduler.unregisterProfile(original);
+    scheduler.registerProfile(profile("alpha", schedule("weekly", "Weekly", "weekly message")));
+
+    assertEquals(List.of("weekly"), store.list().stream().map(ScheduledTaskView::key).toList());
+    assertFalse(store.isEnabled(dailyId));
+    assertEquals(1, store.executions(dailyId, 10).size());
+  }
+
+  @Test
+  void staleCronCallbackCannotRunThePreviousConfigurationAfterReload() {
+    InMemoryTaskStore store = new InMemoryTaskStore();
+    Profile initial = profile("alpha", schedule("daily", "Daily", "old message"));
+    Profile reloaded = profile("alpha", schedule("daily", "Daily", "new message"));
+    AgentService service = mock(AgentService.class);
+    TaskScheduler taskScheduler = mock(TaskScheduler.class);
+    @SuppressWarnings("unchecked")
+    ScheduledFuture<?> future = mock(ScheduledFuture.class);
+    List<Runnable> callbacks = new ArrayList<>();
+    SessionManager sessions = mock(SessionManager.class);
+    when(sessions.getOrCreate(any(), any(), any())).thenReturn(new Session("s", "alpha"));
+    when(taskScheduler.schedule(any(Runnable.class), any(Trigger.class)))
+        .thenAnswer(
+            invocation -> {
+              callbacks.add(invocation.getArgument(0, Runnable.class));
+              return future;
+            });
+    AgentScheduler scheduler =
+        new AgentScheduler(
+            taskScheduler,
+            new ProfileRegistry(Map.of("alpha", initial)),
+            service,
+            sessions,
+            store);
+
+    scheduler.registerProfile(initial);
+    scheduler.unregisterProfile(initial);
+    scheduler.registerProfile(reloaded);
+    callbacks.getFirst().run();
+
+    verify(service, never()).process(any(Session.class), any());
+  }
+
+  @Test
+  void runNowByScheduleIdTargetsTheMatchingProfileWhenKeysAreShared() {
+    InMemoryTaskStore store = new InMemoryTaskStore();
+    Profile alpha = profile("alpha", schedule("daily", "Alpha daily", "alpha message"));
+    Profile beta = profile("beta", schedule("daily", "Beta daily", "beta message"));
+    ProfileRegistry profiles = new ProfileRegistry(Map.of("alpha", alpha, "beta", beta));
+    AgentService service = mock(AgentService.class);
+    SessionManager sessions = mock(SessionManager.class);
+    when(sessions.getOrCreate(any(), any(), any())).thenAnswer(invocation -> new Session("s", invocation.getArgument(2)));
+    AgentScheduler scheduler = scheduler(store, profiles, service, sessions);
+    scheduler.registerAll();
+
+    scheduler.runNow(store.scheduleId("beta", "daily"));
+
+    verify(service).process(any(Session.class), org.mockito.ArgumentMatchers.eq("beta message"));
+  }
+
+  private static AgentScheduler scheduler(InMemoryTaskStore store, ProfileRegistry profiles) {
+    return scheduler(store, profiles, mock(AgentService.class), mock(SessionManager.class));
+  }
+
+  private static AgentScheduler scheduler(
+      InMemoryTaskStore store, ProfileRegistry profiles, AgentService service, SessionManager sessions) {
+    TaskScheduler taskScheduler = mock(TaskScheduler.class);
+    @SuppressWarnings("unchecked")
+    ScheduledFuture<?> future = mock(ScheduledFuture.class);
+    doReturn(future).when(taskScheduler).schedule(any(Runnable.class), any(Trigger.class));
+    return new AgentScheduler(taskScheduler, profiles, service, sessions, store);
+  }
+
+  private static Profile profile(String name, ScheduleConfig schedule) {
+    return new Profile(
+        name,
+        null,
+        null,
+        new Profile.ProviderRef("test", "test", null),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(schedule),
+        List.of(),
+        Profile.Settings.defaults());
+  }
+
+  private static ScheduleConfig schedule(String key, String name, String message) {
+    return new ScheduleConfig(key, name, CRON, ZONE, message);
+  }
+
+  private static final class InMemoryTaskStore implements ScheduledTaskStore {
+    private final Map<String, ScheduledTaskView> tasksById = new LinkedHashMap<>();
+    private final Map<String, String> idsByProfileAndKey = new LinkedHashMap<>();
+    private final Map<String, List<TaskExecutionView>> executions = new LinkedHashMap<>();
+    private final Set<String> retiredIds = new HashSet<>();
+
+    @Override
+    public String reconcile(
+        String profileName,
+        String key,
+        String name,
+        String cron,
+        String zone,
+        String message,
+        Instant nextRunAt) {
+      String profileAndKey = profileName + "/" + key;
+      String scheduleId =
+          idsByProfileAndKey.computeIfAbsent(
+              profileAndKey, ignored -> "schedule-" + (idsByProfileAndKey.size() + 1));
+      retiredIds.remove(scheduleId);
+      ScheduledTaskView old = tasksById.get(scheduleId);
+      tasksById.put(
+          scheduleId,
+          new ScheduledTaskView(
+              scheduleId,
+              profileName,
+              key,
+              name,
+              cron,
+              zone,
+              message,
+              old == null || old.enabled(),
+              nextRunAt,
+              old == null ? null : old.lastRunAt(),
+              old == null ? null : old.lastStatus(),
+              old == null ? 0 : old.runCount()));
+      return scheduleId;
+    }
+
+    @Override
+    public void recordExecution(
+        String scheduleId,
+        String sessionId,
+        Instant startedAt,
+        boolean success,
+        String errorMessage,
+        long durationMs,
+        Instant nextRunAt) {
+      ScheduledTaskView task = tasksById.get(scheduleId);
+      tasksById.put(
+          scheduleId,
+          new ScheduledTaskView(
+              task.scheduleId(),
+              task.profileName(),
+              task.key(),
+              task.name(),
+              task.cron(),
+              task.zone(),
+              task.message(),
+              task.enabled(),
+              nextRunAt,
+              startedAt,
+              success ? "SUCCESS" : "FAILED",
+              task.runCount() + 1));
+      executions
+          .computeIfAbsent(scheduleId, ignored -> new ArrayList<>())
+          .add(new TaskExecutionView(scheduleId, null, false, sessionId, startedAt, success, errorMessage, durationMs));
+    }
+
+    @Override
+    public boolean isEnabled(String scheduleId) {
+      return !retiredIds.contains(scheduleId) && tasksById.get(scheduleId).enabled();
+    }
+
+    @Override
+    public void setEnabled(String scheduleId, boolean enabled) {
+      ScheduledTaskView task = tasksById.get(scheduleId);
+      tasksById.put(
+          scheduleId,
+          new ScheduledTaskView(
+              task.scheduleId(),
+              task.profileName(),
+              task.key(),
+              task.name(),
+              task.cron(),
+              task.zone(),
+              task.message(),
+              enabled,
+              task.nextRunAt(),
+              task.lastRunAt(),
+              task.lastStatus(),
+              task.runCount()));
+    }
+
+    @Override
+    public void retire(String profileName, String key) {
+      String scheduleId = idsByProfileAndKey.get(profileName + "/" + key);
+      if (scheduleId != null) {
+        retiredIds.add(scheduleId);
+      }
+    }
+
+    @Override
+    public List<ScheduledTaskView> list() {
+      return tasksById.values().stream().filter(task -> !retiredIds.contains(task.scheduleId())).toList();
+    }
+
+    @Override
+    public List<ScheduledTaskView> findByKey(String key) {
+      return tasksById.values().stream()
+          .filter(task -> !retiredIds.contains(task.scheduleId()) && task.key().equals(key))
+          .toList();
+    }
+
+    @Override
+    public boolean exists(String scheduleId) {
+      return tasksById.containsKey(scheduleId);
+    }
+
+    @Override
+    public List<TaskExecutionView> executions(String scheduleId, int limit) {
+      return executions.getOrDefault(scheduleId, List.of()).stream().limit(limit).toList();
+    }
+
+    String scheduleId(String profileName, String key) {
+      return idsByProfileAndKey.get(profileName + "/" + key);
+    }
+
+    ScheduledTaskView onlyTask() {
+      return tasksById.values().iterator().next();
+    }
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentSchedulerIdentityTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentSchedulerIdentityTest.java
@@ -38,7 +38,8 @@ class AgentSchedulerIdentityTest {
     InMemoryTaskStore store = new InMemoryTaskStore();
     Profile alpha = profile("alpha", schedule("daily", "Alpha daily", "alpha message"));
     Profile beta = profile("beta", schedule("daily", "Beta daily", "beta message"));
-    AgentScheduler scheduler = scheduler(store, new ProfileRegistry(Map.of("alpha", alpha, "beta", beta)));
+    AgentScheduler scheduler =
+        scheduler(store, new ProfileRegistry(Map.of("alpha", alpha, "beta", beta)));
 
     scheduler.registerAll();
 
@@ -57,7 +58,8 @@ class AgentSchedulerIdentityTest {
     scheduler.registerProfile(initial);
     String scheduleId = store.scheduleId("alpha", "daily");
     store.setEnabled(scheduleId, false);
-    store.recordExecution(scheduleId, "legacy-session", Instant.EPOCH, true, null, 1, Instant.EPOCH);
+    store.recordExecution(
+        scheduleId, "legacy-session", Instant.EPOCH, true, null, 1, Instant.EPOCH);
 
     scheduler.unregisterProfile(initial);
     Profile reloaded = profile("alpha", schedule("daily", "Renamed daily", "second message"));
@@ -107,11 +109,7 @@ class AgentSchedulerIdentityTest {
             });
     AgentScheduler scheduler =
         new AgentScheduler(
-            taskScheduler,
-            new ProfileRegistry(Map.of("alpha", initial)),
-            service,
-            sessions,
-            store);
+            taskScheduler, new ProfileRegistry(Map.of("alpha", initial)), service, sessions, store);
 
     scheduler.registerProfile(initial);
     scheduler.unregisterProfile(initial);
@@ -129,7 +127,8 @@ class AgentSchedulerIdentityTest {
     ProfileRegistry profiles = new ProfileRegistry(Map.of("alpha", alpha, "beta", beta));
     AgentService service = mock(AgentService.class);
     SessionManager sessions = mock(SessionManager.class);
-    when(sessions.getOrCreate(any(), any(), any())).thenAnswer(invocation -> new Session("s", invocation.getArgument(2)));
+    when(sessions.getOrCreate(any(), any(), any()))
+        .thenAnswer(invocation -> new Session("s", invocation.getArgument(2)));
     AgentScheduler scheduler = scheduler(store, profiles, service, sessions);
     scheduler.registerAll();
 
@@ -143,7 +142,10 @@ class AgentSchedulerIdentityTest {
   }
 
   private static AgentScheduler scheduler(
-      InMemoryTaskStore store, ProfileRegistry profiles, AgentService service, SessionManager sessions) {
+      InMemoryTaskStore store,
+      ProfileRegistry profiles,
+      AgentService service,
+      SessionManager sessions) {
     TaskScheduler taskScheduler = mock(TaskScheduler.class);
     @SuppressWarnings("unchecked")
     ScheduledFuture<?> future = mock(ScheduledFuture.class);
@@ -236,7 +238,16 @@ class AgentSchedulerIdentityTest {
               task.runCount() + 1));
       executions
           .computeIfAbsent(scheduleId, ignored -> new ArrayList<>())
-          .add(new TaskExecutionView(scheduleId, null, false, sessionId, startedAt, success, errorMessage, durationMs));
+          .add(
+              new TaskExecutionView(
+                  scheduleId,
+                  null,
+                  false,
+                  sessionId,
+                  startedAt,
+                  success,
+                  errorMessage,
+                  durationMs));
     }
 
     @Override
@@ -274,7 +285,9 @@ class AgentSchedulerIdentityTest {
 
     @Override
     public List<ScheduledTaskView> list() {
-      return tasksById.values().stream().filter(task -> !retiredIds.contains(task.scheduleId())).toList();
+      return tasksById.values().stream()
+          .filter(task -> !retiredIds.contains(task.scheduleId()))
+          .toList();
     }
 
     @Override

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentSchedulerRegisterTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentSchedulerRegisterTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.oryxos.core.profile.Profile;
 import io.oryxos.core.profile.Profile.ScheduleConfig;
@@ -15,16 +16,15 @@ import io.oryxos.core.session.SessionManager;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
 
-/** 课件《第29节》验收 harness：AgentSchedulerRegisterTest——registerProfile 留句柄、定时来自 Agent。 */
 class AgentSchedulerRegisterTest {
 
   private static final String CRON = "0 0 9 * * *";
   private static final String ZONE = "Asia/Shanghai";
+  private static final String SCHEDULE_ID = "schedule-ops-morning";
 
   private TaskScheduler taskScheduler;
   private ScheduledTaskStore taskStore;
@@ -35,8 +35,24 @@ class AgentSchedulerRegisterTest {
     taskScheduler = mock(TaskScheduler.class);
     taskStore = mock(ScheduledTaskStore.class);
     ScheduledFuture<?> future = mock(ScheduledFuture.class);
-    // ScheduledFuture<?> 通配符：doReturn 避开 thenReturn 的类型捕获问题
     doReturn(future).when(taskScheduler).schedule(any(Runnable.class), any(Trigger.class));
+    when(taskStore.reconcile(any(), any(), any(), any(), any(), any(), any())).thenReturn(SCHEDULE_ID);
+    when(taskStore.list())
+        .thenReturn(
+            List.of(
+                new ScheduledTaskView(
+                    SCHEDULE_ID,
+                    "ops",
+                    "morning",
+                    "Morning run",
+                    CRON,
+                    ZONE,
+                    "run now",
+                    true,
+                    null,
+                    null,
+                    null,
+                    0)));
     scheduler =
         new AgentScheduler(
             taskScheduler,
@@ -46,7 +62,7 @@ class AgentSchedulerRegisterTest {
             taskStore);
   }
 
-  private static Profile profileWithSchedule(String name, ScheduleConfig sc) {
+  private static Profile profileWithSchedule(String name, ScheduleConfig schedule) {
     return new Profile(
         name,
         null,
@@ -56,40 +72,38 @@ class AgentSchedulerRegisterTest {
         List.of(),
         List.of(),
         List.of(),
-        List.of(sc),
+        List.of(schedule),
         List.of(),
         Profile.Settings.defaults());
   }
 
   @Test
-  @DisplayName("registerProfile 后 scheduledTasks 有可注销句柄")
-  void registerProfile_leavesCancellableHandle() {
+  void registerProfileLeavesCancellableHandleByScheduleId() {
     scheduler.registerProfile(
-        profileWithSchedule("ops", new ScheduleConfig("morning", CRON, ZONE, "到点了")));
+        profileWithSchedule("ops", new ScheduleConfig("morning", "Morning run", CRON, ZONE, "run now")));
 
-    assertTrue(scheduler.hasScheduledTask("morning"), "登记带定时的 Agent 后留有可注销句柄");
-    assertFalse(scheduler.hasScheduledTask("nonexistent"));
+    assertTrue(scheduler.hasScheduledTask(SCHEDULE_ID));
+    assertFalse(scheduler.hasScheduledTask("morning"));
   }
 
   @Test
-  @DisplayName("unregisterProfile 注销定时、移除句柄（30 节删除/改定时用）")
-  void unregisterProfile_cancelsAndRemovesHandle() {
-    Profile p = profileWithSchedule("ops", new ScheduleConfig("morning", CRON, ZONE, "到点了"));
-    scheduler.registerProfile(p);
-    assertTrue(scheduler.hasScheduledTask("morning"));
+  void unregisterProfileCancelsAndRemovesTheScheduleIdHandle() {
+    Profile profile =
+        profileWithSchedule("ops", new ScheduleConfig("morning", "Morning run", CRON, ZONE, "run now"));
+    scheduler.registerProfile(profile);
+    assertTrue(scheduler.hasScheduledTask(SCHEDULE_ID));
 
-    scheduler.unregisterProfile(p);
+    scheduler.unregisterProfile(profile);
 
-    assertFalse(scheduler.hasScheduledTask("morning"), "注销后句柄被移除、定时被 cancel");
+    assertFalse(scheduler.hasScheduledTask(SCHEDULE_ID));
   }
 
   @Test
-  @DisplayName("cron/时区来自 Profile.schedules，不来自别处")
-  void cronAndZoneComeFromProfileSchedules() {
+  void reconcilesProfileKeyAndDefinitionBeforeScheduling() {
     scheduler.registerProfile(
-        profileWithSchedule("ops", new ScheduleConfig("morning", CRON, ZONE, "到点了")));
+        profileWithSchedule("ops", new ScheduleConfig("morning", "Morning run", CRON, ZONE, "run now")));
 
-    // taskStore.register 收到的 cron/zone 正是 Profile.schedules 里声明的那对
-    verify(taskStore).register(eq("morning"), eq("ops"), eq(CRON), eq(ZONE), eq("到点了"), any());
+    verify(taskStore)
+        .reconcile(eq("ops"), eq("morning"), eq("Morning run"), eq(CRON), eq(ZONE), eq("run now"), any());
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentSchedulerRegisterTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentSchedulerRegisterTest.java
@@ -36,7 +36,8 @@ class AgentSchedulerRegisterTest {
     taskStore = mock(ScheduledTaskStore.class);
     ScheduledFuture<?> future = mock(ScheduledFuture.class);
     doReturn(future).when(taskScheduler).schedule(any(Runnable.class), any(Trigger.class));
-    when(taskStore.reconcile(any(), any(), any(), any(), any(), any(), any())).thenReturn(SCHEDULE_ID);
+    when(taskStore.reconcile(any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(SCHEDULE_ID);
     when(taskStore.list())
         .thenReturn(
             List.of(
@@ -80,7 +81,8 @@ class AgentSchedulerRegisterTest {
   @Test
   void registerProfileLeavesCancellableHandleByScheduleId() {
     scheduler.registerProfile(
-        profileWithSchedule("ops", new ScheduleConfig("morning", "Morning run", CRON, ZONE, "run now")));
+        profileWithSchedule(
+            "ops", new ScheduleConfig("morning", "Morning run", CRON, ZONE, "run now")));
 
     assertTrue(scheduler.hasScheduledTask(SCHEDULE_ID));
     assertFalse(scheduler.hasScheduledTask("morning"));
@@ -89,7 +91,8 @@ class AgentSchedulerRegisterTest {
   @Test
   void unregisterProfileCancelsAndRemovesTheScheduleIdHandle() {
     Profile profile =
-        profileWithSchedule("ops", new ScheduleConfig("morning", "Morning run", CRON, ZONE, "run now"));
+        profileWithSchedule(
+            "ops", new ScheduleConfig("morning", "Morning run", CRON, ZONE, "run now"));
     scheduler.registerProfile(profile);
     assertTrue(scheduler.hasScheduledTask(SCHEDULE_ID));
 
@@ -101,9 +104,11 @@ class AgentSchedulerRegisterTest {
   @Test
   void reconcilesProfileKeyAndDefinitionBeforeScheduling() {
     scheduler.registerProfile(
-        profileWithSchedule("ops", new ScheduleConfig("morning", "Morning run", CRON, ZONE, "run now")));
+        profileWithSchedule(
+            "ops", new ScheduleConfig("morning", "Morning run", CRON, ZONE, "run now")));
 
     verify(taskStore)
-        .reconcile(eq("ops"), eq("morning"), eq("Morning run"), eq(CRON), eq(ZONE), eq("run now"), any());
+        .reconcile(
+            eq("ops"), eq("morning"), eq("Morning run"), eq(CRON), eq(ZONE), eq("run now"), any());
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentSchedulerTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentSchedulerTest.java
@@ -200,6 +200,11 @@ class AgentSchedulerTest {
   }
 
   @Test
+  void logValuesCannotInjectAdditionalLines() {
+    assertEquals("daily__forged-entry", AgentScheduler.sanitizeLogValue("daily\r\nforged-entry"));
+  }
+
+  @Test
   void noSchedulesMakesRegistrationANoop() {
     when(profileRegistry.all()).thenReturn(List.of(profileWith(List.of())));
 

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentSchedulerTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentSchedulerTest.java
@@ -98,7 +98,8 @@ class AgentSchedulerTest {
     SimpleTriggerContext context =
         new SimpleTriggerContext(Instant.EPOCH, Instant.EPOCH, Instant.EPOCH);
     assertEquals(
-        new CronTrigger(CRON, ZoneId.of(ZONE)).nextExecution(context), trigger.nextExecution(context));
+        new CronTrigger(CRON, ZoneId.of(ZONE)).nextExecution(context),
+        trigger.nextExecution(context));
     assertNotEquals(
         new CronTrigger(CRON, ZoneId.of("America/New_York")).nextExecution(context),
         trigger.nextExecution(context));
@@ -170,8 +171,10 @@ class AgentSchedulerTest {
     Profile beta = profileNamed("beta-agent", sc("beta-task"));
     Session alphaSession = new Session("alpha-sid", "alpha-agent");
     Session betaSession = new Session("beta-sid", "beta-agent");
-    when(sessionManager.getOrCreate("scheduler", "scheduler", "alpha-agent")).thenReturn(alphaSession);
-    when(sessionManager.getOrCreate("scheduler", "scheduler", "beta-agent")).thenReturn(betaSession);
+    when(sessionManager.getOrCreate("scheduler", "scheduler", "alpha-agent"))
+        .thenReturn(alphaSession);
+    when(sessionManager.getOrCreate("scheduler", "scheduler", "beta-agent"))
+        .thenReturn(betaSession);
 
     scheduler.runOnce(alpha, sc("alpha-task"), "alpha-schedule");
     scheduler.runOnce(beta, sc("beta-task"), "beta-schedule");

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentSchedulerTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentSchedulerTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.locks.Lock;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.scheduling.TaskScheduler;
@@ -32,10 +31,6 @@ import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.scheduling.support.SimpleTriggerContext;
 
-/**
- * 课件《第25节》验收 harness：AgentSchedulerTest——一个类覆盖四个坑。诀窍是**别真等时间**：{@code runOnce}
- * 是独立方法，直接调它就能测全部行为逻辑；cron 触发本身是 Spring 的事，只验"注册参数传对了"。
- */
 class AgentSchedulerTest {
 
   private static final String PROFILE_NAME = "ops-agent";
@@ -56,14 +51,19 @@ class AgentSchedulerTest {
     sessionManager = mock(SessionManager.class);
     profileRegistry = mock(ProfileRegistry.class);
     taskStore = mock(ScheduledTaskStore.class);
-    // 28 节：默认所有任务启用，否则 runOnce 会因停用而跳过（Mockito boolean 默认 false）
     when(taskStore.isEnabled(any())).thenReturn(true);
+    when(taskStore.reconcile(any(), any(), any(), any(), any(), any(), any()))
+        .thenAnswer(invocation -> invocation.getArgument(0) + "-" + invocation.getArgument(1));
     scheduler =
         new AgentScheduler(taskScheduler, profileRegistry, agentService, sessionManager, taskStore);
   }
 
-  private static ScheduleConfig sc(String id) {
-    return new ScheduleConfig(id, CRON, ZONE, "汇总昨天的 PR 进度");
+  private static ScheduleConfig sc(String key) {
+    return new ScheduleConfig(key, key, CRON, ZONE, "summarize today's PR progress");
+  }
+
+  private static String scheduleId(String key) {
+    return PROFILE_NAME + "-" + key;
   }
 
   private static Profile profileWith(List<ScheduleConfig> schedules) {
@@ -86,7 +86,6 @@ class AgentSchedulerTest {
   }
 
   @Test
-  @DisplayName("注册时CronTrigger带上配置的cron和时区")
   void registerPassesCronAndZoneToTrigger() {
     when(profileRegistry.all()).thenReturn(List.of(profileWith(List.of(sc("daily")))));
 
@@ -95,28 +94,20 @@ class AgentSchedulerTest {
     ArgumentCaptor<Trigger> captor = ArgumentCaptor.forClass(Trigger.class);
     verify(taskScheduler).schedule(any(Runnable.class), captor.capture());
     CronTrigger trigger = assertInstanceOf(CronTrigger.class, captor.getValue());
-    assertEquals(CRON, trigger.getExpression(), "cron 表达式必须来自配置");
-    // 时区行为回归：CronTrigger.equals 只比 cron 不比时区，故用固定 TriggerContext 下的"下一次触发时刻"证明时区生效——
-    // 与"同 cron + 配置时区"参照一致、与别的时区不一致，证明时区没被服务器默认顶掉（坑四）。
-    SimpleTriggerContext ctx =
+    assertEquals(CRON, trigger.getExpression());
+    SimpleTriggerContext context =
         new SimpleTriggerContext(Instant.EPOCH, Instant.EPOCH, Instant.EPOCH);
     assertEquals(
-        new CronTrigger(CRON, ZoneId.of(ZONE)).nextExecution(ctx),
-        trigger.nextExecution(ctx),
-        "时区必须来自配置");
+        new CronTrigger(CRON, ZoneId.of(ZONE)).nextExecution(context), trigger.nextExecution(context));
     assertNotEquals(
-        new CronTrigger(CRON, ZoneId.of("America/New_York")).nextExecution(ctx),
-        trigger.nextExecution(ctx),
-        "时区不能被服务器默认顶掉");
+        new CronTrigger(CRON, ZoneId.of("America/New_York")).nextExecution(context),
+        trigger.nextExecution(context));
   }
 
   @Test
-  @DisplayName("上一次还没跑完_本次触发直接跳过")
-  void previousRunStillActive_currentTriggerSkipped() throws InterruptedException {
+  void previousRunStillActiveSkipsCurrentTrigger() throws InterruptedException {
     Profile profile = profileWith(List.of(sc("task-1")));
-    Lock lock = scheduler.lockFor("task-1");
-    // 真实重叠是跨线程的（调度线程池）：ReentrantLock 对同线程可重入，必须让另一线程占着锁，
-    // runOnce 的 tryLock 才会真失败。用闩确保占锁完成后再触发、断言完再放锁。
+    Lock lock = scheduler.lockFor(scheduleId("task-1"));
     CountDownLatch locked = new CountDownLatch(1);
     CountDownLatch release = new CountDownLatch(1);
     Thread holder =
@@ -126,18 +117,18 @@ class AgentSchedulerTest {
               locked.countDown();
               try {
                 release.await();
-              } catch (InterruptedException e) {
+              } catch (InterruptedException exception) {
                 Thread.currentThread().interrupt();
               } finally {
                 lock.unlock();
               }
             });
     holder.start();
-    locked.await(); // 确保另一线程已占锁，模拟"上一次还在跑"
+    locked.await();
 
     try {
-      scheduler.runOnce(profile, sc("task-1"));
-      verify(agentService, never()).process(any(), any()); // 没有叠加执行
+      scheduler.runOnce(profile, sc("task-1"), scheduleId("task-1"));
+      verify(agentService, never()).process(any(), any());
     } finally {
       release.countDown();
       holder.join();
@@ -145,82 +136,71 @@ class AgentSchedulerTest {
   }
 
   @Test
-  @DisplayName("任务抛异常_不外抛且锁必须被释放")
-  void taskThrows_notRethrown_lockReleased() {
+  void taskFailureIsNotRethrownAndLockIsReleased() {
     Profile profile = profileWith(List.of(sc("task-1")));
     when(sessionManager.getOrCreate(any(), any(), any()))
         .thenReturn(new Session("sched-sid", PROFILE_NAME));
     when(agentService.process(any(), any())).thenThrow(new RuntimeException("boom"));
 
-    assertDoesNotThrow(() -> scheduler.runOnce(profile, sc("task-1"))); // 调度器不死
+    assertDoesNotThrow(() -> scheduler.runOnce(profile, sc("task-1"), scheduleId("task-1")));
 
-    scheduler.runOnce(profile, sc("task-1")); // 二进宫：再触发一次
-    // 能进来第二次——锁真的在 finally 放了，没有永久卡死
+    scheduler.runOnce(profile, sc("task-1"), scheduleId("task-1"));
     verify(agentService, times(2)).process(any(), any());
   }
 
   @Test
-  @DisplayName("会话三元组固定_两次触发拿同一Session")
-  void sessionIdentityFixed_reusesSameSession() {
+  void sessionIdentityIsFixedForRepeatedSchedulerRuns() {
     Profile profile = profileWith(List.of(sc("task-1")));
     Session shared = new Session("sched-sid", PROFILE_NAME);
     when(sessionManager.getOrCreate("scheduler", "scheduler", PROFILE_NAME)).thenReturn(shared);
 
-    scheduler.runOnce(profile, sc("task-1"));
-    scheduler.runOnce(profile, sc("task-1"));
+    scheduler.runOnce(profile, sc("task-1"), scheduleId("task-1"));
+    scheduler.runOnce(profile, sc("task-1"), scheduleId("task-1"));
 
-    // 三元组固定 scheduler/scheduler/profileName
     verify(sessionManager, times(2)).getOrCreate("scheduler", "scheduler", PROFILE_NAME);
-    // 两次都拿到同一个 Session（复用、历史累积）
-    ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
-    verify(agentService, times(2)).process(sessionCaptor.capture(), eq("汇总昨天的 PR 进度"));
-    assertSame(shared, sessionCaptor.getAllValues().get(0));
-    assertSame(shared, sessionCaptor.getAllValues().get(1));
+    ArgumentCaptor<Session> captor = ArgumentCaptor.forClass(Session.class);
+    verify(agentService, times(2)).process(captor.capture(), eq("summarize today's PR progress"));
+    assertSame(shared, captor.getAllValues().get(0));
+    assertSame(shared, captor.getAllValues().get(1));
   }
 
   @Test
-  @DisplayName("多Agent并存_各自的钟推用各自的Session互不串号")
-  void multipleAgents_eachSchedulerRunUsesItsOwnSession() {
+  void multipleAgentsUseDifferentSchedulerSessions() {
     Profile alpha = profileNamed("alpha-agent", sc("alpha-task"));
     Profile beta = profileNamed("beta-agent", sc("beta-task"));
     Session alphaSession = new Session("alpha-sid", "alpha-agent");
     Session betaSession = new Session("beta-sid", "beta-agent");
-    when(sessionManager.getOrCreate("scheduler", "scheduler", "alpha-agent"))
-        .thenReturn(alphaSession);
-    when(sessionManager.getOrCreate("scheduler", "scheduler", "beta-agent"))
-        .thenReturn(betaSession);
+    when(sessionManager.getOrCreate("scheduler", "scheduler", "alpha-agent")).thenReturn(alphaSession);
+    when(sessionManager.getOrCreate("scheduler", "scheduler", "beta-agent")).thenReturn(betaSession);
 
-    scheduler.runOnce(alpha, sc("alpha-task"));
-    scheduler.runOnce(beta, sc("beta-task"));
+    scheduler.runOnce(alpha, sc("alpha-task"), "alpha-schedule");
+    scheduler.runOnce(beta, sc("beta-task"), "beta-schedule");
 
-    // 两个 Agent 的钟推各自按 profileName 拿到不同 Session——三元组只有 profile 段不同，互不串号
-    ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
-    verify(agentService, times(2)).process(sessionCaptor.capture(), eq("汇总昨天的 PR 进度"));
-    assertSame(alphaSession, sessionCaptor.getAllValues().get(0));
-    assertSame(betaSession, sessionCaptor.getAllValues().get(1));
-    assertNotEquals(
-        alphaSession.sessionId(), betaSession.sessionId(), "不同 Agent 的钟推 Session 必须互相独立");
+    ArgumentCaptor<Session> captor = ArgumentCaptor.forClass(Session.class);
+    verify(agentService, times(2)).process(captor.capture(), eq("summarize today's PR progress"));
+    assertSame(alphaSession, captor.getAllValues().get(0));
+    assertSame(betaSession, captor.getAllValues().get(1));
+    assertNotEquals(alphaSession.sessionId(), betaSession.sessionId());
   }
 
   @Test
-  @DisplayName("单条非法cron不拖垮其它规则的注册")
-  void invalidCronSkipped_othersStillRegistered() {
-    ScheduleConfig bad = new ScheduleConfig("bad", "not-a-cron", ZONE, "x");
+  void invalidCronIsSkippedWithoutBlockingOtherSchedules() {
+    ScheduleConfig bad = new ScheduleConfig("bad", "Bad", "not-a-cron", ZONE, "x");
     ScheduleConfig good = sc("good");
     when(profileRegistry.all()).thenReturn(List.of(profileWith(List.of(bad, good))));
 
-    assertDoesNotThrow(() -> scheduler.registerAll());
+    assertDoesNotThrow(scheduler::registerAll);
 
-    // 坏的被跳过、好的照常注册（只注册成功 1 条）
     verify(taskScheduler, times(1)).schedule(any(Runnable.class), any(Trigger.class));
+    verify(taskStore, never())
+        .reconcile(eq(PROFILE_NAME), eq("bad"), any(), any(), any(), any(), any());
   }
 
   @Test
-  @DisplayName("无任何定时规则_注册空跑不报错")
-  void noSchedules_registerAllIsNoop() {
+  void noSchedulesMakesRegistrationANoop() {
     when(profileRegistry.all()).thenReturn(List.of(profileWith(List.of())));
 
-    assertDoesNotThrow(() -> scheduler.registerAll());
+    assertDoesNotThrow(scheduler::registerAll);
 
     verify(taskScheduler, never()).schedule(any(Runnable.class), any(Trigger.class));
   }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/DeriveProfileTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/DeriveProfileTest.java
@@ -68,7 +68,8 @@ class DeriveProfileTest {
 
     assertEquals(1, p.schedules().size());
     Profile.ScheduleConfig sc = p.schedules().get(0);
-    assertEquals("morning", sc.id());
+    assertEquals("morning", sc.key());
+    assertEquals("morning", sc.name());
     assertEquals("0 0 9 * * *", sc.cron());
     assertEquals("Asia/Shanghai", sc.zone());
     assertEquals("到点了", sc.message());

--- a/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
@@ -84,6 +84,8 @@ class ProfileLoaderTest {
     assertEquals("webhook", profile.notifyChannels().get(0).type()); // notify_channels
     assertEquals("0 0 8 * * *", profile.schedules().get(0).cron());
     assertEquals("Asia/Shanghai", profile.schedules().get(0).zone());
+    assertEquals("morning", profile.schedules().get(0).key());
+    assertEquals("morning", profile.schedules().get(0).name());
     assertEquals(5, profile.settings().maxIterations()); // max_iterations
     assertEquals(15, profile.settings().maxHistoryTurns()); // max_history_turns
   }
@@ -168,5 +170,193 @@ class ProfileLoaderTest {
 
     assertEquals(
         "https://hooks.example.com/team", profile.notifyChannels().get(0).config().get("url"));
+  }
+
+  @Test
+  void 定时配置的key和展示名称被解析() throws IOException {
+    write(
+        "key-and-name.yaml",
+        """
+        name: key-and-name
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - key: daily
+            name: Daily digest
+            cron: "0 0 8 * * *"
+            message: summarize yesterday
+        """);
+
+    Profile.ScheduleConfig schedule =
+        loader().loadAll().get("key-and-name").orElseThrow().schedules().get(0);
+
+    assertEquals("daily", schedule.key());
+    assertEquals("Daily digest", schedule.name());
+  }
+
+  @Test
+  void 定时配置不能同时给出不同的id和key() throws IOException {
+    write(
+        "conflicting-key.yaml",
+        """
+        name: conflicting-key
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - id: legacy-daily
+            key: daily
+            name: Daily digest
+            cron: "0 0 8 * * *"
+        """);
+
+    ProfileValidationException exception =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("conflicting-key.yaml")));
+
+    assertTrue(exception.getMessage().contains("id"));
+    assertTrue(exception.getMessage().contains("key"));
+  }
+
+  @Test
+  void 同一Agent不能重复定义定时key() throws IOException {
+    write(
+        "duplicate-key.yaml",
+        """
+        name: duplicate-key
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - key: daily
+            name: Morning digest
+            cron: "0 0 8 * * *"
+          - key: daily
+            name: Evening digest
+            cron: "0 0 18 * * *"
+        """);
+
+    ProfileValidationException exception =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("duplicate-key.yaml")));
+
+    assertTrue(exception.getMessage().contains("daily"));
+  }
+
+  @Test
+  void 定时key和展示名称不能为空() throws IOException {
+    write(
+        "blank-schedule-fields.yaml",
+        """
+        name: blank-schedule-fields
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - key: " "
+            name: " "
+            cron: "0 0 8 * * *"
+        """);
+
+    ProfileValidationException exception =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("blank-schedule-fields.yaml")));
+
+    assertTrue(exception.getMessage().contains("key"));
+  }
+
+  @Test
+  void 定时展示名称不能为空() throws IOException {
+    write(
+        "blank-schedule-name.yaml",
+        """
+        name: blank-schedule-name
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - key: daily
+            name: " "
+            cron: "0 0 8 * * *"
+        """);
+
+    ProfileValidationException exception =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("blank-schedule-name.yaml")));
+
+    assertTrue(exception.getMessage().contains("name"));
+  }
+
+  @Test
+  void legacyIdMayMatchKeyWhenNameIsExplicit() throws IOException {
+    write(
+        "matching-id-and-key.yaml",
+        """
+        name: matching-id-and-key
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - id: daily
+            key: daily
+            name: Daily digest
+            cron: "0 0 8 * * *"
+        """);
+
+    Profile.ScheduleConfig schedule =
+        loader().loadAll().get("matching-id-and-key").orElseThrow().schedules().get(0);
+
+    assertEquals("daily", schedule.key());
+    assertEquals("Daily digest", schedule.name());
+  }
+
+  @Test
+  void keyOnlyScheduleStillRequiresName() throws IOException {
+    write(
+        "key-only-without-name.yaml",
+        """
+        name: key-only-without-name
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - key: daily
+            cron: "0 0 8 * * *"
+        """);
+
+    ProfileValidationException exception =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("key-only-without-name.yaml")));
+
+    assertTrue(exception.getMessage().contains("name"));
+  }
+
+  @Test
+  void 新key格式即使id相同也必须显式给出name() throws IOException {
+    write(
+        "key-without-name.yaml",
+        """
+        name: key-without-name
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - id: daily
+            key: daily
+            cron: "0 0 8 * * *"
+        """);
+
+    ProfileValidationException exception =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("key-without-name.yaml")));
+
+    assertTrue(exception.getMessage().contains("name"));
   }
 }

--- a/oryxos-storage/src/main/java/io/oryxos/storage/JpaScheduledTaskStore.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/JpaScheduledTaskStore.java
@@ -50,7 +50,7 @@ public class JpaScheduledTaskStore implements ScheduledTaskStore {
   }
 
   @Override
-  @Transactional
+  @Transactional(rollbackFor = Exception.class)
   public void recordExecution(
       String scheduleId,
       String sessionId,

--- a/oryxos-storage/src/main/java/io/oryxos/storage/JpaScheduledTaskStore.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/JpaScheduledTaskStore.java
@@ -94,12 +94,14 @@ public class JpaScheduledTaskStore implements ScheduledTaskStore {
 
   @Override
   public void retire(String profileName, String key) {
-    tasks.findByProfileNameAndScheduleKey(profileName, key).ifPresent(
-        task -> {
-          task.setRetired(true);
-          task.setUpdatedAt(Instant.now());
-          tasks.save(task);
-        });
+    tasks
+        .findByProfileNameAndScheduleKey(profileName, key)
+        .ifPresent(
+            task -> {
+              task.setRetired(true);
+              task.setUpdatedAt(Instant.now());
+              tasks.save(task);
+            });
   }
 
   @Override

--- a/oryxos-storage/src/main/java/io/oryxos/storage/JpaScheduledTaskStore.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/JpaScheduledTaskStore.java
@@ -5,12 +5,11 @@ import io.oryxos.core.agent.ScheduledTaskView;
 import io.oryxos.core.agent.TaskExecutionView;
 import java.time.Instant;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.transaction.annotation.Transactional;
 
-/**
- * {@link ScheduledTaskStore} 的 JPA 实现（28 节）：任务状态入 scheduled_tasks、执行历史入 task_executions。
- *
- * <p>register 幂等 upsert（已存在则保留 enabled 与 run_count）；recordExecution 写一条历史并更新任务状态。
- */
+/** JPA-backed runtime state and execution history for configured schedules. */
 public class JpaScheduledTaskStore implements ScheduledTaskStore {
 
   private final ScheduledTaskRepository tasks;
@@ -22,111 +21,144 @@ public class JpaScheduledTaskStore implements ScheduledTaskStore {
   }
 
   @Override
-  public void register(
-      String taskId,
+  public String reconcile(
       String profileName,
+      String key,
+      String name,
       String cron,
       String zone,
       String message,
       Instant nextRunAt) {
-    ScheduledTask task = tasks.findById(taskId).orElse(null);
+    ScheduledTask task = tasks.findByProfileNameAndScheduleKey(profileName, key).orElse(null);
     if (task == null) {
       task = new ScheduledTask();
-      task.setTaskId(taskId);
-      task.setEnabled(true); // 新任务默认启用
+      task.setScheduleId(UUID.randomUUID().toString());
+      task.setProfileName(profileName);
+      task.setScheduleKey(key);
+      task.setEnabled(true);
       task.setRunCount(0);
     }
-    task.setProfileName(profileName);
+    task.setRetired(false);
+    task.setDisplayName(name);
     task.setCron(cron);
     task.setZone(zone);
     task.setMessage(message);
     task.setNextRunAt(nextRunAt);
     task.setUpdatedAt(Instant.now());
     tasks.save(task);
+    return task.getScheduleId();
   }
 
   @Override
+  @Transactional
   public void recordExecution(
-      String taskId,
+      String scheduleId,
       String sessionId,
       Instant startedAt,
       boolean success,
       String errorMessage,
       long durationMs,
       Instant nextRunAt) {
-    TaskExecution exec = new TaskExecution();
-    exec.setTaskId(taskId);
-    exec.setSessionId(sessionId);
-    exec.setStartedAt(startedAt);
-    exec.setSuccess(success);
-    exec.setErrorMessage(errorMessage);
-    exec.setDurationMs(durationMs);
-    executions.save(exec);
+    ScheduledTask task = requireSchedule(scheduleId);
+    TaskExecution execution = new TaskExecution();
+    execution.setScheduleId(scheduleId);
+    execution.setLegacyMigrated(false);
+    execution.setSessionId(sessionId);
+    execution.setStartedAt(startedAt);
+    execution.setSuccess(success);
+    execution.setErrorMessage(errorMessage);
+    execution.setDurationMs(durationMs);
+    executions.save(execution);
 
-    tasks
-        .findById(taskId)
-        .ifPresent(
-            task -> {
-              task.setLastRunAt(startedAt);
-              task.setLastStatus(success ? "success" : "failed");
-              task.setRunCount(task.getRunCount() + 1);
-              task.setNextRunAt(nextRunAt);
-              task.setUpdatedAt(Instant.now());
-              tasks.save(task);
-            });
+    task.setLastRunAt(startedAt);
+    task.setLastStatus(success ? "success" : "failed");
+    task.setRunCount(task.getRunCount() + 1);
+    task.setNextRunAt(nextRunAt);
+    task.setUpdatedAt(Instant.now());
+    tasks.save(task);
   }
 
   @Override
-  public boolean isEnabled(String taskId) {
-    return tasks.findById(taskId).map(ScheduledTask::isEnabled).orElse(true); // fail-open
+  public boolean isEnabled(String scheduleId) {
+    ScheduledTask task = requireSchedule(scheduleId);
+    return !task.isRetired() && task.isEnabled();
   }
 
   @Override
-  public void setEnabled(String taskId, boolean enabled) {
-    tasks
-        .findById(taskId)
-        .ifPresent(
-            task -> {
-              task.setEnabled(enabled);
-              task.setUpdatedAt(Instant.now());
-              tasks.save(task);
-            });
+  public void setEnabled(String scheduleId, boolean enabled) {
+    ScheduledTask task = requireSchedule(scheduleId);
+    task.setEnabled(enabled);
+    task.setUpdatedAt(Instant.now());
+    tasks.save(task);
+  }
+
+  @Override
+  public void retire(String profileName, String key) {
+    tasks.findByProfileNameAndScheduleKey(profileName, key).ifPresent(
+        task -> {
+          task.setRetired(true);
+          task.setUpdatedAt(Instant.now());
+          tasks.save(task);
+        });
   }
 
   @Override
   public List<ScheduledTaskView> list() {
-    return tasks.findAll().stream().map(JpaScheduledTaskStore::toTaskView).toList();
+    return tasks.findByRetiredFalse().stream().map(JpaScheduledTaskStore::toTaskView).toList();
   }
 
   @Override
-  public List<TaskExecutionView> executions(String taskId, int limit) {
-    return executions.findByTaskIdOrderByStartedAtDesc(taskId).stream()
+  public List<ScheduledTaskView> findByKey(String key) {
+    return tasks.findByScheduleKeyAndRetiredFalse(key).stream()
+        .map(JpaScheduledTaskStore::toTaskView)
+        .toList();
+  }
+
+  @Override
+  public boolean exists(String scheduleId) {
+    return tasks.existsById(scheduleId);
+  }
+
+  @Override
+  public List<TaskExecutionView> executions(String scheduleId, int limit) {
+    requireSchedule(scheduleId);
+    return executions.findByScheduleIdOrderByStartedAtDesc(scheduleId).stream()
         .limit(limit)
         .map(JpaScheduledTaskStore::toExecutionView)
         .toList();
   }
 
-  private static ScheduledTaskView toTaskView(ScheduledTask t) {
+  private static ScheduledTaskView toTaskView(ScheduledTask task) {
     return new ScheduledTaskView(
-        t.getTaskId(),
-        t.getProfileName(),
-        t.getCron(),
-        t.getZone(),
-        t.getMessage(),
-        t.isEnabled(),
-        t.getNextRunAt(),
-        t.getLastRunAt(),
-        t.getLastStatus(),
-        t.getRunCount());
+        task.getScheduleId(),
+        task.getProfileName(),
+        task.getScheduleKey(),
+        task.getDisplayName(),
+        task.getCron(),
+        task.getZone(),
+        task.getMessage(),
+        task.isEnabled(),
+        task.getNextRunAt(),
+        task.getLastRunAt(),
+        task.getLastStatus(),
+        task.getRunCount());
   }
 
-  private static TaskExecutionView toExecutionView(TaskExecution e) {
+  private static TaskExecutionView toExecutionView(TaskExecution execution) {
     return new TaskExecutionView(
-        e.getTaskId(),
-        e.getSessionId(),
-        e.getStartedAt(),
-        e.isSuccess(),
-        e.getErrorMessage(),
-        e.getDurationMs());
+        execution.getScheduleId(),
+        execution.getLegacyTaskKey(),
+        execution.isLegacyMigrated(),
+        execution.getSessionId(),
+        execution.getStartedAt(),
+        execution.isSuccess(),
+        execution.getErrorMessage(),
+        execution.getDurationMs());
+  }
+
+  private ScheduledTask requireSchedule(String scheduleId) {
+    return tasks
+        .findById(scheduleId)
+        .orElseThrow(() -> new NoSuchElementException("Unknown scheduleId: " + scheduleId));
   }
 }

--- a/oryxos-storage/src/main/java/io/oryxos/storage/ScheduleSchemaUpgrade.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/ScheduleSchemaUpgrade.java
@@ -30,7 +30,8 @@ public final class ScheduleSchemaUpgrade {
           "run_count",
           "updated_at");
   private static final Set<String> LEGACY_EXECUTION_COLUMNS =
-      Set.of("id", "task_id", "session_id", "started_at", "success", "error_message", "duration_ms");
+      Set.of(
+          "id", "task_id", "session_id", "started_at", "success", "error_message", "duration_ms");
   private static final Set<String> CURRENT_TASK_COLUMNS =
       Set.of(
           "schedule_id",
@@ -107,7 +108,8 @@ public final class ScheduleSchemaUpgrade {
   }
 
   private static boolean isCurrent(
-      Connection connection, Set<String> taskColumns, Set<String> executionColumns) throws SQLException {
+      Connection connection, Set<String> taskColumns, Set<String> executionColumns)
+      throws SQLException {
     return taskColumns.equals(CURRENT_TASK_COLUMNS)
         && executionColumns.equals(CURRENT_EXECUTION_COLUMNS)
         && hasPrimaryKey(connection, "scheduled_tasks", "schedule_id")
@@ -164,7 +166,8 @@ public final class ScheduleSchemaUpgrade {
   }
 
   private static boolean isLegacy(Set<String> taskColumns, Set<String> executionColumns) {
-    return taskColumns.equals(LEGACY_TASK_COLUMNS) && executionColumns.equals(LEGACY_EXECUTION_COLUMNS);
+    return taskColumns.equals(LEGACY_TASK_COLUMNS)
+        && executionColumns.equals(LEGACY_EXECUTION_COLUMNS);
   }
 
   private static IllegalStateException unsupported(
@@ -330,7 +333,8 @@ public final class ScheduleSchemaUpgrade {
   }
 
   private static void verifyRowCounts(
-      Connection connection, long expectedTaskRows, long expectedExecutionRows) throws SQLException {
+      Connection connection, long expectedTaskRows, long expectedExecutionRows)
+      throws SQLException {
     long actualTaskRows = rowCount(connection, "scheduled_tasks");
     long actualExecutionRows = rowCount(connection, "task_executions");
     if (actualTaskRows != expectedTaskRows || actualExecutionRows != expectedExecutionRows) {

--- a/oryxos-storage/src/main/java/io/oryxos/storage/ScheduleSchemaUpgrade.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/ScheduleSchemaUpgrade.java
@@ -62,6 +62,10 @@ public final class ScheduleSchemaUpgrade {
 
   private final DataSource dataSource;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "The injected DataSource is an intentionally shared connection factory and cannot be defensively copied.")
   public ScheduleSchemaUpgrade(DataSource dataSource) {
     this.dataSource = dataSource;
   }
@@ -69,8 +73,8 @@ public final class ScheduleSchemaUpgrade {
   /** Upgrade a recognized old schema, skip the current schema, and reject any other shape. */
   public void upgrade() {
     try (Connection connection = dataSource.getConnection()) {
-      Set<String> taskColumns = tableColumns(connection, "scheduled_tasks");
-      Set<String> executionColumns = tableColumns(connection, "task_executions");
+      Set<String> taskColumns = scheduledTaskColumns(connection);
+      Set<String> executionColumns = taskExecutionColumns(connection);
       if (taskColumns.isEmpty() && executionColumns.isEmpty()) {
         return;
       }
@@ -110,10 +114,10 @@ public final class ScheduleSchemaUpgrade {
   private static boolean isCurrent(
       Connection connection, Set<String> taskColumns, Set<String> executionColumns)
       throws SQLException {
-    return taskColumns.equals(CURRENT_TASK_COLUMNS)
-        && executionColumns.equals(CURRENT_EXECUTION_COLUMNS)
-        && hasPrimaryKey(connection, "scheduled_tasks", "schedule_id")
-        && hasUniqueIndex(connection, "scheduled_tasks", Set.of("profile_name", "schedule_key"));
+    return CURRENT_TASK_COLUMNS.equals(taskColumns)
+        && CURRENT_EXECUTION_COLUMNS.equals(executionColumns)
+        && hasScheduledTaskPrimaryKey(connection)
+        && hasScheduleIdentityUniqueIndex(connection);
   }
 
   private static boolean isPreRetirementCurrent(
@@ -121,18 +125,17 @@ public final class ScheduleSchemaUpgrade {
       throws SQLException {
     Set<String> preRetirementTaskColumns = new HashSet<>(CURRENT_TASK_COLUMNS);
     preRetirementTaskColumns.remove("retired");
-    return taskColumns.equals(preRetirementTaskColumns)
-        && executionColumns.equals(CURRENT_EXECUTION_COLUMNS)
-        && hasPrimaryKey(connection, "scheduled_tasks", "schedule_id")
-        && hasUniqueIndex(connection, "scheduled_tasks", Set.of("profile_name", "schedule_key"));
+    return preRetirementTaskColumns.equals(taskColumns)
+        && CURRENT_EXECUTION_COLUMNS.equals(executionColumns)
+        && hasScheduledTaskPrimaryKey(connection)
+        && hasScheduleIdentityUniqueIndex(connection);
   }
 
-  private static boolean hasPrimaryKey(Connection connection, String table, String column)
-      throws SQLException {
+  private static boolean hasScheduledTaskPrimaryKey(Connection connection) throws SQLException {
     try (Statement statement = connection.createStatement();
-        ResultSet rows = statement.executeQuery("PRAGMA table_info(" + table + ")")) {
+        ResultSet rows = statement.executeQuery("PRAGMA table_info(scheduled_tasks)")) {
       while (rows.next()) {
-        if (column.equals(rows.getString("name")) && rows.getInt("pk") == 1) {
+        if ("schedule_id".equals(rows.getString("name")) && rows.getInt("pk") == 1) {
           return true;
         }
       }
@@ -140,24 +143,25 @@ public final class ScheduleSchemaUpgrade {
     }
   }
 
-  private static boolean hasUniqueIndex(Connection connection, String table, Set<String> columns)
-      throws SQLException {
+  private static boolean hasScheduleIdentityUniqueIndex(Connection connection) throws SQLException {
     try (Statement statement = connection.createStatement();
-        ResultSet indexes = statement.executeQuery("PRAGMA index_list(" + table + ")")) {
+        ResultSet indexes = statement.executeQuery("PRAGMA index_list(scheduled_tasks)")) {
       while (indexes.next()) {
         if (indexes.getInt("unique") != 1) {
           continue;
         }
         String indexName = indexes.getString("name");
         Set<String> indexedColumns = new HashSet<>();
-        try (Statement indexStatement = connection.createStatement();
-            ResultSet indexColumns =
-                indexStatement.executeQuery("PRAGMA index_info(" + indexName + ")")) {
-          while (indexColumns.next()) {
-            indexedColumns.add(indexColumns.getString("name"));
+        try (PreparedStatement indexStatement =
+            connection.prepareStatement("SELECT name FROM pragma_index_info(?)")) {
+          indexStatement.setString(1, indexName);
+          try (ResultSet indexColumns = indexStatement.executeQuery()) {
+            while (indexColumns.next()) {
+              indexedColumns.add(indexColumns.getString("name"));
+            }
           }
         }
-        if (indexedColumns.equals(columns)) {
+        if (indexedColumns.equals(Set.of("profile_name", "schedule_key"))) {
           return true;
         }
       }
@@ -184,8 +188,8 @@ public final class ScheduleSchemaUpgrade {
     try (Statement statement = connection.createStatement()) {
       statement.execute("BEGIN IMMEDIATE");
       begun = true;
-      long taskRowCount = rowCount(connection, "scheduled_tasks");
-      long executionRowCount = rowCount(connection, "task_executions");
+      long taskRowCount = scheduledTaskRowCount(connection);
+      long executionRowCount = taskExecutionRowCount(connection);
       createReplacementTables(statement);
       Map<String, String> legacyToScheduleId = copyTasks(connection);
       copyExecutions(connection, legacyToScheduleId);
@@ -243,7 +247,7 @@ public final class ScheduleSchemaUpgrade {
   }
 
   private static Map<String, String> copyTasks(Connection connection) throws SQLException {
-    Map<String, String> legacyToScheduleId = new HashMap<>();
+    Map<String, String> legacyToScheduleId = new HashMap<>(16);
     try (Statement select = connection.createStatement();
         ResultSet rows = select.executeQuery("SELECT * FROM scheduled_tasks");
         PreparedStatement insert =
@@ -311,10 +315,10 @@ public final class ScheduleSchemaUpgrade {
     }
   }
 
-  private static Set<String> tableColumns(Connection connection, String table) throws SQLException {
+  private static Set<String> scheduledTaskColumns(Connection connection) throws SQLException {
     Set<String> columns = new HashSet<>();
     try (Statement statement = connection.createStatement();
-        ResultSet rows = statement.executeQuery("PRAGMA table_info(" + table + ")")) {
+        ResultSet rows = statement.executeQuery("PRAGMA table_info(scheduled_tasks)")) {
       while (rows.next()) {
         columns.add(rows.getString("name"));
       }
@@ -322,11 +326,32 @@ public final class ScheduleSchemaUpgrade {
     return columns;
   }
 
-  private static long rowCount(Connection connection, String table) throws SQLException {
+  private static Set<String> taskExecutionColumns(Connection connection) throws SQLException {
+    Set<String> columns = new HashSet<>();
     try (Statement statement = connection.createStatement();
-        ResultSet rows = statement.executeQuery("SELECT COUNT(*) FROM " + table)) {
+        ResultSet rows = statement.executeQuery("PRAGMA table_info(task_executions)")) {
+      while (rows.next()) {
+        columns.add(rows.getString("name"));
+      }
+    }
+    return columns;
+  }
+
+  private static long scheduledTaskRowCount(Connection connection) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rows = statement.executeQuery("SELECT COUNT(*) FROM scheduled_tasks")) {
       if (!rows.next()) {
-        throw new SQLException("Could not count rows in " + table);
+        throw new SQLException("Could not count rows in scheduled_tasks");
+      }
+      return rows.getLong(1);
+    }
+  }
+
+  private static long taskExecutionRowCount(Connection connection) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rows = statement.executeQuery("SELECT COUNT(*) FROM task_executions")) {
+      if (!rows.next()) {
+        throw new SQLException("Could not count rows in task_executions");
       }
       return rows.getLong(1);
     }
@@ -335,8 +360,8 @@ public final class ScheduleSchemaUpgrade {
   private static void verifyRowCounts(
       Connection connection, long expectedTaskRows, long expectedExecutionRows)
       throws SQLException {
-    long actualTaskRows = rowCount(connection, "scheduled_tasks");
-    long actualExecutionRows = rowCount(connection, "task_executions");
+    long actualTaskRows = scheduledTaskRowCount(connection);
+    long actualExecutionRows = taskExecutionRowCount(connection);
     if (actualTaskRows != expectedTaskRows || actualExecutionRows != expectedExecutionRows) {
       throw new SQLException(
           "Scheduled-task migration changed row counts: tasks "

--- a/oryxos-storage/src/main/java/io/oryxos/storage/ScheduleSchemaUpgrade.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/ScheduleSchemaUpgrade.java
@@ -1,0 +1,356 @@
+package io.oryxos.storage;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import javax.sql.DataSource;
+
+/** One-time, structure-detected migration for the original scheduler tables. */
+public final class ScheduleSchemaUpgrade {
+
+  private static final Set<String> LEGACY_TASK_COLUMNS =
+      Set.of(
+          "task_id",
+          "profile_name",
+          "cron",
+          "zone",
+          "message",
+          "enabled",
+          "next_run_at",
+          "last_run_at",
+          "last_status",
+          "run_count",
+          "updated_at");
+  private static final Set<String> LEGACY_EXECUTION_COLUMNS =
+      Set.of("id", "task_id", "session_id", "started_at", "success", "error_message", "duration_ms");
+  private static final Set<String> CURRENT_TASK_COLUMNS =
+      Set.of(
+          "schedule_id",
+          "profile_name",
+          "schedule_key",
+          "display_name",
+          "cron",
+          "zone",
+          "message",
+          "enabled",
+          "retired",
+          "next_run_at",
+          "last_run_at",
+          "last_status",
+          "run_count",
+          "updated_at");
+  private static final Set<String> CURRENT_EXECUTION_COLUMNS =
+      Set.of(
+          "id",
+          "schedule_id",
+          "legacy_task_key",
+          "legacy_migrated",
+          "session_id",
+          "started_at",
+          "success",
+          "error_message",
+          "duration_ms");
+
+  private final DataSource dataSource;
+
+  public ScheduleSchemaUpgrade(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  /** Upgrade a recognized old schema, skip the current schema, and reject any other shape. */
+  public void upgrade() {
+    try (Connection connection = dataSource.getConnection()) {
+      Set<String> taskColumns = tableColumns(connection, "scheduled_tasks");
+      Set<String> executionColumns = tableColumns(connection, "task_executions");
+      if (taskColumns.isEmpty() && executionColumns.isEmpty()) {
+        return;
+      }
+      if (isCurrent(connection, taskColumns, executionColumns)) {
+        ensureExecutionIndex(connection);
+        return;
+      }
+      if (isPreRetirementCurrent(connection, taskColumns, executionColumns)) {
+        addRetiredColumn(connection);
+        ensureExecutionIndex(connection);
+        return;
+      }
+      if (!isLegacy(taskColumns, executionColumns)) {
+        throw unsupported(taskColumns, executionColumns);
+      }
+      rebuildLegacyTables(connection);
+    } catch (SQLException e) {
+      throw new IllegalStateException("Failed to upgrade scheduled-task schema", e);
+    }
+  }
+
+  private static void ensureExecutionIndex(Connection connection) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_task_executions_schedule ON task_executions (schedule_id)");
+    }
+  }
+
+  /** Extends the first scheduleId schema without a migration-version table. */
+  private static void addRetiredColumn(Connection connection) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "ALTER TABLE scheduled_tasks ADD COLUMN retired BOOLEAN NOT NULL DEFAULT 0");
+    }
+  }
+
+  private static boolean isCurrent(
+      Connection connection, Set<String> taskColumns, Set<String> executionColumns) throws SQLException {
+    return taskColumns.equals(CURRENT_TASK_COLUMNS)
+        && executionColumns.equals(CURRENT_EXECUTION_COLUMNS)
+        && hasPrimaryKey(connection, "scheduled_tasks", "schedule_id")
+        && hasUniqueIndex(connection, "scheduled_tasks", Set.of("profile_name", "schedule_key"));
+  }
+
+  private static boolean isPreRetirementCurrent(
+      Connection connection, Set<String> taskColumns, Set<String> executionColumns)
+      throws SQLException {
+    Set<String> preRetirementTaskColumns = new HashSet<>(CURRENT_TASK_COLUMNS);
+    preRetirementTaskColumns.remove("retired");
+    return taskColumns.equals(preRetirementTaskColumns)
+        && executionColumns.equals(CURRENT_EXECUTION_COLUMNS)
+        && hasPrimaryKey(connection, "scheduled_tasks", "schedule_id")
+        && hasUniqueIndex(connection, "scheduled_tasks", Set.of("profile_name", "schedule_key"));
+  }
+
+  private static boolean hasPrimaryKey(Connection connection, String table, String column)
+      throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rows = statement.executeQuery("PRAGMA table_info(" + table + ")")) {
+      while (rows.next()) {
+        if (column.equals(rows.getString("name")) && rows.getInt("pk") == 1) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
+  private static boolean hasUniqueIndex(Connection connection, String table, Set<String> columns)
+      throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet indexes = statement.executeQuery("PRAGMA index_list(" + table + ")")) {
+      while (indexes.next()) {
+        if (indexes.getInt("unique") != 1) {
+          continue;
+        }
+        String indexName = indexes.getString("name");
+        Set<String> indexedColumns = new HashSet<>();
+        try (Statement indexStatement = connection.createStatement();
+            ResultSet indexColumns =
+                indexStatement.executeQuery("PRAGMA index_info(" + indexName + ")")) {
+          while (indexColumns.next()) {
+            indexedColumns.add(indexColumns.getString("name"));
+          }
+        }
+        if (indexedColumns.equals(columns)) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
+  private static boolean isLegacy(Set<String> taskColumns, Set<String> executionColumns) {
+    return taskColumns.equals(LEGACY_TASK_COLUMNS) && executionColumns.equals(LEGACY_EXECUTION_COLUMNS);
+  }
+
+  private static IllegalStateException unsupported(
+      Set<String> taskColumns, Set<String> executionColumns) {
+    return new IllegalStateException(
+        "Unsupported scheduled-task schema; refusing to modify data. scheduled_tasks="
+            + taskColumns
+            + ", task_executions="
+            + executionColumns);
+  }
+
+  private static void rebuildLegacyTables(Connection connection) throws SQLException {
+    boolean begun = false;
+    try (Statement statement = connection.createStatement()) {
+      statement.execute("BEGIN IMMEDIATE");
+      begun = true;
+      long taskRowCount = rowCount(connection, "scheduled_tasks");
+      long executionRowCount = rowCount(connection, "task_executions");
+      createReplacementTables(statement);
+      Map<String, String> legacyToScheduleId = copyTasks(connection);
+      copyExecutions(connection, legacyToScheduleId);
+      statement.execute("DROP TABLE scheduled_tasks");
+      statement.execute("DROP TABLE task_executions");
+      statement.execute("ALTER TABLE scheduled_tasks_new RENAME TO scheduled_tasks");
+      statement.execute("ALTER TABLE task_executions_new RENAME TO task_executions");
+      statement.execute(
+          "CREATE INDEX idx_task_executions_schedule ON task_executions (schedule_id)");
+      verifyRowCounts(connection, taskRowCount, executionRowCount);
+      statement.execute("COMMIT");
+    } catch (SQLException e) {
+      if (begun) {
+        rollback(connection);
+      }
+      throw e;
+    }
+  }
+
+  private static void createReplacementTables(Statement statement) throws SQLException {
+    statement.execute(
+        """
+        CREATE TABLE scheduled_tasks_new (
+          schedule_id VARCHAR(36) PRIMARY KEY,
+          profile_name VARCHAR(255) NOT NULL,
+          schedule_key VARCHAR(255) NOT NULL,
+          display_name VARCHAR(255) NOT NULL,
+          cron VARCHAR(128) NOT NULL,
+          zone VARCHAR(64),
+          message TEXT,
+          enabled BOOLEAN NOT NULL DEFAULT 1,
+          retired BOOLEAN NOT NULL DEFAULT 0,
+          next_run_at TIMESTAMP,
+          last_run_at TIMESTAMP,
+          last_status VARCHAR(16),
+          run_count INTEGER NOT NULL DEFAULT 0,
+          updated_at TIMESTAMP NOT NULL,
+          UNIQUE (profile_name, schedule_key)
+        )
+        """);
+    statement.execute(
+        """
+        CREATE TABLE task_executions_new (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          schedule_id VARCHAR(36),
+          legacy_task_key VARCHAR(255),
+          legacy_migrated BOOLEAN NOT NULL DEFAULT 0,
+          session_id VARCHAR(512),
+          started_at TIMESTAMP NOT NULL,
+          success BOOLEAN NOT NULL,
+          error_message TEXT,
+          duration_ms INTEGER NOT NULL
+        )
+        """);
+  }
+
+  private static Map<String, String> copyTasks(Connection connection) throws SQLException {
+    Map<String, String> legacyToScheduleId = new HashMap<>();
+    try (Statement select = connection.createStatement();
+        ResultSet rows = select.executeQuery("SELECT * FROM scheduled_tasks");
+        PreparedStatement insert =
+            connection.prepareStatement(
+                """
+                INSERT INTO scheduled_tasks_new (
+                  schedule_id, profile_name, schedule_key, display_name, cron, zone, message, enabled,
+                  retired, next_run_at, last_run_at, last_status, run_count, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """)) {
+      while (rows.next()) {
+        String legacyKey = rows.getString("task_id");
+        String scheduleId = UUID.randomUUID().toString();
+        legacyToScheduleId.put(legacyKey, scheduleId);
+        insert.setString(1, scheduleId);
+        insert.setString(2, rows.getString("profile_name"));
+        insert.setString(3, legacyKey);
+        insert.setString(4, legacyKey);
+        insert.setString(5, rows.getString("cron"));
+        insert.setString(6, rows.getString("zone"));
+        insert.setString(7, rows.getString("message"));
+        insert.setObject(8, rows.getObject("enabled"));
+        insert.setBoolean(9, false);
+        insert.setObject(10, rows.getObject("next_run_at"));
+        insert.setObject(11, rows.getObject("last_run_at"));
+        insert.setString(12, rows.getString("last_status"));
+        insert.setObject(13, rows.getObject("run_count"));
+        insert.setObject(14, rows.getObject("updated_at"));
+        insert.executeUpdate();
+      }
+    }
+    return legacyToScheduleId;
+  }
+
+  private static void copyExecutions(Connection connection, Map<String, String> legacyToScheduleId)
+      throws SQLException {
+    try (Statement select = connection.createStatement();
+        ResultSet rows = select.executeQuery("SELECT * FROM task_executions");
+        PreparedStatement insert =
+            connection.prepareStatement(
+                """
+                INSERT INTO task_executions_new (
+                  id, schedule_id, legacy_task_key, legacy_migrated, session_id, started_at, success,
+                  error_message, duration_ms)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """)) {
+      while (rows.next()) {
+        String legacyKey = rows.getString("task_id");
+        String scheduleId = legacyToScheduleId.get(legacyKey);
+        insert.setObject(1, rows.getObject("id"));
+        if (scheduleId == null) {
+          insert.setNull(2, Types.VARCHAR);
+        } else {
+          insert.setString(2, scheduleId);
+        }
+        insert.setString(3, legacyKey);
+        insert.setBoolean(4, true);
+        insert.setString(5, rows.getString("session_id"));
+        insert.setObject(6, rows.getObject("started_at"));
+        insert.setObject(7, rows.getObject("success"));
+        insert.setString(8, rows.getString("error_message"));
+        insert.setObject(9, rows.getObject("duration_ms"));
+        insert.executeUpdate();
+      }
+    }
+  }
+
+  private static Set<String> tableColumns(Connection connection, String table) throws SQLException {
+    Set<String> columns = new HashSet<>();
+    try (Statement statement = connection.createStatement();
+        ResultSet rows = statement.executeQuery("PRAGMA table_info(" + table + ")")) {
+      while (rows.next()) {
+        columns.add(rows.getString("name"));
+      }
+    }
+    return columns;
+  }
+
+  private static long rowCount(Connection connection, String table) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rows = statement.executeQuery("SELECT COUNT(*) FROM " + table)) {
+      if (!rows.next()) {
+        throw new SQLException("Could not count rows in " + table);
+      }
+      return rows.getLong(1);
+    }
+  }
+
+  private static void verifyRowCounts(
+      Connection connection, long expectedTaskRows, long expectedExecutionRows) throws SQLException {
+    long actualTaskRows = rowCount(connection, "scheduled_tasks");
+    long actualExecutionRows = rowCount(connection, "task_executions");
+    if (actualTaskRows != expectedTaskRows || actualExecutionRows != expectedExecutionRows) {
+      throw new SQLException(
+          "Scheduled-task migration changed row counts: tasks "
+              + expectedTaskRows
+              + " -> "
+              + actualTaskRows
+              + ", executions "
+              + expectedExecutionRows
+              + " -> "
+              + actualExecutionRows);
+    }
+  }
+
+  private static void rollback(Connection connection) {
+    try (Statement rollback = connection.createStatement()) {
+      rollback.execute("ROLLBACK");
+    } catch (SQLException ignored) {
+      // The original exception has the actionable context.
+    }
+  }
+}

--- a/oryxos-storage/src/main/java/io/oryxos/storage/ScheduledTask.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/ScheduledTask.java
@@ -12,11 +12,17 @@ import java.time.Instant;
 public class ScheduledTask {
 
   @Id
-  @Column(name = "task_id")
-  private String taskId;
+  @Column(name = "schedule_id")
+  private String scheduleId;
 
   @Column(name = "profile_name", nullable = false)
   private String profileName;
+
+  @Column(name = "schedule_key", nullable = false)
+  private String scheduleKey;
+
+  @Column(name = "display_name", nullable = false)
+  private String displayName;
 
   @Column(nullable = false)
   private String cron;
@@ -27,6 +33,9 @@ public class ScheduledTask {
 
   @Column(nullable = false)
   private boolean enabled;
+
+  @Column(nullable = false)
+  private boolean retired;
 
   @Column(name = "next_run_at")
   private Instant nextRunAt;
@@ -43,12 +52,12 @@ public class ScheduledTask {
   @Column(name = "updated_at", nullable = false)
   private Instant updatedAt;
 
-  public String getTaskId() {
-    return taskId;
+  public String getScheduleId() {
+    return scheduleId;
   }
 
-  public void setTaskId(String taskId) {
-    this.taskId = taskId;
+  public void setScheduleId(String scheduleId) {
+    this.scheduleId = scheduleId;
   }
 
   public String getProfileName() {
@@ -57,6 +66,22 @@ public class ScheduledTask {
 
   public void setProfileName(String profileName) {
     this.profileName = profileName;
+  }
+
+  public String getScheduleKey() {
+    return scheduleKey;
+  }
+
+  public void setScheduleKey(String scheduleKey) {
+    this.scheduleKey = scheduleKey;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public void setDisplayName(String displayName) {
+    this.displayName = displayName;
   }
 
   public String getCron() {
@@ -89,6 +114,14 @@ public class ScheduledTask {
 
   public void setEnabled(boolean enabled) {
     this.enabled = enabled;
+  }
+
+  public boolean isRetired() {
+    return retired;
+  }
+
+  public void setRetired(boolean retired) {
+    this.retired = retired;
   }
 
   public Instant getNextRunAt() {

--- a/oryxos-storage/src/main/java/io/oryxos/storage/ScheduledTaskRepository.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/ScheduledTaskRepository.java
@@ -1,6 +1,15 @@
 package io.oryxos.storage;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /** scheduled_tasks 读写通道。 */
-public interface ScheduledTaskRepository extends JpaRepository<ScheduledTask, String> {}
+public interface ScheduledTaskRepository extends JpaRepository<ScheduledTask, String> {
+
+  Optional<ScheduledTask> findByProfileNameAndScheduleKey(String profileName, String scheduleKey);
+
+  List<ScheduledTask> findByRetiredFalse();
+
+  List<ScheduledTask> findByScheduleKeyAndRetiredFalse(String scheduleKey);
+}

--- a/oryxos-storage/src/main/java/io/oryxos/storage/TaskExecution.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/TaskExecution.java
@@ -17,8 +17,14 @@ public class TaskExecution {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(name = "task_id", nullable = false)
-  private String taskId;
+  @Column(name = "schedule_id")
+  private String scheduleId;
+
+  @Column(name = "legacy_task_key")
+  private String legacyTaskKey;
+
+  @Column(name = "legacy_migrated", nullable = false)
+  private boolean legacyMigrated;
 
   @Column(name = "session_id")
   private String sessionId;
@@ -39,12 +45,28 @@ public class TaskExecution {
     return id;
   }
 
-  public String getTaskId() {
-    return taskId;
+  public String getScheduleId() {
+    return scheduleId;
   }
 
-  public void setTaskId(String taskId) {
-    this.taskId = taskId;
+  public void setScheduleId(String scheduleId) {
+    this.scheduleId = scheduleId;
+  }
+
+  public String getLegacyTaskKey() {
+    return legacyTaskKey;
+  }
+
+  public void setLegacyTaskKey(String legacyTaskKey) {
+    this.legacyTaskKey = legacyTaskKey;
+  }
+
+  public boolean isLegacyMigrated() {
+    return legacyMigrated;
+  }
+
+  public void setLegacyMigrated(boolean legacyMigrated) {
+    this.legacyMigrated = legacyMigrated;
   }
 
   public String getSessionId() {

--- a/oryxos-storage/src/main/java/io/oryxos/storage/TaskExecutionRepository.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/TaskExecutionRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 /** task_executions 读写通道；按任务查历史（开始时间倒序）。 */
 public interface TaskExecutionRepository extends JpaRepository<TaskExecution, Long> {
 
-  List<TaskExecution> findByTaskIdOrderByStartedAtDesc(String taskId);
+  List<TaskExecution> findByScheduleIdOrderByStartedAtDesc(String scheduleId);
 }

--- a/oryxos-storage/src/main/resources/schema.sql
+++ b/oryxos-storage/src/main/resources/schema.sql
@@ -47,30 +47,35 @@ CREATE INDEX IF NOT EXISTS idx_sessions_profile ON sessions (profile_name);
 -- scheduled_tasks：定时任务登记 + 运行状态（28 节）。定义来源是 skill/Profile 的 schedules（重启从文件重新注册）；
 -- 本表存"任务状态 + 下次触发"，重启后状态/历史仍在，管理台可看可管（启用/停用、立即执行）。
 CREATE TABLE IF NOT EXISTS scheduled_tasks (
-    task_id VARCHAR(255) PRIMARY KEY,
+    schedule_id VARCHAR(36) PRIMARY KEY,
     profile_name VARCHAR(255) NOT NULL,
+    schedule_key VARCHAR(255) NOT NULL,
+    display_name VARCHAR(255) NOT NULL,
     cron VARCHAR(128) NOT NULL,
     zone VARCHAR(64),
     message TEXT,
     enabled BOOLEAN NOT NULL DEFAULT 1,
+    retired BOOLEAN NOT NULL DEFAULT 0,
     next_run_at TIMESTAMP,
     last_run_at TIMESTAMP,
     last_status VARCHAR(16),
     run_count INTEGER NOT NULL DEFAULT 0,
-    updated_at TIMESTAMP NOT NULL
+    updated_at TIMESTAMP NOT NULL,
+    UNIQUE (profile_name, schedule_key)
 );
 
 -- task_executions：定时任务每次执行的历史（28 节；成功失败都记，重启不丢，管理台可回看）
 CREATE TABLE IF NOT EXISTS task_executions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    task_id VARCHAR(255) NOT NULL,
+    schedule_id VARCHAR(36),
+    legacy_task_key VARCHAR(255),
+    legacy_migrated BOOLEAN NOT NULL DEFAULT 0,
     session_id VARCHAR(512),
     started_at TIMESTAMP NOT NULL,
     success BOOLEAN NOT NULL,
     error_message TEXT,
     duration_ms INTEGER NOT NULL
 );
-CREATE INDEX IF NOT EXISTS idx_task_executions_task ON task_executions (task_id);
 
 -- agent_executions：Agent 维度的每次执行历史（第 32 节；手动触发 / 定时触发都记，含起止时间与状态）
 -- ended_at 为空表示"运行中"；成功失败都记，重启不丢，管理台按 Agent 回看。

--- a/oryxos-storage/src/test/java/io/oryxos/storage/JpaScheduledTaskStoreTest.java
+++ b/oryxos-storage/src/test/java/io/oryxos/storage/JpaScheduledTaskStoreTest.java
@@ -1,0 +1,169 @@
+package io.oryxos.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.oryxos.core.agent.ScheduledTaskView;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class JpaScheduledTaskStoreTest {
+
+  @Mock private ScheduledTaskRepository tasks;
+  @Mock private TaskExecutionRepository executions;
+
+  private final Map<String, ScheduledTask> persistedTasks = new HashMap<>();
+  private JpaScheduledTaskStore store;
+
+  @BeforeEach
+  void setUp() {
+    store = new JpaScheduledTaskStore(tasks, executions);
+  }
+
+  @Test
+  void sameScheduleKeyInDifferentProfilesKeepsTwoIndependentRows() {
+    stubReconcile();
+    stubFindByKey();
+    Instant nextRun = Instant.parse("2026-08-15T01:00:00Z");
+
+    String alphaId =
+        store.reconcile("alpha", "daily", "Alpha morning", "0 0 9 * * *", null, "a", nextRun);
+    String betaId =
+        store.reconcile("beta", "daily", "Beta morning", "0 0 9 * * *", null, "b", nextRun);
+    String alphaReloadedId =
+        store.reconcile("alpha", "daily", "Renamed Alpha", "0 0 10 * * *", null, "changed", nextRun);
+
+    assertThat(alphaId).isNotBlank().isNotEqualTo(betaId);
+    assertThat(alphaReloadedId).isEqualTo(alphaId);
+    assertThat(persistedTasks).hasSize(2);
+    assertThat(persistedTasks.get(identity("alpha", "daily")).getDisplayName())
+        .isEqualTo("Renamed Alpha");
+    assertThat(store.findByKey("daily"))
+        .extracting(view -> view.scheduleId())
+        .containsExactlyInAnyOrder(alphaId, betaId);
+  }
+
+  @Test
+  void unknownScheduleIdDoesNotSilentlyEnableOrUpdateHistory() {
+    stubFindById();
+
+    assertThatThrownBy(() -> store.isEnabled("missing"))
+        .isInstanceOf(NoSuchElementException.class)
+        .hasMessageContaining("missing");
+    assertThatThrownBy(() -> store.setEnabled("missing", false))
+        .isInstanceOf(NoSuchElementException.class)
+        .hasMessageContaining("missing");
+    assertThatThrownBy(
+            () ->
+                store.recordExecution(
+                    "missing", "session", Instant.now(), true, null, 1L, Instant.now()))
+        .isInstanceOf(NoSuchElementException.class)
+        .hasMessageContaining("missing");
+  }
+
+  @Test
+  void recordsNewExecutionAgainstScheduleIdAndNeverMarksItAsLegacy() {
+    stubReconcile();
+    stubFindById();
+    String scheduleId =
+        store.reconcile(
+            "alpha", "daily", "Alpha morning", "0 0 9 * * *", null, "a", Instant.now());
+
+    store.recordExecution(scheduleId, "session", Instant.now(), true, null, 12L, Instant.now());
+
+    ArgumentCaptor<TaskExecution> captured = ArgumentCaptor.forClass(TaskExecution.class);
+    verify(executions).save(captured.capture());
+    assertThat(captured.getValue().getScheduleId()).isEqualTo(scheduleId);
+    assertThat(captured.getValue().isLegacyMigrated()).isFalse();
+    assertThat(captured.getValue().getLegacyTaskKey()).isNull();
+  }
+
+  @Test
+  void retiringAKeyHidesItFromRuntimeLookupsButReconcileReactivatesItsStableId() {
+    stubReconcile();
+    stubFindByKey();
+    stubActiveList();
+    stubFindById();
+    String originalId =
+        store.reconcile(
+            "alpha", "daily", "Daily", "0 0 9 * * *", null, "daily", Instant.now());
+
+    store.retire("alpha", "daily");
+
+    assertThat(store.list()).isEmpty();
+    assertThat(store.findByKey("daily")).isEmpty();
+    assertThat(store.isEnabled(originalId)).isFalse();
+
+    String reactivatedId =
+        store.reconcile(
+            "alpha", "daily", "Daily restored", "0 0 9 * * *", null, "daily", Instant.now());
+
+    assertThat(reactivatedId).isEqualTo(originalId);
+    assertThat(store.list()).singleElement().extracting(ScheduledTaskView::name).isEqualTo("Daily restored");
+  }
+
+  private void stubReconcile() {
+    when(tasks.findByProfileNameAndScheduleKey(anyString(), anyString()))
+        .thenAnswer(
+            invocation ->
+                Optional.ofNullable(
+                    persistedTasks.get(
+                        identity(
+                            invocation.getArgument(0, String.class),
+                            invocation.getArgument(1, String.class)))));
+    when(tasks.save(any(ScheduledTask.class)))
+        .thenAnswer(
+            invocation -> {
+              ScheduledTask task = invocation.getArgument(0, ScheduledTask.class);
+              persistedTasks.put(identity(task.getProfileName(), task.getScheduleKey()), task);
+              return task;
+            });
+  }
+
+  private void stubFindById() {
+    when(tasks.findById(anyString()))
+        .thenAnswer(
+            invocation ->
+                persistedTasks.values().stream()
+                    .filter(task -> task.getScheduleId().equals(invocation.getArgument(0, String.class)))
+                    .findFirst());
+  }
+
+  private void stubFindByKey() {
+    when(tasks.findByScheduleKeyAndRetiredFalse(anyString()))
+        .thenAnswer(
+            invocation ->
+                persistedTasks.values().stream()
+                    .filter(
+                        task ->
+                            !task.isRetired()
+                                && task
+                                    .getScheduleKey()
+                                    .equals(invocation.getArgument(0, String.class)))
+                    .toList());
+  }
+
+  private void stubActiveList() {
+    when(tasks.findByRetiredFalse())
+        .thenAnswer(
+            invocation -> persistedTasks.values().stream().filter(task -> !task.isRetired()).toList());
+  }
+
+  private static String identity(String profileName, String key) {
+    return profileName + '\0' + key;
+  }
+}

--- a/oryxos-storage/src/test/java/io/oryxos/storage/JpaScheduledTaskStoreTest.java
+++ b/oryxos-storage/src/test/java/io/oryxos/storage/JpaScheduledTaskStoreTest.java
@@ -45,7 +45,8 @@ class JpaScheduledTaskStoreTest {
     String betaId =
         store.reconcile("beta", "daily", "Beta morning", "0 0 9 * * *", null, "b", nextRun);
     String alphaReloadedId =
-        store.reconcile("alpha", "daily", "Renamed Alpha", "0 0 10 * * *", null, "changed", nextRun);
+        store.reconcile(
+            "alpha", "daily", "Renamed Alpha", "0 0 10 * * *", null, "changed", nextRun);
 
     assertThat(alphaId).isNotBlank().isNotEqualTo(betaId);
     assertThat(alphaReloadedId).isEqualTo(alphaId);
@@ -80,8 +81,7 @@ class JpaScheduledTaskStoreTest {
     stubReconcile();
     stubFindById();
     String scheduleId =
-        store.reconcile(
-            "alpha", "daily", "Alpha morning", "0 0 9 * * *", null, "a", Instant.now());
+        store.reconcile("alpha", "daily", "Alpha morning", "0 0 9 * * *", null, "a", Instant.now());
 
     store.recordExecution(scheduleId, "session", Instant.now(), true, null, 12L, Instant.now());
 
@@ -99,8 +99,7 @@ class JpaScheduledTaskStoreTest {
     stubActiveList();
     stubFindById();
     String originalId =
-        store.reconcile(
-            "alpha", "daily", "Daily", "0 0 9 * * *", null, "daily", Instant.now());
+        store.reconcile("alpha", "daily", "Daily", "0 0 9 * * *", null, "daily", Instant.now());
 
     store.retire("alpha", "daily");
 
@@ -113,7 +112,10 @@ class JpaScheduledTaskStoreTest {
             "alpha", "daily", "Daily restored", "0 0 9 * * *", null, "daily", Instant.now());
 
     assertThat(reactivatedId).isEqualTo(originalId);
-    assertThat(store.list()).singleElement().extracting(ScheduledTaskView::name).isEqualTo("Daily restored");
+    assertThat(store.list())
+        .singleElement()
+        .extracting(ScheduledTaskView::name)
+        .isEqualTo("Daily restored");
   }
 
   private void stubReconcile() {
@@ -139,7 +141,9 @@ class JpaScheduledTaskStoreTest {
         .thenAnswer(
             invocation ->
                 persistedTasks.values().stream()
-                    .filter(task -> task.getScheduleId().equals(invocation.getArgument(0, String.class)))
+                    .filter(
+                        task ->
+                            task.getScheduleId().equals(invocation.getArgument(0, String.class)))
                     .findFirst());
   }
 
@@ -151,8 +155,7 @@ class JpaScheduledTaskStoreTest {
                     .filter(
                         task ->
                             !task.isRetired()
-                                && task
-                                    .getScheduleKey()
+                                && task.getScheduleKey()
                                     .equals(invocation.getArgument(0, String.class)))
                     .toList());
   }
@@ -160,7 +163,8 @@ class JpaScheduledTaskStoreTest {
   private void stubActiveList() {
     when(tasks.findByRetiredFalse())
         .thenAnswer(
-            invocation -> persistedTasks.values().stream().filter(task -> !task.isRetired()).toList());
+            invocation ->
+                persistedTasks.values().stream().filter(task -> !task.isRetired()).toList());
   }
 
   private static String identity(String profileName, String key) {

--- a/oryxos-storage/src/test/java/io/oryxos/storage/ScheduleSchemaUpgradeTest.java
+++ b/oryxos-storage/src/test/java/io/oryxos/storage/ScheduleSchemaUpgradeTest.java
@@ -1,0 +1,252 @@
+package io.oryxos.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sqlite.SQLiteDataSource;
+
+class ScheduleSchemaUpgradeTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void upgradesLegacySchemaWithoutDroppingTasksOrExecutionHistory() throws Exception {
+    SQLiteDataSource dataSource = dataSource("legacy.db");
+    createLegacySchema(dataSource);
+    execute(
+        dataSource,
+        """
+        INSERT INTO scheduled_tasks (task_id, profile_name, cron, zone, message, enabled,
+            next_run_at, last_run_at, last_status, run_count, updated_at)
+        VALUES ('daily', 'alpha', '0 0 9 * * *', 'Asia/Shanghai', 'morning', 0,
+            '2026-08-15T01:00:00Z', '2026-08-14T01:00:00Z', 'success', 7, '2026-08-14T01:00:00Z')
+        """,
+        """
+        INSERT INTO task_executions (task_id, session_id, started_at, success, error_message, duration_ms)
+        VALUES ('daily', 'session-1', '2026-08-14T01:00:00Z', 1, NULL, 123),
+               ('orphan', 'session-2', '2026-08-14T02:00:00Z', 0, 'gone', 456)
+        """);
+
+    new ScheduleSchemaUpgrade(dataSource).upgrade();
+
+    try (Connection connection = dataSource.getConnection()) {
+      assertThat(count(connection, "scheduled_tasks")).isEqualTo(1);
+      assertThat(count(connection, "task_executions")).isEqualTo(2);
+      assertThat(columnNames(connection, "scheduled_tasks"))
+          .contains("schedule_id", "schedule_key", "display_name")
+          .doesNotContain("task_id");
+      assertThat(columnNames(connection, "task_executions"))
+          .contains("schedule_id", "legacy_task_key", "legacy_migrated")
+          .doesNotContain("task_id");
+
+      try (Statement statement = connection.createStatement();
+          ResultSet resultSet =
+              statement.executeQuery(
+                  "SELECT schedule_id, profile_name, schedule_key, display_name, enabled, retired, run_count"
+                      + " FROM scheduled_tasks")) {
+        assertThat(resultSet.next()).isTrue();
+        String scheduleId = resultSet.getString("schedule_id");
+        assertThat(scheduleId).isNotBlank();
+        assertThat(resultSet.getString("profile_name")).isEqualTo("alpha");
+        assertThat(resultSet.getString("schedule_key")).isEqualTo("daily");
+        assertThat(resultSet.getString("display_name")).isEqualTo("daily");
+        assertThat(resultSet.getBoolean("enabled")).isFalse();
+        assertThat(resultSet.getBoolean("retired")).isFalse();
+        assertThat(resultSet.getLong("run_count")).isEqualTo(7);
+
+        try (Statement historyStatement = connection.createStatement();
+            ResultSet histories =
+                historyStatement.executeQuery(
+                    "SELECT schedule_id, legacy_task_key, legacy_migrated FROM task_executions ORDER BY id")) {
+          assertThat(histories.next()).isTrue();
+          assertThat(histories.getString("schedule_id")).isEqualTo(scheduleId);
+          assertThat(histories.getString("legacy_task_key")).isEqualTo("daily");
+          assertThat(histories.getBoolean("legacy_migrated")).isTrue();
+          assertThat(histories.next()).isTrue();
+          assertThat(histories.getString("schedule_id")).isNull();
+          assertThat(histories.getString("legacy_task_key")).isEqualTo("orphan");
+          assertThat(histories.getBoolean("legacy_migrated")).isTrue();
+        }
+      }
+    }
+  }
+
+  @Test
+  void isIdempotentAfterLegacySchemaHasBeenUpgraded() throws Exception {
+    SQLiteDataSource dataSource = dataSource("idempotent.db");
+    createLegacySchema(dataSource);
+    execute(
+        dataSource,
+        """
+        INSERT INTO scheduled_tasks (task_id, profile_name, cron, enabled, run_count, updated_at)
+        VALUES ('daily', 'alpha', '0 0 9 * * *', 1, 0, '2026-08-14T01:00:00Z')
+        """);
+
+    ScheduleSchemaUpgrade upgrade = new ScheduleSchemaUpgrade(dataSource);
+    upgrade.upgrade();
+    upgrade.upgrade();
+
+    try (Connection connection = dataSource.getConnection()) {
+      assertThat(count(connection, "scheduled_tasks")).isEqualTo(1);
+      assertThat(count(connection, "task_executions")).isZero();
+    }
+  }
+
+  @Test
+  void addsRetiredFlagToTheFirstScheduleIdSchemaWithoutLosingRows() throws Exception {
+    SQLiteDataSource dataSource = dataSource("pre-retirement-current.db");
+    createPreRetirementCurrentSchema(dataSource);
+    execute(
+        dataSource,
+        """
+        INSERT INTO scheduled_tasks (schedule_id, profile_name, schedule_key, display_name, cron, enabled,
+            run_count, updated_at)
+        VALUES ('11111111-1111-1111-1111-111111111111', 'alpha', 'daily', 'Daily',
+            '0 0 9 * * *', 1, 2, '2026-08-14T01:00:00Z')
+        """);
+
+    new ScheduleSchemaUpgrade(dataSource).upgrade();
+
+    try (Connection connection = dataSource.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet resultSet =
+            statement.executeQuery("SELECT retired FROM scheduled_tasks WHERE schedule_key = 'daily'")) {
+      assertThat(columnNames(connection, "scheduled_tasks")).contains("retired");
+      assertThat(count(connection, "scheduled_tasks")).isEqualTo(1);
+      assertThat(resultSet.next()).isTrue();
+      assertThat(resultSet.getBoolean("retired")).isFalse();
+    }
+  }
+
+  @Test
+  void rejectsMixedOrUnknownScheduleTablesRatherThanGuessingAtData() throws Exception {
+    SQLiteDataSource dataSource = dataSource("unknown.db");
+    execute(
+        dataSource,
+        "CREATE TABLE scheduled_tasks (schedule_id TEXT PRIMARY KEY, profile_name TEXT NOT NULL)",
+        "CREATE TABLE task_executions (id INTEGER PRIMARY KEY, task_id TEXT NOT NULL)");
+
+    assertThatThrownBy(() -> new ScheduleSchemaUpgrade(dataSource).upgrade())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Unsupported scheduled-task schema");
+  }
+
+  @Test
+  void rejectsCurrentColumnsWhenTheIdentityConstraintsAreMissing() throws Exception {
+    SQLiteDataSource dataSource = dataSource("missing-constraints.db");
+    execute(
+        dataSource,
+        "CREATE TABLE scheduled_tasks (schedule_id TEXT, profile_name TEXT, schedule_key TEXT, display_name TEXT, cron TEXT, zone TEXT, message TEXT, enabled BOOLEAN, retired BOOLEAN, next_run_at TEXT, last_run_at TEXT, last_status TEXT, run_count INTEGER, updated_at TEXT)",
+        "CREATE TABLE task_executions (id INTEGER, schedule_id TEXT, legacy_task_key TEXT, legacy_migrated BOOLEAN, session_id TEXT, started_at TEXT, success BOOLEAN, error_message TEXT, duration_ms INTEGER)");
+
+    assertThatThrownBy(() -> new ScheduleSchemaUpgrade(dataSource).upgrade())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Unsupported scheduled-task schema");
+  }
+
+  private SQLiteDataSource dataSource(String fileName) {
+    SQLiteDataSource dataSource = new SQLiteDataSource();
+    dataSource.setUrl("jdbc:sqlite:" + tempDir.resolve(fileName));
+    return dataSource;
+  }
+
+  private static void createLegacySchema(SQLiteDataSource dataSource) throws Exception {
+    execute(
+        dataSource,
+        """
+        CREATE TABLE scheduled_tasks (
+          task_id VARCHAR(255) PRIMARY KEY,
+          profile_name VARCHAR(255) NOT NULL,
+          cron VARCHAR(128) NOT NULL,
+          zone VARCHAR(64),
+          message TEXT,
+          enabled BOOLEAN NOT NULL DEFAULT 1,
+          next_run_at TIMESTAMP,
+          last_run_at TIMESTAMP,
+          last_status VARCHAR(16),
+          run_count INTEGER NOT NULL DEFAULT 0,
+          updated_at TIMESTAMP NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE task_executions (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          task_id VARCHAR(255) NOT NULL,
+          session_id VARCHAR(512),
+          started_at TIMESTAMP NOT NULL,
+          success BOOLEAN NOT NULL,
+          error_message TEXT,
+          duration_ms INTEGER NOT NULL
+        )
+        """);
+  }
+
+  private static void createPreRetirementCurrentSchema(SQLiteDataSource dataSource) throws Exception {
+    execute(
+        dataSource,
+        """
+        CREATE TABLE scheduled_tasks (
+          schedule_id VARCHAR(36) PRIMARY KEY,
+          profile_name VARCHAR(255) NOT NULL,
+          schedule_key VARCHAR(255) NOT NULL,
+          display_name VARCHAR(255) NOT NULL,
+          cron VARCHAR(128) NOT NULL,
+          zone VARCHAR(64),
+          message TEXT,
+          enabled BOOLEAN NOT NULL DEFAULT 1,
+          next_run_at TIMESTAMP,
+          last_run_at TIMESTAMP,
+          last_status VARCHAR(16),
+          run_count INTEGER NOT NULL DEFAULT 0,
+          updated_at TIMESTAMP NOT NULL,
+          UNIQUE (profile_name, schedule_key)
+        )
+        """,
+        """
+        CREATE TABLE task_executions (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          schedule_id VARCHAR(36),
+          legacy_task_key VARCHAR(255),
+          legacy_migrated BOOLEAN NOT NULL DEFAULT 0,
+          session_id VARCHAR(512),
+          started_at TIMESTAMP NOT NULL,
+          success BOOLEAN NOT NULL,
+          error_message TEXT,
+          duration_ms INTEGER NOT NULL
+        )
+        """);
+  }
+
+  private static void execute(SQLiteDataSource dataSource, String... statements) throws Exception {
+    try (Connection connection = dataSource.getConnection(); Statement statement = connection.createStatement()) {
+      for (String sql : statements) {
+        statement.execute(sql);
+      }
+    }
+  }
+
+  private static long count(Connection connection, String table) throws Exception {
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM " + table)) {
+      assertThat(resultSet.next()).isTrue();
+      return resultSet.getLong(1);
+    }
+  }
+
+  private static java.util.List<String> columnNames(Connection connection, String table) throws Exception {
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery("PRAGMA table_info(" + table + ")")) {
+      java.util.List<String> names = new java.util.ArrayList<>();
+      while (resultSet.next()) {
+        names.add(resultSet.getString("name"));
+      }
+      return names;
+    }
+  }
+}

--- a/oryxos-storage/src/test/java/io/oryxos/storage/ScheduleSchemaUpgradeTest.java
+++ b/oryxos-storage/src/test/java/io/oryxos/storage/ScheduleSchemaUpgradeTest.java
@@ -116,7 +116,8 @@ class ScheduleSchemaUpgradeTest {
     try (Connection connection = dataSource.getConnection();
         Statement statement = connection.createStatement();
         ResultSet resultSet =
-            statement.executeQuery("SELECT retired FROM scheduled_tasks WHERE schedule_key = 'daily'")) {
+            statement.executeQuery(
+                "SELECT retired FROM scheduled_tasks WHERE schedule_key = 'daily'")) {
       assertThat(columnNames(connection, "scheduled_tasks")).contains("retired");
       assertThat(count(connection, "scheduled_tasks")).isEqualTo(1);
       assertThat(resultSet.next()).isTrue();
@@ -187,7 +188,8 @@ class ScheduleSchemaUpgradeTest {
         """);
   }
 
-  private static void createPreRetirementCurrentSchema(SQLiteDataSource dataSource) throws Exception {
+  private static void createPreRetirementCurrentSchema(SQLiteDataSource dataSource)
+      throws Exception {
     execute(
         dataSource,
         """
@@ -224,7 +226,8 @@ class ScheduleSchemaUpgradeTest {
   }
 
   private static void execute(SQLiteDataSource dataSource, String... statements) throws Exception {
-    try (Connection connection = dataSource.getConnection(); Statement statement = connection.createStatement()) {
+    try (Connection connection = dataSource.getConnection();
+        Statement statement = connection.createStatement()) {
       for (String sql : statements) {
         statement.execute(sql);
       }
@@ -239,7 +242,8 @@ class ScheduleSchemaUpgradeTest {
     }
   }
 
-  private static java.util.List<String> columnNames(Connection connection, String table) throws Exception {
+  private static java.util.List<String> columnNames(Connection connection, String table)
+      throws Exception {
     try (Statement statement = connection.createStatement();
         ResultSet resultSet = statement.executeQuery("PRAGMA table_info(" + table + ")")) {
       java.util.List<String> names = new java.util.ArrayList<>();

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -243,8 +243,8 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   }
 
   /**
-   * 若为 IPv4-mapped 或 NAT64 well-known prefix，返回嵌入的 IPv4；否则原样返回。JDK 常把 mapped 字面量直接解成
-   * {@link java.net.Inet4Address}，此展开主要兜住仍以 16 字节返回的形态与 NAT64。
+   * 若为 IPv4-mapped 或 NAT64 well-known prefix，返回嵌入的 IPv4；否则原样返回。JDK 常把 mapped 字面量直接解成 {@link
+   * java.net.Inet4Address}，此展开主要兜住仍以 16 字节返回的形态与 NAT64。
    */
   private static InetAddress unwrapEmbeddedIpv4(InetAddress addr) {
     byte[] b = addr.getAddress();

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -243,8 +243,8 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   }
 
   /**
-   * 若为 IPv4-mapped 或 NAT64 well-known prefix，返回嵌入的 IPv4；否则原样返回。JDK 常把 mapped 字面量直接解成 {@link
-   * java.net.Inet4Address}，此展开主要兜住仍以 16 字节返回的形态与 NAT64。
+   * 若为 IPv4-mapped 或 NAT64 well-known prefix，返回嵌入的 IPv4；否则原样返回。JDK 常把 mapped 字面量直接解成
+   * {@link java.net.Inet4Address}，此展开主要兜住仍以 16 字节返回的形态与 NAT64。
    */
   private static InetAddress unwrapEmbeddedIpv4(InetAddress addr) {
     byte[] b = addr.getAddress();

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -48,7 +48,7 @@ async function logout() {
 const TOP_NAV = [
   { key: 'overview', label: '概览' },
   { key: 'agents', label: 'Agent 列表' },
-  { key: 'schedules', label: '定时任务', path: '/api/v1/schedules' },
+  { key: 'schedules', label: '定时任务', path: '/api/v2/schedules' },
   // Skill 列表（第 32 节）：全局 Skill 库，自定义加载器（loadSkills）不走通用 path。知识库仍为占位页
   { key: 'skills', label: 'Skill 列表' },
   { key: 'knowledge', label: '知识库' },
@@ -165,7 +165,7 @@ function cols(key) {
   if (key === 'tools') return ['name', 'description']
   if (key === 'providers') return ['name', 'status']
   if (key === 'schedules')
-    return ['taskId', 'profileName', 'cron', 'zone', 'enabled', 'runCount', 'lastStatus', 'lastRunAt']
+    return ['name', 'profileName', 'key', 'cron', 'zone', 'enabled', 'runCount', 'lastStatus', 'lastRunAt']
   if (key === 'sessions')
     return ['sessionId', 'profileName', 'channel', 'status', 'messageCount', 'lastActiveAt']
   return []
@@ -359,18 +359,18 @@ function roleLabel(role) {
 }
 
 // —— 定时任务管理动作（28 节：管理台可管，不再只读）——
-const busy = ref(null) // 正在操作的 taskId，防重复点击
+const busy = ref(null) // 正在操作的 scheduleId，防重复点击
 
 // 立即执行一次（POST /schedules/{id}/run），跑完刷新列表
-async function runTask(id) {
-  busy.value = id
+async function runTask(scheduleId) {
+  busy.value = scheduleId
   try {
-    const res = await fetch(`/api/v1/schedules/${id}/run`, { method: 'POST' })
+    const res = await fetch(`/api/v2/schedules/${encodeURIComponent(scheduleId)}/run`, { method: 'POST' })
     const body = await res.json()
     if (body.code !== 0) throw new Error(body.message || '执行失败')
     await load('schedules')
     // 若正打开着这个任务的执行记录，跑完顺手刷新
-    if (execDetail.value?.taskId === id) await openExecutions(id)
+    if (execDetail.value?.scheduleId === scheduleId) await openExecutions(scheduleId)
   } catch (e) {
     state.schedules = { ...state.schedules, error: e.message }
   } finally {
@@ -379,17 +379,17 @@ async function runTask(id) {
 }
 
 // 执行记录历史：点"执行记录"拉 GET /schedules/{id}/executions
-const execDetail = ref(null) // {loading, error, taskId, data:[{startedAt,success,durationMs,errorMessage,sessionId}]}
+const execDetail = ref(null) // {loading, error, scheduleId, data:[{startedAt,success,durationMs,errorMessage,sessionId}]}
 
-async function openExecutions(taskId) {
-  execDetail.value = { loading: true, error: null, taskId, data: null }
+async function openExecutions(scheduleId) {
+  execDetail.value = { loading: true, error: null, scheduleId, data: null }
   try {
-    const res = await fetch(`/api/v1/schedules/${encodeURIComponent(taskId)}/executions`)
+    const res = await fetch(`/api/v2/schedules/${encodeURIComponent(scheduleId)}/executions`)
     const body = await res.json()
     if (body.code !== 0) throw new Error(body.message || '加载失败')
-    execDetail.value = { loading: false, error: null, taskId, data: body.data }
+    execDetail.value = { loading: false, error: null, scheduleId, data: body.data }
   } catch (e) {
-    execDetail.value = { loading: false, error: e.message, taskId, data: null }
+    execDetail.value = { loading: false, error: e.message, scheduleId, data: null }
   }
 }
 
@@ -399,9 +399,9 @@ function closeExecutions() {
 
 // 启用/停用（PUT /schedules/{id}），切换后刷新列表
 async function toggleTask(row) {
-  busy.value = row.taskId
+  busy.value = row.scheduleId
   try {
-    const res = await fetch(`/api/v1/schedules/${row.taskId}`, {
+    const res = await fetch(`/api/v2/schedules/${encodeURIComponent(row.scheduleId)}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ enabled: !row.enabled }),
@@ -2132,7 +2132,7 @@ const outputRows = computed(() =>
               <!-- 执行记录详情视图 -->
               <div v-if="execDetail">
                 <button class="btn back" @click="closeExecutions">← 返回定时任务</button>
-                <div class="sess-meta"><span class="mono">{{ execDetail.taskId }}</span><span class="empty">执行记录（最近 100 条）</span></div>
+                <div class="sess-meta"><span class="mono">{{ execDetail.scheduleId }}</span><span class="empty">执行记录（最近 100 条）</span></div>
                 <p v-if="execDetail.loading" class="empty">加载中…</p>
                 <p v-else-if="execDetail.error" class="error">出错：{{ execDetail.error }}</p>
                 <template v-else-if="execDetail.data">
@@ -2141,7 +2141,7 @@ const outputRows = computed(() =>
                     <thead><tr><th>开始时间</th><th>结果</th><th>耗时(ms)</th><th>会话</th><th>错误</th></tr></thead>
                     <tbody>
                       <tr v-for="(e, i) in execDetail.data" :key="i">
-                        <td class="mono">{{ e.startedAt }}</td>
+                        <td class="mono">{{ e.startedAt }}<span v-if="e.legacyMigrated" class="tag">迁移前历史{{ e.legacyTaskKey ? `: ${e.legacyTaskKey}` : '' }}</span></td>
                         <td><span :class="e.success ? 'ok' : 'off'">{{ e.success ? '成功' : '失败' }}</span></td>
                         <td>{{ e.durationMs }}</td>
                         <td class="mono">{{ e.sessionId ?? '—' }}</td>
@@ -2158,15 +2158,15 @@ const outputRows = computed(() =>
                 </thead>
                 <tbody>
                   <tr v-if="!state.schedules.data.length"><td :colspan="cols('schedules').length + 1" class="empty">（暂无定时任务 · 在 Profile 的 schedules 里定义）</td></tr>
-                  <tr v-for="row in state.schedules.data" :key="row.taskId">
-                    <td v-for="c in cols('schedules')" :key="c" :class="{ mono: c === 'taskId' || c === 'cron' }">
+                  <tr v-for="row in state.schedules.data" :key="row.scheduleId">
+                    <td v-for="c in cols('schedules')" :key="c" :class="{ mono: c === 'key' || c === 'cron' }">
                       <span v-if="c === 'enabled'" :class="row.enabled ? 'ok' : 'off'">{{ row.enabled ? '启用' : '停用' }}</span>
                       <template v-else>{{ row[c] ?? '—' }}</template>
                     </td>
                     <td class="ops">
-                      <button class="btn" :disabled="busy === row.taskId" @click="runTask(row.taskId)">立即执行</button>
-                      <button class="btn" :disabled="busy === row.taskId" @click="toggleTask(row)">{{ row.enabled ? '停用' : '启用' }}</button>
-                      <button class="btn" @click="openExecutions(row.taskId)">执行记录</button>
+                      <button class="btn" :disabled="busy === row.scheduleId" @click="runTask(row.scheduleId)">立即执行</button>
+                      <button class="btn" :disabled="busy === row.scheduleId" @click="toggleTask(row)">{{ row.enabled ? '停用' : '启用' }}</button>
+                      <button class="btn" @click="openExecutions(row.scheduleId)">执行记录</button>
                     </td>
                   </tr>
                 </tbody>

--- a/oryxos-web/src/main/java/io/oryxos/web/GlobalExceptionHandler.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import io.oryxos.web.controller.dto.SkillReferenceConflictView;
 import io.oryxos.web.error.AgentTimeoutException;
 import io.oryxos.web.error.ProviderUnavailableException;
 import io.oryxos.web.error.ResourceNotFoundException;
+import io.oryxos.web.error.ScheduleKeyAmbiguityException;
 import io.oryxos.web.error.SessionNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,6 +74,15 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiResponse<Void>> handleSessionUpdateConflict(
       SessionUpdateConflictException ex) {
     LOG.warn("Session update conflict: {}", sanitize(ex.getMessage()));
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(ApiResponse.error(HttpStatus.CONFLICT.value(), ex.getMessage()));
+  }
+
+  /** 409 - a deprecated v1 schedule key identifies multiple schedules. */
+  @ExceptionHandler(ScheduleKeyAmbiguityException.class)
+  public ResponseEntity<ApiResponse<Void>> handleScheduleKeyAmbiguity(
+      ScheduleKeyAmbiguityException ex) {
+    LOG.warn("Ambiguous schedule key: {}", sanitize(ex.getMessage()));
     return ResponseEntity.status(HttpStatus.CONFLICT)
         .body(ApiResponse.error(HttpStatus.CONFLICT.value(), ex.getMessage()));
   }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/ScheduleApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/ScheduleApiController.java
@@ -2,11 +2,16 @@ package io.oryxos.web.controller;
 
 import io.oryxos.core.agent.AgentScheduler;
 import io.oryxos.core.agent.ScheduledTaskStore;
+import io.oryxos.core.agent.ScheduledTaskView;
 import io.oryxos.web.common.ApiResponse;
 import io.oryxos.web.controller.dto.ExecutionView;
-import io.oryxos.web.controller.dto.ScheduleView;
+import io.oryxos.web.controller.dto.LegacyScheduleView;
 import io.oryxos.web.controller.dto.SetEnabledRequest;
+import io.oryxos.web.error.ResourceNotFoundException;
+import io.oryxos.web.error.ScheduleKeyAmbiguityException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,8 +52,10 @@ public class ScheduleApiController {
 
   /** 列出全部定时任务及其运行状态。 */
   @GetMapping
-  public ApiResponse<List<ScheduleView>> list() {
-    return ApiResponse.ok(taskStore.list().stream().map(ScheduleView::from).toList());
+  public ApiResponse<List<LegacyScheduleView>> list() {
+    List<ScheduledTaskView> schedules = taskStore.list();
+    rejectAmbiguousLegacyKeys(schedules);
+    return ApiResponse.ok(schedules.stream().map(LegacyScheduleView::from).toList());
   }
 
   /** 查某任务最近的执行历史（默认最多 100 条）。 */
@@ -57,29 +64,51 @@ public class ScheduleApiController {
       @PathVariable String id,
       @RequestParam(name = "limit", defaultValue = "" + DEFAULT_EXECUTION_LIMIT) int limit) {
     int capped = limit <= 0 || limit > DEFAULT_EXECUTION_LIMIT ? DEFAULT_EXECUTION_LIMIT : limit;
+    String scheduleId = resolveScheduleId(id);
     return ApiResponse.ok(
-        taskStore.executions(id, capped).stream().map(ExecutionView::from).toList());
+        taskStore.executions(scheduleId, capped).stream().map(ExecutionView::from).toList());
   }
 
-  /** 立即执行一次（手动触发，无视启用状态）。任务不存在时 scheduler 抛 IllegalArgumentException→400。 */
+  /** 立即执行一次（手动触发，无视启用状态）。 */
   @PostMapping("/{id}/run")
   public ApiResponse<List<ExecutionView>> run(@PathVariable String id) {
-    scheduler.runNow(id);
+    String scheduleId = resolveScheduleId(id);
+    scheduler.runNow(scheduleId);
     // 执行完把这次（及历史）结果回给调用方，省一次二次查询
     return ApiResponse.ok(
-        taskStore.executions(id, DEFAULT_EXECUTION_LIMIT).stream()
+        taskStore.executions(scheduleId, DEFAULT_EXECUTION_LIMIT).stream()
             .map(ExecutionView::from)
             .toList());
   }
 
   /** 启用/停用一条定时任务。 */
   @PutMapping("/{id}")
-  public ApiResponse<List<ScheduleView>> setEnabled(
+  public ApiResponse<List<LegacyScheduleView>> setEnabled(
       @PathVariable String id, @RequestBody(required = false) SetEnabledRequest body) {
     if (body == null || body.enabled() == null) {
       throw new IllegalArgumentException("请求体缺少 enabled（true 启用 / false 停用）");
     }
-    taskStore.setEnabled(id, body.enabled());
-    return ApiResponse.ok(taskStore.list().stream().map(ScheduleView::from).toList());
+    taskStore.setEnabled(resolveScheduleId(id), body.enabled());
+    return ApiResponse.ok(taskStore.list().stream().map(LegacyScheduleView::from).toList());
+  }
+
+  private String resolveScheduleId(String key) {
+    List<ScheduledTaskView> matches = taskStore.findByKey(key);
+    if (matches.isEmpty()) {
+      throw new ResourceNotFoundException("Schedule key not found: " + key);
+    }
+    if (matches.size() > 1) {
+      throw new ScheduleKeyAmbiguityException(key);
+    }
+    return matches.getFirst().scheduleId();
+  }
+
+  private static void rejectAmbiguousLegacyKeys(List<ScheduledTaskView> schedules) {
+    Set<String> seen = new HashSet<>();
+    for (ScheduledTaskView schedule : schedules) {
+      if (!seen.add(schedule.key())) {
+        throw new ScheduleKeyAmbiguityException(schedule.key());
+      }
+    }
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/ScheduleV2ApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/ScheduleV2ApiController.java
@@ -23,7 +23,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v2")
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = {"EI_EXPOSE_REP2", "SPRING_ENDPOINT"},
-    justification = "The injected services are shared Spring singletons and the endpoint is internal-only.")
+    justification =
+        "The injected services are shared Spring singletons and the endpoint is internal-only.")
 public class ScheduleV2ApiController {
 
   private static final int DEFAULT_EXECUTION_LIMIT = 100;

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/ScheduleV2ApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/ScheduleV2ApiController.java
@@ -1,0 +1,106 @@
+package io.oryxos.web.controller;
+
+import io.oryxos.core.agent.AgentScheduler;
+import io.oryxos.core.agent.ScheduledTaskStore;
+import io.oryxos.core.agent.ScheduledTaskView;
+import io.oryxos.web.common.ApiResponse;
+import io.oryxos.web.controller.dto.ExecutionView;
+import io.oryxos.web.controller.dto.ScheduleView;
+import io.oryxos.web.controller.dto.SetEnabledRequest;
+import io.oryxos.web.error.ResourceNotFoundException;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Runtime schedule API that addresses every operation by the stable scheduleId. */
+@RestController
+@RequestMapping("/api/v2")
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = {"EI_EXPOSE_REP2", "SPRING_ENDPOINT"},
+    justification = "The injected services are shared Spring singletons and the endpoint is internal-only.")
+public class ScheduleV2ApiController {
+
+  private static final int DEFAULT_EXECUTION_LIMIT = 100;
+
+  private final ScheduledTaskStore taskStore;
+  private final AgentScheduler scheduler;
+
+  public ScheduleV2ApiController(ScheduledTaskStore taskStore, AgentScheduler scheduler) {
+    this.taskStore = taskStore;
+    this.scheduler = scheduler;
+  }
+
+  @GetMapping("/schedules")
+  public ApiResponse<List<ScheduleView>> list() {
+    return ApiResponse.ok(taskStore.list().stream().map(ScheduleView::from).toList());
+  }
+
+  @GetMapping("/schedules/{scheduleId}/executions")
+  public ApiResponse<List<ExecutionView>> executions(
+      @PathVariable String scheduleId,
+      @RequestParam(name = "limit", defaultValue = "" + DEFAULT_EXECUTION_LIMIT) int limit) {
+    if (!taskStore.exists(scheduleId)) {
+      throw new ResourceNotFoundException("Schedule not found: " + scheduleId);
+    }
+    return ApiResponse.ok(
+        taskStore.executions(scheduleId, capExecutionLimit(limit)).stream()
+            .map(ExecutionView::from)
+            .toList());
+  }
+
+  @PostMapping("/schedules/{scheduleId}/run")
+  public ApiResponse<List<ExecutionView>> run(@PathVariable String scheduleId) {
+    requireSchedule(scheduleId);
+    scheduler.runNow(scheduleId);
+    return ApiResponse.ok(
+        taskStore.executions(scheduleId, DEFAULT_EXECUTION_LIMIT).stream()
+            .map(ExecutionView::from)
+            .toList());
+  }
+
+  @PutMapping("/schedules/{scheduleId}")
+  public ApiResponse<List<ScheduleView>> setEnabled(
+      @PathVariable String scheduleId, @RequestBody(required = false) SetEnabledRequest body) {
+    if (body == null || body.enabled() == null) {
+      throw new IllegalArgumentException("Request body must contain enabled");
+    }
+    requireSchedule(scheduleId);
+    taskStore.setEnabled(scheduleId, body.enabled());
+    return list();
+  }
+
+  @PostMapping("/agents/{profileName}/schedules/{key}/run")
+  public ApiResponse<List<ExecutionView>> runByProfileAndKey(
+      @PathVariable String profileName, @PathVariable String key) {
+    ScheduledTaskView schedule =
+        taskStore.findByKey(key).stream()
+            .filter(candidate -> candidate.profileName().equals(profileName))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new ResourceNotFoundException(
+                        "Schedule key not found for profile: " + profileName + "/" + key));
+    scheduler.runNow(profileName, key);
+    return ApiResponse.ok(
+        taskStore.executions(schedule.scheduleId(), DEFAULT_EXECUTION_LIMIT).stream()
+            .map(ExecutionView::from)
+            .toList());
+  }
+
+  private ScheduledTaskView requireSchedule(String scheduleId) {
+    return taskStore.list().stream()
+        .filter(schedule -> schedule.scheduleId().equals(scheduleId))
+        .findFirst()
+        .orElseThrow(() -> new ResourceNotFoundException("Schedule not found: " + scheduleId));
+  }
+
+  private static int capExecutionLimit(int limit) {
+    return limit <= 0 || limit > DEFAULT_EXECUTION_LIMIT ? DEFAULT_EXECUTION_LIMIT : limit;
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/AgentView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/AgentView.java
@@ -27,7 +27,7 @@ public record AgentView(
     Profile.ProviderRef pr = p.provider();
     List<ScheduleView> scheds =
         p.schedules().stream()
-            .map(s -> new ScheduleView(s.id(), s.cron(), s.zone(), s.message()))
+            .map(s -> new ScheduleView(s.key(), s.name(), s.cron(), s.zone(), s.message()))
             .toList();
     return new AgentView(
         p.name(),
@@ -39,5 +39,5 @@ public record AgentView(
         scheds);
   }
 
-  public record ScheduleView(String id, String cron, String zone, String message) {}
+  public record ScheduleView(String key, String name, String cron, String zone, String message) {}
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ExecutionView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ExecutionView.java
@@ -5,7 +5,9 @@ import java.time.Instant;
 
 /** GET /schedules/{id}/executions 视图：一次执行历史。 */
 public record ExecutionView(
-    String taskId,
+    String scheduleId,
+    String legacyTaskKey,
+    boolean legacyMigrated,
     String sessionId,
     Instant startedAt,
     boolean success,
@@ -14,6 +16,13 @@ public record ExecutionView(
 
   public static ExecutionView from(TaskExecutionView e) {
     return new ExecutionView(
-        e.taskId(), e.sessionId(), e.startedAt(), e.success(), e.errorMessage(), e.durationMs());
+        e.scheduleId(),
+        e.legacyTaskKey(),
+        e.legacyMigrated(),
+        e.sessionId(),
+        e.startedAt(),
+        e.success(),
+        e.errorMessage(),
+        e.durationMs());
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/LegacyScheduleView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/LegacyScheduleView.java
@@ -1,0 +1,32 @@
+package io.oryxos.web.controller.dto;
+
+import io.oryxos.core.agent.ScheduledTaskView;
+import java.time.Instant;
+
+/** Compatibility projection returned by the deprecated v1 schedules endpoint. */
+public record LegacyScheduleView(
+    String taskId,
+    String profileName,
+    String cron,
+    String zone,
+    String message,
+    boolean enabled,
+    Instant nextRunAt,
+    Instant lastRunAt,
+    String lastStatus,
+    long runCount) {
+
+  public static LegacyScheduleView from(ScheduledTaskView task) {
+    return new LegacyScheduleView(
+        task.key(),
+        task.profileName(),
+        task.cron(),
+        task.zone(),
+        task.message(),
+        task.enabled(),
+        task.nextRunAt(),
+        task.lastRunAt(),
+        task.lastStatus(),
+        task.runCount());
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ScheduleView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ScheduleView.java
@@ -5,8 +5,10 @@ import java.time.Instant;
 
 /** GET /schedules 视图：定时任务状态。 */
 public record ScheduleView(
-    String taskId,
+    String scheduleId,
     String profileName,
+    String key,
+    String name,
     String cron,
     String zone,
     String message,
@@ -18,8 +20,10 @@ public record ScheduleView(
 
   public static ScheduleView from(ScheduledTaskView t) {
     return new ScheduleView(
-        t.taskId(),
+        t.scheduleId(),
         t.profileName(),
+        t.key(),
+        t.name(),
         t.cron(),
         t.zone(),
         t.message(),

--- a/oryxos-web/src/main/java/io/oryxos/web/error/ScheduleKeyAmbiguityException.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/error/ScheduleKeyAmbiguityException.java
@@ -1,0 +1,9 @@
+package io.oryxos.web.error;
+
+/** Raised when a v1 schedule key resolves to more than one profile-owned schedule. */
+public class ScheduleKeyAmbiguityException extends RuntimeException {
+
+  public ScheduleKeyAmbiguityException(String key) {
+    super("Schedule key is ambiguous across profiles: " + key);
+  }
+}

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/ScheduleApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/ScheduleApiControllerTest.java
@@ -1,0 +1,148 @@
+package io.oryxos.web.controller;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.oryxos.core.agent.AgentScheduler;
+import io.oryxos.core.agent.ScheduledTaskStore;
+import io.oryxos.core.agent.ScheduledTaskView;
+import io.oryxos.core.agent.TaskExecutionView;
+import io.oryxos.web.GlobalExceptionHandler;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class ScheduleApiControllerTest {
+
+  private static final ScheduledTaskView ALPHA_DAILY =
+      new ScheduledTaskView(
+          "schedule-alpha-daily",
+          "alpha",
+          "daily",
+          "Alpha daily report",
+          "0 0 9 * * *",
+          "Asia/Shanghai",
+          "send alpha report",
+          true,
+          null,
+          null,
+          null,
+          0);
+
+  private static final ScheduledTaskView BETA_DAILY =
+      new ScheduledTaskView(
+          "schedule-beta-daily",
+          "beta",
+          "daily",
+          "Beta daily report",
+          "0 0 9 * * *",
+          "Asia/Shanghai",
+          "send beta report",
+          true,
+          null,
+          null,
+          null,
+          0);
+
+  private ScheduledTaskStore taskStore;
+  private AgentScheduler scheduler;
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setUp() {
+    taskStore = mock(ScheduledTaskStore.class);
+    scheduler = mock(AgentScheduler.class);
+    mvc =
+        MockMvcBuilders.standaloneSetup(
+                new ScheduleApiController(taskStore, scheduler),
+                new ScheduleV2ApiController(taskStore, scheduler))
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+  }
+
+  @Test
+  void v2RunTargetsTheExactScheduleId() throws Exception {
+    when(taskStore.list()).thenReturn(List.of(ALPHA_DAILY));
+    when(taskStore.executions("schedule-alpha-daily", 100))
+        .thenReturn(
+            List.of(
+                new TaskExecutionView(
+                    "schedule-alpha-daily",
+                    null,
+                    false,
+                    "session-1",
+                    Instant.parse("2026-08-14T00:00:00Z"),
+                    true,
+                    null,
+                    12)));
+
+    mvc.perform(post("/api/v2/schedules/schedule-alpha-daily/run"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].scheduleId").value("schedule-alpha-daily"));
+
+    verify(scheduler).runNow("schedule-alpha-daily");
+  }
+
+  @Test
+  void v2ListExposesScheduleIdentityAndConfigurationIdentity() throws Exception {
+    when(taskStore.list()).thenReturn(List.of(ALPHA_DAILY));
+
+    mvc.perform(get("/api/v2/schedules"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].scheduleId").value("schedule-alpha-daily"))
+        .andExpect(jsonPath("$.data[0].profileName").value("alpha"))
+        .andExpect(jsonPath("$.data[0].key").value("daily"))
+        .andExpect(jsonPath("$.data[0].name").value("Alpha daily report"));
+  }
+
+  @Test
+  void v2HistoryRemainsAvailableForRetiredScheduleId() throws Exception {
+    when(taskStore.exists("retired-daily")).thenReturn(true);
+    when(taskStore.executions("retired-daily", 100))
+        .thenReturn(
+            List.of(
+                new TaskExecutionView(
+                    "retired-daily",
+                    null,
+                    false,
+                    "session-1",
+                    Instant.parse("2026-08-14T00:00:00Z"),
+                    true,
+                    null,
+                    12)));
+
+    mvc.perform(get("/api/v2/schedules/retired-daily/executions"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].scheduleId").value("retired-daily"));
+  }
+
+  @Test
+  void v1RunRejectsAmbiguousLegacyKeyInsteadOfRunningTheFirstMatch() throws Exception {
+    when(taskStore.findByKey("daily")).thenReturn(List.of(ALPHA_DAILY, BETA_DAILY));
+
+    mvc.perform(post("/api/v1/schedules/daily/run"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value(409));
+
+    verify(scheduler, never()).runNow(anyString());
+  }
+
+  @Test
+  void v1ListRejectsAmbiguousLegacyKeyInsteadOfReturningDuplicateTaskIds() throws Exception {
+    when(taskStore.list()).thenReturn(List.of(ALPHA_DAILY, BETA_DAILY));
+
+    mvc.perform(get("/api/v1/schedules"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value(409));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,8 @@
 
         <!-- OWASP Dependency-Check is skipped by default for fast local builds and enabled in CI. -->
         <owasp.skip>true</owasp.skip>
+        <!-- Integration smoke tests stay opt-in but can be enabled with -DexcludedGroups=. -->
+        <excludedGroups>integration</excludedGroups>
     </properties>
 
     <modules>
@@ -161,7 +163,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
-                        <excludedGroups>integration</excludedGroups>
+                        <excludedGroups>${excludedGroups}</excludedGroups>
                     </configuration>
                 </plugin>
 

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -535,17 +535,29 @@ Marks the session as archived. Data is retained in SQLite; the session is exclud
 
 ## Schedules
 
-Scheduled tasks are derived from the `schedules` block in each Agent's `AGENT.md`. The web manager can list, inspect, trigger, and toggle them.
+Scheduled tasks are derived from the `schedules` block in each Agent's `AGENT.md`. New clients must use the v2 endpoints below: `scheduleId` is the stable runtime identity, while `key` is only Agent-local. The v1 endpoints in the following legacy section resolve a key only when it is unambiguous; otherwise they return `409`.
+
+### v2 runtime API
+
+- `GET /api/v2/schedules`
+- `POST /api/v2/schedules/{scheduleId}/run`
+- `PUT /api/v2/schedules/{scheduleId}`
+- `GET /api/v2/schedules/{scheduleId}/executions?limit=20`
+- `POST /api/v2/agents/{profileName}/schedules/{key}/run`
+
+Each v2 schedule contains `scheduleId`, `profileName`, `key`, `name`, and its runtime state. Execution rows include `legacyMigrated` and `legacyTaskKey` for history imported from the pre-v2 schema.
+
+### Deprecated v1 compatibility API
 
 ### List schedules
 
 **GET** `/api/v1/schedules`
 
 ```json
-// data — ScheduleView[]
+// data — LegacyScheduleView[]
 [
   {
-    "taskId": "weather-daily:morning",
+    "taskId": "morning",
     "profileName": "weather-daily",
     "cron": "0 0 8 * * *",
     "zone": "Asia/Shanghai",
@@ -569,8 +581,10 @@ Returns execution history for a task (`limit` caps the rows).
 // data — ExecutionView[]
 [
   {
-    "taskId": "weather-daily:morning",
-    "sessionId": "schedule:weather-daily:morning",
+    "scheduleId": "ae3d1f7b-245c-4c37-bbf7-38a6db55bfce",
+    "legacyTaskKey": null,
+    "legacyMigrated": false,
+    "sessionId": "schedule:ae3d1f7b-245c-4c37-bbf7-38a6db55bfce",
     "startedAt": "2026-07-22T00:00:00Z",
     "success": true,
     "errorMessage": null,
@@ -588,7 +602,7 @@ Triggers the task immediately and returns the resulting execution record(s).
 ```json
 // data — ExecutionView[]
 [
-  { "taskId": "weather-daily:morning", "sessionId": "schedule:weather-daily:morning", "startedAt": "2026-07-22T09:30:00Z", "success": true, "errorMessage": null, "durationMs": 1730 }
+  { "scheduleId": "ae3d1f7b-245c-4c37-bbf7-38a6db55bfce", "legacyTaskKey": null, "legacyMigrated": false, "sessionId": "schedule:ae3d1f7b-245c-4c37-bbf7-38a6db55bfce", "startedAt": "2026-07-22T09:30:00Z", "success": true, "errorMessage": null, "durationMs": 1730 }
 ]
 ```
 
@@ -602,9 +616,9 @@ Triggers the task immediately and returns the resulting execution record(s).
 ```
 
 ```json
-// data — ScheduleView[] (the updated schedule list)
+// data — LegacyScheduleView[] (the updated schedule list)
 [
-  { "taskId": "weather-daily:morning", "profileName": "weather-daily", "cron": "0 0 8 * * *", "zone": "Asia/Shanghai", "message": "推送今天的天气和穿衣建议", "enabled": false, "nextRunAt": null, "lastRunAt": "2026-07-22T00:00:00Z", "lastStatus": "success", "runCount": 12 }
+  { "taskId": "morning", "profileName": "weather-daily", "cron": "0 0 8 * * *", "zone": "Asia/Shanghai", "message": "推送今天的天气和穿衣建议", "enabled": false, "nextRunAt": null, "lastRunAt": "2026-07-22T00:00:00Z", "lastStatus": "success", "runCount": 12 }
 ]
 ```
 

--- a/website/docs/profile.md
+++ b/website/docs/profile.md
@@ -52,7 +52,8 @@ bootstrap:
   - USER.md
 
 schedules:
-  - id: morning-check
+  - key: morning-check
+    name: Morning check
     cron: "0 0 8 * * *"
     zone: Asia/Shanghai
     message: Run the morning health check.
@@ -186,11 +187,12 @@ Bootstrap files are prepended to the system prompt in the order listed. They app
 
 ## Schedules
 
-`schedules` declares cron-triggered runs of the agent. Each entry fires the agent's body as the task at the given time. Scheduled tasks can also be listed, run on demand, and enabled/disabled through the `/api/v1/schedules` API and the admin console.
+`schedules` declares cron-triggered runs of the agent. Each entry requires an Agent-local `key` and a display `name`; OryxOS assigns a stable global `scheduleId` for runtime operations. Use `/api/v2/schedules` and the admin console for listing, running, history, and enable/disable.
 
 ```yaml
 schedules:
-  - id: morning-check
+  - key: morning-check
+    name: Morning check
     cron: "0 0 8 * * *"     # Spring cron: sec min hour day month weekday
     zone: Asia/Shanghai
     message: Run the morning health check.

--- a/website/zh/docs/api.md
+++ b/website/zh/docs/api.md
@@ -539,13 +539,29 @@ null
 
 ### 列出定时任务
 
+新客户端必须使用 v2：`scheduleId` 是全局稳定的运行态身份，`key` 只在单个 Agent 内唯一。
+
+### v2 运行态 API
+
+- **GET** `/api/v2/schedules`
+- **POST** `/api/v2/schedules/{scheduleId}/run`
+- **PUT** `/api/v2/schedules/{scheduleId}`
+- **GET** `/api/v2/schedules/{scheduleId}/executions?limit=20`
+- **POST** `/api/v2/agents/{profileName}/schedules/{key}/run`
+
+任务列表返回 `scheduleId`、`profileName`、`key`、`name` 和运行态字段。执行历史返回 `scheduleId`；由旧库迁入的记录会带 `legacyMigrated: true` 与 `legacyTaskKey`。
+
+### 已弃用的 v1 兼容 API
+
+下面的 v1 路径参数仍按旧配置 `key` 解析，只在全库唯一匹配时兼容；多个 Agent 使用相同 key 时一律返回 HTTP 409，不会静默选择其中一条。
+
 **GET** `/api/v1/schedules`
 
 ```json
-// data —— ScheduleView[]
+// data —— LegacyScheduleView[]
 [
   {
-    "taskId": "weather-daily:morning",
+    "taskId": "morning",
     "profileName": "weather-daily",
     "cron": "0 0 8 * * *",
     "zone": "Asia/Shanghai",
@@ -569,8 +585,10 @@ null
 // data —— ExecutionView[]
 [
   {
-    "taskId": "weather-daily:morning",
-    "sessionId": "schedule:weather-daily:morning",
+    "scheduleId": "ae3d1f7b-245c-4c37-bbf7-38a6db55bfce",
+    "legacyTaskKey": null,
+    "legacyMigrated": false,
+    "sessionId": "schedule:ae3d1f7b-245c-4c37-bbf7-38a6db55bfce",
     "startedAt": "2026-07-22T00:00:00Z",
     "success": true,
     "errorMessage": null,
@@ -588,7 +606,7 @@ null
 ```json
 // data —— ExecutionView[]
 [
-  { "taskId": "weather-daily:morning", "sessionId": "schedule:weather-daily:morning", "startedAt": "2026-07-22T09:30:00Z", "success": true, "errorMessage": null, "durationMs": 1730 }
+  { "scheduleId": "ae3d1f7b-245c-4c37-bbf7-38a6db55bfce", "legacyTaskKey": null, "legacyMigrated": false, "sessionId": "schedule:ae3d1f7b-245c-4c37-bbf7-38a6db55bfce", "startedAt": "2026-07-22T09:30:00Z", "success": true, "errorMessage": null, "durationMs": 1730 }
 ]
 ```
 
@@ -602,9 +620,9 @@ null
 ```
 
 ```json
-// data —— ScheduleView[]（更新后的任务列表）
+// data —— LegacyScheduleView[]（更新后的任务列表）
 [
-  { "taskId": "weather-daily:morning", "profileName": "weather-daily", "cron": "0 0 8 * * *", "zone": "Asia/Shanghai", "message": "推送今天的天气和穿衣建议", "enabled": false, "nextRunAt": null, "lastRunAt": "2026-07-22T00:00:00Z", "lastStatus": "success", "runCount": 12 }
+  { "taskId": "morning", "profileName": "weather-daily", "cron": "0 0 8 * * *", "zone": "Asia/Shanghai", "message": "推送今天的天气和穿衣建议", "enabled": false, "nextRunAt": null, "lastRunAt": "2026-07-22T00:00:00Z", "lastStatus": "success", "runCount": 12 }
 ]
 ```
 

--- a/website/zh/docs/profile.md
+++ b/website/zh/docs/profile.md
@@ -52,7 +52,8 @@ bootstrap:
   - USER.md
 
 schedules:
-  - id: morning-check
+  - key: morning-check
+    name: 晨间检查
     cron: "0 0 8 * * *"
     zone: Asia/Shanghai
     message: 执行早晨健康检查。
@@ -185,11 +186,12 @@ Bootstrap 文件按列出的顺序注入 system prompt，提供跨所有 Agent �
 
 ## Schedules
 
-`schedules` 声明该 Agent 的定时触发任务。每条到点时以 Agent 正文作为任务触发一次。定时任务也可通过 `/api/v1/schedules` 接口和管理台列出、立即运行、启用/停用。
+`schedules` 声明该 Agent 的定时触发任务。每条必须定义 Agent 内的 `key` 与展示 `name`；OryxOS 会为运行态生成稳定且全局唯一的 `scheduleId`。列表、立即运行、历史和启停请使用 `/api/v2/schedules` 与管理台。
 
 ```yaml
 schedules:
-  - id: morning-check
+  - key: morning-check
+    name: 晨间检查
     cron: "0 0 8 * * *"     # Spring cron：秒 分 时 日 月 周
     zone: Asia/Shanghai
     message: 执行早晨健康检查。


### PR DESCRIPTION
Closes #134

## Summary

- Separate schedule configuration (`key`, `name`) from the stable runtime `scheduleId`.
- Add an idempotent SQLite structure upgrade that preserves legacy task rows and execution history without Flyway.
- Move the scheduler, locks, task state, history, management UI, and v2 API to `scheduleId`.
- Keep v1 key endpoints only where unambiguous; duplicate keys now produce HTTP 409.

## Migration and behavior

- Legacy SQLite tables are rebuilt in one `BEGIN IMMEDIATE` transaction and retain their row counts; unknown table shapes abort startup.
- `(profileName, key)` determines a stable ID. Same keys in separate profiles remain independent.
- Renaming a key retires the old schedule instead of deleting its history. Retired histories remain queryable by v2 `scheduleId`, but cannot be run or enabled.
- Scheduler refresh invalidates old callbacks with a per-schedule generation under the schedule lock.

## Verification

- Cross-module focused Maven regression: profile parsing, scheduler identity/refresh, storage migration, v1/v2 API, and boot-upgrade tests.
- `RestartRecoveryIT` explicitly enabled with `-Dgroups=integration -DexcludedGroups=`: 1 passed.
- `mvn -pl oryxos-boot -am -DskipTests package` passed.
- A copy-safe startup verification upgraded `D:\oryxos\oryxos.db` after a backup; its task and execution counts remained zero and the new `retired` column is present.

The broad reactor test suite still has pre-existing Windows sandbox failures in skill/real-path tests that create symlinks (`AccessDeniedException`); the schedule-focused tests pass.
