### PR TITLE
docs: mention admin console auth in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The workspace defaults to `.oryxos/` but is configurable — set `ORYXOS_ROOT` (
 | `http://localhost:8080/admin/` | **Web Manager** — Vue 3 console |
 | `http://localhost:8080/swagger-ui` | OpenAPI docs |
 
-The Web Manager is a Vue 3 + Vite console (same stack and dark-orange theme as the site) with pages for **agent management** (create, one-sentence LLM generation, file editor, per-agent session and memory views), **provider and notify-channel CRUD**, **scheduled tasks**, **sessions, tools, sandbox whitelist**, and a **workspace file browser**. It is built to `oryxos-web/src/main/resources/static/admin/` and served by Spring at `/admin`, so the fat JAR ships it — no separate frontend process.
+The Web Manager is a Vue 3 + Vite console (same stack and dark-orange theme as the site) with pages for **agent management** (create, one-sentence LLM generation, file editor, per-agent session and memory views), **provider and notify-channel CRUD**, **scheduled tasks**, **sessions, tools, sandbox whitelist**, and a **workspace file browser**. It is built to `oryxos-web/src/main/resources/static/admin/` and served by Spring at `/admin`, so the fat JAR ships it — no separate frontend process. The console supports optional HTTP Basic Auth (disabled by default) — see [Authentication](https://oryxos.robustmq.com/docs/auth).
 
 <p align="center">
   <img src="website/public/images/manager.jpg" alt="OryxOS Web Manager console" width="100%"/>


### PR DESCRIPTION
The Web Manager section never mentioned the console's optional HTTP Basic Auth (oryxos.web.auth.enabled + `oryxos user add`), already shipped and documented at website/docs/auth.md. Add one line linking to it so readers of the top-level README know it exists.