### PR TITLE
release: 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 本文件记录 OryxOS 的版本变更。格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [0.1.3-RELEASE] - 2026-08-18
+
+### Added
+- Windows PowerShell 安装脚本（`feat(scripts)`，#176）。
+- Provider `/models` 拉取支持 connect/read 超时配置，避免挂起阻塞管理台线程（#178）。
+
+### Fixed
+- HTTP 跨重定向（跨域）时剥离敏感凭证头（`Authorization`/`Cookie` 等），降低凭证泄漏风险（#182）。
+- 文件操作沙箱校验复检时序对齐：`download_file`/`edit_file`/`list_dir` 等关键路径降低 TOCTOU 风险（#180/#184/#175）。
+- 前后复检与 sandbox enforcement 整体加固（与多项 file recheck 修复一起落地）。
+
+### Security
+- 强化跨域重定向下的敏感头处理，防止跨域跳转带走用户凭证。
+
+### Docs
+- 更新 README 版本徽标、前端概览版本展示到 `0.1.3`。
+
 ## [0.1.2-RELEASE] - 2026-08-10
 
 ### Added
@@ -64,6 +81,7 @@
 - Web REST API（`/api/v1`）与 CLI 子命令（`init`/`chat`/`serve`/`gateway` 等）。
 - SQLite 持久化与 `tool_invocations` / `llm_calls` 审计表 Day-One 写入。
 
+[0.1.3-RELEASE]: https://github.com/oryx-labs/oryxos/compare/v0.1.2-RELEASE...v0.1.3-RELEASE
 [0.1.2-RELEASE]: https://github.com/oryx-labs/oryxos/compare/v0.1.1-RELEASE...v0.1.2-RELEASE
 [0.1.1-RELEASE]: https://github.com/oryx-labs/oryxos/compare/v0.1.0-RELEASE...v0.1.1-RELEASE
 [0.1.0-RELEASE]: https://github.com/oryx-labs/oryxos/releases/tag/v0.1.0-RELEASE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,56 @@
 
 ### Added
 - Windows PowerShell 安装脚本（`feat(scripts)`，#176）。
-- Provider `/models` 拉取支持 connect/read 超时配置，避免挂起阻塞管理台线程（#178）。
+- Provider 连通性测试（#97）。
+- LLM Provider HTTP 调用 connect/read 超时（#88）。
+- 管理台重复登录失败按用户名与来源 IP 锁定（`feat(web)`，#92）。
 
 ### Fixed
-- HTTP 跨重定向（跨域）时剥离敏感凭证头（`Authorization`/`Cookie` 等），降低凭证泄漏风险（#182）。
-- 文件操作沙箱校验复检时序对齐：`download_file`/`edit_file`/`list_dir` 等关键路径降低 TOCTOU 风险（#180/#184/#175）。
-- 前后复检与 sandbox enforcement 整体加固（与多项 file recheck 修复一起落地）。
+- Provider `/models` RestClient 设置 connect/read 超时，避免挂起阻塞管理台（#178）。
+- 控制台日志显式 UTF-8 charset，修复中文 Windows 终端乱码（#176）。
+- `download_file` 在 `createDirectories` 之后、`Files.write` 之前复检 `FILE_WRITE`（#180）。
+- `edit_file` 在 `readString` 前复检 `FILE_WRITE`（#184）。
+- `list_dir` 列目录前复检 `FILE_READ`（#175）。
+- `write_file`/`append_file`/`edit_file` 写前复检 `FILE_WRITE`（#166）。
+- `download_file` 写前复检 `FILE_WRITE`（#144）。
+- `delete_file` 目录检测不跟随软链（#146）。
+- `copy_file`/`move_file` 写前复检沙箱；拒绝目录目标（#148）。
+- `grep`/`glob` 遍历前解析目录软链；`**/` 匹配 walk 根目录文件（#150）。
+- `json_extract` 区分 JSON `null` 与路径缺失（#152）。
+- Tool RestClient connect/read 超时（#138）。
+- 本地 vLLM/Ollama 端点强制 HTTP/1.1（#133）。
+- Provider ChatModel 缓存按 provider name 有界（#84）。
+- shell stdout/stderr 与 CLI stdin 按默认 charset 解码（#129/#121）。
+- `serve`/`gateway` 无交互环境抛出 `UnsupportedUserInteraction`（#119）。
+- `notify` 默认 channel 从全局 registry 读取（#123）。
+- HTTP write 与 `notify` 重定向每跳复检白名单（#112/#117）。
+- 审计写入失败不再掩盖 LLM/Tool 主流程结果（#95）。
+- `MEMORY.md` 追加串行化与原子写入（#86）。
+- Markdown 记忆条目 section header 消毒（#164）。
+- 管理台 `BasicAuthFilter` 应用登录锁定（#161）。
+- 会话聊天新回复自动滚底；重载后保留滚动位置（#100/#101）。
+- Skill 导入 GitHub 路径空格编码为 `%20`（#142）。
+- HTTPS 反代下 `Secure` cookie 尊重 `X-Forwarded-Proto`；登录使旧 session 失效（#90）。
+- 恢复 `main` CI 绿：spotless + SpotBugs（#115）。
+- CI spotless 快速失败与 deploy-pages 超时（#162）。
+- 默认模型示例改为 `deepseek-v4-flash`（#80）。
 
 ### Security
-- 强化跨域重定向下的敏感头处理，防止跨域跳转带走用户凭证。
+- 修复 shell 白名单 bypass（#98）。
+- HTTP 跨域重定向时剥离 `Authorization`/`Cookie` 等敏感凭证头（#182）。
+- `web_search` 重定向 SSRF：`Redirect.NEVER` + endpoint `HTTP_READ` 校验（#156）。
+- NAT64/IPv4-mapped 嵌入 SSRF 拦截（#127）。
+- HTTP 请求必须 http(s) scheme；HTTP_READ 必须 http(s) host（#136/#131）。
+- Skill 导入 SSRF 拦截 IPv6 ULA（#110）。
 
 ### Docs
-- 更新 README 版本徽标、前端概览版本展示到 `0.1.3`。
+- shell/HTTP 沙箱文档与实现对齐（#125）。
+- HTTP 白名单文档区分 HTTP_READ vs HTTP_REQUEST（#104）。
+- 英文文档 allowlist → whitelist（#105）。
+- 修复过时 jar 路径与文档链接（#106）。
+- 中文快速开始补充 Windows 说明（#102）。
+- 网站侧边栏增加 Auth 页（#99）。
+- README 版本徽章升级至 0.1.3。
 
 ## [0.1.2-RELEASE] - 2026-08-10
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/oryx-labs/oryxos/releases"><img src="https://img.shields.io/badge/version-0.1.2-orange?style=flat-square" alt="version"/></a>
+  <a href="https://github.com/oryx-labs/oryxos/releases"><img src="https://img.shields.io/badge/version-0.1.3-orange?style=flat-square" alt="version"/></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-native-8A2BE2?style=flat-square" alt="MCP native"/></a>
   <a href="https://www.apache.org/licenses/LICENSE-2.0"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0"/></a>
 </p>

--- a/oryxos-boot/pom.xml
+++ b/oryxos-boot/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.2-RELEASE</version>
+        <version>0.1.3-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-boot</artifactId>

--- a/oryxos-channel-cli/pom.xml
+++ b/oryxos-channel-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.2-RELEASE</version>
+        <version>0.1.3-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-channel-cli</artifactId>

--- a/oryxos-cli/pom.xml
+++ b/oryxos-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.2-RELEASE</version>
+        <version>0.1.3-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-cli</artifactId>

--- a/oryxos-core/pom.xml
+++ b/oryxos-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.2-RELEASE</version>
+        <version>0.1.3-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-core</artifactId>

--- a/oryxos-memory/pom.xml
+++ b/oryxos-memory/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.2-RELEASE</version>
+        <version>0.1.3-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-memory</artifactId>

--- a/oryxos-provider/pom.xml
+++ b/oryxos-provider/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.2-RELEASE</version>
+        <version>0.1.3-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-provider</artifactId>

--- a/oryxos-storage/pom.xml
+++ b/oryxos-storage/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.2-RELEASE</version>
+        <version>0.1.3-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-storage</artifactId>

--- a/oryxos-tool/pom.xml
+++ b/oryxos-tool/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.2-RELEASE</version>
+        <version>0.1.3-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-tool</artifactId>

--- a/oryxos-web/pom.xml
+++ b/oryxos-web/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.2-RELEASE</version>
+        <version>0.1.3-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-web</artifactId>

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -149,7 +149,7 @@ const overviewCards = computed(() => [
 const overview = {
   tagline: '装在你自己基础设施上的分布式 AI Agent 操作系统 —— 统一底座运行多个业务 Agent',
   status: '运行中',
-  version: 'v0.1.0 · 开发预览',
+  version: 'v0.1.3 · RELEASE',
   capabilities: [
     { name: '对接 LLM', desc: '显式 Provider 映射，多家协议统一' },
     { name: 'ReAct 循环', desc: '自实现推理–行动循环，完全可控' },

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.oryxos</groupId>
     <artifactId>oryxos</artifactId>
-    <version>0.1.2-RELEASE</version>
+    <version>0.1.3-RELEASE</version>
     <packaging>pom</packaging>
 
     <name>OryxOS</name>

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -12,7 +12,7 @@ install.ps1 — Windows 下安装 OryxOS CLI（构建 jar + 注册 PowerShell �
 
 说明：
   • 幂等可重复运行：$PROFILE 中旧函数块（begin/end 标记之间）会被替换为最新版本。
-  • jar 文件名带版本号（如 oryxos-boot-0.1.2-RELEASE.jar），函数内用通配符动态
+    • jar 文件名带版本号（如 oryxos-boot-0.1.3-RELEASE.jar），函数内用通配符动态
     解析最新产物，且排除 spring-boot repackage 留下的 *.jar.original。
 #>
 

--- a/specs/013-overview-dynamic-data/data-model.md
+++ b/specs/013-overview-dynamic-data/data-model.md
@@ -74,7 +74,7 @@ public SessionStats stats() {
 const overview = reactive({
   tagline: '装在你自己基础设施上的分布式 AI Agent 操作系统...',
   status: '运行中',
-  version: 'v0.1.0 · 开发预览',
+  version: 'v0.1.3 · RELEASE',
   stats: {
     agents: { value: null, loading: true, error: null },
     tools: { value: null, loading: true, error: null },


### PR DESCRIPTION
## Summary
- 按标准 Release workflow 重新发布 `0.1.3-RELEASE`。
- 将 `pom.xml` / 模块版本从 `0.1.2-RELEASE` 升到 `0.1.3-RELEASE`。
- 补全 `CHANGELOG.md` 的 `0.1.3-RELEASE` 段（格式对齐 0.1.2），并更新 README 版本徽章。

此前手动 tag / GitHub Release 已删除；本 PR 合入后由 `.github/workflows/release.yml` 自动打 `v0.1.3-RELEASE` 并上传 `dist/oryxos-0.1.3-RELEASE.tar.gz`。

## Test plan
- [ ] PR 标题确认为 `release: 0.1.3`（触发 Release workflow）
- [ ] 合入后确认 Actions → Release 为 success（非 skipped）
- [ ] 确认 GitHub Release `v0.1.3-RELEASE` 由 CI 创建，产物为 `oryxos-0.1.3-RELEASE.tar.gz`


Made with [Cursor](https://cursor.com)