### PR TITLE
fix(web): ignore spoofed X-Forwarded-For for login lockout

### DIFF
--- a/oryxos-web/src/main/java/io/oryxos/web/controller/AuthApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/AuthApiController.java
@@ -7,6 +7,7 @@ import io.oryxos.web.common.ApiResponse;
 import io.oryxos.web.config.WebAuthProperties;
 import io.oryxos.web.controller.dto.AuthMeView;
 import io.oryxos.web.controller.dto.LoginRequest;
+import io.oryxos.web.security.ClientIp;
 import io.oryxos.web.security.LoginAttemptService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -82,7 +83,7 @@ public class AuthApiController {
           HttpStatus.BAD_REQUEST.value(), "username and password are required");
     }
     // 暴力破解防护：同「用户名|来源 IP」连续失败超限即 429，不碰密码校验（锁定期内也不给密码探针）。
-    String attemptKey = loginRequest.username() + "|" + request.getRemoteAddr();
+    String attemptKey = loginRequest.username() + "|" + ClientIp.peerAddress(request);
     if (loginAttemptService.isBlocked(attemptKey)) {
       response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
       return ApiResponse.error(HttpStatus.TOO_MANY_REQUESTS.value(), TOO_MANY_ATTEMPTS_MESSAGE);

--- a/oryxos-web/src/main/java/io/oryxos/web/security/BasicAuthFilter.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/BasicAuthFilter.java
@@ -162,7 +162,7 @@ public class BasicAuthFilter extends OncePerRequestFilter {
     if (credentials == null || credentials.length != BASIC_CREDENTIAL_PARTS) {
       return BasicOutcome.NONE;
     }
-    String attemptKey = credentials[0] + "|" + request.getRemoteAddr();
+    String attemptKey = credentials[0] + "|" + ClientIp.peerAddress(request);
     if (loginAttemptService.isBlocked(attemptKey)) {
       return BasicOutcome.LOCKED;
     }

--- a/oryxos-web/src/main/java/io/oryxos/web/security/ClientIp.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/ClientIp.java
@@ -1,0 +1,32 @@
+package io.oryxos.web.security;
+
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletRequestWrapper;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * 登录锁定用的客户端地址：取 TCP 对端，不取 {@code X-Forwarded-For} / {@code Forwarded} 改写后的地址。
+ *
+ * <p>{@code server.forward-headers-strategy=framework} 会注册 {@code ForwardedHeaderFilter}，把 {@link
+ * HttpServletRequest#getRemoteAddr()} 换成客户端声称的转发头。Cookie 的 {@code Secure} 需要 {@code
+ * X-Forwarded-Proto}，但锁定键若也信转发头，攻击者每次换一个 {@code X-Forwarded-For} 就能绕过「用户名|IP」失败上限。
+ *
+ * <p>解开 wrapper 后的对端：直连是攻击者真实 IP；前面是反代时是反代 IP（同用户名在该反代后共用一把锁——文档里「未区分客户端时退化为按用户名锁」的兜底）。
+ */
+public final class ClientIp {
+
+  private static final String UNKNOWN = "unknown";
+
+  private ClientIp() {}
+
+  /** 供 {@link LoginAttemptService} 拼「用户名|IP」键：不可被请求头伪造。 */
+  public static String peerAddress(HttpServletRequest request) {
+    ServletRequest current = request;
+    while (current instanceof ServletRequestWrapper wrapper) {
+      current = wrapper.getRequest();
+    }
+    String addr =
+        current instanceof HttpServletRequest http ? http.getRemoteAddr() : request.getRemoteAddr();
+    return addr == null || addr.isBlank() ? UNKNOWN : addr;
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/security/LoginAttemptService.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/LoginAttemptService.java
@@ -10,8 +10,10 @@ import java.util.concurrent.ConcurrentHashMap;
  * 登录暴力破解防护（纯内存，无后台线程——宪法七同步模型）：同一「用户名|来源 IP」连续失败 {@value #MAX_FAILURES} 次后锁 {@link
  * #LOCK_DURATION}，窗口内成功登录清零。
  *
- * <p>键取用户名+IP 组合而非单用户名：攻击者猜不中密码也能靠失败次数把合法账号锁死（拒绝服务）；组合键下锁的只是 该来源，合法用户从自己的 IP 登录不受影响。反代未传
- * X-Forwarded-For 时所有请求同 IP，退化为按用户名锁——可接受的兜底。
+ * <p>键取用户名+<strong>TCP 对端</strong>而非单用户名：攻击者猜不中密码也能靠失败次数把合法账号锁死（拒绝服务）；组合键下锁的只是 该来源，合法用户从自己的 IP
+ * 登录不受影响。IP 必须用 {@link ClientIp#peerAddress}，不能用 {@code request.getRemoteAddr()}——后者在 {@code
+ * ForwardedHeaderFilter} 下会被 {@code X-Forwarded-For} 改写，换头即可绕过锁定。 前面是反代时对端是反代
+ * IP，同用户名在该反代后共用一把锁——可接受的兜底。
  *
  * <p>惰性过期：查询时发现锁已到期或失败窗口已过即删条目，无定时清理线程；条目超过 {@link #SWEEP_THRESHOLD} 时顺手全表清一次过期项，防恶意大量用户名撑内存。
  */

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/AuthApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/AuthApiControllerTest.java
@@ -3,6 +3,7 @@ package io.oryxos.web.controller;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -232,6 +233,50 @@ class AuthApiControllerTest {
                 .cookie(new jakarta.servlet.http.Cookie("oryxos_session", "sid-123")))
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.code").value(401));
+  }
+
+  @Test
+  @DisplayName("login_轮换X-Forwarded-For不能绕过锁定")
+  void login_spoofedXForwardedFor_doesNotBypassLockout() throws Exception {
+    when(userService.verify("admin", "wrong")).thenReturn(false);
+    LoginAttemptService attempts = new LoginAttemptService();
+    MockMvc proxiedMvc =
+        MockMvcBuilders.standaloneSetup(
+                new AuthApiController(userService, sessionService, properties, attempts))
+            .addFilters(new org.springframework.web.filter.ForwardedHeaderFilter())
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+
+    for (int i = 0; i < 5; i++) {
+      proxiedMvc
+          .perform(
+              post("/api/v1/auth/login")
+                  .header("X-Forwarded-For", "1.1.1." + i)
+                  .with(
+                      request -> {
+                        request.setRemoteAddr("127.0.0.1");
+                        return request;
+                      })
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"username\":\"admin\",\"password\":\"wrong\"}"))
+          .andExpect(status().isUnauthorized());
+    }
+
+    proxiedMvc
+        .perform(
+            post("/api/v1/auth/login")
+                .header("X-Forwarded-For", "9.9.9.9")
+                .with(
+                    request -> {
+                      request.setRemoteAddr("127.0.0.1");
+                      return request;
+                    })
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"admin\",\"password\":\"wrong\"}"))
+        .andExpect(status().isTooManyRequests())
+        .andExpect(jsonPath("$.code").value(429));
+
+    verify(userService, times(5)).verify("admin", "wrong");
   }
 
   private static WebSession newSession(String username, String sessionId) {

--- a/oryxos-web/src/test/java/io/oryxos/web/security/BasicAuthFilterTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/security/BasicAuthFilterTest.java
@@ -269,6 +269,56 @@ class BasicAuthFilterTest {
         .andExpect(header().string("WWW-Authenticate", "Basic realm=\"MySystem\""));
   }
 
+  @Test
+  @DisplayName("enabled=true_轮换X-Forwarded-For不能绕过Basic锁定")
+  void spoofedXForwardedFor_doesNotBypassLockout() throws Exception {
+    properties.setEnabled(true);
+    when(userService.verify("admin", "wrong")).thenReturn(false);
+    MockMvc proxied =
+        MockMvcBuilders.standaloneSetup(new StubController())
+            .addFilters(
+                new org.springframework.web.filter.ForwardedHeaderFilter(),
+                new BasicAuthFilter(
+                    userService,
+                    sessionService,
+                    properties,
+                    new ObjectMapper(),
+                    loginAttemptService))
+            .build();
+
+    for (int i = 0; i < LoginAttemptService.MAX_FAILURES; i++) {
+      String spoof = "1.1.1." + i;
+      proxied
+          .perform(
+              get("/admin/")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .header("X-Forwarded-For", spoof)
+                  .with(
+                      request -> {
+                        request.setRemoteAddr("127.0.0.1");
+                        return request;
+                      })
+                  .header("Authorization", basic("admin", "wrong")))
+          .andExpect(status().isUnauthorized());
+    }
+
+    proxied
+        .perform(
+            get("/admin/")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("X-Forwarded-For", "9.9.9.9")
+                .with(
+                    request -> {
+                      request.setRemoteAddr("127.0.0.1");
+                      return request;
+                    })
+                .header("Authorization", basic("admin", "wrong")))
+        .andExpect(status().isTooManyRequests())
+        .andExpect(jsonPath("$.code").value(429));
+
+    verify(userService, times(LoginAttemptService.MAX_FAILURES)).verify("admin", "wrong");
+  }
+
   private static String basic(String user, String pass) {
     return "Basic "
         + java.util.Base64.getEncoder()

--- a/oryxos-web/src/test/java/io/oryxos/web/security/ClientIpTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/security/ClientIpTest.java
@@ -1,0 +1,43 @@
+package io.oryxos.web.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class ClientIpTest {
+
+  @Test
+  @DisplayName("无 wrapper_返回 remoteAddr")
+  void unwrapped_returnsRemoteAddr() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRemoteAddr("10.0.0.8");
+    assertThat(ClientIp.peerAddress(request)).isEqualTo("10.0.0.8");
+  }
+
+  @Test
+  @DisplayName("ForwardedHeaderFilter 式 wrapper 改写 getRemoteAddr 后仍取对端")
+  void wrapperSpoofedRemoteAddr_stillReturnsPeer() {
+    MockHttpServletRequest peer = new MockHttpServletRequest();
+    peer.setRemoteAddr("127.0.0.1");
+    HttpServletRequest spoofed =
+        new HttpServletRequestWrapper(peer) {
+          @Override
+          public String getRemoteAddr() {
+            return "8.8.8.8";
+          }
+        };
+    assertThat(ClientIp.peerAddress(spoofed)).isEqualTo("127.0.0.1");
+  }
+
+  @Test
+  @DisplayName("remoteAddr 空_unknown")
+  void blankRemoteAddr_unknown() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRemoteAddr("  ");
+    assertThat(ClientIp.peerAddress(request)).isEqualTo("unknown");
+  }
+}


### PR DESCRIPTION
## Summary
- Login lockout keys `username|IP`, but `ForwardedHeaderFilter` rewrites `getRemoteAddr()` from client-controlled `X-Forwarded-For`, so rotating that header bypasses the 5-failure cap on `/api/v1/auth/login` and Basic Auth.
- Use the TCP peer (`ClientIp.peerAddress`) after unwrapping servlet wrappers. Cookie `Secure` still needs `X-Forwarded-Proto` (#90), so forwarded-header processing stays on.

Closes #189

## Test plan
- [x] `ClientIpTest` — wrapper that spoofs `getRemoteAddr()` still returns the real peer
- [x] `AuthApiControllerTest.login_spoofedXForwardedFor_doesNotBypassLockout`
- [x] `BasicAuthFilterTest.spoofedXForwardedFor_doesNotBypassLockout`
- [ ] CI `Java CI`