### PR TITLE
fix(tool): recheck FILE_WRITE after createDirectories in download_file

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -168,14 +168,15 @@ public class HttpTools {
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path)); // 先校验落盘路径
     byte[] data = read(url, byte[].class); // 读远端：放行 + 内网黑名单 + 逐跳重定向重校验
     byte[] bytes = data == null ? new byte[0] : data;
-    // 落盘前再 enforce：拉网窗口内路径可能被换成指向白名单外的软链（对齐 FileTools.grep/glob 纵深）
-    sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     try {
       Path file = Path.of(path);
       Path parent = file.getParent();
       if (parent != null) {
         Files.createDirectories(parent);
       }
+      // 写前复检：与 write_file 同款——createDirectories 之后、Files.write 之前。
+      // 复检若放在建目录前，通过后父路径仍可被换成外向软链，写出白名单。
+      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
       Files.write(file, bytes);
       return "已下载到: " + path + "（" + bytes.length + " 字节）";
     } catch (IOException e) {

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
@@ -158,20 +158,24 @@ class HttpToolsTest {
   @DisplayName("download_file 落盘前复检 FILE_WRITE（防拉网窗口内路径逃逸）")
   void downloadFileRechecksPathBeforeWrite(@TempDir Path dir) throws IOException {
     AtomicInteger fileWrites = new AtomicInteger();
+    Path nested = dir.resolve("nested");
+    Path target = nested.resolve("payload.bin");
     Sandbox sandbox =
         action -> {
           if (action.type() == ActionType.FILE_WRITE) {
-            if (fileWrites.incrementAndGet() >= 2) {
+            int n = fileWrites.incrementAndGet();
+            if (n >= 2) {
+              // 复检必须在 createDirectories 之后：此时父目录应已存在
+              assertTrue(Files.isDirectory(nested), "写前复检应发生在 createDirectories 之后");
               throw new SandboxViolationException("复检拒绝: " + action.target());
             }
           }
         };
-    Path target = dir.resolve("payload.bin");
     HttpTools guarded = new HttpTools(sandbox, RestClient.create());
 
     assertThrows(
         SandboxViolationException.class, () -> guarded.downloadFile(url(), target.toString()));
-    assertEquals(2, fileWrites.get(), "应在下载前后各 enforce 一次 FILE_WRITE");
+    assertEquals(2, fileWrites.get(), "应在下载前与 Files.write 前各 enforce 一次 FILE_WRITE");
     assertTrue(Files.notExists(target), "复检拒绝后不得落盘");
   }
 


### PR DESCRIPTION
## Summary
- Move `download_file` second `FILE_WRITE` recheck to after `createDirectories` and before `Files.write`
- Align with `write_file` ordering to close post-recheck parent symlink TOCTOU
- Assert parent dir exists at recheck time in `HttpToolsTest`

Fixes #179

## Test plan
- [x] `mvn -pl oryxos-tool -am test -Dtest=HttpToolsTest`
- [x] CI green