### PR TITLE
fix(tool): strip credential headers on cross-origin HTTP write redirects

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -92,17 +92,11 @@ public class HttpTools {
   private String write(
       HttpMethod method, String url, String headers, String body, boolean jsonBody) {
     String current = url;
+    String hopHeaders = headers;
     for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
       sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, current)); // 每跳校验
       RestClient.RequestBodySpec spec = hopClient.method(method).uri(current);
-      if (headers != null && !headers.isBlank()) {
-        for (String line : HEADER_LINE_SEP.split(headers)) {
-          int colon = line.indexOf(':');
-          if (colon > 0) {
-            spec.header(line.substring(0, colon).strip(), line.substring(colon + 1).strip());
-          }
-        }
-      }
+      applyCustomHeaders(spec, hopHeaders);
       if (body != null && !body.isBlank()) {
         if (jsonBody) {
           spec.contentType(MediaType.APPLICATION_JSON);
@@ -115,12 +109,88 @@ public class HttpTools {
         if (location == null || location.isBlank()) {
           return resp.getBody();
         }
-        current = URI.create(current).resolve(location).toString();
+        String next = URI.create(current).resolve(location).toString();
+        // 跨源重定向剥离敏感头：对齐浏览器，防白名单内 A 302→白名单内 B 时泄露 Authorization/Cookie
+        if (!sameOrigin(current, next)) {
+          hopHeaders = stripSensitiveHeaders(hopHeaders);
+        }
+        current = next;
         continue;
       }
       return resp.getBody();
     }
     throw new IllegalStateException("重定向次数过多，拒绝: " + url);
+  }
+
+  private static void applyCustomHeaders(RestClient.RequestBodySpec spec, String headers) {
+    if (headers == null || headers.isBlank()) {
+      return;
+    }
+    for (String line : HEADER_LINE_SEP.split(headers)) {
+      int colon = line.indexOf(':');
+      if (colon > 0) {
+        spec.header(line.substring(0, colon).strip(), line.substring(colon + 1).strip());
+      }
+    }
+  }
+
+  /** scheme + host + effective port；跨源重定向时不得继续携带凭证类头。 */
+  static boolean sameOrigin(String from, String to) {
+    URI a = URI.create(from);
+    URI b = URI.create(to);
+    return Objects.equals(a.getScheme(), b.getScheme())
+        && Objects.equals(hostOf(a), hostOf(b))
+        && effectivePort(a) == effectivePort(b);
+  }
+
+  private static String hostOf(URI uri) {
+    String host = uri.getHost();
+    return host == null ? "" : host.toLowerCase(Locale.ROOT);
+  }
+
+  private static int effectivePort(URI uri) {
+    int port = uri.getPort();
+    if (port >= 0) {
+      return port;
+    }
+    if ("https".equalsIgnoreCase(uri.getScheme())) {
+      return 443;
+    }
+    if ("http".equalsIgnoreCase(uri.getScheme())) {
+      return 80;
+    }
+    return -1;
+  }
+
+  /** 去掉跨源重定向不应转发的头（Authorization / Proxy-Authorization / Cookie / Cookie2）。 同浏览器对跨站重定向的凭证剥离习惯。 */
+  static String stripSensitiveHeaders(String headers) {
+    if (headers == null || headers.isBlank()) {
+      return headers;
+    }
+    StringBuilder kept = new StringBuilder();
+    for (String line : HEADER_LINE_SEP.split(headers)) {
+      int colon = line.indexOf(':');
+      if (colon <= 0) {
+        continue;
+      }
+      String name = line.substring(0, colon).strip();
+      if (isSensitiveHeaderName(name)) {
+        continue;
+      }
+      if (kept.length() > 0) {
+        kept.append('\n');
+      }
+      kept.append(name).append(':').append(line.substring(colon + 1).strip());
+    }
+    return kept.toString();
+  }
+
+  private static boolean isSensitiveHeaderName(String name) {
+    String n = name.toLowerCase(Locale.ROOT);
+    return "authorization".equals(n)
+        || "proxy-authorization".equals(n)
+        || "cookie".equals(n)
+        || "cookie2".equals(n);
   }
 
   @Tool(name = "http_get", description = "发起一个 HTTP GET 请求，返回响应体")

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -48,6 +48,11 @@ public class HttpTools {
   private static final Pattern BLANK_LINES = Pattern.compile("\\n{3,}");
   private static final Pattern HEADER_LINE_SEP = Pattern.compile("\\R");
 
+  private static final String HTTP_SCHEME = "http";
+  private static final String HTTPS_SCHEME = "https";
+  private static final int DEFAULT_HTTP_PORT = 80;
+  private static final int DEFAULT_HTTPS_PORT = 443;
+
   private final Sandbox sandbox;
 
   /** 读写共用：**禁自动重定向**，由本类手动逐跳跟随并每跳重过沙箱校验。不使用注入的 RestClient 默认跟随行为（否则写请求会在首跳过白名单后跟到任意 Location）。 */
@@ -153,11 +158,11 @@ public class HttpTools {
     if (port >= 0) {
       return port;
     }
-    if ("https".equalsIgnoreCase(uri.getScheme())) {
-      return 443;
+    if (HTTPS_SCHEME.equalsIgnoreCase(uri.getScheme())) {
+      return DEFAULT_HTTPS_PORT;
     }
-    if ("http".equalsIgnoreCase(uri.getScheme())) {
-      return 80;
+    if (HTTP_SCHEME.equalsIgnoreCase(uri.getScheme())) {
+      return DEFAULT_HTTP_PORT;
     }
     return -1;
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -153,15 +153,20 @@ public class HttpTools {
     return host == null ? "" : host.toLowerCase(Locale.ROOT);
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "URI scheme tokens are ASCII; Locale.ROOT lowercasing is the correct case-fold for http/https comparison.")
   private static int effectivePort(URI uri) {
     int port = uri.getPort();
     if (port >= 0) {
       return port;
     }
-    if (HTTPS_SCHEME.equalsIgnoreCase(uri.getScheme())) {
+    String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+    if (HTTPS_SCHEME.equals(scheme)) {
       return DEFAULT_HTTPS_PORT;
     }
-    if (HTTP_SCHEME.equalsIgnoreCase(uri.getScheme())) {
+    if (HTTP_SCHEME.equals(scheme)) {
       return DEFAULT_HTTP_PORT;
     }
     return -1;
@@ -190,6 +195,10 @@ public class HttpTools {
     return kept.toString();
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "HTTP header names are ASCII tokens; Locale.ROOT lowercasing is the correct case-fold for Authorization/Cookie matching.")
   private static boolean isSensitiveHeaderName(String name) {
     String n = name.toLowerCase(Locale.ROOT);
     return "authorization".equals(n)

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
@@ -155,6 +155,69 @@ class HttpToolsTest {
   }
 
   @Test
+  @DisplayName("http_request 跨源 302 不得把 Authorization 带到下一跳（白名单内主机亦然）")
+  void httpRequestCrossOriginRedirectStripsAuthorization() throws IOException {
+    HttpServer entry = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    HttpServer sink = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    AtomicInteger sinkHits = new AtomicInteger();
+    List<String> sinkAuth = new ArrayList<>();
+    List<String> sinkTrace = new ArrayList<>();
+    try {
+      sink.createContext(
+          "/",
+          exchange -> {
+            sinkHits.incrementAndGet();
+            String auth = exchange.getRequestHeaders().getFirst("Authorization");
+            if (auth != null) {
+              sinkAuth.add(auth);
+            }
+            String trace = exchange.getRequestHeaders().getFirst("X-Trace-Id");
+            if (trace != null) {
+              sinkTrace.add(trace);
+            }
+            byte[] response = "ok".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+          });
+      String sinkUrl = "http://127.0.0.1:" + sink.getAddress().getPort() + "/sink";
+      entry.createContext(
+          "/",
+          exchange -> {
+            exchange.getResponseHeaders().add("Location", sinkUrl);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+          });
+      entry.start();
+      sink.start();
+
+      // 两台都在白名单：#111 不会拦；修复前 Authorization 会跟到 sink
+      Sandbox whitelist =
+          new WhitelistSandbox(
+              new FileSandboxProperties(List.of()),
+              new ShellSandboxProperties(List.of()),
+              new HttpSandboxProperties(List.of("localhost", "127.0.0.1")));
+      HttpTools guarded = new HttpTools(whitelist, RestClient.create());
+      String start = "http://localhost:" + entry.getAddress().getPort() + "/";
+
+      String body =
+          guarded.httpRequest(
+              "POST",
+              start,
+              "Authorization: Bearer secret-token\nX-Trace-Id: keep-me",
+              "{\"x\":1}");
+
+      assertEquals("ok", body);
+      assertEquals(1, sinkHits.get());
+      assertTrue(sinkAuth.isEmpty(), "跨源重定向不得转发 Authorization");
+      assertEquals(List.of("keep-me"), sinkTrace, "非敏感自定义头仍可转发");
+    } finally {
+      entry.stop(0);
+      sink.stop(0);
+    }
+  }
+
+  @Test
   @DisplayName("download_file 落盘前复检 FILE_WRITE（防拉网窗口内路径逃逸）")
   void downloadFileRechecksPathBeforeWrite(@TempDir Path dir) throws IOException {
     AtomicInteger fileWrites = new AtomicInteger();


### PR DESCRIPTION
## Summary
- Strip `Authorization` / `Proxy-Authorization` / `Cookie` / `Cookie2` on cross-origin write redirects
- Keep non-sensitive custom headers; same-origin redirects unchanged
- Add regression: allowlisted localhost→127.0.0.1 must not leak Bearer token

Fixes #181

## Test plan
- [x] `mvn -pl oryxos-tool -am test -Dtest=HttpToolsTest`
- [ ] CI green