### PR TITLE
fix(web): treat AGENT.md and skills paths case-insensitively

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentStore.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentStore.java
@@ -216,6 +216,10 @@ public class AgentStore {
     }
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "Reserved path segment 'skills' is ASCII; equalsIgnoreCase is the intended case-fold for Windows/macOS filenames.")
   private Path writableTarget(Path dir, String relativePath) {
     Path target = dir.resolve(relativePath).normalize();
     if (!target.startsWith(dir)) {

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentStore.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentStore.java
@@ -222,7 +222,8 @@ public class AgentStore {
       throw new IllegalArgumentException("非法文件路径: " + relativePath);
     }
     Path relative = dir.relativize(target);
-    if (relative.getNameCount() > 0 && SKILLS_NAMESPACE.equals(relative.getName(0).toString())) {
+    if (relative.getNameCount() > 0
+        && SKILLS_NAMESPACE.equalsIgnoreCase(relative.getName(0).toString())) {
       throw new IllegalArgumentException("skills/ 是 Agent Skill 绑定保留目录，禁止写普通文件");
     }
     requireSafe(target);

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentStoreTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentStoreTest.java
@@ -118,4 +118,12 @@ class AgentStoreTest {
     assertEquals("old", Files.readString(agent.resolve("AGENT.md")));
     assertTrue(Files.isDirectory(agent.resolve("collision")));
   }
+
+  @Test
+  @DisplayName("writeAll 拒绝 Skills/ 大小写变体占用绑定命名空间")
+  void writeAllRejectsSkillsNamespaceIgnoringCase() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store.writeAll("demo", Map.of("Skills/report/SKILL.md", "copy")));
+  }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
@@ -168,6 +168,10 @@ public class WorkspaceApiController {
    * {@code String.equals} 区分大小写，会绕过 {@link AgentLifecycleService#update} 直接写盘，schedules 变更不注销旧
    * cron。
    */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "AGENT.md is an ASCII reserved filename; equalsIgnoreCase matches case-insensitive filesystems.")
   private Path agentDirOfAgentFile(Path target) {
     if (!AGENT_FILE.equalsIgnoreCase(String.valueOf(target.getFileName()))) {
       return null;
@@ -180,6 +184,10 @@ public class WorkspaceApiController {
   }
 
   /** {@code agents/<name>/skills/**}（大小写不敏感），含尚未落盘的 {@code Skills/} 后缀。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "skills is an ASCII reserved path segment; equalsIgnoreCase matches case-insensitive filesystems.")
   private boolean isAgentSkillsPath(Path target) {
     Path relative = relativeUnderAgents(target);
     return relative != null

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
@@ -46,7 +46,10 @@ public class WorkspaceApiController {
   private static final String AGENT_FILE = "AGENT.md";
   private static final String AGENTS_DIR = "agents";
   private static final String SKILLS_DIR = "skills";
-  private static final int AGENT_SKILL_PATH_SEGMENTS = 3;
+  private static final String PARENT_PATH_SEGMENT = "..";
+
+  /** 相对 {@code agents/}：{@code <name>/AGENT.md} 与 {@code <name>/skills/...} 的最小段数。 */
+  private static final int AGENT_CHILD_SEGMENTS = 2;
 
   private final Path oryxosRoot;
   private final AgentLifecycleService lifecycle;
@@ -133,10 +136,7 @@ public class WorkspaceApiController {
       throw new IllegalArgumentException("path 为空"); // → 400
     }
     Path target = resolveWithinRoot(path);
-    Path relative = oryxosRoot.relativize(target);
-    if (relative.getNameCount() >= AGENT_SKILL_PATH_SEGMENTS
-        && AGENTS_DIR.equals(relative.getName(0).toString())
-        && SKILLS_DIR.equals(relative.getName(2).toString())) {
+    if (isAgentSkillsPath(target)) {
       throw new IllegalArgumentException("Agent skills/ 是绑定视图，禁止从工作区入口写入");
     }
     if (RealPathBoundary.isWithin(oryxosRoot.resolve(SKILLS_DIR), target)) {
@@ -161,16 +161,50 @@ public class WorkspaceApiController {
     return ApiResponse.ok(null);
   }
 
-  /** target 若是 {@code agents/<name>/AGENT.md} 则返回其 Agent 目录，否则 null。 */
+  /**
+   * target 若是 {@code agents/<name>/AGENT.md}（大小写不敏感）则返回其 Agent 目录，否则 null。
+   *
+   * <p>macOS/Windows 默认大小写不敏感：{@code agent.md} / {@code Agents/...} 仍指向同一文件，但 {@code Path.equals} /
+   * {@code String.equals} 区分大小写，会绕过 {@link AgentLifecycleService#update} 直接写盘，schedules 变更不注销旧
+   * cron。
+   */
   private Path agentDirOfAgentFile(Path target) {
-    if (!AGENT_FILE.equals(String.valueOf(target.getFileName()))) {
+    if (!AGENT_FILE.equalsIgnoreCase(String.valueOf(target.getFileName()))) {
       return null;
     }
-    Path agentDir = target.getParent();
-    if (agentDir == null || agentDir.getParent() == null) {
+    Path relative = relativeUnderAgents(target);
+    if (relative == null || relative.getNameCount() != AGENT_CHILD_SEGMENTS) {
       return null;
     }
-    return oryxosRoot.resolve("agents").equals(agentDir.getParent()) ? agentDir : null;
+    return target.getParent();
+  }
+
+  /** {@code agents/<name>/skills/**}（大小写不敏感），含尚未落盘的 {@code Skills/} 后缀。 */
+  private boolean isAgentSkillsPath(Path target) {
+    Path relative = relativeUnderAgents(target);
+    return relative != null
+        && relative.getNameCount() >= AGENT_CHILD_SEGMENTS
+        && SKILLS_DIR.equalsIgnoreCase(relative.getName(1).toString());
+  }
+
+  /** 相对真实 {@code agents/} 的路径；越出该目录或含 {@code ..} 则 null。 */
+  private Path relativeUnderAgents(Path target) {
+    Path agentsReal = RealPathBoundary.project(oryxosRoot.resolve(AGENTS_DIR)).projectedReal();
+    Path relative;
+    try {
+      relative = agentsReal.relativize(target).normalize();
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+    if (relative.getNameCount() == 0 || relative.isAbsolute()) {
+      return null;
+    }
+    for (int i = 0; i < relative.getNameCount(); i++) {
+      if (PARENT_PATH_SEGMENT.equals(relative.getName(i).toString())) {
+        return null;
+      }
+    }
+    return relative;
   }
 
   private FileNode treeOf(Path node) {
@@ -212,10 +246,10 @@ public class WorkspaceApiController {
       throw new IllegalArgumentException("路径越界，拒绝访问: " + path);
     }
     try {
-      RealPathBoundary.requireWithin(oryxosRoot, target);
+      // 用投影真实路径做后续分类：大小写不敏感盘上 Agents/agent.md 会回到 agents/AGENT.md。
+      return RealPathBoundary.requireWithin(oryxosRoot, target);
     } catch (UncheckedIOException e) {
       throw new IllegalArgumentException("路径真实目标无法安全解析，拒绝访问: " + path, e);
     }
-    return target;
   }
 }

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
@@ -25,17 +25,17 @@ class WorkspaceApiControllerTest {
 
   @TempDir Path oryxosRoot;
   private MockMvc mvc;
+  private io.oryxos.core.agent.AgentLifecycleService lifecycle;
 
   @BeforeEach
   void setUp() throws IOException {
     Path agent = Files.createDirectories(oryxosRoot.resolve("agents").resolve("demo"));
     Files.writeString(agent.resolve("AGENT.md"), "---\nname: demo\n---\n正文内容");
     Files.createDirectories(oryxosRoot.resolve("archive"));
+    lifecycle = org.mockito.Mockito.mock(io.oryxos.core.agent.AgentLifecycleService.class);
     mvc =
         MockMvcBuilders.standaloneSetup(
-                new WorkspaceApiController(
-                    oryxosRoot.toString(),
-                    org.mockito.Mockito.mock(io.oryxos.core.agent.AgentLifecycleService.class)))
+                new WorkspaceApiController(oryxosRoot.toString(), lifecycle))
             .setControllerAdvice(new GlobalExceptionHandler())
             .build();
   }
@@ -129,6 +129,49 @@ class WorkspaceApiControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"path\":\"agents/demo/skills/report/SKILL.md\",\"content\":\"bad\"}"))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("写 AGENT.md 走 lifecycle.update，不直接落盘")
+  void writeAgentMarkdown_goesThroughUpdate() throws Exception {
+    mvc.perform(
+            post("/api/v1/workspace/file")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"path\":\"agents/demo/AGENT.md\",\"content\":\"---\\nname: demo\\n---\\n新正文\"}"))
+        .andExpect(status().isOk());
+    org.mockito.Mockito.verify(lifecycle).update("demo", "---\nname: demo\n---\n新正文");
+    org.junit.jupiter.api.Assertions.assertEquals(
+        "---\nname: demo\n---\n正文内容", Files.readString(oryxosRoot.resolve("agents/demo/AGENT.md")));
+  }
+
+  @Test
+  @DisplayName("agent.md 大小写不同仍走 update，不能绕过重注册")
+  void writeAgentMarkdown_wrongCaseStillGoesThroughUpdate() throws Exception {
+    mvc.perform(
+            post("/api/v1/workspace/file")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"path\":\"agents/demo/agent.md\",\"content\":\"---\\nname: demo\\n---\\nbypass\"}"))
+        .andExpect(status().isOk());
+    org.mockito.Mockito.verify(lifecycle).update("demo", "---\nname: demo\n---\nbypass");
+    try (java.util.stream.Stream<Path> entries = Files.list(oryxosRoot.resolve("agents/demo"))) {
+      org.junit.jupiter.api.Assertions.assertFalse(
+          entries.anyMatch(p -> "agent.md".equals(String.valueOf(p.getFileName()))),
+          "不得另写一份 agent.md 绕过 update");
+    }
+  }
+
+  @Test
+  @DisplayName("Skills/ 大小写不同仍禁止写入绑定视图")
+  void writeThroughAgentSkillsWrongCaseIsRejected() throws Exception {
+    mvc.perform(
+            post("/api/v1/workspace/file")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"path\":\"agents/demo/Skills/report/SKILL.md\",\"content\":\"bad\"}"))
+        .andExpect(status().isBadRequest());
+    org.junit.jupiter.api.Assertions.assertFalse(
+        Files.exists(oryxosRoot.resolve("agents/demo/Skills/report/SKILL.md")));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Workspace file writes used case-sensitive `equals` to detect `AGENT.md` and `skills/`. On macOS/Windows, `agent.md` is the same file, so the write skipped `AgentLifecycleService.update` and left old cron jobs registered.
- Classify with the projected real path and `equalsIgnoreCase`. `AgentStore` rejects `Skills/` the same way.

Closes #193

## Test plan
- [x] `WorkspaceApiControllerTest.writeAgentMarkdown_goesThroughUpdate`
- [x] `WorkspaceApiControllerTest.writeAgentMarkdown_wrongCaseStillGoesThroughUpdate`
- [x] `WorkspaceApiControllerTest.writeThroughAgentSkillsWrongCaseIsRejected`
- [x] `AgentStoreTest.writeAllRejectsSkillsNamespaceIgnoringCase`
- [ ] CI `Java CI`