### PR TITLE
fix(tool): do not replay POST body on 301/302/303 redirects

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -53,6 +53,12 @@ public class HttpTools {
   private static final int DEFAULT_HTTP_PORT = 80;
   private static final int DEFAULT_HTTPS_PORT = 443;
 
+  /** RFC 9110：这些 3xx 不得自动重放原方法与 body，浏览器会改成 GET。 */
+  private static final int STATUS_MOVED_PERMANENTLY = 301;
+
+  private static final int STATUS_FOUND = 302;
+  private static final int STATUS_SEE_OTHER = 303;
+
   private final Sandbox sandbox;
 
   /** 读写共用：**禁自动重定向**，由本类手动逐跳跟随并每跳重过沙箱校验。不使用注入的 RestClient 默认跟随行为（否则写请求会在首跳过白名单后跟到任意 Location）。 */
@@ -98,15 +104,18 @@ public class HttpTools {
       HttpMethod method, String url, String headers, String body, boolean jsonBody) {
     String current = url;
     String hopHeaders = headers;
+    HttpMethod hopMethod = method;
+    String hopBody = body;
+    boolean hopJsonBody = jsonBody;
     for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
       sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, current)); // 每跳校验
-      RestClient.RequestBodySpec spec = hopClient.method(method).uri(current);
+      RestClient.RequestBodySpec spec = hopClient.method(hopMethod).uri(current);
       applyCustomHeaders(spec, hopHeaders);
-      if (body != null && !body.isBlank()) {
-        if (jsonBody) {
+      if (hopBody != null && !hopBody.isBlank()) {
+        if (hopJsonBody) {
           spec.contentType(MediaType.APPLICATION_JSON);
         }
-        spec.body(body);
+        spec.body(hopBody);
       }
       ResponseEntity<String> resp = spec.retrieve().toEntity(String.class);
       if (resp.getStatusCode().is3xxRedirection()) {
@@ -119,12 +128,24 @@ public class HttpTools {
         if (!sameOrigin(current, next)) {
           hopHeaders = stripSensitiveHeaders(hopHeaders);
         }
+        // 301/302/303：不得把原 POST/PUT body 带到下一跳（RFC 9110 + 浏览器行为）。307/308 才保留方法与 body。
+        if (switchesToGet(resp.getStatusCode().value())) {
+          hopMethod = HttpMethod.GET;
+          hopBody = null;
+          hopJsonBody = false;
+        }
         current = next;
         continue;
       }
       return resp.getBody();
     }
     throw new IllegalStateException("重定向次数过多，拒绝: " + url);
+  }
+
+  static boolean switchesToGet(int status) {
+    return status == STATUS_MOVED_PERMANENTLY
+        || status == STATUS_FOUND
+        || status == STATUS_SEE_OTHER;
   }
 
   private static void applyCustomHeaders(RestClient.RequestBodySpec spec, String headers) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyPoster.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyPoster.java
@@ -7,6 +7,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.Objects;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
@@ -21,6 +22,9 @@ public final class NotifyPoster {
   private static final int MAX_REDIRECTS = 5;
   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
   private static final Duration READ_TIMEOUT = Duration.ofSeconds(20);
+  private static final int STATUS_MOVED_PERMANENTLY = 301;
+  private static final int STATUS_FOUND = 302;
+  private static final int STATUS_SEE_OTHER = 303;
 
   private final Sandbox sandbox;
   private final RestClient hopClient;
@@ -37,23 +41,26 @@ public final class NotifyPoster {
     this.hopClient = RestClient.builder().requestFactory(hopFactory).build();
   }
 
-  /** POST JSON body 到 url；3xx 时跟随 Location，每跳先过沙箱。 */
+  /** POST JSON body 到 url；3xx 时跟随 Location，每跳先过沙箱。301/302/303 下一跳改为 GET 且不再带 body。 */
   public void postJson(String url, Object body) {
     String current = url;
+    HttpMethod hopMethod = HttpMethod.POST;
+    Object hopBody = body;
     for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
       sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, current));
-      ResponseEntity<Void> resp =
-          hopClient
-              .post()
-              .uri(current)
-              .contentType(MediaType.APPLICATION_JSON)
-              .body(body)
-              .retrieve()
-              .toBodilessEntity();
+      RestClient.RequestBodySpec spec = hopClient.method(hopMethod).uri(current);
+      if (hopBody != null) {
+        spec.contentType(MediaType.APPLICATION_JSON).body(hopBody);
+      }
+      ResponseEntity<Void> resp = spec.retrieve().toBodilessEntity();
       if (resp.getStatusCode().is3xxRedirection()) {
         String location = resp.getHeaders().getFirst("Location");
         if (location == null || location.isBlank()) {
           return;
+        }
+        if (switchesToGet(resp.getStatusCode().value())) {
+          hopMethod = HttpMethod.GET;
+          hopBody = null;
         }
         current = URI.create(current).resolve(location).toString();
         continue;
@@ -61,5 +68,11 @@ public final class NotifyPoster {
       return;
     }
     throw new IllegalStateException("通知推送重定向次数过多，拒绝: " + url);
+  }
+
+  private static boolean switchesToGet(int status) {
+    return status == STATUS_MOVED_PERMANENTLY
+        || status == STATUS_FOUND
+        || status == STATUS_SEE_OTHER;
   }
 }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
@@ -218,6 +218,106 @@ class HttpToolsTest {
   }
 
   @Test
+  @DisplayName("http_request 跨源 302 不得把 POST body 带到下一跳（改 GET）")
+  void httpRequest302DoesNotReplayPostBody() throws IOException {
+    HttpServer entry = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    HttpServer sink = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    List<String> sinkMethods = new ArrayList<>();
+    List<String> sinkBodies = new ArrayList<>();
+    try {
+      sink.createContext(
+          "/",
+          exchange -> {
+            sinkMethods.add(exchange.getRequestMethod());
+            sinkBodies.add(
+                new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            byte[] response = "ok".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+          });
+      String sinkUrl = "http://127.0.0.1:" + sink.getAddress().getPort() + "/sink";
+      entry.createContext(
+          "/",
+          exchange -> {
+            exchange.getRequestBody().readAllBytes();
+            exchange.getResponseHeaders().add("Location", sinkUrl);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+          });
+      entry.start();
+      sink.start();
+
+      Sandbox whitelist =
+          new WhitelistSandbox(
+              new FileSandboxProperties(List.of()),
+              new ShellSandboxProperties(List.of()),
+              new HttpSandboxProperties(List.of("localhost", "127.0.0.1")));
+      HttpTools guarded = new HttpTools(whitelist, RestClient.create());
+      String start = "http://localhost:" + entry.getAddress().getPort() + "/";
+
+      String body = guarded.httpRequest("POST", start, null, "{\"secret\":\"token\"}");
+
+      assertEquals("ok", body);
+      assertEquals(List.of("GET"), sinkMethods, "302 下一跳应改为 GET");
+      assertEquals(List.of(""), sinkBodies, "302 不得把 POST body 转到下一跳");
+    } finally {
+      entry.stop(0);
+      sink.stop(0);
+    }
+  }
+
+  @Test
+  @DisplayName("http_request 跨源 307 应保留 POST 与 body")
+  void httpRequest307PreservesPostBody() throws IOException {
+    HttpServer entry = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    HttpServer sink = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    List<String> sinkMethods = new ArrayList<>();
+    List<String> sinkBodies = new ArrayList<>();
+    try {
+      sink.createContext(
+          "/",
+          exchange -> {
+            sinkMethods.add(exchange.getRequestMethod());
+            sinkBodies.add(
+                new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            byte[] response = "ok".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+          });
+      String sinkUrl = "http://127.0.0.1:" + sink.getAddress().getPort() + "/sink";
+      entry.createContext(
+          "/",
+          exchange -> {
+            exchange.getRequestBody().readAllBytes();
+            exchange.getResponseHeaders().add("Location", sinkUrl);
+            exchange.sendResponseHeaders(307, -1);
+            exchange.close();
+          });
+      entry.start();
+      sink.start();
+
+      Sandbox whitelist =
+          new WhitelistSandbox(
+              new FileSandboxProperties(List.of()),
+              new ShellSandboxProperties(List.of()),
+              new HttpSandboxProperties(List.of("localhost", "127.0.0.1")));
+      HttpTools guarded = new HttpTools(whitelist, RestClient.create());
+      String start = "http://localhost:" + entry.getAddress().getPort() + "/";
+
+      String body = guarded.httpRequest("POST", start, null, "{\"keep\":true}");
+
+      assertEquals("ok", body);
+      assertEquals(List.of("POST"), sinkMethods, "307 应保留 POST");
+      assertEquals(List.of("{\"keep\":true}"), sinkBodies, "307 应保留 body");
+    } finally {
+      entry.stop(0);
+      sink.stop(0);
+    }
+  }
+
+  @Test
   @DisplayName("download_file 落盘前复检 FILE_WRITE（防拉网窗口内路径逃逸）")
   void downloadFileRechecksPathBeforeWrite(@TempDir Path dir) throws IOException {
     AtomicInteger fileWrites = new AtomicInteger();

--- a/oryxos-tool/src/test/java/io/oryxos/tool/notify/WebhookNotifyAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/notify/WebhookNotifyAdapterTest.java
@@ -157,4 +157,52 @@ class WebhookNotifyAdapterTest {
       sink.stop(0);
     }
   }
+
+  @Test
+  @DisplayName("白名单内 302 不得把通知 POST body 转到下一跳")
+  void redirect302DoesNotReplayPostBody() throws IOException {
+    HttpServer entry = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    HttpServer sink = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    List<String> sinkMethods = new ArrayList<>();
+    List<String> sinkBodies = new ArrayList<>();
+    try {
+      sink.createContext(
+          "/",
+          exchange -> {
+            sinkMethods.add(exchange.getRequestMethod());
+            sinkBodies.add(
+                new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+          });
+      String sinkUrl = "http://127.0.0.1:" + sink.getAddress().getPort() + "/sink";
+      entry.createContext(
+          "/",
+          exchange -> {
+            exchange.getRequestBody().readAllBytes();
+            exchange.getResponseHeaders().add("Location", sinkUrl);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+          });
+      entry.start();
+      sink.start();
+
+      WebhookNotifyAdapter guarded =
+          new WebhookNotifyAdapter(
+              new NotifyPoster(
+                  new WhitelistSandbox(
+                      new FileSandboxProperties(List.of()),
+                      new ShellSandboxProperties(List.of()),
+                      new HttpSandboxProperties(List.of("localhost", "127.0.0.1")))));
+      String start = "http://localhost:" + entry.getAddress().getPort() + "/";
+
+      guarded.send(webhookTarget(start), "secret-notify");
+
+      assertEquals(List.of("GET"), sinkMethods, "302 下一跳应改为 GET");
+      assertEquals(List.of(""), sinkBodies, "302 不得把通知 body 转到下一跳");
+    } finally {
+      entry.stop(0);
+      sink.stop(0);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Follow-up to #182: `http_request` / notify still forwarded the original POST method and JSON body on 301/302/303, even after stripping `Authorization`/`Cookie`.
- Align with RFC 9110 / browsers: 301/302/303 become GET with no body; 307/308 keep method + body (cross-origin hops still strip sensitive headers).

Closes #187

## Test plan
- [x] `mvn -pl oryxos-tool -am test -Dtest=HttpToolsTest,WebhookNotifyAdapterTest`
- [ ] CI quality gate green