### PR TITLE
fix(tool): recheck sandbox before read/delete

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -47,6 +47,9 @@ public class FileTools {
       throw new IllegalArgumentException("文件不存在或不是普通文件: " + path);
     }
     try {
+      // Recheck right before the read, same as write_file: closes the TOCTOU window where the
+      // path could be swapped for an outbound symlink between the first enforce and readString.
+      sandbox.enforce(new SandboxAction(ActionType.FILE_READ, path));
       return Files.readString(file);
     } catch (IOException e) {
       throw new UncheckedIOException("读取文件失败: " + path, e);
@@ -265,6 +268,9 @@ public class FileTools {
       throw new IllegalArgumentException("拒绝删除目录（本工具只删文件）: " + path);
     }
     try {
+      // Recheck right before the delete, same as write_file: closes the TOCTOU window where the
+      // path could be swapped for an outbound symlink between the first enforce and deleteIfExists.
+      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
       return Files.deleteIfExists(file) ? "已删除: " + path : "文件不存在: " + path;
     } catch (IOException e) {
       throw new UncheckedIOException("删除文件失败: " + path, e);

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -239,6 +239,44 @@ class FileToolsTest {
   }
 
   @Test
+  @DisplayName("read_file rechecks FILE_READ right before the read (closes TOCTOU window)")
+  void readFileRechecksPathBeforeRead() throws IOException {
+    Path target = dir.resolve("read-escape.txt");
+    Files.writeString(target, "secret");
+    AtomicInteger fileReads = new AtomicInteger();
+    Sandbox sandbox =
+        action -> {
+          if (action.type() == ActionType.FILE_READ && fileReads.incrementAndGet() >= 2) {
+            throw new SandboxViolationException("recheck rejected: " + action.target());
+          }
+        };
+    FileTools guarded = new FileTools(sandbox);
+
+    assertThrows(SandboxViolationException.class, () -> guarded.readFile(target.toString()));
+    assertEquals(
+        2, fileReads.get(), "should enforce FILE_READ once before and once right before the read");
+  }
+
+  @Test
+  @DisplayName("delete_file rechecks FILE_WRITE right before the delete (closes TOCTOU window)")
+  void deleteFileRechecksPathBeforeDelete() throws IOException {
+    Path target = dir.resolve("delete-escape.txt");
+    Files.writeString(target, "secret");
+    AtomicInteger fileWrites = new AtomicInteger();
+    Sandbox sandbox =
+        action -> {
+          if (action.type() == ActionType.FILE_WRITE && fileWrites.incrementAndGet() >= 2) {
+            throw new SandboxViolationException("recheck rejected: " + action.target());
+          }
+        };
+    FileTools guarded = new FileTools(sandbox);
+
+    assertThrows(SandboxViolationException.class, () -> guarded.deleteFile(target.toString()));
+    assertEquals(2, fileWrites.get());
+    assertTrue(Files.exists(target), "must not delete after the recheck is rejected");
+  }
+
+  @Test
   @DisplayName("list_dir 列出目录条目")
   void listDirShowsEntries() throws IOException {
     Files.writeString(dir.resolve("x.txt"), "");


### PR DESCRIPTION
Same TOCTOU class as write_file/append_file/edit_file: the path can be swapped for an outbound symlink between the first enforce and the actual Files.readString/deleteIfExists call. Recheck immediately before IO.

Fixes #169, #170

This is my first PR to OryxOS — I set up the project locally, ran through the agent/notify workflow to get familiar with it, and wanted to use that as the entry point to also test the contribution workflow end to end.

write_file, append_file, and edit_file already recheck the sandbox whitelist immediately before touching the filesystem, to close a TOCTOU window where the path could be swapped for an outbound symlink between the first check and the actual I/O. read_file and delete_file were missing that second check, so this closes the same gap for both (fixes #169, #170). Added regression tests following the existing writeFileRechecksPathBeforeWrite pattern.

Thanks for putting this project together — good first-PR experience.