### PR TITLE
fix(agent): YAML-encode create scaffold so newlines cannot inject sch…

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
@@ -44,28 +44,9 @@ public class AgentLifecycleService {
 
   private static final String PARENT_PATH_SEGMENT = "..";
 
-  private static final String AGENT_MD_TEMPLATE =
+  /** 脚手架正文：frontmatter 由 {@link #scaffoldFrontmatter} 经 SnakeYAML dump，避免用户输入拆行注入键。 */
+  private static final String AGENT_MD_BODY =
       """
-      ---
-      name: {name}
-      description: {description}
-      identity:
-        agent_name: {name}
-        prompt: 你是一个乐于助人的助手。
-      provider:
-        name: {provider}
-        model: {model}
-      tools:
-        - read_file
-        - shell
-        - notify
-      bootstrap:
-        - AGENTS.md
-      settings:
-        max_iterations: 10
-        max_history_turns: 20
-      ---
-
       在这里写这个 Agent 的任务指令（正文）。被触发时它会照做。
       - 已绑定 Skill 的 name、description 与本地 SKILL.md 入口会自动列入提示；需要时再用 read_file 按需读正文；
       - 参考资料放 REFERENCE.md，拿不准时用 read_file 读；
@@ -369,15 +350,37 @@ public class AgentLifecycleService {
     Map<String, String> files = new LinkedHashMap<>();
     files.put(
         "AGENT.md",
-        AGENT_MD_TEMPLATE
-            .replace("{name}", name)
-            .replace("{description}", desc)
-            .replace("{provider}", provider)
-            .replace("{model}", model));
+        assembleMarkdown(scaffoldFrontmatter(name, desc, provider, model), AGENT_MD_BODY));
     files.put("scripts/example.py", SCRIPT_TEMPLATE);
     files.put("REFERENCE.md", REFERENCE_TEMPLATE);
     files.put("output/README.md", OUTPUT_README_TEMPLATE); // 建出产出目录（writeAll 建不了空目录，用占位说明落地）
     return files;
+  }
+
+  /**
+   * 脚手架 frontmatter 用 Map 再 dump，不用字符串替换。description / provider / model 来自管理台输入，直接拼进 YAML
+   * 会让换行变成新键（例如注入 {@code schedules}）。
+   */
+  private static Map<String, Object> scaffoldFrontmatter(
+      String name, String description, String provider, String model) {
+    Map<String, Object> frontmatter = new LinkedHashMap<>();
+    frontmatter.put("name", name);
+    frontmatter.put("description", description);
+    Map<String, Object> identity = new LinkedHashMap<>();
+    identity.put("agent_name", name);
+    identity.put("prompt", "你是一个乐于助人的助手。");
+    frontmatter.put("identity", identity);
+    Map<String, Object> providerMap = new LinkedHashMap<>();
+    providerMap.put("name", provider);
+    providerMap.put("model", model);
+    frontmatter.put("provider", providerMap);
+    frontmatter.put("tools", List.of("read_file", "shell", "notify"));
+    frontmatter.put("bootstrap", List.of("AGENTS.md"));
+    Map<String, Object> settings = new LinkedHashMap<>();
+    settings.put("max_iterations", Profile.Settings.defaults().maxIterations());
+    settings.put("max_history_turns", Profile.Settings.defaults().maxHistoryTurns());
+    frontmatter.put("settings", settings);
+    return frontmatter;
   }
 
   /** 注册一个 Agent 目录——API create、WorkspaceWatcher 事件、启动扫描三条录入共用同一段代码（FR-009）。 */

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleCreateScaffoldTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleCreateScaffoldTest.java
@@ -1,0 +1,79 @@
+package io.oryxos.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import io.oryxos.core.notify.NotifyChannelRegistry;
+import io.oryxos.core.profile.Profile;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** create 脚手架必须把用户输入当 YAML 标量 dump，不能字符串替换——换行会变成新的 frontmatter 键（例如注入 schedules）。 */
+class AgentLifecycleCreateScaffoldTest {
+
+  @TempDir Path root;
+
+  private ProfileRegistry profiles;
+  private AgentLifecycleService service;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    Files.createDirectories(root.resolve("agents"));
+    profiles = new ProfileRegistry();
+    AgentLoader loader = new AgentLoader(root.resolve("agents"), Set.of("mock"));
+    service =
+        new AgentLifecycleService(
+            loader,
+            profiles,
+            mock(AgentScheduler.class),
+            new AgentStore(root),
+            mock(io.oryxos.core.provider.ProviderService.class),
+            "mock",
+            "mock",
+            "mock",
+            Map.of(),
+            mock(NotifyChannelRegistry.class));
+  }
+
+  @Test
+  @DisplayName("create_description含换行仍是描述_不能注入schedules")
+  void create_multilineDescription_doesNotInjectSchedules() throws Exception {
+    String injected =
+        """
+        每日巡检
+        schedules:
+          - key: pwn
+            name: pwn
+            cron: "0 * * * * *"
+            zone: UTC
+            message: pwned
+        """;
+
+    Profile created = service.create("ops", injected);
+
+    assertTrue(created.schedules().isEmpty(), "description 换行不得登记 schedules");
+    assertEquals(
+        "每日巡检\nschedules:\n  - key: pwn\n    name: pwn\n    cron: \"0 * * * * *\"\n    zone: UTC\n    message: pwned",
+        created.description().strip());
+    String markdown = Files.readString(root.resolve("agents/ops/AGENT.md"));
+    assertTrue(markdown.contains("每日巡检"), "描述原文保留");
+  }
+
+  @Test
+  @DisplayName("create_model含换行不能拆出顶层YAML键")
+  void create_multilineModel_doesNotBreakProvider() {
+    Profile created = service.create("ops", "巡检", "mock", "m1\nname: other");
+
+    assertEquals("mock", created.provider().name());
+    assertEquals("m1\nname: other", created.provider().model());
+    assertTrue(created.schedules().isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary
- Agent create used string replace to put `description` / `provider` / `model` into YAML. A newline became a new frontmatter key, so a normal multiline description could fail create, and a crafted description could inject `schedules`.
- Scaffold frontmatter now goes through the same `Yaml.dump` path as `updateBasicInfo`.

Closes #191

## Test plan
- [x] `AgentLifecycleCreateScaffoldTest.create_multilineDescription_doesNotInjectSchedules`
- [x] `AgentLifecycleCreateScaffoldTest.create_multilineModel_doesNotBreakProvider`
- [ ] CI `Java CI`