### PR TITLE
fix(tool): recheck FILE_WRITE before readString in edit_file

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -107,6 +107,8 @@ public class FileTools {
       throw new IllegalArgumentException("文件不存在或不是普通文件: " + path);
     }
     try {
+      // 读前复检：与 read_file 同款——防首次校验到 readString 间路径被换成外向软链读出白名单
+      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
       String content = Files.readString(file);
       int first = content.indexOf(oldString);
       if (first < 0) {
@@ -116,6 +118,7 @@ public class FileTools {
         // 多处匹配会改错地方——要求唯一，逼调用方给足上下文（Claude Code/Cursor 同款约束）
         throw new IllegalArgumentException("原文本在文件中出现多次，无法定位唯一编辑点: " + path);
       }
+      // 写前复检：与 write_file 同款
       sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
       Files.writeString(file, content.replace(oldString, newString));
       return "已编辑: " + path;

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -257,9 +257,9 @@ class FileToolsTest {
   }
 
   @Test
-  @DisplayName("edit_file 写回前复检 FILE_WRITE")
-  void editFileRechecksPathBeforeWrite() throws IOException {
-    Path target = dir.resolve("edit.txt");
+  @DisplayName("edit_file 读前复检 FILE_WRITE（防 readString 窗口读出白名单）")
+  void editFileRechecksPathBeforeRead() throws IOException {
+    Path target = dir.resolve("edit-read.txt");
     Files.writeString(target, "hello");
     AtomicInteger fileWrites = new AtomicInteger();
     Sandbox sandbox =
@@ -273,7 +273,28 @@ class FileToolsTest {
     assertThrows(
         SandboxViolationException.class,
         () -> guarded.editFile(target.toString(), "hello", "world"));
-    assertEquals(2, fileWrites.get());
+    assertEquals(2, fileWrites.get(), "应在入口与 readString 前各 enforce 一次");
+    assertEquals("hello", Files.readString(target), "读前复检拒绝后不得改写");
+  }
+
+  @Test
+  @DisplayName("edit_file 写回前复检 FILE_WRITE")
+  void editFileRechecksPathBeforeWrite() throws IOException {
+    Path target = dir.resolve("edit.txt");
+    Files.writeString(target, "hello");
+    AtomicInteger fileWrites = new AtomicInteger();
+    Sandbox sandbox =
+        action -> {
+          if (action.type() == ActionType.FILE_WRITE && fileWrites.incrementAndGet() >= 3) {
+            throw new SandboxViolationException("复检拒绝: " + action.target());
+          }
+        };
+    FileTools guarded = new FileTools(sandbox);
+
+    assertThrows(
+        SandboxViolationException.class,
+        () -> guarded.editFile(target.toString(), "hello", "world"));
+    assertEquals(3, fileWrites.get(), "入口 / 读前 / 写前共三次 FILE_WRITE");
     assertEquals("hello", Files.readString(target), "复检拒绝后不得改写");
   }
 


### PR DESCRIPTION
Close the TOCTOU window between the initial sandbox check and Files.readString so a swapped outbound symlink cannot leak whitelist-external content. Keep the existing write-before recheck.

## Summary
- Recheck `FILE_WRITE` immediately before `Files.readString` in `edit_file`
- Keep the existing write-before recheck (three enforces: entry / read / write)
- Add `editFileRechecksPathBeforeRead`; update write-side test to assert 3rd enforce

Fixes #183

## Test plan
- [x] `mvn -pl oryxos-tool -am test -Dtest=FileToolsTest`
- [ ] CI green