### PR TITLE
fix(tool): recheck FILE_READ before list_dir

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -80,11 +80,15 @@ public class FileTools {
     if (!Files.isDirectory(dir)) {
       throw new IllegalArgumentException("目录不存在: " + path);
     }
-    try (Stream<Path> entries = Files.list(dir)) {
-      return entries
-          .map(p -> String.valueOf(p.getFileName()))
-          .sorted()
-          .collect(Collectors.joining("\n"));
+    try {
+      // 列举前复检：与 write_file / read_file 同款——防首次校验到 Files.list 间路径被换成外向软链
+      sandbox.enforce(new SandboxAction(ActionType.FILE_READ, path));
+      try (Stream<Path> entries = Files.list(dir)) {
+        return entries
+            .map(p -> String.valueOf(p.getFileName()))
+            .sorted()
+            .collect(Collectors.joining("\n"));
+      }
     } catch (IOException e) {
       throw new UncheckedIOException("列目录失败: " + path, e);
     }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -251,6 +251,23 @@ class FileToolsTest {
   }
 
   @Test
+  @DisplayName("list_dir 列举前复检 FILE_READ")
+  void listDirRechecksPathBeforeList() throws IOException {
+    Files.writeString(dir.resolve("x.txt"), "");
+    AtomicInteger fileReads = new AtomicInteger();
+    Sandbox sandbox =
+        action -> {
+          if (action.type() == ActionType.FILE_READ && fileReads.incrementAndGet() >= 2) {
+            throw new SandboxViolationException("复检拒绝: " + action.target());
+          }
+        };
+    FileTools guarded = new FileTools(sandbox);
+
+    assertThrows(SandboxViolationException.class, () -> guarded.listDir(dir.toString()));
+    assertEquals(2, fileReads.get(), "应在 list 前后各 enforce 一次 FILE_READ");
+  }
+
+  @Test
   @DisplayName("读不存在的文件_报错点名路径")
   void readMissingFileFailsWithPath() {
     IllegalArgumentException ex =


### PR DESCRIPTION
Same TOCTOU class as write_file/read_file: directory path can be swapped for an outbound symlink between the first enforce and Files.list, leaking out-of-whitelist names. Recheck immediately before listing.

## Summary
- Second `FILE_READ` enforce after directory check, before `Files.list`
- Adds regression coverage in `FileToolsTest`

Fixes #174

## Test plan
- [ ] `FileToolsTest.listDirRechecksPathBeforeList`
- [ ] `FileToolsTest.listDirShowsEntries` still green
- [ ] Existing FileTools sandbox tests still green
- [ ] CI Build & quality gate green