### PR TITLE
fix(agent): quote YAML names so yes/on/null stay strings

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLoader.java
@@ -76,7 +76,13 @@ public class AgentLoader {
     if (!Files.isRegularFile(agentMd)) {
       throw new ProfileValidationException("Agent 目录缺少 AGENT.md: " + agentDir.getFileName());
     }
-    return parse(Files.readString(agentMd), String.valueOf(agentDir.getFileName()));
+    Profile profile = parse(Files.readString(agentMd), String.valueOf(agentDir.getFileName()));
+    String dirName = String.valueOf(agentDir.getFileName());
+    if (!dirName.equals(profile.name())) {
+      throw new ProfileValidationException(
+          "Agent name 与目录名不一致: " + profile.name() + " != " + dirName);
+    }
+    return profile;
   }
 
   /**

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentMarkdown.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentMarkdown.java
@@ -20,7 +20,11 @@ public final class AgentMarkdown {
   private static final char SINGLE_QUOTE = '\'';
   private static final char DOUBLE_QUOTE = '"';
 
-  private AgentMarkdown() {}
+  /** 双引号 YAML 标量：避免 {@code yes}/{@code on}/{@code null} 被 YAML 1.1 收成布尔或空。 */
+  public static String yamlDoubleQuoted(String value) {
+    String text = value == null ? "" : value;
+    return "\"" + text.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+  }
 
   /** 拆分结果：frontmatter 不可变、缺省为空 Map；body 为去掉围栏后的正文。 */
   public record Parsed(Map<String, Object> frontmatter, String body) {
@@ -141,7 +145,7 @@ public final class AgentMarkdown {
         break;
       }
       if (isTopLevelKey(lines[i], key)) {
-        lines[i] = key + ": " + value;
+        lines[i] = key + ": " + yamlDoubleQuoted(value);
         replaced = true;
       }
     }
@@ -152,7 +156,7 @@ public final class AgentMarkdown {
       return String.join(newline, lines);
     }
     List<String> inserted = new ArrayList<>(Arrays.asList(lines));
-    inserted.add(1, key + ": " + value);
+    inserted.add(1, key + ": " + yamlDoubleQuoted(value));
     return String.join(newline, inserted);
   }
 

--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -106,8 +106,8 @@ public class ProfileLoader {
   }
 
   private Profile toProfile(Map<String, Object> map, String source) {
-    String name = asString(map.get("name"));
-    if (name == null || name.isBlank()) {
+    Object rawName = map.get("name");
+    if (!(rawName instanceof String name) || name.isBlank()) {
       throw new ProfileValidationException("Profile 缺少 name 字段: " + source);
     }
     Profile.ProviderRef provider = toProviderRef(asMap(map.get("provider")), name);

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillLoader.java
@@ -78,8 +78,11 @@ public class SkillLoader {
   public Skill parse(String markdown, String fallbackName) {
     AgentMarkdown.Parsed parsed = AgentMarkdown.split(markdown);
     Object nameVal = parsed.frontmatter().get("name");
-    String name = nameVal == null ? null : String.valueOf(nameVal).strip();
-    if (name == null || name.isBlank()) {
+    if (!(nameVal instanceof String rawName)) {
+      throw new IllegalArgumentException("SKILL.md 缺少 name: " + fallbackName);
+    }
+    String name = rawName.strip();
+    if (name.isBlank()) {
       throw new IllegalArgumentException("SKILL.md 缺少 name: " + fallbackName);
     }
     Object descVal = parsed.frontmatter().get("description");

--- a/oryxos-core/src/main/java/io/oryxos/core/skill/SkillService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/skill/SkillService.java
@@ -276,7 +276,8 @@ public class SkillService {
    */
   private static String toSkillMarkdown(String name, String description, String body) {
     String text = body == null ? "" : body;
-    StringBuilder frontmatter = new StringBuilder("---\nname: ").append(name).append('\n');
+    StringBuilder frontmatter =
+        new StringBuilder("---\nname: ").append(AgentMarkdown.yamlDoubleQuoted(name)).append('\n');
     if (description != null && !description.isBlank()) {
       frontmatter.append("description: ").append(yamlQuote(description)).append('\n');
     }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentMarkdownTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentMarkdownTest.java
@@ -73,7 +73,7 @@ class AgentMarkdownTest {
     assertEquals("---\nname: ops\n---\nbody", output);
     assertTrue(AgentMarkdown.hasLegacySkills(input));
     assertEquals(
-        "---\nname: renamed\n---\nbody",
+        "---\nname: \"renamed\"\n---\nbody",
         AgentMarkdown.replaceTopLevelScalar("---\n\"name\": old\n---\nbody", "name", "renamed"));
   }
 
@@ -81,11 +81,11 @@ class AgentMarkdownTest {
   @DisplayName("标量替换会更新重复键并在缺失时插入")
   void replaceTopLevelScalarUpdatesDuplicatesAndInsertsMissingKey() {
     assertEquals(
-        "---\nname: next\nname: next\n---\nbody",
+        "---\nname: \"next\"\nname: \"next\"\n---\nbody",
         AgentMarkdown.replaceTopLevelScalar(
             "---\nname: first\n\"name\": second\n---\nbody", "name", "next"));
     assertEquals(
-        "---\nname: next\ndescription: d\n---\nbody",
+        "---\nname: \"next\"\ndescription: d\n---\nbody",
         AgentMarkdown.replaceTopLevelScalar("---\ndescription: d\n---\nbody", "name", "next"));
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentYamlImplicitNameTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentYamlImplicitNameTest.java
@@ -1,0 +1,50 @@
+package io.oryxos.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import io.oryxos.core.notify.NotifyChannelRegistry;
+import io.oryxos.core.profile.Profile;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AgentYamlImplicitNameTest {
+
+  @TempDir Path root;
+
+  @Test
+  @DisplayName("create_名yes不能被YAML收成true")
+  void create_yesRemainsYes() throws Exception {
+    Files.createDirectories(root.resolve("agents"));
+    ProfileRegistry profiles = new ProfileRegistry();
+    AgentLoader loader = new AgentLoader(root.resolve("agents"), Set.of("mock"));
+    AgentLifecycleService service =
+        new AgentLifecycleService(
+            loader,
+            profiles,
+            mock(AgentScheduler.class),
+            new AgentStore(root),
+            mock(io.oryxos.core.provider.ProviderService.class),
+            "mock",
+            "mock",
+            "mock",
+            Map.of(),
+            mock(NotifyChannelRegistry.class));
+
+    Profile created = service.create("yes", "布尔词名");
+
+    assertEquals("yes", created.name());
+    assertTrue(profiles.get("yes").isPresent());
+    assertTrue(profiles.get("true").isEmpty());
+    assertTrue(Files.isDirectory(root.resolve("agents/yes")));
+    Profile reloaded = loader.deriveProfile(root.resolve("agents/yes"));
+    assertEquals("yes", reloaded.name());
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/DeriveProfileTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/DeriveProfileTest.java
@@ -1,6 +1,7 @@
 package io.oryxos.core.agent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.oryxos.core.profile.Profile;
 import java.io.IOException;
@@ -73,5 +74,22 @@ class DeriveProfileTest {
     assertEquals("0 0 9 * * *", sc.cron());
     assertEquals("Asia/Shanghai", sc.zone());
     assertEquals("到点了", sc.message());
+  }
+
+  @Test
+  @DisplayName("未加引号的 YAML 1.1 布尔词不能冒充 Agent name")
+  void deriveProfile_unquotedYesIsNotAName() throws IOException {
+    Path dir = writeAgent("yes", "name: yes\nprovider:\n  name: deepseek\n  model: deepseek-chat");
+    assertThrows(
+        Exception.class, () -> new AgentLoader(agentsDir, Set.of("deepseek")).deriveProfile(dir));
+  }
+
+  @Test
+  @DisplayName("加引号的 yes 与目录名一致")
+  void deriveProfile_quotedYesMatchesDirectory() throws IOException {
+    Path dir =
+        writeAgent("yes", "name: \"yes\"\nprovider:\n  name: deepseek\n  model: deepseek-chat");
+    Profile p = new AgentLoader(agentsDir, Set.of("deepseek")).deriveProfile(dir);
+    assertEquals("yes", p.name());
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillImportFilesTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillImportFilesTest.java
@@ -63,7 +63,8 @@ class SkillImportFilesTest {
     assertEquals("myname", s.name());
     assertTrue(Files.isRegularFile(oryxosRoot.resolve("skills/myname/SKILL.md")));
     assertTrue(
-        Files.readString(oryxosRoot.resolve("skills/myname/SKILL.md")).contains("name: myname"));
+        Files.readString(oryxosRoot.resolve("skills/myname/SKILL.md"))
+            .contains("name: \"myname\""));
   }
 
   @Test

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillLoaderTest.java
@@ -27,5 +27,8 @@ class SkillLoaderTest {
         () -> loader.parse("---\ndescription: d\n---\nbody", "fallback"));
     assertThrows(
         IllegalArgumentException.class, () -> loader.parse("---\nname: valid\n---\nbody", "valid"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> loader.parse("---\nname: yes\ndescription: d\n---\nbody", "yes"));
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillServiceTest.java
@@ -41,6 +41,20 @@ class SkillServiceTest {
   }
 
   @Test
+  @DisplayName("create_YAML1.1布尔词yes仍是字符串名_重启可加载")
+  void create_yamlBooleanWord_staysStringName() throws Exception {
+    Skill created = service.create("yes", "布尔词名", "正文必须非空");
+    assertEquals("yes", created.name());
+    assertTrue(registry.get("yes").isPresent());
+    assertTrue(registry.get("true").isEmpty());
+
+    SkillLoader reloaded = new SkillLoader(oryxosRoot.resolve("skills"));
+    SkillRegistry afterRestart = reloaded.loadAll();
+    assertTrue(afterRestart.get("yes").isPresent(), "重启后仍按目录名 yes 加载");
+    assertTrue(afterRestart.get("true").isEmpty());
+  }
+
+  @Test
   @DisplayName("create 同名 → 400（IllegalArgumentException）")
   void create_duplicate_rejected() {
     service.create("dup", "d", "b");


### PR DESCRIPTION
## Summary
- Unquoted `name: yes` / `on` / `null` is a YAML 1.1 boolean or null. The directory stays `yes` but the registry key becomes `true`, so lookups 404 and Skill reload skips the folder.
- Quote scalar names on write, reject non-string names when parsing, and require Agent frontmatter name to match the directory.

Closes #196

## Test plan
- [x] `AgentYamlImplicitNameTest.create_yesRemainsYes`
- [x] `SkillServiceTest.create_yamlBooleanWord_staysStringName`
- [x] `DeriveProfileTest.deriveProfile_unquotedYesIsNotAName`
- [x] `DeriveProfileTest.deriveProfile_quotedYesMatchesDirectory`
- [ ] CI `Java CI`