### PR TITLE
fix(mcp): roll back tools and close client when connect fails mid-way

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/mcp/McpClientService.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/mcp/McpClientService.java
@@ -71,23 +71,26 @@ public class McpClientService {
       lastErrors.put(config.name(), msg);
       return;
     }
+    McpSyncClient client = null;
+    List<String> toolNames = new ArrayList<>();
     try {
-      McpSyncClient client = clientFactory.apply(config);
+      client = clientFactory.apply(config);
       client.initialize();
-      List<String> toolNames = new ArrayList<>();
-      client
-          .listTools()
-          .tools()
-          .forEach(
-              tool -> {
-                registry.registerMcpTool(config.name(), new McpToolAdapter(client, tool));
-                toolNames.add(tool.name());
-              });
+      for (var tool : client.listTools().tools()) {
+        registry.registerMcpTool(config.name(), new McpToolAdapter(client, tool));
+        toolNames.add(tool.name());
+      }
       activeClients.put(config.name(), client);
       registeredTools.put(config.name(), toolNames);
       lastErrors.remove(config.name());
     } catch (RuntimeException e) {
-      // 外部依赖失联不拖垮自身启动——只 WARN，OryxOS 照常起（课件守点）
+      // 外部依赖失联不拖垮自身启动——只 WARN，OryxOS 照常起（课件守点）。
+      // listTools 中途失败（重名、协议错）时：已注册的工具必须卸掉，客户端必须关掉，否则
+      // 管理台显示未连接，Agent 仍能调到半截 MCP 工具，stdio 子进程也会泄漏。
+      for (String toolName : toolNames) {
+        registry.unregister(toolName);
+      }
+      closeQuietly(config.name(), client);
       LOG.warn("MCP server {} 连接失败，跳过它的工具: {}", s(config.name()), s(e.getMessage()));
       lastErrors.put(config.name(), e.getMessage());
     }
@@ -99,15 +102,19 @@ public class McpClientService {
       registry.unregister(toolName);
     }
     registeredTools.remove(serverName);
-    McpSyncClient client = activeClients.remove(serverName);
-    if (client != null) {
-      try {
-        client.closeGracefully();
-      } catch (RuntimeException e) {
-        LOG.warn("MCP server {} 断开连接时出错（忽略）: {}", s(serverName), s(e.getMessage()));
-      }
-    }
+    closeQuietly(serverName, activeClients.remove(serverName));
     lastErrors.remove(serverName);
+  }
+
+  private static void closeQuietly(String serverName, McpSyncClient client) {
+    if (client == null) {
+      return;
+    }
+    try {
+      client.closeGracefully();
+    } catch (RuntimeException e) {
+      LOG.warn("MCP server {} 断开连接时出错（忽略）: {}", s(serverName), s(e.getMessage()));
+    }
   }
 
   /** 单个 server 的运行时状态：是否连上、给了哪些工具、失败原因。 */

--- a/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpClientServiceTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpClientServiceTest.java
@@ -2,13 +2,20 @@ package io.oryxos.tool.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
+import io.oryxos.core.OryxTool;
+import io.oryxos.core.ToolResult;
 import io.oryxos.core.mcp.McpServerConfig;
+import io.oryxos.core.mcp.McpServerStatus;
 import io.oryxos.tool.ToolRegistry;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -112,6 +119,74 @@ class McpClientServiceTest {
     assertTrue(configs.get(0).command().startsWith("npx"));
     assertTrue(configs.get(0).env().get("TOKEN").contains("${ORYX_TEST_UNSET_ENV}"), "缺失占位保留原样");
     assertTrue(new McpConfigLoader(dir.resolve("nope.yaml")).load().isEmpty());
+  }
+
+  @Test
+  @DisplayName("listTools 中途撞名：已注册 MCP 工具回滚，客户端关闭")
+  void listToolsFailure_unregistersPartialToolsAndClosesClient() throws IOException {
+    OryxTool builtin = stubTool("http_get");
+    ToolRegistry registry = new ToolRegistry();
+    registry.register(builtin);
+
+    McpSyncClient client = mock(McpSyncClient.class);
+    when(client.listTools())
+        .thenReturn(
+            new McpSchema.ListToolsResult(
+                List.of(mcpTool("unique_mcp_tool", "ok"), mcpTool("http_get", "collide")), null));
+    McpConfigLoader loader =
+        loaderWith("servers:\n  - name: leaky\n    transport: stdio\n    command: c\n");
+    McpClientService service = new McpClientService(loader, config -> client);
+
+    service.connectAll(registry);
+
+    assertFalse(registry.contains("unique_mcp_tool"), "中途失败不得留下半截 MCP 工具");
+    assertSame(builtin, registry.get("http_get").orElseThrow());
+    assertTrue(registry.mcpToolOwners().isEmpty());
+    verify(client).closeGracefully();
+
+    McpServerStatus status = service.status("leaky");
+    assertFalse(status.connected());
+    assertTrue(status.toolNames().isEmpty());
+    assertTrue(status.error() != null && status.error().contains("http_get"));
+  }
+
+  @Test
+  @DisplayName("initialize 失败也要关掉已构造的客户端")
+  void initializeFailure_closesClient() throws IOException {
+    McpSyncClient client = mock(McpSyncClient.class);
+    doThrow(new IllegalStateException("handshake failed")).when(client).initialize();
+    McpConfigLoader loader =
+        loaderWith("servers:\n  - name: dead\n    transport: stdio\n    command: c\n");
+    ToolRegistry registry = new ToolRegistry();
+
+    new McpClientService(loader, config -> client).connectAll(registry);
+
+    assertTrue(registry.all().isEmpty());
+    verify(client).closeGracefully();
+  }
+
+  private static OryxTool stubTool(String name) {
+    return new OryxTool() {
+      @Override
+      public String getName() {
+        return name;
+      }
+
+      @Override
+      public String getDescription() {
+        return name;
+      }
+
+      @Override
+      public String getInputSchema() {
+        return "{}";
+      }
+
+      @Override
+      public ToolResult execute(JsonNode input) {
+        return ToolResult.ok("ok");
+      }
+    };
   }
 
   @Test


### PR DESCRIPTION
Fixes #199

## Summary
- On `listTools` / `initialize` failure, unregister tools registered in that attempt
- Always `closeGracefully()` the MCP client so stdio processes do not leak
- Keep admin status disconnected; leftover MCP tools are no longer callable

## Test plan
- [x] `McpClientServiceTest` name-collision mid-loop: partial tools gone, builtin `http_get` unchanged, client closed
- [x] `initialize` throw: client closed, registry empty