### PR TITLE
feat(knowledge): 契约骨架与本地后端引擎（014 impl-A）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ OryxOS 是用 Java 实现的面向企业场景的 **Distributed AI Agent OS**。
 
 ---
 
-## 模块结构（9 个）
+## 模块结构（10 个）
 
 ```
 oryxos/
@@ -34,6 +34,10 @@ oryxos/
 │                        #   多 Provider 显式映射
 ├── oryxos-memory        # 能力三：MemoryService 门面、LongTermMemory、
 │                        #   MemoryTools（save/recall）
+├── oryxos-knowledge     # 知识库（014）：LocalKnowledgeBackend（契约第一个插件）、
+│                        #   解析/切分/向量化索引流水线、双路召回+RRF 检索、
+│                        #   ChunkStore 可插拔存储、KnowledgeTools（retrieve_knowledge）
+│                        #   （契约与绑定服务在 oryxos-core/knowledge/，依赖倒置）
 ├── oryxos-tool          # 能力四：内置 Tool（文件/Shell/HTTP）、MCP Client、
 │                        #   ToolRegistry、SandboxChecker
 ├── oryxos-channel-cli   # CLI Channel：oryxos chat 实现

--- a/docs/TechnicalSolution.md
+++ b/docs/TechnicalSolution.md
@@ -647,13 +647,14 @@ session list
 
 ## 10. 项目工程结构
 
-OryxOS 是 Maven 多模块项目，由 9 个模块组成：
+OryxOS 是 Maven 多模块项目，由 10 个模块组成：
 
 | 模块名 | 职责 |
 |--------|------|
 | `oryxos-core` | 核心抽象和接口：`OryxTool` 接口、`Session`、`Profile`、`ContextLoader`、`AgentLoader`（扫 `.oryxos/agents/`、`deriveProfile`）、`ReActLoop`、`PromptBuilder`、`ToolExecutor`、`AgentService`、`AgentScheduler`（定时触发）、`AgentLifecycleService`（扩展阶段，编排"定义一个 Agent（Agent 目录落盘 + 派生 Profile + 注册 + Scheduler）"） |
 | `oryxos-provider` | 核心能力一：`ProviderService`、Function Calling 适配、Provider 配置（provider name 到 `ChatModel` 显式映射） |
 | `oryxos-memory` | 核心能力三：`MemoryService` 统一门面、`LongTermMemory`、`MemoryTools`（`save_memory` / `recall_memory`） |
+| `oryxos-knowledge` | 知识库（014）：内置本地后端 `LocalKnowledgeBackend`（知识标准操作契约的第一个插件）、解析/切分/向量化索引流水线（两段式 + 双缓冲）、双路召回 + RRF 融合检索、`ChunkStore` 可插拔向量存储（默认 SQLite）、`KnowledgeTools`（`retrieve_knowledge`）。契约与绑定服务在 `oryxos-core/knowledge/`（依赖倒置），依赖 core + storage |
 | `oryxos-tool` | 核心能力四：内置 Tool（`FileTools`、`ShellTools`、`HttpTools`、`NotifyTools`）、`McpClientService`、`McpToolAdapter`、`ToolRegistry`、`Sandbox` 接口 + `WhitelistSandbox` 实现、`NotifyChannelAdapter` 接口 + `WebhookNotifyAdapter` 实现（三合一模块） |
 | `oryxos-channel-cli` | CLI Channel：`CliChannel`、`oryxos chat` 命令实现 |
 | `oryxos-web` | 核心能力五：`WebServer`、6 个 `ApiController`、`GlobalExceptionHandler`、OpenAPI 文档 |

--- a/oryxos-boot/pom.xml
+++ b/oryxos-boot/pom.xml
@@ -29,6 +29,10 @@
         </dependency>
         <dependency>
             <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-knowledge</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
             <artifactId>oryxos-tool</artifactId>
         </dependency>
         <dependency>

--- a/oryxos-core/src/main/java/io/oryxos/core/embedding/TextEmbedder.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/embedding/TextEmbedder.java
@@ -1,0 +1,29 @@
+package io.oryxos.core.embedding;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 文本向量化端口——检索基建的通用组件，不带 knowledge 语义（FR-016：记忆语义化升级复用同一端口）。 跨模块契约放 core（依赖倒置）：oryxos-provider
+ * 出实现（复用 Provider 注册表凭证）， oryxos-knowledge 消费。同步签名（宪法 VII）。
+ */
+public interface TextEmbedder {
+
+  /** 把一段文本转成单位化 float 向量；服务不可用时抛出可读 RuntimeException（上层降级，FR-013）。 */
+  float[] embed(String text);
+
+  /** 向量化模型标识（provider/model），随片段落库用于一致性校验（FR-014）。 */
+  String modelId();
+
+  /** 向量维度。 */
+  int dimensions();
+
+  /** 批量向量化；默认逐条调用，支持批量端点的实现可覆盖。 */
+  default List<float[]> embedAll(List<String> texts) {
+    List<float[]> vectors = new ArrayList<>(texts.size());
+    for (String text : texts) {
+      vectors.add(embed(text));
+    }
+    return vectors;
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/BoundKnowledgeDescriptor.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/BoundKnowledgeDescriptor.java
@@ -1,0 +1,14 @@
+package io.oryxos.core.knowledge;
+
+import java.nio.file.Path;
+
+/**
+ * 一条有效的 Agent 知识库绑定（渐进披露只消费 name + description，FR-005）。
+ *
+ * @param name 库名
+ * @param description 库描述
+ * @param linkPath Agent 本地绑定链接的绝对路径
+ * @param targetDir 公共知识库目录的真实路径
+ */
+public record BoundKnowledgeDescriptor(
+    String name, String description, Path linkPath, Path targetDir) {}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeAdmin.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeAdmin.java
@@ -1,0 +1,29 @@
+package io.oryxos.core.knowledge;
+
+import io.oryxos.core.knowledge.model.DocumentStatus;
+import java.util.List;
+
+/**
+ * 可选管理契约：仅声明了对应能力的后端实现（FR-006）。未声明能力的调用由上层入口按 {@link
+ * io.oryxos.core.knowledge.model.KnowledgeCapabilities} 可读拒绝，不落到本接口。
+ */
+public interface KnowledgeAdmin {
+
+  /** 创建知识库（目录 + 清单）；重名拒绝。 */
+  void createBase(String name, String description);
+
+  /** 删除知识库及其索引数据；引用保护（FR-011）由上层先行校验。 */
+  void deleteBase(String name);
+
+  /** 导入（或重新导入）库内一份已落盘文档：同步解析校验，后台切分向量化（Clarify-Q3 两段式）。 */
+  DocumentStatus importDocument(String kbName, String relPath);
+
+  /** 删除库内一份文档及其索引片段（FR-008 单文档操作）。 */
+  void deleteDocument(String kbName, String relPath);
+
+  /** 双缓冲重建全库索引（FR-024）：旧索引持续服务，新索引就绪后原子切换。 */
+  void rebuild(String kbName);
+
+  /** 库内全部文档的索引状态。 */
+  List<DocumentStatus> status(String kbName);
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeBackend.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeBackend.java
@@ -1,0 +1,21 @@
+package io.oryxos.core.knowledge;
+
+import io.oryxos.core.knowledge.model.KnowledgeCapabilities;
+import java.util.Optional;
+
+/**
+ * 知识后端插件 = 检索（必选）+ 能力声明 + 可选管理访问器（FR-006）。
+ *
+ * <p>契约测试（contracts/knowledge-spi.md §2 第 7 条）要求 {@code admin()} 的有无与能力声明一致： 声明了任一管理能力却返回
+ * empty（或反之）视为契约违约。
+ */
+public interface KnowledgeBackend extends KnowledgeRetriever {
+
+  /** 注册名（local / 远程插件名），清单 {@code backend:} 字段按此解析。 */
+  String name();
+
+  KnowledgeCapabilities capabilities();
+
+  /** 声明了管理能力时必须返回实现；纯检索后端返回 empty。 */
+  Optional<KnowledgeAdmin> admin();
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeBackendRegistry.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeBackendRegistry.java
@@ -1,0 +1,47 @@
+package io.oryxos.core.knowledge;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 后端插件按名显式注册表（宪法 III 同款哲学；规避 AgentScope 无插件发现机制之坑，research D9）。
+ *
+ * <p>内置本地后端以保留名 {@code local} 注册且恒可用；清单未声明 backend 的库落到它。
+ */
+public final class KnowledgeBackendRegistry {
+
+  /** 内置本地后端的保留注册名。 */
+  public static final String LOCAL = "local";
+
+  private final Map<String, KnowledgeBackend> backends = new LinkedHashMap<>();
+
+  public synchronized void register(KnowledgeBackend backend) {
+    String name = backend.name();
+    if (name == null || name.isBlank()) {
+      throw new IllegalArgumentException("知识后端注册名不能为空");
+    }
+    if (backends.containsKey(name)) {
+      throw new IllegalArgumentException("知识后端重复注册: " + name);
+    }
+    backends.put(name, backend);
+  }
+
+  public synchronized Optional<KnowledgeBackend> byName(String name) {
+    return Optional.ofNullable(backends.get(name));
+  }
+
+  /** 内置本地后端；未注册说明装配缺陷，直接失败而不是静默降级。 */
+  public synchronized KnowledgeBackend localDefault() {
+    KnowledgeBackend local = backends.get(LOCAL);
+    if (local == null) {
+      throw new IllegalStateException("内置本地知识后端未注册（装配缺陷）");
+    }
+    return local;
+  }
+
+  public synchronized List<String> names() {
+    return List.copyOf(backends.keySet());
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeBindingInspection.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeBindingInspection.java
@@ -1,0 +1,13 @@
+package io.oryxos.core.knowledge;
+
+import java.util.List;
+
+/** 一个 Agent 的知识库绑定巡检快照：有效绑定 + 非法项。每次现算，无缓存（绑定唯一真相源是文件系统）。 */
+public record KnowledgeBindingInspection(
+    List<BoundKnowledgeDescriptor> bindings, List<KnowledgeBindingIssue> issues) {
+
+  public KnowledgeBindingInspection {
+    bindings = bindings == null ? List.of() : List.copyOf(bindings);
+    issues = issues == null ? List.of() : List.copyOf(issues);
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeBindingIssue.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeBindingIssue.java
@@ -1,0 +1,42 @@
+package io.oryxos.core.knowledge;
+
+import java.nio.file.Path;
+
+/**
+ * 一条非法知识库绑定的巡检结论（FR-002：与 Skill 绑定同一分类学）。
+ *
+ * @param agentName Agent 名
+ * @param agentState Agent 目录状态
+ * @param entryName 绑定项名
+ * @param path 绑定项绝对路径
+ * @param type 非法类别
+ * @param message 可读说明
+ */
+public record KnowledgeBindingIssue(
+    String agentName,
+    AgentState agentState,
+    String entryName,
+    Path path,
+    Type type,
+    String message) {
+
+  /** 非法绑定类别。 */
+  public enum Type {
+    /** 目标不存在。 */
+    DANGLING,
+    /** 绝对链接 / 真实目标越出知识库根。 */
+    ESCAPED,
+    /** 不是受控软连接 / 目标不是合法知识库目录。 */
+    INVALID_TARGET,
+    /** 链接名与目录名或清单 name 不一致。 */
+    NAME_MISMATCH
+  }
+
+  /** Agent 目录状态。 */
+  public enum AgentState {
+    ACTIVE,
+    ARCHIVED,
+    /** 缺少有效 AGENT.md 的目录。 */
+    INVALID
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeBindingService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeBindingService.java
@@ -1,0 +1,527 @@
+package io.oryxos.core.knowledge;
+
+import io.oryxos.core.fs.RealPathBoundary;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Agent 知识库绑定的文件系统协调者（FR-002）：{@code agents/<agent>/knowledge/<kb>} 指向 {@code
+ * ../../../knowledge/<kb>} 的受控相对软连接是绑定的唯一事实来源，AGENT.md frontmatter 不声明知识库。范式与 {@code
+ * AgentSkillBindingService} 同构——同一分类学、同一真实路径门禁。
+ */
+public class KnowledgeBindingService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KnowledgeBindingService.class);
+  private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9_-]+");
+  private static final String AGENT_FILE = "AGENT.md";
+  private static final String LINKS_DIR = "knowledge";
+
+  private final Path agentsDir;
+  private final Path archiveDir;
+  private final Path knowledgeDir;
+
+  public KnowledgeBindingService(Path oryxosRoot) {
+    Path root = oryxosRoot.toAbsolutePath().normalize();
+    this.agentsDir = root.resolve("agents");
+    this.archiveDir = root.resolve("archive");
+    this.knowledgeDir = root.resolve(LINKS_DIR);
+  }
+
+  /** 创建固定相对链接；重复绑定同一有效库幂等。 */
+  public synchronized BoundKnowledgeDescriptor bind(String agentName, String kbName) {
+    String agent = safe(agentName, "Agent");
+    String kb = safe(kbName, "知识库");
+    Path agentDir = requireAgent(agent);
+    requireKnowledgeBase(kb);
+    Path linksDir = requireRealLinksDir(agentDir);
+    Path link = linksDir.resolve(kb);
+    if (!Files.exists(link, LinkOption.NOFOLLOW_LINKS)) {
+      try {
+        Files.createDirectories(linksDir);
+        Files.createSymbolicLink(link, expectedTarget(kb));
+      } catch (IOException e) {
+        throw new UncheckedIOException("创建 Agent 知识库绑定失败: " + agent + "/" + kb, e);
+      }
+    }
+    return inspect(agent).bindings().stream()
+        .filter(binding -> binding.name().equals(kb))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("知识库绑定位置被无效条目占用或未通过校验: " + link));
+  }
+
+  /** 只删除受控固定链接；不存在幂等。 */
+  public synchronized void unbind(String agentName, String kbName) {
+    String agent = safe(agentName, "Agent");
+    String kb = safe(kbName, "知识库");
+    Path link = requireRealLinksDir(requireAgent(agent)).resolve(kb);
+    if (!Files.exists(link, LinkOption.NOFOLLOW_LINKS)) {
+      return;
+    }
+    requireControlledLink(link, kb);
+    try {
+      Files.delete(link);
+    } catch (IOException e) {
+      throw new UncheckedIOException("解绑 Agent 知识库失败: " + agent + "/" + kb, e);
+    }
+  }
+
+  /** 整体替换一个 Agent 的绑定集合；I/O 失败回滚本次新增，损坏绑定先修复再替换。 */
+  public synchronized KnowledgeBindingInspection replaceBindings(
+      String agentName, List<String> desiredKbs) {
+    String agent = safe(agentName, "Agent");
+    requireAgent(agent);
+    List<String> desired = normalizedNames(desiredKbs);
+    desired.forEach(this::requireKnowledgeBase);
+    KnowledgeBindingInspection before = inspect(agent);
+    if (!before.issues().isEmpty()) {
+      throw new IllegalArgumentException("Agent 存在损坏的知识库绑定，修复后才能整体替换: " + agent);
+    }
+    Set<String> current = new LinkedHashSet<>();
+    before.bindings().forEach(binding -> current.add(binding.name()));
+    if (current.equals(new LinkedHashSet<>(desired))) {
+      return before;
+    }
+    List<String> created = new ArrayList<>();
+    try {
+      for (String kb : desired) {
+        if (!current.contains(kb)) {
+          bind(agent, kb);
+          created.add(kb);
+        }
+      }
+      for (String kb : current) {
+        if (!desired.contains(kb)) {
+          unbind(agent, kb);
+        }
+      }
+      return inspect(agent);
+    } catch (RuntimeException e) {
+      for (String kb : created) {
+        try {
+          unbind(agent, kb);
+        } catch (RuntimeException cleanupFailure) {
+          LOG.warn("回滚知识库绑定失败: {}/{}", sanitize(agent), sanitize(kb));
+        }
+      }
+      throw e;
+    }
+  }
+
+  /** 每次返回新的稳定快照；无缓存参与。 */
+  public KnowledgeBindingInspection inspect(String agentName) {
+    String agent = safe(agentName, "Agent");
+    Path agentDir = agentsDir.resolve(agent);
+    if (!Files.isDirectory(agentDir, LinkOption.NOFOLLOW_LINKS)) {
+      return new KnowledgeBindingInspection(List.of(), List.of());
+    }
+    KnowledgeBindingIssue.AgentState state =
+        Files.isRegularFile(agentDir.resolve(AGENT_FILE))
+            ? KnowledgeBindingIssue.AgentState.ACTIVE
+            : KnowledgeBindingIssue.AgentState.INVALID;
+    return inspectDirectory(agent, agentDir, state);
+  }
+
+  /** 找出活跃与归档 Agent 中对某库的全部受控引用（含 dangling），供删除保护。 */
+  public synchronized List<KnowledgeReference> references(String kbName) {
+    String kb = safe(kbName, "知识库");
+    List<KnowledgeReference> references = new ArrayList<>();
+    collectReferences(agentsDir, KnowledgeReference.AgentState.ACTIVE, kb, references, false);
+    collectReferences(archiveDir, KnowledgeReference.AgentState.ARCHIVED, kb, references, true);
+    return references.stream()
+        .sorted(
+            Comparator.comparing(KnowledgeReference::agentName)
+                .thenComparing(reference -> reference.state().name())
+                .thenComparing(KnowledgeReference::directoryName))
+        .toList();
+  }
+
+  /** 删除保护（FR-011）：仍被引用则抛 {@link KnowledgeReferencedException}，不制造悬空软连接。 */
+  public synchronized void ensureDeletable(String kbName) {
+    List<KnowledgeReference> refs = references(kbName);
+    if (!refs.isEmpty()) {
+      throw new KnowledgeReferencedException(kbName, refs);
+    }
+  }
+
+  /** 全工作区巡检：活跃 + 归档 Agent 的全部绑定项，稳定排序。 */
+  public synchronized List<KnowledgeBindingIssue> reconcile() {
+    List<KnowledgeBindingIssue> issues = new ArrayList<>();
+    scanContainer(agentsDir, KnowledgeBindingIssue.AgentState.ACTIVE, false, issues);
+    scanContainer(archiveDir, KnowledgeBindingIssue.AgentState.ARCHIVED, true, issues);
+    return issues.stream()
+        .sorted(
+            Comparator.comparing(KnowledgeBindingIssue::agentName)
+                .thenComparing(issue -> issue.agentState().name())
+                .thenComparing(KnowledgeBindingIssue::entryName)
+                .thenComparing(issue -> issue.type().name()))
+        .toList();
+  }
+
+  private KnowledgeBindingInspection inspectDirectory(
+      String agent, Path agentDir, KnowledgeBindingIssue.AgentState state) {
+    List<BoundKnowledgeDescriptor> valid = new ArrayList<>();
+    List<KnowledgeBindingIssue> issues = new ArrayList<>();
+    Path linksDir = agentDir.resolve(LINKS_DIR);
+    if (!Files.isDirectory(linksDir, LinkOption.NOFOLLOW_LINKS)) {
+      return new KnowledgeBindingInspection(valid, issues);
+    }
+    if (state == KnowledgeBindingIssue.AgentState.INVALID) {
+      issues.add(
+          issue(
+              agent,
+              state,
+              LINKS_DIR,
+              linksDir,
+              KnowledgeBindingIssue.Type.INVALID_TARGET,
+              "Agent 目录缺少有效 AGENT.md"));
+      return new KnowledgeBindingInspection(valid, issues);
+    }
+    try (Stream<Path> entries = Files.list(linksDir)) {
+      entries.sorted().forEach(entry -> inspectEntry(agent, state, entry, valid, issues));
+    } catch (IOException e) {
+      issues.add(
+          issue(
+              agent,
+              state,
+              LINKS_DIR,
+              linksDir,
+              KnowledgeBindingIssue.Type.INVALID_TARGET,
+              "无法读取 Agent knowledge 目录: " + e.getMessage()));
+    }
+    return new KnowledgeBindingInspection(
+        valid.stream().sorted(Comparator.comparing(BoundKnowledgeDescriptor::name)).toList(),
+        issues);
+  }
+
+  private void inspectEntry(
+      String agent,
+      KnowledgeBindingIssue.AgentState state,
+      Path entry,
+      List<BoundKnowledgeDescriptor> valid,
+      List<KnowledgeBindingIssue> issues) {
+    String entryName = String.valueOf(entry.getFileName());
+    if (!SAFE_NAME.matcher(entryName).matches() || !Files.isSymbolicLink(entry)) {
+      issues.add(
+          issue(
+              agent,
+              state,
+              entryName,
+              entry,
+              KnowledgeBindingIssue.Type.INVALID_TARGET,
+              "绑定项必须是安全命名的相对软连接"));
+      return;
+    }
+    if (!validateLexicalTarget(agent, state, entryName, entry, issues)) {
+      return;
+    }
+    Path targetReal = resolveRealTarget(agent, state, entryName, entry, issues);
+    if (targetReal == null) {
+      return;
+    }
+    inspectManifest(agent, state, entryName, entry, targetReal, valid, issues);
+  }
+
+  private boolean validateLexicalTarget(
+      String agent,
+      KnowledgeBindingIssue.AgentState state,
+      String entryName,
+      Path entry,
+      List<KnowledgeBindingIssue> issues) {
+    Path rawTarget;
+    try {
+      rawTarget = Files.readSymbolicLink(entry);
+    } catch (IOException e) {
+      issues.add(
+          issue(
+              agent,
+              state,
+              entryName,
+              entry,
+              KnowledgeBindingIssue.Type.INVALID_TARGET,
+              "无法读取软连接: " + e.getMessage()));
+      return false;
+    }
+    if (rawTarget.isAbsolute()) {
+      issues.add(
+          issue(agent, state, entryName, entry, KnowledgeBindingIssue.Type.ESCAPED, "绑定必须使用相对软连接"));
+      return false;
+    }
+    Path parent = entry.getParent();
+    Path lexicalTarget =
+        parent == null ? null : parent.resolve(rawTarget).toAbsolutePath().normalize();
+    if (lexicalTarget == null
+        || !lexicalTarget.startsWith(knowledgeDir)
+        || !rawTarget.equals(expectedTarget(entryName))) {
+      KnowledgeBindingIssue.Type type;
+      if (lexicalTarget == null || !lexicalTarget.startsWith(knowledgeDir)) {
+        type = KnowledgeBindingIssue.Type.ESCAPED;
+      } else if (!entryName.equals(String.valueOf(rawTarget.getFileName()))) {
+        type = KnowledgeBindingIssue.Type.NAME_MISMATCH;
+      } else {
+        type = KnowledgeBindingIssue.Type.INVALID_TARGET;
+      }
+      issues.add(
+          issue(
+              agent,
+              state,
+              entryName,
+              entry,
+              type,
+              "绑定目标不是固定相对路径 ../../../knowledge/" + entryName));
+      return false;
+    }
+    if (!Files.exists(entry)) {
+      issues.add(
+          issue(agent, state, entryName, entry, KnowledgeBindingIssue.Type.DANGLING, "绑定目标不存在"));
+      return false;
+    }
+    return true;
+  }
+
+  private Path resolveRealTarget(
+      String agent,
+      KnowledgeBindingIssue.AgentState state,
+      String entryName,
+      Path entry,
+      List<KnowledgeBindingIssue> issues) {
+    try {
+      Path targetReal = entry.toRealPath();
+      RealPathBoundary.requireWithin(knowledgeDir, targetReal);
+      return targetReal;
+    } catch (RuntimeException | IOException e) {
+      issues.add(
+          issue(
+              agent,
+              state,
+              entryName,
+              entry,
+              KnowledgeBindingIssue.Type.ESCAPED,
+              "绑定真实目标越过知识库根或无法解析"));
+      return null;
+    }
+  }
+
+  private void inspectManifest(
+      String agent,
+      KnowledgeBindingIssue.AgentState state,
+      String entryName,
+      Path entry,
+      Path targetReal,
+      List<BoundKnowledgeDescriptor> valid,
+      List<KnowledgeBindingIssue> issues) {
+    if (!Files.isDirectory(targetReal)
+        || !Files.isRegularFile(targetReal.resolve(KnowledgeManifest.FILE))) {
+      issues.add(
+          issue(
+              agent,
+              state,
+              entryName,
+              entry,
+              KnowledgeBindingIssue.Type.INVALID_TARGET,
+              "绑定目标不是含 " + KnowledgeManifest.FILE + " 的目录"));
+      return;
+    }
+    if (!entryName.equals(String.valueOf(targetReal.getFileName()))) {
+      issues.add(
+          issue(
+              agent,
+              state,
+              entryName,
+              entry,
+              KnowledgeBindingIssue.Type.NAME_MISMATCH,
+              "链接名与知识库目录名不一致"));
+      return;
+    }
+    try {
+      KnowledgeManifest manifest = KnowledgeManifest.read(targetReal);
+      valid.add(
+          new BoundKnowledgeDescriptor(
+              manifest.name(),
+              manifest.description(),
+              entry.toAbsolutePath().normalize(),
+              targetReal));
+    } catch (RuntimeException e) {
+      KnowledgeBindingIssue.Type type =
+          e.getMessage() != null && e.getMessage().contains("不一致")
+              ? KnowledgeBindingIssue.Type.NAME_MISMATCH
+              : KnowledgeBindingIssue.Type.INVALID_TARGET;
+      issues.add(issue(agent, state, entryName, entry, type, e.getMessage()));
+    }
+  }
+
+  private void scanContainer(
+      Path container,
+      KnowledgeBindingIssue.AgentState expectedState,
+      boolean skipReservedDirs,
+      List<KnowledgeBindingIssue> issues) {
+    if (!Files.isDirectory(container, LinkOption.NOFOLLOW_LINKS)) {
+      return;
+    }
+    try (Stream<Path> dirs = Files.list(container)) {
+      dirs.filter(path -> Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS))
+          .filter(path -> !skipReservedDirs || !"skills".equals(String.valueOf(path.getFileName())))
+          .sorted()
+          .forEach(
+              dir -> {
+                String name = String.valueOf(dir.getFileName());
+                KnowledgeBindingIssue.AgentState state =
+                    Files.isRegularFile(dir.resolve(AGENT_FILE))
+                        ? expectedState
+                        : KnowledgeBindingIssue.AgentState.INVALID;
+                issues.addAll(inspectDirectory(name, dir, state).issues());
+              });
+    } catch (IOException e) {
+      throw new UncheckedIOException("扫描 Agent 知识库绑定失败: " + container, e);
+    }
+  }
+
+  private void collectReferences(
+      Path container,
+      KnowledgeReference.AgentState state,
+      String kb,
+      List<KnowledgeReference> output,
+      boolean skipReservedDirs) {
+    if (!Files.isDirectory(container, LinkOption.NOFOLLOW_LINKS)) {
+      return;
+    }
+    try (Stream<Path> dirs = Files.list(container)) {
+      dirs.filter(path -> Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS))
+          .filter(path -> !skipReservedDirs || !"skills".equals(String.valueOf(path.getFileName())))
+          .sorted()
+          .forEach(
+              dir -> {
+                Path link = dir.resolve(LINKS_DIR).resolve(kb);
+                if (!Files.isSymbolicLink(link)) {
+                  return;
+                }
+                try {
+                  if (!Files.readSymbolicLink(link).equals(expectedTarget(kb))) {
+                    return;
+                  }
+                } catch (IOException e) {
+                  return;
+                }
+                String directoryName = String.valueOf(dir.getFileName());
+                output.add(
+                    new KnowledgeReference(
+                        agentName(dir, directoryName),
+                        state,
+                        directoryName,
+                        link.toAbsolutePath().normalize()));
+              });
+    } catch (IOException e) {
+      throw new UncheckedIOException("扫描知识库引用失败: " + container, e);
+    }
+  }
+
+  private static String agentName(Path directory, String fallback) {
+    Path file = directory.resolve(AGENT_FILE);
+    if (!Files.isRegularFile(file)) {
+      return fallback;
+    }
+    try {
+      for (String line : Files.readAllLines(file)) {
+        String stripped = line.strip();
+        if (stripped.startsWith("name:")) {
+          String name = stripped.substring("name:".length()).strip();
+          return name.isBlank() ? fallback : name;
+        }
+      }
+    } catch (IOException | RuntimeException e) {
+      return fallback;
+    }
+    return fallback;
+  }
+
+  /** knowledge/ 绑定目录若被替换为越界软连接，写操作前拒绝（与 Skill skills/ 同款门禁）。 */
+  private Path requireRealLinksDir(Path agentDir) {
+    Path linksDir = agentDir.resolve(LINKS_DIR);
+    if (Files.exists(linksDir, LinkOption.NOFOLLOW_LINKS)
+        && !RealPathBoundary.isWithin(agentDir, linksDir)) {
+      throw new IllegalArgumentException(
+          "Agent knowledge/ 目录真实路径越界（疑似被替换为符号链接），拒绝操作: " + sanitize(linksDir.toString()));
+    }
+    return linksDir;
+  }
+
+  private Path requireAgent(String agent) {
+    Path dir = agentsDir.resolve(agent);
+    if (!Files.isDirectory(dir, LinkOption.NOFOLLOW_LINKS)
+        || !Files.isRegularFile(dir.resolve(AGENT_FILE))) {
+      throw new IllegalArgumentException("Agent 不存在或定义无效: " + agent);
+    }
+    RealPathBoundary.requireWithin(agentsDir, dir);
+    return dir;
+  }
+
+  private Path requireKnowledgeBase(String kb) {
+    Path dir = knowledgeDir.resolve(kb);
+    if (!Files.isDirectory(dir, LinkOption.NOFOLLOW_LINKS)) {
+      throw new IllegalArgumentException("知识库不存在: " + kb);
+    }
+    RealPathBoundary.requireWithin(knowledgeDir, dir);
+    KnowledgeManifest manifest = KnowledgeManifest.read(dir);
+    if (!kb.equals(manifest.name())) {
+      throw new IllegalArgumentException("知识库 name 与目录不一致: " + kb);
+    }
+    return dir.toAbsolutePath().normalize();
+  }
+
+  private static void requireControlledLink(Path link, String kb) {
+    if (!Files.isSymbolicLink(link)) {
+      throw new IllegalArgumentException("绑定位置不是软连接，拒绝删除: " + link);
+    }
+    try {
+      if (!Files.readSymbolicLink(link).equals(expectedTarget(kb))) {
+        throw new IllegalArgumentException("绑定不是受控固定链接，拒绝删除: " + link);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("读取绑定失败: " + link, e);
+    }
+  }
+
+  private static List<String> normalizedNames(List<String> names) {
+    if (names == null) {
+      return List.of();
+    }
+    return names.stream().map(name -> safe(name, "知识库")).distinct().sorted().toList();
+  }
+
+  private static Path expectedTarget(String kb) {
+    return Path.of("..", "..", "..", LINKS_DIR, kb);
+  }
+
+  private static KnowledgeBindingIssue issue(
+      String agent,
+      KnowledgeBindingIssue.AgentState state,
+      String entry,
+      Path path,
+      KnowledgeBindingIssue.Type type,
+      String message) {
+    return new KnowledgeBindingIssue(
+        agent, state, entry, path.toAbsolutePath().normalize(), type, sanitize(message));
+  }
+
+  private static String safe(String name, String kind) {
+    if (name == null || !SAFE_NAME.matcher(name).matches()) {
+      throw new IllegalArgumentException("非法 " + kind + " 名（只允许字母/数字/下划线/连字符）: " + name);
+    }
+    return name;
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeImportException.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeImportException.java
@@ -1,0 +1,13 @@
+package io.oryxos.core.knowledge;
+
+/** 文档导入的同步校验失败（不支持类型 / 扫描件 PDF / 超限等）：入口即拒绝，不进状态机、 不产生半完成记录（Clarify-Q3）。message 面向管理员可读。 */
+public class KnowledgeImportException extends RuntimeException {
+
+  public KnowledgeImportException(String message) {
+    super(message);
+  }
+
+  public KnowledgeImportException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeManifest.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeManifest.java
@@ -1,0 +1,104 @@
+package io.oryxos.core.knowledge;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * KNOWLEDGE.md 清单（FR-001/FR-015）：frontmatter 承载 name/description/backend 与远程连接引用。 只读
+ * frontmatter，不读正文（库级说明不入索引）；连接引用里的 {@code ${ENV_VAR}} 占位原样保留， 由具体后端插件在使用时按环境变量解析——清单层绝不落明文凭证（宪法
+ * VI）。
+ *
+ * @param name 库名，必须与目录名一致
+ * @param description 描述（渐进披露注入的元数据）
+ * @param backend 后端插件名，缺省 local
+ * @param connection 远程后端连接引用（原样字符串），本地库为空 Map
+ */
+public record KnowledgeManifest(
+    String name, String description, String backend, Map<String, String> connection) {
+
+  /** 清单文件名。 */
+  public static final String FILE = "KNOWLEDGE.md";
+
+  private static final String FENCE = "---";
+
+  public KnowledgeManifest {
+    connection = connection == null ? Map.of() : Map.copyOf(connection);
+  }
+
+  /** 读取并校验一个知识库目录的清单；非法清单抛可读 {@link IllegalArgumentException}（US4 场景 3）。 */
+  public static KnowledgeManifest read(Path kbDirectory) {
+    Path file = kbDirectory.resolve(FILE);
+    if (!Files.isRegularFile(file)) {
+      throw new IllegalArgumentException("知识库目录缺少 " + FILE + ": " + kbDirectory.getFileName());
+    }
+    Map<?, ?> map = frontmatter(file, kbDirectory);
+    String name = value(map.get("name"));
+    String description = value(map.get("description"));
+    if (name.isBlank()) {
+      throw new IllegalArgumentException(FILE + " 缺少 name: " + kbDirectory.getFileName());
+    }
+    if (description.isBlank()) {
+      throw new IllegalArgumentException(FILE + " 缺少 description: " + kbDirectory.getFileName());
+    }
+    String directoryName = String.valueOf(kbDirectory.getFileName());
+    if (!directoryName.equals(name)) {
+      throw new IllegalArgumentException("知识库 name 与目录名不一致: " + name + " != " + directoryName);
+    }
+    String backend = value(map.get("backend"));
+    if (backend.isBlank()) {
+      backend = KnowledgeBackendRegistry.LOCAL;
+    }
+    return new KnowledgeManifest(name, description, backend, connectionOf(map.get("connection")));
+  }
+
+  private static Map<?, ?> frontmatter(Path file, Path kbDirectory) {
+    try (BufferedReader reader = Files.newBufferedReader(file)) {
+      if (!FENCE.equals(reader.readLine())) {
+        throw new IllegalArgumentException(FILE + " 缺少 frontmatter: " + kbDirectory.getFileName());
+      }
+      StringBuilder yaml = new StringBuilder();
+      String line;
+      boolean closed = false;
+      while ((line = reader.readLine()) != null) {
+        if (FENCE.equals(line.strip())) {
+          closed = true;
+          break;
+        }
+        yaml.append(line).append('\n');
+      }
+      if (!closed) {
+        throw new IllegalArgumentException(FILE + " frontmatter 未闭合: " + kbDirectory.getFileName());
+      }
+      Object loaded = new Yaml().load(yaml.toString());
+      if (!(loaded instanceof Map<?, ?> map)) {
+        throw new IllegalArgumentException(
+            FILE + " frontmatter 不是对象: " + kbDirectory.getFileName());
+      }
+      return map;
+    } catch (IOException e) {
+      throw new UncheckedIOException("读取 " + FILE + " 失败: " + file, e);
+    }
+  }
+
+  private static Map<String, String> connectionOf(Object raw) {
+    if (raw == null) {
+      return Map.of();
+    }
+    if (!(raw instanceof Map<?, ?> map)) {
+      throw new IllegalArgumentException(FILE + " connection 必须是键值对象");
+    }
+    Map<String, String> connection = new LinkedHashMap<>();
+    map.forEach((key, value) -> connection.put(String.valueOf(key), value(value)));
+    return connection;
+  }
+
+  private static String value(Object value) {
+    return value == null ? "" : String.valueOf(value).strip();
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeReference.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeReference.java
@@ -1,0 +1,21 @@
+package io.oryxos.core.knowledge;
+
+import java.nio.file.Path;
+
+/**
+ * 某知识库被一个 Agent 引用的事实（删除保护 FR-011 的证据行）。
+ *
+ * @param agentName Agent 名（AGENT.md frontmatter name，取不到时用目录名）
+ * @param state 引用方状态
+ * @param directoryName Agent 目录名
+ * @param linkPath 绑定链接绝对路径
+ */
+public record KnowledgeReference(
+    String agentName, AgentState state, String directoryName, Path linkPath) {
+
+  /** 引用方 Agent 状态。 */
+  public enum AgentState {
+    ACTIVE,
+    ARCHIVED
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeReferencedException.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeReferencedException.java
@@ -1,0 +1,28 @@
+package io.oryxos.core.knowledge;
+
+import java.util.List;
+
+/** 删除仍被 Agent 引用的知识库时抛出（FR-011）；Web 层映射 409 并携带引用 Agent 清单 （照 SkillReferencedException 先例）。 */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "SE_BAD_FIELD",
+    justification =
+        "This in-process HTTP mapping exception is never Java-serialized; references are immutable response data.")
+public class KnowledgeReferencedException extends IllegalStateException {
+
+  private final String kbName;
+  private final List<KnowledgeReference> references;
+
+  public KnowledgeReferencedException(String kbName, List<KnowledgeReference> references) {
+    super("知识库仍被 " + references.size() + " 个 Agent 引用，拒绝删除: " + kbName);
+    this.kbName = kbName;
+    this.references = List.copyOf(references);
+  }
+
+  public String kbName() {
+    return kbName;
+  }
+
+  public List<KnowledgeReference> references() {
+    return references;
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeRetriever.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeRetriever.java
@@ -1,0 +1,12 @@
+package io.oryxos.core.knowledge;
+
+import io.oryxos.core.knowledge.model.KnowledgeHit;
+import io.oryxos.core.knowledge.model.KnowledgeQuery;
+import java.util.List;
+
+/** 必选契约：所有后端插件必须实现（FR-006）。同步签名（宪法 VII，规避 AgentScope 全 Mono 之坑）。 */
+public interface KnowledgeRetriever {
+
+  /** 在 {@code query.kbNames()} 圈定的库范围内检索；每条结果必须带出处（或显式标注出处不可用）。 */
+  List<KnowledgeHit> retrieve(KnowledgeQuery query);
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeService.java
@@ -1,0 +1,26 @@
+package io.oryxos.core.knowledge;
+
+import io.oryxos.core.knowledge.model.KnowledgeBaseInfo;
+import io.oryxos.core.knowledge.model.KnowledgeHit;
+import java.util.List;
+
+/**
+ * 知识门面——运行时唯一入口：圈定发起 Agent 的绑定库范围 → 逐库路由后端 → 跨库融合取全局 top-K（FR-020 /
+ * Clarify-Q2）。实现随运行时接线落地（impl-B）；契约先行以便 ContextLoader 消费。
+ */
+public interface KnowledgeService {
+
+  /**
+   * 在 Agent 绑定库范围内检索。
+   *
+   * @param agentName 发起 Agent（检索范围 = 其绑定库，FR-004）
+   * @param query 检索查询
+   * @param topK 可空；空取默认值
+   * @param kbNameOrNull 可选限定单库；不存在或未绑定时抛出可读 {@link IllegalArgumentException}
+   */
+  List<KnowledgeHit> retrieveForAgent(
+      String agentName, String query, Integer topK, String kbNameOrNull);
+
+  /** 全部知识库投影（管理台列表 / CLI / REST 共用）。 */
+  List<KnowledgeBaseInfo> listBases();
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/model/Citation.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/model/Citation.java
@@ -1,0 +1,23 @@
+package io.oryxos.core.knowledge.model;
+
+/**
+ * 出处——检索命中的一等公民字段（规避 AgentScope 把出处埋弱类型 payload 的教训，research D9）。
+ *
+ * @param kbName 知识库名
+ * @param relPath 库内相对路径；远程后端映射不到时为空串并以 {@code readable=false} 显式标注
+ * @param position 片段位置：markdown/纯文本用片段序号（如 "3"），PDF 用页码（如 "page:2"）
+ * @param readable 本地可跟读（可按路径 read_file 读取原文）；远程无本地文件时为 false
+ */
+public record Citation(String kbName, String relPath, String position, boolean readable) {
+
+  /** 出处不可用（远程后端缺字段）时的占位显示文本。 */
+  public static final String UNAVAILABLE = "出处不可用";
+
+  /** 统一渲染格式 {@code [库名] 文件路径 #片段位置}；出处不可用时显式标注而不是给出假路径。 */
+  public String display() {
+    if (relPath == null || relPath.isBlank()) {
+      return "[" + kbName + "] " + UNAVAILABLE;
+    }
+    return "[" + kbName + "] " + relPath + " #" + position;
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/model/DocumentState.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/model/DocumentState.java
@@ -1,0 +1,13 @@
+package io.oryxos.core.knowledge.model;
+
+/** 文档索引状态机（Clarify-Q3 两段式上传）：同步校验失败不进状态机，入口即拒绝。 */
+public enum DocumentState {
+  /** 已通过同步校验，等待后台索引。 */
+  PENDING,
+  /** 后台虚拟线程切分/向量化中。 */
+  INDEXING,
+  /** 索引完成，可被检索命中。 */
+  READY,
+  /** 索引失败，携带可读原因，可重试。 */
+  FAILED
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/model/DocumentStatus.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/model/DocumentStatus.java
@@ -1,0 +1,15 @@
+package io.oryxos.core.knowledge.model;
+
+import java.time.Instant;
+
+/**
+ * 库详情页的文档清单行（FR-008 索引状态可随时查询）。
+ *
+ * @param relPath 库内相对路径
+ * @param state 状态机当前状态
+ * @param chunkCount 片段数（未就绪为 0）
+ * @param failureReason FAILED 时的可读原因，其余为 null
+ * @param indexedAt 最近成功索引时间，可空
+ */
+public record DocumentStatus(
+    String relPath, DocumentState state, int chunkCount, String failureReason, Instant indexedAt) {}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/model/KnowledgeBaseInfo.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/model/KnowledgeBaseInfo.java
@@ -1,0 +1,23 @@
+package io.oryxos.core.knowledge.model;
+
+import java.time.Instant;
+
+/**
+ * 知识库列表投影：管理台列表页 / CLI {@code oryxos knowledge list} / REST 共用（FR-009/021）。
+ *
+ * @param name 库名（目录名，唯一）
+ * @param description 描述（KNOWLEDGE.md frontmatter）
+ * @param backend 后端插件名（缺省 local）
+ * @param documentCount 文档数
+ * @param chunkCount 片段数
+ * @param indexStatus 汇总索引状态（就绪 / 索引中 / 失败 / 空）
+ * @param lastIndexedAt 最近索引时间，可空
+ */
+public record KnowledgeBaseInfo(
+    String name,
+    String description,
+    String backend,
+    int documentCount,
+    int chunkCount,
+    String indexStatus,
+    Instant lastIndexedAt) {}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/model/KnowledgeCapabilities.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/model/KnowledgeCapabilities.java
@@ -1,0 +1,25 @@
+package io.oryxos.core.knowledge.model;
+
+/**
+ * 后端插件能力声明（FR-006）：检索是必选契约不在此声明；管理操作逐项可选。 未声明能力的调用必须在入口被可读拒绝，规避 AgentScope
+ * 「写操作运行时抛异常」的契约谎言（research D9）。
+ *
+ * @param createDelete 支持建库/删库
+ * @param importDocs 支持文档导入
+ * @param rebuild 支持重建索引
+ * @param status 支持索引状态查询
+ * @param rerank 精排能力位（声明后其结果直通流水线精排槽位，FR-004）
+ */
+public record KnowledgeCapabilities(
+    boolean createDelete, boolean importDocs, boolean rebuild, boolean status, boolean rerank) {
+
+  /** 内置本地后端：全管理能力，v1 无精排（research D10）。 */
+  public static KnowledgeCapabilities localFull() {
+    return new KnowledgeCapabilities(true, true, true, true, false);
+  }
+
+  /** 仅检索能力（典型远程只读后端 / 测试桩）。 */
+  public static KnowledgeCapabilities retrieveOnly() {
+    return new KnowledgeCapabilities(false, false, false, false, false);
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/model/KnowledgeHit.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/model/KnowledgeHit.java
@@ -1,0 +1,27 @@
+package io.oryxos.core.knowledge.model;
+
+import java.util.Map;
+
+/**
+ * 一条检索命中。出处是硬契约（非空）；payload 是平台特有字段的逃生舱（highlight、rerank 分数等）， 契约字段保持稳定（research D9）。
+ *
+ * @param citation 出处，不得为 null
+ * @param content 片段文本
+ * @param score 融合后相关性分数（跨库可比：RRF 名次分）
+ * @param degraded 本条结果产生于降级路径（embedding 不可用走关键词，FR-013）
+ * @param payload 平台特有附加字段；无则空 Map
+ */
+public record KnowledgeHit(
+    Citation citation,
+    String content,
+    double score,
+    boolean degraded,
+    Map<String, Object> payload) {
+
+  public KnowledgeHit {
+    if (citation == null) {
+      throw new IllegalArgumentException("检索命中必须携带出处（Citation 一等公民硬契约）");
+    }
+    payload = payload == null ? Map.of() : Map.copyOf(payload);
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/model/KnowledgeQuery.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/model/KnowledgeQuery.java
@@ -1,0 +1,26 @@
+package io.oryxos.core.knowledge.model;
+
+import java.util.List;
+
+/**
+ * 检索入参最小公约数（research D9：topK 之外的平台特有参数沉到各插件配置）。
+ *
+ * @param query 检索查询文本
+ * @param topK 返回片段数上限（跨库聚合后的全局 top-K，Clarify-Q2）
+ * @param kbNames 检索范围（由门面按发起 Agent 的绑定圈定，插件不自行扩大范围）
+ */
+public record KnowledgeQuery(String query, int topK, List<String> kbNames) {
+
+  /** 未显式指定 topK 时的默认值（spec Assumptions）。 */
+  public static final int DEFAULT_TOP_K = 5;
+
+  public KnowledgeQuery {
+    if (query == null || query.isBlank()) {
+      throw new IllegalArgumentException("检索查询不能为空");
+    }
+    if (topK <= 0) {
+      topK = DEFAULT_TOP_K;
+    }
+    kbNames = kbNames == null ? List.of() : List.copyOf(kbNames);
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeBindingServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeBindingServiceTest.java
@@ -1,0 +1,149 @@
+package io.oryxos.core.knowledge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class KnowledgeBindingServiceTest {
+
+  @TempDir Path root;
+
+  private KnowledgeBindingService service;
+
+  @BeforeEach
+  void setUp() {
+    KnowledgeWorkspaceFixture.workspace(root);
+    KnowledgeWorkspaceFixture.knowledgeBase(root, "ops", "运维手册", Map.of("a.md", "# 内容"));
+    KnowledgeWorkspaceFixture.knowledgeBase(root, "faq", "产品FAQ", Map.of("q.md", "# 问答"));
+    KnowledgeWorkspaceFixture.agent(root, "assistant");
+    service = new KnowledgeBindingService(root);
+  }
+
+  @Test
+  void bindCreatesFixedRelativeLinkAndInspectReturnsMetadata() throws IOException {
+    BoundKnowledgeDescriptor bound = service.bind("assistant", "ops");
+
+    assertEquals("ops", bound.name());
+    assertEquals("运维手册", bound.description());
+    Path link = root.resolve("agents/assistant/knowledge/ops");
+    assertTrue(Files.isSymbolicLink(link));
+    assertEquals(Path.of("..", "..", "..", "knowledge", "ops"), Files.readSymbolicLink(link));
+
+    // 幂等：重复绑定同一有效库不报错
+    assertEquals("ops", service.bind("assistant", "ops").name());
+  }
+
+  @Test
+  void bindRejectsUnknownKnowledgeBaseAndUnknownAgent() {
+    assertThrows(IllegalArgumentException.class, () -> service.bind("assistant", "nope"));
+    assertThrows(IllegalArgumentException.class, () -> service.bind("ghost", "ops"));
+    assertThrows(IllegalArgumentException.class, () -> service.bind("assistant", "../escape"));
+  }
+
+  @Test
+  void unbindIsIdempotentAndRefusesUncontrolledEntries() throws IOException {
+    service.bind("assistant", "ops");
+    service.unbind("assistant", "ops");
+    service.unbind("assistant", "ops"); // 幂等
+
+    // 绑定位置被普通目录占用：拒绝删除
+    Files.createDirectories(root.resolve("agents/assistant/knowledge/ops"));
+    assertThrows(IllegalArgumentException.class, () -> service.unbind("assistant", "ops"));
+  }
+
+  @Test
+  void replaceBindingsSwapsWholeSet() {
+    service.bind("assistant", "ops");
+
+    KnowledgeBindingInspection after = service.replaceBindings("assistant", List.of("faq"));
+
+    assertEquals(1, after.bindings().size());
+    assertEquals("faq", after.bindings().get(0).name());
+    assertTrue(after.issues().isEmpty());
+  }
+
+  @Test
+  void inspectClassifiesIllegalBindings() throws IOException {
+    // 绝对链接 → ESCAPED
+    KnowledgeWorkspaceFixture.rawBinding(
+        root, "assistant", "abs", root.resolve("knowledge/ops").toAbsolutePath());
+    // 名称与目标不一致 → NAME_MISMATCH
+    KnowledgeWorkspaceFixture.rawBinding(
+        root, "assistant", "wrongname", Path.of("..", "..", "..", "knowledge", "ops"));
+    // 目标不存在 → DANGLING
+    KnowledgeWorkspaceFixture.rawBinding(
+        root, "assistant", "gone", Path.of("..", "..", "..", "knowledge", "gone"));
+    // 普通目录混入绑定命名空间 → INVALID_TARGET
+    Files.createDirectories(root.resolve("agents/assistant/knowledge/plaindir"));
+
+    KnowledgeBindingInspection inspection = service.inspect("assistant");
+
+    assertTrue(inspection.bindings().isEmpty());
+    assertEquals(4, inspection.issues().size());
+    assertEquals(
+        List.of(
+            KnowledgeBindingIssue.Type.ESCAPED,
+            KnowledgeBindingIssue.Type.DANGLING,
+            KnowledgeBindingIssue.Type.INVALID_TARGET,
+            KnowledgeBindingIssue.Type.NAME_MISMATCH),
+        inspection.issues().stream().map(KnowledgeBindingIssue::type).toList());
+  }
+
+  @Test
+  void escapedRealTargetIsRejectedEvenWithLexicalCompliance() throws IOException {
+    // knowledge/evil 目录本身是指向库根之外的软连接：词法合规但真实路径越界
+    Path outside = Files.createDirectories(root.resolve("outside"));
+    Files.writeString(
+        outside.resolve(KnowledgeManifest.FILE), "---\nname: evil\ndescription: x\n---\n");
+    Files.createSymbolicLink(root.resolve("knowledge/evil"), outside.toAbsolutePath());
+    KnowledgeWorkspaceFixture.rawBinding(
+        root, "assistant", "evil", Path.of("..", "..", "..", "knowledge", "evil"));
+
+    KnowledgeBindingInspection inspection = service.inspect("assistant");
+
+    assertTrue(inspection.bindings().isEmpty());
+    assertEquals(KnowledgeBindingIssue.Type.ESCAPED, inspection.issues().get(0).type());
+  }
+
+  @Test
+  void referencesAndDeleteProtection() {
+    KnowledgeWorkspaceFixture.agent(root, "another");
+    service.bind("assistant", "ops");
+    service.bind("another", "ops");
+
+    List<KnowledgeReference> refs = service.references("ops");
+    assertEquals(2, refs.size());
+    assertEquals("another", refs.get(0).agentName());
+
+    KnowledgeReferencedException rejected =
+        assertThrows(KnowledgeReferencedException.class, () -> service.ensureDeletable("ops"));
+    assertEquals(2, rejected.references().size());
+
+    service.unbind("assistant", "ops");
+    service.unbind("another", "ops");
+    service.ensureDeletable("ops"); // 不再抛
+  }
+
+  @Test
+  void reconcileAggregatesIssuesAcrossAgents() {
+    KnowledgeWorkspaceFixture.agent(root, "another");
+    KnowledgeWorkspaceFixture.rawBinding(
+        root, "another", "gone", Path.of("..", "..", "..", "knowledge", "gone"));
+    service.bind("assistant", "ops");
+
+    List<KnowledgeBindingIssue> issues = service.reconcile();
+
+    assertEquals(1, issues.size());
+    assertEquals("another", issues.get(0).agentName());
+    assertEquals(KnowledgeBindingIssue.Type.DANGLING, issues.get(0).type());
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeManifestTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeManifestTest.java
@@ -1,0 +1,69 @@
+package io.oryxos.core.knowledge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class KnowledgeManifestTest {
+
+  @TempDir Path root;
+
+  @Test
+  void readsManifestWithLocalBackendDefault() throws IOException {
+    Path dir = Files.createDirectories(root.resolve("ops-manual"));
+    Files.writeString(
+        dir.resolve(KnowledgeManifest.FILE),
+        "---\nname: ops-manual\ndescription: 运维手册\n---\n库级说明正文不入索引\n");
+
+    KnowledgeManifest manifest = KnowledgeManifest.read(dir);
+
+    assertEquals("ops-manual", manifest.name());
+    assertEquals("运维手册", manifest.description());
+    assertEquals("local", manifest.backend());
+    assertTrue(manifest.connection().isEmpty());
+  }
+
+  @Test
+  void keepsEnvPlaceholderUnresolvedForRemoteBackend() throws IOException {
+    Path dir = Files.createDirectories(root.resolve("remote-kb"));
+    Files.writeString(
+        dir.resolve(KnowledgeManifest.FILE),
+        "---\nname: remote-kb\ndescription: 远程库\nbackend: ragflow\nconnection:\n"
+            + "  base_url: https://ragflow.internal\n  api_key: ${RAGFLOW_API_KEY}\n---\n");
+
+    KnowledgeManifest manifest = KnowledgeManifest.read(dir);
+
+    assertEquals("ragflow", manifest.backend());
+    // 凭证占位原样保留：清单层绝不解析/落明文（宪法 VI）
+    assertEquals("${RAGFLOW_API_KEY}", manifest.connection().get("api_key"));
+  }
+
+  @Test
+  void rejectsMissingFieldsAndNameMismatch() throws IOException {
+    Path noName = Files.createDirectories(root.resolve("no-name"));
+    Files.writeString(noName.resolve(KnowledgeManifest.FILE), "---\ndescription: x\n---\n");
+    assertThrows(IllegalArgumentException.class, () -> KnowledgeManifest.read(noName));
+
+    Path noDesc = Files.createDirectories(root.resolve("no-desc"));
+    Files.writeString(noDesc.resolve(KnowledgeManifest.FILE), "---\nname: no-desc\n---\n");
+    assertThrows(IllegalArgumentException.class, () -> KnowledgeManifest.read(noDesc));
+
+    Path mismatch = Files.createDirectories(root.resolve("actual"));
+    Files.writeString(
+        mismatch.resolve(KnowledgeManifest.FILE), "---\nname: other\ndescription: x\n---\n");
+    assertThrows(IllegalArgumentException.class, () -> KnowledgeManifest.read(mismatch));
+
+    Path missing = Files.createDirectories(root.resolve("missing"));
+    assertThrows(IllegalArgumentException.class, () -> KnowledgeManifest.read(missing));
+
+    Path noFence = Files.createDirectories(root.resolve("no-fence"));
+    Files.writeString(noFence.resolve(KnowledgeManifest.FILE), "name: no-fence\n");
+    assertThrows(IllegalArgumentException.class, () -> KnowledgeManifest.read(noFence));
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeWorkspaceFixture.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeWorkspaceFixture.java
@@ -1,0 +1,80 @@
+package io.oryxos.core.knowledge;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/** 跨故事共享的知识库工作区测试夹具（T002）：临时目录内搭 agents/ + knowledge/ 与各种绑定形态。 */
+public final class KnowledgeWorkspaceFixture {
+
+  private KnowledgeWorkspaceFixture() {}
+
+  /** 建出 .oryxos 形态的根：agents/ + knowledge/。 */
+  public static Path workspace(Path root) {
+    try {
+      Files.createDirectories(root.resolve("agents"));
+      Files.createDirectories(root.resolve("knowledge"));
+      return root;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /** 建一个合法知识库目录：KNOWLEDGE.md + 文档文件。 */
+  public static Path knowledgeBase(
+      Path root, String name, String description, Map<String, String> documents) {
+    try {
+      Path dir = Files.createDirectories(root.resolve("knowledge").resolve(name));
+      Files.writeString(
+          dir.resolve(KnowledgeManifest.FILE),
+          "---\nname: " + name + "\ndescription: " + description + "\n---\n");
+      for (Map.Entry<String, String> doc : documents.entrySet()) {
+        Path file = dir.resolve(doc.getKey());
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, doc.getValue());
+      }
+      return dir;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /** 建一个最小合法 Agent 目录（含 AGENT.md）。 */
+  public static Path agent(Path root, String name) {
+    try {
+      Path dir = Files.createDirectories(root.resolve("agents").resolve(name));
+      Files.writeString(dir.resolve("AGENT.md"), "---\nname: " + name + "\n---\n任务指令");
+      return dir;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /** 手工建一条受控相对绑定链接（不经服务，供 GitOps 视角测试）。 */
+  public static Path binding(Path root, String agentName, String kbName) {
+    try {
+      Path linksDir =
+          Files.createDirectories(root.resolve("agents").resolve(agentName).resolve("knowledge"));
+      Path link = linksDir.resolve(kbName);
+      Files.createSymbolicLink(link, Path.of("..", "..", "..", "knowledge", kbName));
+      return link;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /** 建一条指定原始目标的绑定链接（用于构造绝对/越界/错名等非法形态）。 */
+  public static Path rawBinding(Path root, String agentName, String entryName, Path target) {
+    try {
+      Path linksDir =
+          Files.createDirectories(root.resolve("agents").resolve(agentName).resolve("knowledge"));
+      Path link = linksDir.resolve(entryName);
+      Files.createSymbolicLink(link, target);
+      return link;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/oryxos-knowledge/pom.xml
+++ b/oryxos-knowledge/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.oryxos</groupId>
+        <artifactId>oryxos</artifactId>
+        <version>0.1.3-RELEASE</version>
+    </parent>
+
+    <artifactId>oryxos-knowledge</artifactId>
+    <name>OryxOS Knowledge</name>
+    <description>Knowledge base: local backend plugin, chunking/embedding/index pipeline, retrieval</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-storage</artifactId>
+        </dependency>
+        <!-- 文本型 PDF 解析（014 研判 D11：唯一新增运行时依赖；扫描件识别拒绝） -->
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+        </dependency>
+        <!-- @Tool 注解（impl-B 的 KnowledgeTools 走同款注解管道，schema 自动生成） -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/LocalKnowledgeBackend.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/LocalKnowledgeBackend.java
@@ -1,0 +1,269 @@
+package io.oryxos.knowledge;
+
+import io.oryxos.core.embedding.TextEmbedder;
+import io.oryxos.core.fs.RealPathBoundary;
+import io.oryxos.core.knowledge.KnowledgeAdmin;
+import io.oryxos.core.knowledge.KnowledgeBackend;
+import io.oryxos.core.knowledge.KnowledgeBackendRegistry;
+import io.oryxos.core.knowledge.KnowledgeManifest;
+import io.oryxos.core.knowledge.model.Citation;
+import io.oryxos.core.knowledge.model.DocumentStatus;
+import io.oryxos.core.knowledge.model.KnowledgeCapabilities;
+import io.oryxos.core.knowledge.model.KnowledgeHit;
+import io.oryxos.core.knowledge.model.KnowledgeQuery;
+import io.oryxos.knowledge.index.KnowledgeIndexService;
+import io.oryxos.knowledge.retrieve.RetrievalPipeline;
+import io.oryxos.knowledge.store.ChunkStore;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * 内置本地后端——契约的第一个插件（FR-015 缺省实现，零外部服务依赖）：文档在本机、索引在 SQLite、检索走「双路召回（向量余弦 ∥ 关键词）→ RRF 名次融合 → 精排槽位（v1
+ * 空）」（FR-004）。 embedding 不可用或向量模型不一致时向量路关停、关键词路独立服务并逐条标注降级（FR-013/014）。
+ */
+public class LocalKnowledgeBackend implements KnowledgeBackend, KnowledgeAdmin {
+
+  private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9_-]+");
+
+  /** 每路召回候选量与 topK 的倍数：给融合层留足重排空间。 */
+  private static final int ROUTE_FACTOR = 4;
+
+  private final Path knowledgeRoot;
+  private final ChunkStore store;
+  private final KnowledgeIndexService indexService;
+  private final Supplier<TextEmbedder> embedderSupplier;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "store/indexService 为装配层注入的共享单例，构造注入存同一引用正是意图（镜像既有 SuppressFBWarnings 模式）。")
+  public LocalKnowledgeBackend(
+      Path knowledgeRoot,
+      ChunkStore store,
+      KnowledgeIndexService indexService,
+      Supplier<TextEmbedder> embedderSupplier) {
+    this.knowledgeRoot = knowledgeRoot.toAbsolutePath().normalize();
+    this.store = store;
+    this.indexService = indexService;
+    this.embedderSupplier = embedderSupplier;
+  }
+
+  @Override
+  public String name() {
+    return KnowledgeBackendRegistry.LOCAL;
+  }
+
+  @Override
+  public KnowledgeCapabilities capabilities() {
+    return KnowledgeCapabilities.localFull();
+  }
+
+  @Override
+  public Optional<KnowledgeAdmin> admin() {
+    return Optional.of(this);
+  }
+
+  @Override
+  public List<KnowledgeHit> retrieve(KnowledgeQuery query) {
+    List<KnowledgeHit> all = new ArrayList<>();
+    for (String kbName : query.kbNames()) {
+      all.addAll(retrieveOne(kbName, query.query(), query.topK()));
+    }
+    // 跨库融合取全局 top-K：结果条数与绑定库数无关（FR-020 / Clarify-Q2）
+    return all.stream()
+        .sorted(Comparator.comparingDouble(KnowledgeHit::score).reversed())
+        .limit(query.topK())
+        .toList();
+  }
+
+  private List<KnowledgeHit> retrieveOne(String kbName, String query, int topK) {
+    long generation = indexService.activeGeneration(kbName);
+    List<ChunkStore.ChunkRecord> chunks = store.chunks(kbName, generation);
+    if (chunks.isEmpty()) {
+      return List.of();
+    }
+    Map<Long, String> relPaths = new HashMap<>(chunks.size());
+    store.documents(kbName, generation).forEach(doc -> relPaths.put(doc.id(), doc.relPath()));
+    Map<Long, ChunkStore.ChunkRecord> byId = new HashMap<>(chunks.size());
+    chunks.forEach(chunk -> byId.put(chunk.id(), chunk));
+
+    String degradedReason = null;
+    List<RetrievalPipeline.Candidate> vectorRoute = List.of();
+    TextEmbedder embedder = tryEmbedder();
+    if (embedder == null) {
+      degradedReason = "向量化服务不可用，已降级为关键词检索";
+    } else {
+      String mismatch = modelMismatch(chunks, embedder.modelId());
+      if (mismatch != null) {
+        // FR-014：拒绝新旧向量混合比较，关键词路独立服务并提示重建，不静默返回错误排序
+        degradedReason = mismatch;
+      } else {
+        vectorRoute = vectorRecall(chunks, embedder, query, topK * ROUTE_FACTOR);
+      }
+    }
+    List<RetrievalPipeline.Candidate> keywordRoute =
+        keywordRecall(chunks, query, topK * ROUTE_FACTOR);
+
+    boolean degraded = degradedReason != null;
+    Map<String, Object> payload = degraded ? Map.of("degraded_reason", degradedReason) : Map.of();
+    List<KnowledgeHit> hits = new ArrayList<>();
+    for (RetrievalPipeline.Fused fused :
+        RetrievalPipeline.fuseByRank(topK, vectorRoute, keywordRoute)) {
+      ChunkStore.ChunkRecord chunk = byId.get(fused.id());
+      String relPath = relPaths.getOrDefault(chunk.documentId(), "");
+      String position =
+          chunk.pageNo() != null ? "page:" + chunk.pageNo() : String.valueOf(chunk.seq());
+      hits.add(
+          new KnowledgeHit(
+              new Citation(kbName, relPath, position, true),
+              chunk.content(),
+              fused.score(),
+              degraded,
+              payload));
+    }
+    return hits;
+  }
+
+  private TextEmbedder tryEmbedder() {
+    try {
+      return embedderSupplier.get();
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
+  /** 存量向量模型与当前配置不一致时返回可读原因；一致返回 null（FR-014）。 */
+  private static String modelMismatch(List<ChunkStore.ChunkRecord> chunks, String currentModel) {
+    for (ChunkStore.ChunkRecord chunk : chunks) {
+      if (chunk.embedding() != null
+          && chunk.embeddingModel() != null
+          && !chunk.embeddingModel().equals(currentModel)) {
+        return "向量模型不一致（存量 "
+            + chunk.embeddingModel()
+            + " ≠ 当前 "
+            + currentModel
+            + "），请重建索引；已降级为关键词检索";
+      }
+    }
+    return null;
+  }
+
+  private static List<RetrievalPipeline.Candidate> vectorRecall(
+      List<ChunkStore.ChunkRecord> chunks, TextEmbedder embedder, String query, int limit) {
+    float[] queryVector;
+    try {
+      queryVector = embedder.embed(query);
+    } catch (RuntimeException e) {
+      return List.of();
+    }
+    return chunks.stream()
+        .filter(
+            chunk -> chunk.embedding() != null && chunk.embedding().length == queryVector.length)
+        .map(
+            chunk ->
+                new RetrievalPipeline.Candidate(
+                    chunk.id(), RetrievalPipeline.cosine(queryVector, chunk.embedding())))
+        .sorted(Comparator.comparingDouble(RetrievalPipeline.Candidate::score).reversed())
+        .limit(limit)
+        .toList();
+  }
+
+  /** 关键词路：空白分词的包含计数 + 整句包含加权；子串匹配天然覆盖中文（Edge Cases 中英混排）。 */
+  private static List<RetrievalPipeline.Candidate> keywordRecall(
+      List<ChunkStore.ChunkRecord> chunks, String query, int limit) {
+    String whole = query.toLowerCase(Locale.ROOT).strip();
+    String[] tokens = whole.split("\\s+");
+    return chunks.stream()
+        .map(
+            chunk ->
+                new RetrievalPipeline.Candidate(chunk.id(), keywordScore(chunk, whole, tokens)))
+        .filter(candidate -> candidate.score() > 0)
+        .sorted(Comparator.comparingDouble(RetrievalPipeline.Candidate::score).reversed())
+        .limit(limit)
+        .toList();
+  }
+
+  private static double keywordScore(ChunkStore.ChunkRecord chunk, String whole, String[] tokens) {
+    String content = chunk.content().toLowerCase(Locale.ROOT);
+    double score = 0;
+    for (String token : tokens) {
+      if (!token.isBlank() && content.contains(token)) {
+        score += 1;
+      }
+    }
+    if (content.contains(whole)) {
+      score += 2;
+    }
+    return score;
+  }
+
+  // ---- KnowledgeAdmin（全能力声明，FR-006 契约诚实）----
+
+  @Override
+  public void createBase(String name, String description) {
+    if (name == null || !SAFE_NAME.matcher(name).matches()) {
+      throw new IllegalArgumentException("非法知识库名（只允许字母/数字/下划线/连字符）: " + name);
+    }
+    Path dir = knowledgeRoot.resolve(name);
+    if (Files.exists(dir)) {
+      throw new IllegalArgumentException("知识库已存在: " + name);
+    }
+    String desc = description == null ? "" : description.replace('\r', ' ').replace('\n', ' ');
+    try {
+      Files.createDirectories(dir);
+      Files.writeString(
+          dir.resolve(KnowledgeManifest.FILE),
+          "---\nname: " + name + "\ndescription: " + desc + "\nbackend: local\n---\n");
+    } catch (IOException e) {
+      throw new UncheckedIOException("创建知识库失败: " + name, e);
+    }
+  }
+
+  @Override
+  public void deleteBase(String name) {
+    Path dir = RealPathBoundary.requireWithin(knowledgeRoot, knowledgeRoot.resolve(name));
+    if (!Files.isDirectory(dir)) {
+      throw new IllegalArgumentException("知识库不存在: " + name);
+    }
+    indexService.deleteBase(name);
+    try (Stream<Path> walk = Files.walk(dir)) {
+      List<Path> paths = walk.sorted(Comparator.reverseOrder()).toList();
+      for (Path path : paths) {
+        Files.delete(path);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("删除知识库目录失败: " + name, e);
+    }
+  }
+
+  @Override
+  public DocumentStatus importDocument(String kbName, String relPath) {
+    return indexService.importDocument(kbName, relPath);
+  }
+
+  @Override
+  public void deleteDocument(String kbName, String relPath) {
+    indexService.deleteDocument(kbName, relPath);
+  }
+
+  @Override
+  public void rebuild(String kbName) {
+    indexService.rebuild(kbName);
+  }
+
+  @Override
+  public List<DocumentStatus> status(String kbName) {
+    return indexService.status(kbName);
+  }
+}

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/Chunker.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/Chunker.java
@@ -1,0 +1,64 @@
+package io.oryxos.knowledge.index;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/** 切分器：标题边界优先、辅以长度上限（spec Assumptions）。契约是「不跨文档、带位置、可回溯」—— 具体参数为实现细节。 */
+public final class Chunker {
+
+  /** 单片段字符上限：兼顾 embedding 输入限制与检索粒度。 */
+  static final int MAX_CHARS = 1600;
+
+  private static final Pattern HEADING = Pattern.compile("^#{1,6}\\s.*");
+
+  /** 段落分隔：连续空行。 */
+  private static final String PARAGRAPH_SEPARATOR = "\\n{2,}";
+
+  /** 把一个解析单元的文本切成有序片段；空白片段丢弃。 */
+  public List<String> split(String text) {
+    List<String> chunks = new ArrayList<>();
+    StringBuilder current = new StringBuilder();
+    for (String paragraph : paragraphsOf(text)) {
+      boolean isHeading = HEADING.matcher(paragraph.strip()).matches();
+      boolean overflow = current.length() + paragraph.length() + 2 > MAX_CHARS;
+      boolean shouldFlush = current.length() > 0 && (isHeading || overflow);
+      if (shouldFlush) {
+        addChunk(chunks, current.toString());
+        current.setLength(0);
+      }
+      if (paragraph.length() > MAX_CHARS) {
+        for (int start = 0; start < paragraph.length(); start += MAX_CHARS) {
+          addChunk(
+              chunks, paragraph.substring(start, Math.min(start + MAX_CHARS, paragraph.length())));
+        }
+        continue;
+      }
+      if (current.length() > 0) {
+        current.append("\n\n");
+      }
+      current.append(paragraph);
+    }
+    if (current.length() > 0) {
+      addChunk(chunks, current.toString());
+    }
+    return chunks;
+  }
+
+  private static List<String> paragraphsOf(String text) {
+    List<String> paragraphs = new ArrayList<>();
+    for (String block : text.split(PARAGRAPH_SEPARATOR)) {
+      if (!block.isBlank()) {
+        paragraphs.add(block.strip());
+      }
+    }
+    return paragraphs;
+  }
+
+  private static void addChunk(List<String> chunks, String chunk) {
+    String trimmed = chunk.strip();
+    if (!trimmed.isEmpty()) {
+      chunks.add(trimmed);
+    }
+  }
+}

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/DocumentParser.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/DocumentParser.java
@@ -1,0 +1,17 @@
+package io.oryxos.knowledge.index;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * 文档解析 SPI——本地后端内部的可扩展分层（FR-003：后续增加格式只加实现，不改契约）。 解析失败（含扫描件 PDF）抛可读 {@link
+ * io.oryxos.core.knowledge.KnowledgeImportException}。
+ */
+public interface DocumentParser {
+
+  /** 按文件名（扩展名）判断是否受理。 */
+  boolean supports(String fileName);
+
+  /** 解析为单元列表；空内容返回空列表由上层按「空文档」处理。 */
+  List<ParsedUnit> parse(Path file);
+}

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/KnowledgeIndexService.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/KnowledgeIndexService.java
@@ -1,0 +1,304 @@
+package io.oryxos.knowledge.index;
+
+import io.oryxos.core.embedding.TextEmbedder;
+import io.oryxos.core.fs.RealPathBoundary;
+import io.oryxos.core.knowledge.KnowledgeImportException;
+import io.oryxos.core.knowledge.KnowledgeManifest;
+import io.oryxos.core.knowledge.model.DocumentState;
+import io.oryxos.core.knowledge.model.DocumentStatus;
+import io.oryxos.knowledge.store.ChunkStore;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 索引流水线（FR-003 / Clarify-Q1/Q3）：两段式导入——同步落盘解析校验（失败入口即拒绝）， 切分与向量化由虚拟线程后台推进，状态机 PENDING → INDEXING →
+ * READY / FAILED 可随时查询； 重建走双缓冲——旧代持续服务，新代就绪原子切换、失败即弃且旧代不受影响（FR-024）。
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "CRLF_INJECTION_LOGS",
+    justification = "所有不可信字符串入日志前均经 sanitize 去除 CR/LF。")
+public class KnowledgeIndexService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KnowledgeIndexService.class);
+
+  /** 单文档大小上限（Edge Cases：超大文档拒绝并提示）。 */
+  static final long MAX_FILE_BYTES = 10L * 1024 * 1024;
+
+  private final Path knowledgeRoot;
+  private final ChunkStore store;
+  private final Supplier<TextEmbedder> embedderSupplier;
+  private final Executor executor;
+  private final List<DocumentParser> parsers =
+      List.of(new MarkdownParser(), new TextParser(), new PdfParser());
+  private final Chunker chunker = new Chunker();
+  private final ConcurrentHashMap<String, Long> activeGenerations = new ConcurrentHashMap<>();
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "store/executor 为装配层注入的共享单例，构造注入存同一引用正是意图（镜像既有 SuppressFBWarnings 模式）。")
+  public KnowledgeIndexService(
+      Path knowledgeRoot,
+      ChunkStore store,
+      Supplier<TextEmbedder> embedderSupplier,
+      Executor executor) {
+    this.knowledgeRoot = knowledgeRoot.toAbsolutePath().normalize();
+    this.store = store;
+    this.embedderSupplier = embedderSupplier;
+    this.executor = executor;
+  }
+
+  /** 当前对检索可见的索引代号：从存量推断一次后内存维护（启动对账重算）。 */
+  public long activeGeneration(String kbName) {
+    return activeGenerations.computeIfAbsent(
+        kbName,
+        kb ->
+            store.allDocuments(kb).stream()
+                .filter(doc -> doc.state() == DocumentState.READY)
+                .mapToLong(ChunkStore.DocumentRecord::generation)
+                .max()
+                .orElse(0L));
+  }
+
+  /** 两段式导入的同步段：校验 + 登记 PENDING + 提交后台索引；返回可查询的初始状态。 */
+  public DocumentStatus importDocument(String kbName, String relPath) {
+    Path file = requireDocumentFile(kbName, relPath);
+    List<ParsedUnit> units = parseValidated(file);
+    long generation = activeGeneration(kbName);
+    String sha = sha256(file);
+    ChunkStore.DocumentRecord existing =
+        store.findDocument(kbName, relPath, generation).orElse(null);
+    if (existing != null
+        && existing.state() == DocumentState.READY
+        && MessageDigest.isEqual(
+            existing.sha256().getBytes(StandardCharsets.UTF_8),
+            sha.getBytes(StandardCharsets.UTF_8))) {
+      return toStatus(existing);
+    }
+    ChunkStore.DocumentRecord pending =
+        store.saveDocument(
+            new ChunkStore.DocumentRecord(
+                existing == null ? null : existing.id(),
+                kbName,
+                relPath,
+                sha,
+                DocumentState.PENDING,
+                null,
+                0,
+                generation,
+                existing == null ? null : existing.indexedAt()));
+    long documentId = pending.id();
+    executor.execute(() -> indexDocument(documentId, kbName, relPath, generation, units));
+    return toStatus(pending);
+  }
+
+  /** 双缓冲重建（FR-024）：新代整体成功才切换；任一文档失败则丢弃新代并抛可读原因，旧代照常服务。 */
+  public synchronized void rebuild(String kbName) {
+    long oldGeneration = activeGeneration(kbName);
+    long newGeneration = oldGeneration + 1;
+    try {
+      for (Path file : listSupportedFiles(kbDir(kbName))) {
+        String relPath = kbDir(kbName).relativize(file).toString();
+        ChunkStore.DocumentRecord record =
+            store.saveDocument(
+                new ChunkStore.DocumentRecord(
+                    null,
+                    kbName,
+                    relPath,
+                    sha256(file),
+                    DocumentState.INDEXING,
+                    null,
+                    0,
+                    newGeneration,
+                    null));
+        indexNow(record, parseValidated(file));
+      }
+      activeGenerations.put(kbName, newGeneration);
+      store.deleteGenerationsBelow(kbName, newGeneration);
+    } catch (RuntimeException e) {
+      store.deleteGeneration(kbName, newGeneration);
+      throw new IllegalStateException("重建索引失败（旧索引不受影响）: " + e.getMessage(), e);
+    }
+  }
+
+  public List<DocumentStatus> status(String kbName) {
+    return store.documents(kbName, activeGeneration(kbName)).stream()
+        .map(KnowledgeIndexService::toStatus)
+        .toList();
+  }
+
+  public void deleteDocument(String kbName, String relPath) {
+    store
+        .findDocument(kbName, relPath, activeGeneration(kbName))
+        .ifPresent(doc -> store.deleteDocument(doc.id()));
+  }
+
+  public void deleteBase(String kbName) {
+    store.deleteBase(kbName);
+    activeGenerations.remove(kbName);
+  }
+
+  /** 后台段：切分 + 向量化 + 落库；任何失败落 FAILED + 可读原因，可重试（FR-013 不静默丢弃）。 */
+  private void indexDocument(
+      long documentId, String kbName, String relPath, long generation, List<ParsedUnit> units) {
+    ChunkStore.DocumentRecord record = store.findDocument(kbName, relPath, generation).orElse(null);
+    if (record == null || record.id() == null || record.id() != documentId) {
+      return; // 已被删除或替换，静默让位
+    }
+    try {
+      indexNow(store.saveDocument(record.withState(DocumentState.INDEXING, null)), units);
+    } catch (RuntimeException e) {
+      LOG.warn(
+          "知识文档索引失败: {}/{}: {}", sanitize(kbName), sanitize(relPath), sanitize(e.getMessage()));
+      store.saveDocument(record.withState(DocumentState.FAILED, readable(e)));
+    }
+  }
+
+  /** 同步完成一份文档的切分向量化落库并置 READY；失败向上抛（调用方决定 FAILED 或整体回滚）。 */
+  private void indexNow(ChunkStore.DocumentRecord record, List<ParsedUnit> units) {
+    TextEmbedder embedder = embedderSupplier.get();
+    List<ChunkStore.ChunkRecord> chunkRecords = new ArrayList<>();
+    int seq = 0;
+    for (ParsedUnit unit : units) {
+      for (String piece : chunker.split(unit.text())) {
+        seq++;
+        float[] vector = embedder.embed(piece);
+        chunkRecords.add(
+            new ChunkStore.ChunkRecord(
+                null,
+                record.id(),
+                record.kbName(),
+                seq,
+                unit.pageNo(),
+                piece,
+                vector,
+                embedder.modelId(),
+                record.generation()));
+      }
+    }
+    store.deleteChunksOf(record.id());
+    store.saveChunks(chunkRecords);
+    store.saveDocument(record.ready(chunkRecords.size(), Instant.now()));
+  }
+
+  /** 同步校验段：类型受理、大小上限、可解析（扫描件在此拒绝）、非空。 */
+  private List<ParsedUnit> parseValidated(Path file) {
+    String fileName = String.valueOf(file.getFileName());
+    DocumentParser parser =
+        parsers.stream()
+            .filter(candidate -> candidate.supports(fileName))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new KnowledgeImportException(
+                        "不支持的文档类型: " + fileName + "（支持 markdown / txt / 文本型 PDF）"));
+    try {
+      if (Files.size(file) > MAX_FILE_BYTES) {
+        throw new KnowledgeImportException("文档超过 10MB 上限: " + fileName);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("读取文档大小失败: " + file, e);
+    }
+    List<ParsedUnit> units = parser.parse(file);
+    if (units.isEmpty()) {
+      throw new KnowledgeImportException("空文档，无可索引内容: " + fileName);
+    }
+    return units;
+  }
+
+  /** 重建/对账用：列出库内全部受支持文档；不支持、空、超限的跳过并告警（Edge Cases）。 */
+  List<Path> listSupportedFiles(Path kbDir) {
+    try (Stream<Path> walk = Files.walk(kbDir)) {
+      return walk.filter(Files::isRegularFile)
+          .filter(file -> !KnowledgeManifest.FILE.equals(String.valueOf(file.getFileName())))
+          .filter(this::scannable)
+          .sorted()
+          .toList();
+    } catch (IOException e) {
+      throw new UncheckedIOException("扫描知识库目录失败: " + kbDir, e);
+    }
+  }
+
+  private boolean scannable(Path file) {
+    String fileName = String.valueOf(file.getFileName());
+    if (parsers.stream().noneMatch(parser -> parser.supports(fileName))) {
+      LOG.warn("跳过不支持的文件类型: {}", sanitize(fileName));
+      return false;
+    }
+    try {
+      long size = Files.size(file);
+      if (size == 0) {
+        LOG.warn("跳过空文档: {}", sanitize(fileName));
+        return false;
+      }
+      if (size > MAX_FILE_BYTES) {
+        LOG.warn("跳过超过 10MB 上限的文档: {}", sanitize(fileName));
+        return false;
+      }
+    } catch (IOException e) {
+      LOG.warn("跳过不可读文件: {}", sanitize(fileName));
+      return false;
+    }
+    return true;
+  }
+
+  private Path requireDocumentFile(String kbName, String relPath) {
+    Path kbDir = kbDir(kbName);
+    Path file = RealPathBoundary.requireWithin(kbDir, kbDir.resolve(relPath));
+    if (!Files.isRegularFile(file)) {
+      throw new KnowledgeImportException("文档不存在: " + kbName + "/" + relPath);
+    }
+    return file;
+  }
+
+  private Path kbDir(String kbName) {
+    Path dir = knowledgeRoot.resolve(kbName);
+    if (!Files.isDirectory(dir)) {
+      throw new IllegalArgumentException("知识库不存在: " + kbName);
+    }
+    return dir;
+  }
+
+  private static DocumentStatus toStatus(ChunkStore.DocumentRecord record) {
+    return new DocumentStatus(
+        record.relPath(),
+        record.state(),
+        record.chunkCount(),
+        record.failureReason(),
+        record.indexedAt());
+  }
+
+  private static String sha256(Path file) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest(Files.readAllBytes(file)));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("JVM 缺少 SHA-256 实现", e);
+    } catch (IOException e) {
+      throw new UncheckedIOException("计算文档指纹失败: " + file, e);
+    }
+  }
+
+  private static String readable(RuntimeException e) {
+    String message = e.getMessage();
+    return message == null || message.isBlank() ? e.getClass().getSimpleName() : message;
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/MarkdownParser.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/MarkdownParser.java
@@ -1,0 +1,31 @@
+package io.oryxos.knowledge.index;
+
+import io.oryxos.core.knowledge.KnowledgeImportException;
+import java.io.IOException;
+import java.nio.charset.MalformedInputException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+/** markdown 解析：整篇一个单元，切分交给 Chunker（标题边界在切分层生效）。 */
+public final class MarkdownParser implements DocumentParser {
+
+  @Override
+  public boolean supports(String fileName) {
+    String lower = fileName.toLowerCase(Locale.ROOT);
+    return lower.endsWith(".md") || lower.endsWith(".markdown");
+  }
+
+  @Override
+  public List<ParsedUnit> parse(Path file) {
+    try {
+      String text = Files.readString(file);
+      return text.isBlank() ? List.of() : List.of(new ParsedUnit(text, null));
+    } catch (MalformedInputException e) {
+      throw new KnowledgeImportException("文件不是合法 UTF-8 文本: " + file.getFileName(), e);
+    } catch (IOException e) {
+      throw new KnowledgeImportException("读取文档失败: " + file.getFileName(), e);
+    }
+  }
+}

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/ParsedUnit.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/ParsedUnit.java
@@ -1,0 +1,4 @@
+package io.oryxos.knowledge.index;
+
+/** 解析器输出的最小单元：markdown/纯文本为整篇一个单元（pageNo 为 null），PDF 每页一个单元 （pageNo 从 1 起，出处用页码，FR-003）。 */
+public record ParsedUnit(String text, Integer pageNo) {}

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/PdfParser.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/PdfParser.java
@@ -1,0 +1,48 @@
+package io.oryxos.knowledge.index;
+
+import io.oryxos.core.knowledge.KnowledgeImportException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+
+/**
+ * 文本型 PDF 解析（Apache PDFBox，research D11）：每页一个单元、出处用页码。 全文无文本层（扫描件）在导入时识别拒绝并给出明确原因（FR-003 /
+ * SC-010），不静默产出空索引。
+ */
+public final class PdfParser implements DocumentParser {
+
+  @Override
+  public boolean supports(String fileName) {
+    return fileName.toLowerCase(Locale.ROOT).endsWith(".pdf");
+  }
+
+  @Override
+  public List<ParsedUnit> parse(Path file) {
+    try (PDDocument document = Loader.loadPDF(file.toFile())) {
+      List<ParsedUnit> units = new ArrayList<>();
+      PDFTextStripper stripper = new PDFTextStripper();
+      boolean hasText = false;
+      for (int page = 1; page <= document.getNumberOfPages(); page++) {
+        stripper.setStartPage(page);
+        stripper.setEndPage(page);
+        String text = stripper.getText(document);
+        if (text != null && !text.isBlank()) {
+          hasText = true;
+          units.add(new ParsedUnit(text, page));
+        }
+      }
+      if (!hasText) {
+        throw new KnowledgeImportException(
+            "PDF 无文本层（疑似扫描件），拒绝导入: " + file.getFileName() + "。请提供文本型 PDF 或先做 OCR");
+      }
+      return units;
+    } catch (IOException e) {
+      throw new KnowledgeImportException("PDF 解析失败: " + file.getFileName(), e);
+    }
+  }
+}

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/TextParser.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/TextParser.java
@@ -1,0 +1,30 @@
+package io.oryxos.knowledge.index;
+
+import io.oryxos.core.knowledge.KnowledgeImportException;
+import java.io.IOException;
+import java.nio.charset.MalformedInputException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+/** 纯文本解析：整篇一个单元。非 UTF-8（疑似二进制）明确拒绝，不静默产出乱码片段。 */
+public final class TextParser implements DocumentParser {
+
+  @Override
+  public boolean supports(String fileName) {
+    return fileName.toLowerCase(Locale.ROOT).endsWith(".txt");
+  }
+
+  @Override
+  public List<ParsedUnit> parse(Path file) {
+    try {
+      String text = Files.readString(file);
+      return text.isBlank() ? List.of() : List.of(new ParsedUnit(text, null));
+    } catch (MalformedInputException e) {
+      throw new KnowledgeImportException("文件不是合法 UTF-8 文本: " + file.getFileName(), e);
+    } catch (IOException e) {
+      throw new KnowledgeImportException("读取文档失败: " + file.getFileName(), e);
+    }
+  }
+}

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/retrieve/RetrievalPipeline.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/retrieve/RetrievalPipeline.java
@@ -1,0 +1,75 @@
+package io.oryxos.knowledge.retrieve;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * 检索流水线的融合段（FR-004）：双路召回结果按名次做 RRF 融合——跨路分数量纲不可比，名次可比 （research D10）。纯函数、不带业务语义（FR-016
+ * 通用基建）。精排为可选槽位：v1 无内置精排， 声明 rerank 能力的后端结果直通。
+ */
+public final class RetrievalPipeline {
+
+  /** RRF 平滑常数（业界惯用 60）：压低头名断层，保留名次序。 */
+  static final int RRF_K = 60;
+
+  private RetrievalPipeline() {}
+
+  /** 一路召回的候选（id + 该路自己的分数，列表须已按分数降序）。 */
+  public record Candidate(long id, double score) {}
+
+  /** 融合结果（id + RRF 分数，降序）。 */
+  public record Fused(long id, double score) {}
+
+  /**
+   * 名次融合：score(id) = Σ_route 1/(K + rank)。任一路为空照常融合（单路即原名次序）。
+   *
+   * @param routes 各路召回结果（每路内部已降序）
+   * @param topK 保留条数
+   */
+  @SafeVarargs
+  public static List<Fused> fuseByRank(int topK, List<Candidate>... routes) {
+    Map<Long, Double> scores = new LinkedHashMap<>();
+    for (List<Candidate> route : routes) {
+      if (route == null) {
+        continue;
+      }
+      for (int rank = 0; rank < route.size(); rank++) {
+        double contribution = 1.0 / (RRF_K + rank + 1);
+        scores.merge(route.get(rank).id(), contribution, Double::sum);
+      }
+    }
+    List<Fused> fused = new ArrayList<>(scores.size());
+    scores.forEach((id, score) -> fused.add(new Fused(id, score)));
+    fused.sort(Comparator.comparingDouble(Fused::score).reversed());
+    return fused.size() > topK ? List.copyOf(fused.subList(0, topK)) : List.copyOf(fused);
+  }
+
+  /** 余弦相似度；调用方保证维度一致（不一致由上层按 FR-014 拒绝混比）。 */
+  public static double cosine(float[] a, float[] b) {
+    if (Objects.isNull(a) || Objects.isNull(b)) {
+      throw new IllegalArgumentException("向量为空，拒绝比较");
+    }
+    // p3c 会把 float[].length 误判为浮点比较，先取成 int 再比
+    int dimA = a.length;
+    int dimB = b.length;
+    if (dimA != dimB) {
+      throw new IllegalArgumentException("向量维度不一致，拒绝比较");
+    }
+    double dot = 0;
+    double normA = 0;
+    double normB = 0;
+    for (int i = 0; i < a.length; i++) {
+      dot += (double) a[i] * b[i];
+      normA += (double) a[i] * a[i];
+      normB += (double) b[i] * b[i];
+    }
+    if (normA <= 0 || normB <= 0) {
+      return 0;
+    }
+    return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+  }
+}

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/store/ChunkStore.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/store/ChunkStore.java
@@ -1,0 +1,79 @@
+package io.oryxos.knowledge.store;
+
+import io.oryxos.core.knowledge.model.DocumentState;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 片段索引存储端口——检索基建的可插拔位（配置键 {@code knowledge.store}，默认 sqlite，research D1）： v0.4 换 pgvector
+ * 只替换实现。接口形状不带业务耦合（FR-016），记忆语义化升级可复用。
+ */
+public interface ChunkStore {
+
+  /** 文档索引记录（派生数据，可从文件系统重建）。 */
+  record DocumentRecord(
+      Long id,
+      String kbName,
+      String relPath,
+      String sha256,
+      DocumentState state,
+      String failureReason,
+      int chunkCount,
+      long generation,
+      Instant indexedAt) {
+
+    public DocumentRecord withState(DocumentState newState, String reason) {
+      return new DocumentRecord(
+          id, kbName, relPath, sha256, newState, reason, chunkCount, generation, indexedAt);
+    }
+
+    public DocumentRecord ready(int chunks, Instant at) {
+      return new DocumentRecord(
+          id, kbName, relPath, sha256, DocumentState.READY, null, chunks, generation, at);
+    }
+  }
+
+  /** 片段记录；embedding 可空（降级期无向量）。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"},
+      justification = "向量数组仅在检索引擎内部流转且约定只读；万级片段热路径上防御性拷贝代价不值。")
+  record ChunkRecord(
+      Long id,
+      long documentId,
+      String kbName,
+      int seq,
+      Integer pageNo,
+      String content,
+      float[] embedding,
+      String embeddingModel,
+      long generation) {}
+
+  /** 插入或按 id 更新；返回带 id 的记录。 */
+  DocumentRecord saveDocument(DocumentRecord document);
+
+  Optional<DocumentRecord> findDocument(String kbName, String relPath, long generation);
+
+  List<DocumentRecord> documents(String kbName, long generation);
+
+  /** 全部代的文档（对账/推断活跃代用）。 */
+  List<DocumentRecord> allDocuments(String kbName);
+
+  /** 删除一份文档及其全部片段。 */
+  void deleteDocument(long documentId);
+
+  void saveChunks(List<ChunkRecord> chunks);
+
+  void deleteChunksOf(long documentId);
+
+  List<ChunkRecord> chunks(String kbName, long generation);
+
+  /** 删除整库全部行。 */
+  void deleteBase(String kbName);
+
+  /** 双缓冲切换后清理旧代（FR-024）。 */
+  void deleteGenerationsBelow(String kbName, long generation);
+
+  /** 重建失败时丢弃未完成的新代，旧代不受影响。 */
+  void deleteGeneration(String kbName, long generation);
+}

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/store/SqliteChunkStore.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/store/SqliteChunkStore.java
@@ -1,0 +1,175 @@
+package io.oryxos.knowledge.store;
+
+import io.oryxos.core.knowledge.model.DocumentState;
+import io.oryxos.storage.KnowledgeChunkEntity;
+import io.oryxos.storage.KnowledgeChunkRepository;
+import io.oryxos.storage.KnowledgeDocumentEntity;
+import io.oryxos.storage.KnowledgeDocumentRepository;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+import java.util.Optional;
+
+/** SQLite 实现（默认档，research D1）：向量以 float32[] 小端序 BLOB 落 knowledge_chunks。 */
+public class SqliteChunkStore implements ChunkStore {
+
+  private final KnowledgeDocumentRepository documents;
+  private final KnowledgeChunkRepository chunks;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "repository 为 Spring 注入的共享单例，构造注入存同一引用正是意图（镜像既有 SuppressFBWarnings 模式）。")
+  public SqliteChunkStore(KnowledgeDocumentRepository documents, KnowledgeChunkRepository chunks) {
+    this.documents = documents;
+    this.chunks = chunks;
+  }
+
+  @Override
+  public DocumentRecord saveDocument(DocumentRecord document) {
+    KnowledgeDocumentEntity entity =
+        document.id() == null
+            ? new KnowledgeDocumentEntity()
+            : documents
+                .findById(document.id())
+                .orElseThrow(() -> new IllegalStateException("文档记录不存在: " + document.id()));
+    entity.setKbName(document.kbName());
+    entity.setRelPath(document.relPath());
+    entity.setContentSha256(document.sha256());
+    entity.setStatus(document.state().name());
+    entity.setFailureReason(document.failureReason());
+    entity.setChunkCount(document.chunkCount());
+    entity.setGeneration(document.generation());
+    entity.setIndexedAt(document.indexedAt());
+    return toRecord(documents.save(entity));
+  }
+
+  @Override
+  public Optional<DocumentRecord> findDocument(String kbName, String relPath, long generation) {
+    return documents
+        .findByKbNameAndRelPathAndGeneration(kbName, relPath, generation)
+        .map(SqliteChunkStore::toRecord);
+  }
+
+  @Override
+  public List<DocumentRecord> documents(String kbName, long generation) {
+    return documents.findByKbNameAndGeneration(kbName, generation).stream()
+        .map(SqliteChunkStore::toRecord)
+        .toList();
+  }
+
+  @Override
+  public List<DocumentRecord> allDocuments(String kbName) {
+    return documents.findByKbName(kbName).stream().map(SqliteChunkStore::toRecord).toList();
+  }
+
+  @Override
+  public void deleteDocument(long documentId) {
+    chunks.deleteByDocumentId(documentId);
+    documents.deleteById(documentId);
+  }
+
+  @Override
+  public void saveChunks(List<ChunkRecord> records) {
+    List<KnowledgeChunkEntity> entities = records.stream().map(SqliteChunkStore::toEntity).toList();
+    chunks.saveAll(entities);
+  }
+
+  @Override
+  public void deleteChunksOf(long documentId) {
+    chunks.deleteByDocumentId(documentId);
+  }
+
+  @Override
+  public List<ChunkRecord> chunks(String kbName, long generation) {
+    return chunks.findByKbNameAndGeneration(kbName, generation).stream()
+        .map(SqliteChunkStore::toRecord)
+        .toList();
+  }
+
+  @Override
+  public void deleteBase(String kbName) {
+    chunks.deleteByKbName(kbName);
+    documents.deleteByKbName(kbName);
+  }
+
+  @Override
+  public void deleteGenerationsBelow(String kbName, long generation) {
+    chunks.deleteByKbNameAndGenerationLessThan(kbName, generation);
+    documents.deleteByKbNameAndGenerationLessThan(kbName, generation);
+  }
+
+  @Override
+  public void deleteGeneration(String kbName, long generation) {
+    chunks.deleteByKbNameAndGeneration(kbName, generation);
+    documents.deleteByKbNameAndGeneration(kbName, generation);
+  }
+
+  private static DocumentRecord toRecord(KnowledgeDocumentEntity entity) {
+    return new DocumentRecord(
+        entity.getId(),
+        entity.getKbName(),
+        entity.getRelPath(),
+        entity.getContentSha256(),
+        DocumentState.valueOf(entity.getStatus()),
+        entity.getFailureReason(),
+        entity.getChunkCount(),
+        entity.getGeneration(),
+        entity.getIndexedAt());
+  }
+
+  private static ChunkRecord toRecord(KnowledgeChunkEntity entity) {
+    return new ChunkRecord(
+        entity.getId(),
+        entity.getDocumentId(),
+        entity.getKbName(),
+        entity.getSeq(),
+        entity.getPageNo(),
+        entity.getContent(),
+        decode(entity.getEmbedding()),
+        entity.getEmbeddingModel(),
+        entity.getGeneration());
+  }
+
+  private static KnowledgeChunkEntity toEntity(ChunkRecord record) {
+    KnowledgeChunkEntity entity = new KnowledgeChunkEntity();
+    entity.setDocumentId(record.documentId());
+    entity.setKbName(record.kbName());
+    entity.setSeq(record.seq());
+    entity.setPageNo(record.pageNo());
+    entity.setContent(record.content());
+    entity.setEmbedding(encode(record.embedding()));
+    entity.setDim(record.embedding() == null ? null : record.embedding().length);
+    entity.setEmbeddingModel(record.embeddingModel());
+    entity.setGeneration(record.generation());
+    return entity;
+  }
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "PZLA_PREFER_ZERO_LENGTH_ARRAYS",
+      justification = "null 表示「无向量」（降级期片段），与零长向量语义不同，不得混淆。")
+  static byte[] encode(float[] vector) {
+    if (vector == null) {
+      return null;
+    }
+    ByteBuffer buffer = ByteBuffer.allocate(vector.length * 4).order(ByteOrder.LITTLE_ENDIAN);
+    for (float value : vector) {
+      buffer.putFloat(value);
+    }
+    return buffer.array();
+  }
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "PZLA_PREFER_ZERO_LENGTH_ARRAYS",
+      justification = "null 表示「无向量」（降级期片段），与零长向量语义不同，不得混淆。")
+  static float[] decode(byte[] bytes) {
+    if (bytes == null) {
+      return null;
+    }
+    ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+    float[] vector = new float[bytes.length / 4];
+    for (int i = 0; i < vector.length; i++) {
+      vector[i] = buffer.getFloat();
+    }
+    return vector;
+  }
+}

--- a/oryxos-knowledge/src/test/java/io/oryxos/knowledge/contract/KnowledgeBackendContractTest.java
+++ b/oryxos-knowledge/src/test/java/io/oryxos/knowledge/contract/KnowledgeBackendContractTest.java
@@ -1,0 +1,279 @@
+package io.oryxos.knowledge.contract;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.oryxos.core.embedding.TextEmbedder;
+import io.oryxos.core.knowledge.KnowledgeImportException;
+import io.oryxos.core.knowledge.KnowledgeManifest;
+import io.oryxos.core.knowledge.model.DocumentState;
+import io.oryxos.core.knowledge.model.DocumentStatus;
+import io.oryxos.core.knowledge.model.KnowledgeHit;
+import io.oryxos.core.knowledge.model.KnowledgeQuery;
+import io.oryxos.knowledge.LocalKnowledgeBackend;
+import io.oryxos.knowledge.index.KnowledgeIndexService;
+import io.oryxos.knowledge.store.InMemoryChunkStore;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * 行为契约测试骨架（T022，contracts/knowledge-spi.md §2）：钉死出处强制、范围限定、降级、 一致性拒绝、mock 确定性、能力诚实、双缓冲。impl-C
+ * 阶段挂「仅检索」远程桩后参数化覆盖（SC-011）。
+ */
+class KnowledgeBackendContractTest {
+
+  @TempDir Path root;
+
+  private InMemoryChunkStore store;
+  private KnowledgeIndexService indexService;
+  private LocalKnowledgeBackend backend;
+  private final AtomicReference<Supplier<TextEmbedder>> embedderRef = new AtomicReference<>();
+  private final List<Runnable> backgroundTasks = new ArrayList<>();
+
+  @BeforeEach
+  void setUp() throws IOException {
+    embedderRef.set(() -> new TestEmbedder("test/v1"));
+    store = new InMemoryChunkStore();
+    Supplier<TextEmbedder> supplier = () -> embedderRef.get().get();
+    indexService = new KnowledgeIndexService(root, store, supplier, backgroundTasks::add);
+    backend = new LocalKnowledgeBackend(root, store, indexService, supplier);
+    createKb("ops", "运维手册");
+    writeDoc("ops", "disk-alert.md", "# 磁盘告警处置\n\n先查 inode 占用，再清理过期日志。");
+  }
+
+  @Test
+  void twoPhaseImportDrivesStateMachineAndCitationIsMandatory() {
+    DocumentStatus pending = backend.importDocument("ops", "disk-alert.md");
+    assertEquals(DocumentState.PENDING, pending.state(), "同步段登记 PENDING（Clarify-Q3）");
+
+    runBackground();
+    DocumentStatus ready = backend.status("ops").get(0);
+    assertEquals(DocumentState.READY, ready.state());
+    assertTrue(ready.chunkCount() > 0);
+
+    List<KnowledgeHit> hits = retrieve("磁盘告警", 5, "ops");
+    assertFalse(hits.isEmpty());
+    KnowledgeHit top = hits.get(0);
+    // 行为契约 1：出处完整（库名 + 相对路径 + 片段位置）且本地可跟读
+    assertEquals("ops", top.citation().kbName());
+    assertEquals("disk-alert.md", top.citation().relPath());
+    assertEquals("1", top.citation().position());
+    assertTrue(top.citation().readable());
+    assertFalse(top.degraded());
+  }
+
+  @Test
+  void retrievalIsDeterministicAcrossRepeatedCalls() {
+    indexReady();
+    writeDoc("ops", "faq.md", "# 常见问题\n\n磁盘满了先扩容还是先清理？");
+    backend.importDocument("ops", "faq.md");
+    runBackground();
+
+    List<String> first =
+        retrieve("磁盘", 5, "ops").stream().map(h -> h.citation().display()).toList();
+    List<String> second =
+        retrieve("磁盘", 5, "ops").stream().map(h -> h.citation().display()).toList();
+
+    // 行为契约 6：确定性向量下同查询恒同排序（SC-004）
+    assertEquals(first, second);
+  }
+
+  @Test
+  void embedderOutageDegradesRetrievalToKeywordAndFailsImportExplicitly() {
+    indexReady();
+    embedderRef.set(
+        () -> {
+          throw new IllegalArgumentException(
+              "未配置 embedding provider（knowledge.embedding.provider）");
+        });
+
+    // 行为契约 4a：检索降级为关键词并逐条标注
+    List<KnowledgeHit> hits = retrieve("磁盘告警", 5, "ops");
+    assertFalse(hits.isEmpty());
+    assertTrue(hits.stream().allMatch(KnowledgeHit::degraded));
+    assertTrue(String.valueOf(hits.get(0).payload().get("degraded_reason")).contains("关键词"));
+
+    // 行为契约 4b：导入显式失败可重试，不静默丢弃
+    writeDoc("ops", "new.md", "# 新文档\n\n内容");
+    backend.importDocument("ops", "new.md");
+    runBackground();
+    DocumentStatus failed =
+        backend.status("ops").stream().filter(s -> s.relPath().equals("new.md")).findFirst().get();
+    assertEquals(DocumentState.FAILED, failed.state());
+    assertTrue(failed.failureReason().contains("embedding"));
+  }
+
+  @Test
+  void embeddingModelChangeRefusesMixedComparisonAndPromptsRebuild() {
+    indexReady();
+    embedderRef.set(() -> new TestEmbedder("test/v2"));
+
+    List<KnowledgeHit> hits = retrieve("磁盘告警", 5, "ops");
+
+    // 行为契约 5：不混比新旧向量、不静默错误排序；关键词路服务并提示重建（FR-014）
+    assertFalse(hits.isEmpty());
+    assertTrue(hits.stream().allMatch(KnowledgeHit::degraded));
+    assertTrue(String.valueOf(hits.get(0).payload().get("degraded_reason")).contains("重建"));
+  }
+
+  @Test
+  void importRejectsUnsupportedEmptyAndScannedAtEntry() throws IOException {
+    Files.writeString(root.resolve("ops").resolve("report.docx"), "x");
+    assertReadableImportError("ops", "report.docx", "不支持");
+
+    Files.writeString(root.resolve("ops").resolve("empty.md"), " \n");
+    assertReadableImportError("ops", "empty.md", "空文档");
+
+    try (PDDocument scanned = new PDDocument()) {
+      scanned.addPage(new PDPage());
+      scanned.save(root.resolve("ops").resolve("scan.pdf").toFile());
+    }
+    assertReadableImportError("ops", "scan.pdf", "扫描件");
+
+    // 入口即拒绝：不产生半完成状态（Edge Cases）
+    assertTrue(backend.status("ops").isEmpty());
+  }
+
+  @Test
+  void rebuildIsDoubleBufferedAndFailureKeepsOldGeneration() throws IOException {
+    indexReady();
+    assertFalse(retrieve("磁盘告警", 5, "ops").isEmpty());
+
+    // 失败路径：目录里混入扫描件 → 重建整体失败，旧代不受影响（FR-024）
+    try (PDDocument scanned = new PDDocument()) {
+      scanned.addPage(new PDPage());
+      scanned.save(root.resolve("ops").resolve("scan.pdf").toFile());
+    }
+    IllegalStateException failure =
+        assertThrows(IllegalStateException.class, () -> backend.rebuild("ops"));
+    assertTrue(failure.getMessage().contains("旧索引不受影响"));
+    assertFalse(retrieve("磁盘告警", 5, "ops").isEmpty(), "重建失败后旧索引照常服务");
+    assertTrue(store.chunks("ops", 1).isEmpty(), "失败的新代已被丢弃");
+
+    // 成功路径：换内容重建 → 新代生效、旧代清理
+    Files.delete(root.resolve("ops").resolve("scan.pdf"));
+    writeDoc("ops", "disk-alert.md", "# 全新处置手册\n\n关于网络故障的全新说明。");
+    backend.rebuild("ops");
+    assertFalse(retrieve("网络故障", 5, "ops").isEmpty());
+    assertTrue(store.chunks("ops", 0).isEmpty(), "切换后旧代已清理");
+  }
+
+  @Test
+  void multiKbRetrievalAggregatesToGlobalTopK() {
+    indexReady();
+    createKb("faq", "产品FAQ");
+    writeDoc("faq", "disk.md", "# 磁盘常见问题\n\n磁盘告警阈值默认 85%。");
+    backend.importDocument("faq", "disk.md");
+    runBackground();
+
+    List<KnowledgeHit> hits = retrieve("磁盘告警", 2, "ops", "faq");
+
+    // 聚合全局 top-K：条数与库数无关（Clarify-Q2）；出处可区分来源库
+    assertEquals(2, hits.size());
+    assertTrue(hits.stream().allMatch(h -> !h.citation().kbName().isBlank()));
+    assertTrue(hits.get(0).score() >= hits.get(1).score());
+  }
+
+  @Test
+  void capabilitiesAreHonestAboutAdminPresence() {
+    // 行为契约 7：能力声明与 admin() 有无一致（规避「契约谎言」）
+    assertTrue(backend.capabilities().importDocs());
+    assertTrue(backend.admin().isPresent());
+    assertEquals("local", backend.name());
+    assertFalse(backend.capabilities().rerank(), "v1 精排只留槽位不实现");
+  }
+
+  // ---- helpers ----
+
+  private void indexReady() {
+    backend.importDocument("ops", "disk-alert.md");
+    runBackground();
+  }
+
+  private void runBackground() {
+    List<Runnable> tasks = new ArrayList<>(backgroundTasks);
+    backgroundTasks.clear();
+    tasks.forEach(Runnable::run);
+  }
+
+  private List<KnowledgeHit> retrieve(String query, int topK, String... kbs) {
+    return backend.retrieve(new KnowledgeQuery(query, topK, List.of(kbs)));
+  }
+
+  private void assertReadableImportError(String kb, String relPath, String keyword) {
+    KnowledgeImportException rejected =
+        assertThrows(KnowledgeImportException.class, () -> backend.importDocument(kb, relPath));
+    assertTrue(rejected.getMessage().contains(keyword), "拒绝原因必须可读: " + rejected.getMessage());
+  }
+
+  private void createKb(String name, String description) {
+    try {
+      Path dir = Files.createDirectories(root.resolve(name));
+      Files.writeString(
+          dir.resolve(KnowledgeManifest.FILE),
+          "---\nname: " + name + "\ndescription: " + description + "\n---\n");
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void writeDoc(String kb, String relPath, String content) {
+    try {
+      Files.writeString(root.resolve(kb).resolve(relPath), content);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** 确定性测试向量器：字符直方图 + 归一化；modelId 可配以测一致性拒绝。 */
+  private static final class TestEmbedder implements TextEmbedder {
+
+    private static final int DIM = 16;
+    private final String modelId;
+
+    TestEmbedder(String modelId) {
+      this.modelId = modelId;
+    }
+
+    @Override
+    public float[] embed(String text) {
+      float[] vector = new float[DIM];
+      for (int i = 0; i < text.length(); i++) {
+        vector[text.charAt(i) % DIM] += 1;
+      }
+      double norm = 0;
+      for (float value : vector) {
+        norm += (double) value * value;
+      }
+      float length = (float) Math.sqrt(norm);
+      if (length > 0) {
+        for (int i = 0; i < DIM; i++) {
+          vector[i] /= length;
+        }
+      }
+      return vector;
+    }
+
+    @Override
+    public String modelId() {
+      return modelId;
+    }
+
+    @Override
+    public int dimensions() {
+      return DIM;
+    }
+  }
+}

--- a/oryxos-knowledge/src/test/java/io/oryxos/knowledge/index/ChunkerTest.java
+++ b/oryxos-knowledge/src/test/java/io/oryxos/knowledge/index/ChunkerTest.java
@@ -1,0 +1,39 @@
+package io.oryxos.knowledge.index;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ChunkerTest {
+
+  private final Chunker chunker = new Chunker();
+
+  @Test
+  void splitsAtHeadingBoundaries() {
+    List<String> chunks = chunker.split("# 磁盘告警\n\n处置步骤一。\n\n# 网络故障\n\n处置步骤二。");
+
+    assertEquals(2, chunks.size());
+    assertTrue(chunks.get(0).contains("磁盘告警"));
+    assertTrue(chunks.get(1).contains("网络故障"));
+  }
+
+  @Test
+  void hardSplitsOverlongParagraphAndKeepsOrder() {
+    String longParagraph = "长内容。".repeat(1000); // 4000 字符 > MAX_CHARS
+    List<String> chunks = chunker.split(longParagraph);
+
+    assertTrue(chunks.size() >= 2, "超长段落必须被硬切");
+    for (String chunk : chunks) {
+      assertTrue(chunk.length() <= Chunker.MAX_CHARS);
+    }
+    assertEquals(longParagraph, String.join("", chunks), "切分可回溯：拼回原文不丢内容");
+  }
+
+  @Test
+  void dropsBlankAndTrimsChunks() {
+    List<String> chunks = chunker.split("\n\n  \n\n有效内容\n\n   \n");
+    assertEquals(List.of("有效内容"), chunks);
+  }
+}

--- a/oryxos-knowledge/src/test/java/io/oryxos/knowledge/index/DocumentParserTest.java
+++ b/oryxos-knowledge/src/test/java/io/oryxos/knowledge/index/DocumentParserTest.java
@@ -1,0 +1,91 @@
+package io.oryxos.knowledge.index;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.oryxos.core.knowledge.KnowledgeImportException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DocumentParserTest {
+
+  @TempDir Path root;
+
+  @Test
+  void markdownAndTextParseAsSingleUnit() throws IOException {
+    Path md = root.resolve("guide.md");
+    Files.writeString(md, "# 标题\n\n内容");
+    List<ParsedUnit> units = new MarkdownParser().parse(md);
+    assertEquals(1, units.size());
+    assertEquals(null, units.get(0).pageNo());
+
+    Path txt = root.resolve("note.txt");
+    Files.writeString(txt, "纯文本内容");
+    assertEquals(1, new TextParser().parse(txt).size());
+
+    Path empty = root.resolve("empty.md");
+    Files.writeString(empty, "  \n ");
+    assertTrue(new MarkdownParser().parse(empty).isEmpty(), "空文档返回空列表");
+  }
+
+  @Test
+  void textParserRejectsBinaryContentReadably() throws IOException {
+    Path binary = root.resolve("fake.txt");
+    Files.write(binary, new byte[] {(byte) 0xC3, (byte) 0x28, (byte) 0x00, (byte) 0xFF});
+    KnowledgeImportException rejected =
+        assertThrows(KnowledgeImportException.class, () -> new TextParser().parse(binary));
+    assertTrue(rejected.getMessage().contains("UTF-8"));
+  }
+
+  @Test
+  void pdfParsesPerPageWithPageNumbers() throws IOException {
+    Path pdf = root.resolve("manual.pdf");
+    try (PDDocument document = new PDDocument()) {
+      writePage(document, "disk alert handling step one");
+      writePage(document, "network failure handling");
+      document.save(pdf.toFile());
+    }
+
+    List<ParsedUnit> units = new PdfParser().parse(pdf);
+
+    assertEquals(2, units.size());
+    assertEquals(1, units.get(0).pageNo());
+    assertEquals(2, units.get(1).pageNo());
+    assertTrue(units.get(0).text().contains("disk alert"));
+  }
+
+  @Test
+  void scannedPdfWithoutTextLayerIsRejectedAtImport() throws IOException {
+    Path scanned = root.resolve("scan.pdf");
+    try (PDDocument document = new PDDocument()) {
+      document.addPage(new PDPage());
+      document.save(scanned.toFile());
+    }
+
+    KnowledgeImportException rejected =
+        assertThrows(KnowledgeImportException.class, () -> new PdfParser().parse(scanned));
+    assertTrue(rejected.getMessage().contains("扫描件"), "拒绝原因必须明确指向扫描件（SC-010）");
+  }
+
+  private static void writePage(PDDocument document, String text) throws IOException {
+    PDPage page = new PDPage();
+    document.addPage(page);
+    try (PDPageContentStream content = new PDPageContentStream(document, page)) {
+      content.beginText();
+      content.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+      content.newLineAtOffset(50, 700);
+      content.showText(text);
+      content.endText();
+    }
+  }
+}

--- a/oryxos-knowledge/src/test/java/io/oryxos/knowledge/retrieve/RetrievalPipelineTest.java
+++ b/oryxos-knowledge/src/test/java/io/oryxos/knowledge/retrieve/RetrievalPipelineTest.java
@@ -1,0 +1,52 @@
+package io.oryxos.knowledge.retrieve;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.oryxos.knowledge.retrieve.RetrievalPipeline.Candidate;
+import io.oryxos.knowledge.retrieve.RetrievalPipeline.Fused;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RetrievalPipelineTest {
+
+  @Test
+  void rrfRewardsPresenceInBothRoutes() {
+    // 片段 1 在两路都靠前；片段 2 只在向量路第一
+    List<Candidate> vector = List.of(new Candidate(2, 0.99), new Candidate(1, 0.80));
+    List<Candidate> keyword = List.of(new Candidate(1, 3.0), new Candidate(3, 1.0));
+
+    List<Fused> fused = RetrievalPipeline.fuseByRank(3, vector, keyword);
+
+    assertEquals(1, fused.get(0).id(), "双路都命中的片段应赢过单路第一（名次融合，不比原始分）");
+    assertEquals(3, fused.size());
+  }
+
+  @Test
+  void topKBoundsResultAndEmptyRouteIsTolerated() {
+    List<Candidate> vector =
+        List.of(new Candidate(1, 0.9), new Candidate(2, 0.8), new Candidate(3, 0.7));
+
+    List<Fused> fused = RetrievalPipeline.fuseByRank(2, vector, List.of());
+
+    assertEquals(2, fused.size());
+    assertEquals(1, fused.get(0).id(), "单路融合保持该路名次序");
+    assertEquals(2, fused.get(1).id());
+  }
+
+  @Test
+  void cosineComputesSimilarityAndRejectsDimensionMismatch() {
+    float[] a = {1, 0, 0};
+    float[] b = {1, 0, 0};
+    float[] c = {0, 1, 0};
+
+    assertEquals(1.0, RetrievalPipeline.cosine(a, b), 1e-9);
+    assertEquals(0.0, RetrievalPipeline.cosine(a, c), 1e-9);
+    assertTrue(RetrievalPipeline.cosine(a, new float[] {-1, 0, 0}) < 0);
+
+    // 维度不一致拒绝比较（FR-014 的底层防线）
+    assertThrows(
+        IllegalArgumentException.class, () -> RetrievalPipeline.cosine(a, new float[] {1, 0}));
+  }
+}

--- a/oryxos-knowledge/src/test/java/io/oryxos/knowledge/store/InMemoryChunkStore.java
+++ b/oryxos-knowledge/src/test/java/io/oryxos/knowledge/store/InMemoryChunkStore.java
@@ -1,0 +1,130 @@
+package io.oryxos.knowledge.store;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** 引擎单测用的内存实现：与 SqliteChunkStore 同语义，免 Spring/SQLite 起箱。 */
+public final class InMemoryChunkStore implements ChunkStore {
+
+  private final AtomicLong ids = new AtomicLong();
+  private final Map<Long, DocumentRecord> documents = new ConcurrentHashMap<>();
+  private final Map<Long, ChunkRecord> chunks = new ConcurrentHashMap<>();
+
+  @Override
+  public synchronized DocumentRecord saveDocument(DocumentRecord document) {
+    long id = document.id() == null ? ids.incrementAndGet() : document.id();
+    DocumentRecord saved =
+        new DocumentRecord(
+            id,
+            document.kbName(),
+            document.relPath(),
+            document.sha256(),
+            document.state(),
+            document.failureReason(),
+            document.chunkCount(),
+            document.generation(),
+            document.indexedAt());
+    documents.put(id, saved);
+    return saved;
+  }
+
+  @Override
+  public Optional<DocumentRecord> findDocument(String kbName, String relPath, long generation) {
+    return documents.values().stream()
+        .filter(
+            doc ->
+                doc.kbName().equals(kbName)
+                    && doc.relPath().equals(relPath)
+                    && doc.generation() == generation)
+        .findFirst();
+  }
+
+  @Override
+  public List<DocumentRecord> documents(String kbName, long generation) {
+    return documents.values().stream()
+        .filter(doc -> doc.kbName().equals(kbName) && doc.generation() == generation)
+        .sorted(Comparator.comparing(DocumentRecord::relPath))
+        .toList();
+  }
+
+  @Override
+  public List<DocumentRecord> allDocuments(String kbName) {
+    return documents.values().stream().filter(doc -> doc.kbName().equals(kbName)).toList();
+  }
+
+  @Override
+  public synchronized void deleteDocument(long documentId) {
+    documents.remove(documentId);
+    chunks.values().removeIf(chunk -> chunk.documentId() == documentId);
+  }
+
+  @Override
+  public synchronized void saveChunks(List<ChunkRecord> records) {
+    for (ChunkRecord record : records) {
+      long id = record.id() == null ? ids.incrementAndGet() : record.id();
+      chunks.put(
+          id,
+          new ChunkRecord(
+              id,
+              record.documentId(),
+              record.kbName(),
+              record.seq(),
+              record.pageNo(),
+              record.content(),
+              record.embedding(),
+              record.embeddingModel(),
+              record.generation()));
+    }
+  }
+
+  @Override
+  public synchronized void deleteChunksOf(long documentId) {
+    chunks.values().removeIf(chunk -> chunk.documentId() == documentId);
+  }
+
+  @Override
+  public List<ChunkRecord> chunks(String kbName, long generation) {
+    return new ArrayList<>(
+        chunks.values().stream()
+            .filter(chunk -> chunk.kbName().equals(kbName) && chunk.generation() == generation)
+            .sorted(Comparator.comparingLong(ChunkRecord::id))
+            .toList());
+  }
+
+  @Override
+  public synchronized void deleteBase(String kbName) {
+    documents.values().removeIf(doc -> doc.kbName().equals(kbName));
+    chunks.values().removeIf(chunk -> chunk.kbName().equals(kbName));
+  }
+
+  @Override
+  public synchronized void deleteGenerationsBelow(String kbName, long generation) {
+    documents
+        .values()
+        .removeIf(doc -> doc.kbName().equals(kbName) && doc.generation() < generation);
+    chunks
+        .values()
+        .removeIf(chunk -> chunk.kbName().equals(kbName) && chunk.generation() < generation);
+  }
+
+  @Override
+  public synchronized void deleteGeneration(String kbName, long generation) {
+    documents
+        .values()
+        .removeIf(doc -> doc.kbName().equals(kbName) && doc.generation() == generation);
+    chunks
+        .values()
+        .removeIf(chunk -> chunk.kbName().equals(kbName) && chunk.generation() == generation);
+  }
+
+  /** 供断言用：记录 Instant 以避免测试里空转。 */
+  public Instant now() {
+    return Instant.now();
+  }
+}

--- a/oryxos-provider/src/main/java/io/oryxos/provider/MockEmbeddingModel.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/MockEmbeddingModel.java
@@ -1,0 +1,77 @@
+package io.oryxos.provider;
+
+import io.oryxos.core.embedding.TextEmbedder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * 内置 mock 向量化：文本 SHA-256 播种的确定性伪随机单位向量——同一文本恒得同一向量、无网络、无 key（SC-004：CI 可稳定断言）。语义无意义但排序确定，足以走通检索全链路。
+ */
+public final class MockEmbeddingModel implements TextEmbedder {
+
+  /** mock 向量维度：够小以省内存，够大以让不同文本的向量可区分。 */
+  static final int DIMENSIONS = 64;
+
+  static final String MODEL_ID = "mock/deterministic";
+
+  @Override
+  public float[] embed(String text) {
+    byte[] seed = sha256(text == null ? "" : text);
+    float[] vector = new float[DIMENSIONS];
+    byte[] block = seed;
+    int produced = 0;
+    int counter = 0;
+    double normSquared = 0;
+    while (produced < DIMENSIONS) {
+      for (int offset = 0;
+          offset + Integer.BYTES <= block.length && produced < DIMENSIONS;
+          offset += Integer.BYTES) {
+        int bits =
+            ((block[offset] & 0xFF) << 24)
+                | ((block[offset + 1] & 0xFF) << 16)
+                | ((block[offset + 2] & 0xFF) << 8)
+                | (block[offset + 3] & 0xFF);
+        // 映射到 [-1, 1)：整数除以 2^31，保持确定性且分布均匀
+        float value = bits / 2147483648.0f;
+        vector[produced++] = value;
+        normSquared += (double) value * value;
+      }
+      counter++;
+      block = sha256(bytesToHex(seed) + ":" + counter);
+    }
+    float norm = (float) Math.sqrt(normSquared);
+    if (norm > 0) {
+      for (int i = 0; i < DIMENSIONS; i++) {
+        vector[i] /= norm;
+      }
+    }
+    return vector;
+  }
+
+  @Override
+  public String modelId() {
+    return MODEL_ID;
+  }
+
+  @Override
+  public int dimensions() {
+    return DIMENSIONS;
+  }
+
+  private static byte[] sha256(String text) {
+    try {
+      return MessageDigest.getInstance("SHA-256").digest(text.getBytes(StandardCharsets.UTF_8));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("JVM 缺少 SHA-256 实现", e);
+    }
+  }
+
+  private static String bytesToHex(byte[] bytes) {
+    StringBuilder hex = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      hex.append(Character.forDigit((b >> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+    }
+    return hex.toString();
+  }
+}

--- a/oryxos-provider/src/main/java/io/oryxos/provider/ProviderEmbeddingModelFactory.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ProviderEmbeddingModelFactory.java
@@ -1,0 +1,110 @@
+package io.oryxos.provider;
+
+import io.oryxos.core.embedding.TextEmbedder;
+import java.util.List;
+import org.springframework.ai.document.MetadataMode;
+import org.springframework.ai.openai.OpenAiEmbeddingModel;
+import org.springframework.ai.openai.OpenAiEmbeddingOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.web.client.RestClient;
+
+/**
+ * 按 Provider 注册表参数手工构造 {@link TextEmbedder}（FR-007：复用同一套凭证，不另建配置）。 复用与 ChatModel 完全相同的 {@link
+ * OpenAiApi} 构建链（stripTrailingV1 / HTTP1.1 / 超时工厂， research D2）；mock 名走内置确定性向量。
+ *
+ * <p>embedding provider 未配置时不静默回退（DeepSeek 等无 embedding 端点，「取第一个可用项」会 静默拿到错误 provider）——调用方拿到可读异常后按
+ * FR-013 走降级或报错（plan 停点 3）。
+ */
+public class ProviderEmbeddingModelFactory {
+
+  private static final String SLASH = "/";
+  private static final String PATH_V1 = "/v1";
+
+  private static final java.util.regex.Pattern TRAILING_VERSION =
+      java.util.regex.Pattern.compile(".*/v\\d+$");
+
+  /** 按单个 provider 参数即时构造；参数缺失给可读错误，不猜测。 */
+  public TextEmbedder buildOne(String name, String apiKey, String baseUrl, String model) {
+    if (name == null || name.isBlank()) {
+      throw new IllegalArgumentException(
+          "未配置 embedding provider（knowledge.embedding.provider）：向量化不可用，"
+              + "请配置支持 embedding 端点的 provider（如 qwen）或 mock");
+    }
+    if (ProviderChatModelFactory.MOCK.equals(name)) {
+      return new MockEmbeddingModel();
+    }
+    if (model == null || model.isBlank()) {
+      throw new IllegalArgumentException(
+          "未配置 embedding 模型（knowledge.embedding.model），provider: " + name);
+    }
+    if (apiKey == null || apiKey.isBlank() || baseUrl == null || baseUrl.isBlank()) {
+      throw new IllegalArgumentException("Provider 缺少 api_key / base_url，无法构造 embedding: " + name);
+    }
+    String base = stripTrailingV1(baseUrl);
+    OpenAiApi.Builder api =
+        OpenAiApi.builder()
+            .baseUrl(base)
+            .apiKey(apiKey)
+            .restClientBuilder(
+                RestClient.builder().requestFactory(ProviderChatModelFactory.timeoutFactory()));
+    if (TRAILING_VERSION.matcher(base).matches()) {
+      // 端点版本已在 baseUrl 里（如 /api/paas/v4），改补无版本的 /embeddings（与 completionsPath 同理）
+      api.embeddingsPath("/embeddings");
+    }
+    OpenAiEmbeddingModel delegate =
+        new OpenAiEmbeddingModel(
+            api.build(), MetadataMode.EMBED, OpenAiEmbeddingOptions.builder().model(model).build());
+    return new SpringAiTextEmbedder(delegate, name + "/" + model);
+  }
+
+  private static String stripTrailingV1(String baseUrl) {
+    String u = baseUrl == null ? "" : baseUrl.strip();
+    while (u.endsWith(SLASH) || u.endsWith(PATH_V1)) {
+      u =
+          u.endsWith(SLASH)
+              ? u.substring(0, u.length() - SLASH.length())
+              : u.substring(0, u.length() - PATH_V1.length());
+    }
+    return u;
+  }
+
+  /** Spring AI 只做协议转换（宪法 II）：包一层适配到 core 的 TextEmbedder 端口。 */
+  static final class SpringAiTextEmbedder implements TextEmbedder {
+
+    private final OpenAiEmbeddingModel delegate;
+    private final String modelId;
+    private volatile int dimensions;
+
+    SpringAiTextEmbedder(OpenAiEmbeddingModel delegate, String modelId) {
+      this.delegate = delegate;
+      this.modelId = modelId;
+    }
+
+    @Override
+    public float[] embed(String text) {
+      float[] vector = delegate.embed(text);
+      dimensions = vector.length;
+      return vector;
+    }
+
+    @Override
+    public List<float[]> embedAll(List<String> texts) {
+      List<float[]> vectors = delegate.embed(texts);
+      if (!vectors.isEmpty()) {
+        dimensions = vectors.get(0).length;
+      }
+      return vectors;
+    }
+
+    @Override
+    public String modelId() {
+      return modelId;
+    }
+
+    /** 维度由首次调用的真实返回确定（不同 provider/model 维度不同，不做硬编码）。 */
+    @Override
+    public int dimensions() {
+      return dimensions;
+    }
+  }
+}

--- a/oryxos-provider/src/test/java/io/oryxos/provider/MockEmbeddingModelTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/MockEmbeddingModelTest.java
@@ -1,0 +1,60 @@
+package io.oryxos.provider;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.oryxos.core.embedding.TextEmbedder;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+class MockEmbeddingModelTest {
+
+  @Test
+  void sameTextAlwaysYieldsSameUnitVector() {
+    TextEmbedder first = new MockEmbeddingModel();
+    TextEmbedder second = new MockEmbeddingModel();
+
+    float[] a = first.embed("磁盘告警怎么处理");
+    float[] b = second.embed("磁盘告警怎么处理");
+
+    // 跨实例确定性（SC-004：CI 可稳定断言）
+    assertArrayEquals(a, b);
+    assertEquals(MockEmbeddingModel.DIMENSIONS, a.length);
+    double norm = 0;
+    for (float value : a) {
+      norm += (double) value * value;
+    }
+    assertEquals(1.0, Math.sqrt(norm), 1e-5, "mock 向量必须单位化");
+  }
+
+  @Test
+  void differentTextsYieldDistinguishableVectors() {
+    TextEmbedder embedder = new MockEmbeddingModel();
+    assertFalse(Arrays.equals(embedder.embed("磁盘告警"), embedder.embed("网络故障")), "不同文本的向量必须可区分");
+  }
+
+  @Test
+  void factoryRoutesMockAndRejectsMissingConfigReadably() {
+    ProviderEmbeddingModelFactory factory = new ProviderEmbeddingModelFactory();
+
+    assertTrue(factory.buildOne("mock", null, null, null) instanceof MockEmbeddingModel);
+
+    // 未配置 provider：可读报错点名配置键，不静默回退（plan 停点 3）
+    IllegalArgumentException noProvider =
+        assertThrows(IllegalArgumentException.class, () -> factory.buildOne(null, "k", "u", "m"));
+    assertTrue(noProvider.getMessage().contains("knowledge.embedding.provider"));
+
+    IllegalArgumentException noModel =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> factory.buildOne("qwen", "key", "https://dashscope.aliyuncs.com", null));
+    assertTrue(noModel.getMessage().contains("knowledge.embedding.model"));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> factory.buildOne("qwen", "", "https://dashscope.aliyuncs.com", "text-embedding-v4"));
+  }
+}

--- a/oryxos-storage/src/main/java/io/oryxos/storage/KnowledgeChunkEntity.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/KnowledgeChunkEntity.java
@@ -1,0 +1,138 @@
+package io.oryxos.storage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/**
+ * knowledge_chunks 行（014 知识库）——embedding 为 float32[] BLOB（小端序编码由上层负责）； dim + embedding_model
+ * 支撑一致性校验（FR-014）。表结构以手工 schema.sql 为唯一权威。
+ */
+@Entity
+@Table(name = "knowledge_chunks")
+public class KnowledgeChunkEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "document_id", nullable = false)
+  private long documentId;
+
+  @Column(name = "kb_name", nullable = false)
+  private String kbName;
+
+  @Column(nullable = false)
+  private int seq;
+
+  @Column(name = "page_no")
+  private Integer pageNo;
+
+  @Column(nullable = false)
+  private String content;
+
+  @Column private byte[] embedding;
+
+  @Column private Integer dim;
+
+  @Column(name = "embedding_model")
+  private String embeddingModel;
+
+  @Column(nullable = false)
+  private long generation;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @PrePersist
+  void onCreate() {
+    if (createdAt == null) {
+      createdAt = Instant.now();
+    }
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public long getDocumentId() {
+    return documentId;
+  }
+
+  public void setDocumentId(long documentId) {
+    this.documentId = documentId;
+  }
+
+  public String getKbName() {
+    return kbName;
+  }
+
+  public void setKbName(String kbName) {
+    this.kbName = kbName;
+  }
+
+  public int getSeq() {
+    return seq;
+  }
+
+  public void setSeq(int seq) {
+    this.seq = seq;
+  }
+
+  public Integer getPageNo() {
+    return pageNo;
+  }
+
+  public void setPageNo(Integer pageNo) {
+    this.pageNo = pageNo;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public void setContent(String content) {
+    this.content = content;
+  }
+
+  public byte[] getEmbedding() {
+    return embedding == null ? null : embedding.clone();
+  }
+
+  public void setEmbedding(byte[] embedding) {
+    this.embedding = embedding == null ? null : embedding.clone();
+  }
+
+  public Integer getDim() {
+    return dim;
+  }
+
+  public void setDim(Integer dim) {
+    this.dim = dim;
+  }
+
+  public String getEmbeddingModel() {
+    return embeddingModel;
+  }
+
+  public void setEmbeddingModel(String embeddingModel) {
+    this.embeddingModel = embeddingModel;
+  }
+
+  public long getGeneration() {
+    return generation;
+  }
+
+  public void setGeneration(long generation) {
+    this.generation = generation;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/oryxos-storage/src/main/java/io/oryxos/storage/KnowledgeChunkRepository.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/KnowledgeChunkRepository.java
@@ -1,0 +1,25 @@
+package io.oryxos.storage;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** knowledge_chunks 读写通道（014 知识库）——检索按库 + 代号全量加载做内存余弦扫描（research D1）。 */
+public interface KnowledgeChunkRepository extends JpaRepository<KnowledgeChunkEntity, Long> {
+
+  List<KnowledgeChunkEntity> findByKbNameAndGeneration(String kbName, long generation);
+
+  long countByKbNameAndGeneration(String kbName, long generation);
+
+  @Transactional(rollbackFor = Exception.class)
+  void deleteByDocumentId(long documentId);
+
+  @Transactional(rollbackFor = Exception.class)
+  void deleteByKbName(String kbName);
+
+  @Transactional(rollbackFor = Exception.class)
+  void deleteByKbNameAndGenerationLessThan(String kbName, long generation);
+
+  @Transactional(rollbackFor = Exception.class)
+  void deleteByKbNameAndGeneration(String kbName, long generation);
+}

--- a/oryxos-storage/src/main/java/io/oryxos/storage/KnowledgeDocumentEntity.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/KnowledgeDocumentEntity.java
@@ -1,0 +1,142 @@
+package io.oryxos.storage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/** knowledge_documents 行（014 知识库）——表结构以手工 schema.sql 为唯一权威。 */
+@Entity
+@Table(name = "knowledge_documents")
+public class KnowledgeDocumentEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "kb_name", nullable = false)
+  private String kbName;
+
+  @Column(name = "rel_path", nullable = false)
+  private String relPath;
+
+  @Column(name = "content_sha256", nullable = false)
+  private String contentSha256;
+
+  /** 状态机文本值：PENDING / INDEXING / READY / FAILED。 */
+  @Column(nullable = false)
+  private String status;
+
+  @Column(name = "failure_reason")
+  private String failureReason;
+
+  @Column(name = "chunk_count", nullable = false)
+  private int chunkCount;
+
+  @Column(nullable = false)
+  private long generation;
+
+  @Column(name = "indexed_at")
+  private Instant indexedAt;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  @PrePersist
+  void onCreate() {
+    Instant now = Instant.now();
+    if (createdAt == null) {
+      createdAt = now;
+    }
+    updatedAt = now;
+  }
+
+  @PreUpdate
+  void onUpdate() {
+    updatedAt = Instant.now();
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getKbName() {
+    return kbName;
+  }
+
+  public void setKbName(String kbName) {
+    this.kbName = kbName;
+  }
+
+  public String getRelPath() {
+    return relPath;
+  }
+
+  public void setRelPath(String relPath) {
+    this.relPath = relPath;
+  }
+
+  public String getContentSha256() {
+    return contentSha256;
+  }
+
+  public void setContentSha256(String contentSha256) {
+    this.contentSha256 = contentSha256;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public String getFailureReason() {
+    return failureReason;
+  }
+
+  public void setFailureReason(String failureReason) {
+    this.failureReason = failureReason;
+  }
+
+  public int getChunkCount() {
+    return chunkCount;
+  }
+
+  public void setChunkCount(int chunkCount) {
+    this.chunkCount = chunkCount;
+  }
+
+  public long getGeneration() {
+    return generation;
+  }
+
+  public void setGeneration(long generation) {
+    this.generation = generation;
+  }
+
+  public Instant getIndexedAt() {
+    return indexedAt;
+  }
+
+  public void setIndexedAt(Instant indexedAt) {
+    this.indexedAt = indexedAt;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/oryxos-storage/src/main/java/io/oryxos/storage/KnowledgeDocumentRepository.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/KnowledgeDocumentRepository.java
@@ -1,0 +1,26 @@
+package io.oryxos.storage;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** knowledge_documents 读写通道（014 知识库）。 */
+public interface KnowledgeDocumentRepository extends JpaRepository<KnowledgeDocumentEntity, Long> {
+
+  List<KnowledgeDocumentEntity> findByKbNameAndGeneration(String kbName, long generation);
+
+  Optional<KnowledgeDocumentEntity> findByKbNameAndRelPathAndGeneration(
+      String kbName, String relPath, long generation);
+
+  List<KnowledgeDocumentEntity> findByKbName(String kbName);
+
+  @Transactional(rollbackFor = Exception.class)
+  void deleteByKbName(String kbName);
+
+  @Transactional(rollbackFor = Exception.class)
+  void deleteByKbNameAndGenerationLessThan(String kbName, long generation);
+
+  @Transactional(rollbackFor = Exception.class)
+  void deleteByKbNameAndGeneration(String kbName, long generation);
+}

--- a/oryxos-storage/src/main/resources/schema.sql
+++ b/oryxos-storage/src/main/resources/schema.sql
@@ -160,3 +160,41 @@ CREATE TABLE IF NOT EXISTS web_sessions (
     created_at TIMESTAMP NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_web_sessions_session ON web_sessions (session_id);
+
+-- knowledge_documents：知识文档索引状态（014 知识库）——库内源文件的派生数据，可从文件系统全量重建。
+-- 状态机 PENDING → INDEXING → READY / FAILED（Clarify-Q3 两段式上传）；generation 为双缓冲代号（FR-024）：
+-- 重建以 generation+1 写新代，旧代持续服务检索，就绪后原子切换并清理旧代。
+CREATE TABLE IF NOT EXISTS knowledge_documents (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    kb_name VARCHAR(128) NOT NULL,
+    rel_path VARCHAR(512) NOT NULL,
+    content_sha256 VARCHAR(64) NOT NULL,
+    status VARCHAR(16) NOT NULL,
+    failure_reason TEXT,
+    chunk_count INTEGER NOT NULL DEFAULT 0,
+    generation INTEGER NOT NULL DEFAULT 0,
+    indexed_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    UNIQUE (kb_name, rel_path, generation)
+);
+CREATE INDEX IF NOT EXISTS idx_kdoc_kb ON knowledge_documents (kb_name, generation);
+
+-- knowledge_chunks：知识片段（检索最小单元）——embedding 为 float32[] BLOB（小端序），检索按库全量加载
+-- 做纯 Java 余弦暴力扫描（research D1）；dim + embedding_model 支撑维度/模型一致性校验（FR-014）：
+-- 与当前配置不一致时拒绝新旧向量混合比较并提示重建。page_no 仅 PDF 文档有值（出处用页码，FR-003）。
+CREATE TABLE IF NOT EXISTS knowledge_chunks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    document_id INTEGER NOT NULL,
+    kb_name VARCHAR(128) NOT NULL,
+    seq INTEGER NOT NULL,
+    page_no INTEGER,
+    content TEXT NOT NULL,
+    embedding BLOB,
+    dim INTEGER,
+    embedding_model VARCHAR(128),
+    generation INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_kchunk_kb ON knowledge_chunks (kb_name, generation);
+CREATE INDEX IF NOT EXISTS idx_kchunk_doc ON knowledge_chunks (document_id);

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <spring-ai.version>1.1.8</spring-ai.version>
         <picocli.version>4.7.6</picocli.version>
         <sqlite-jdbc.version>3.53.2.1</sqlite-jdbc.version>
+        <pdfbox.version>3.0.5</pdfbox.version>
 
         <!-- Infrastructure libraries -->
         <jackson-bom.version>2.21.5</jackson-bom.version>
@@ -55,6 +56,7 @@
         <module>oryxos-core</module>
         <module>oryxos-provider</module>
         <module>oryxos-memory</module>
+        <module>oryxos-knowledge</module>
         <module>oryxos-tool</module>
         <module>oryxos-channel-cli</module>
         <module>oryxos-web</module>
@@ -92,6 +94,11 @@
             </dependency>
             <dependency>
                 <groupId>io.oryxos</groupId>
+                <artifactId>oryxos-knowledge</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.oryxos</groupId>
                 <artifactId>oryxos-tool</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -114,6 +121,13 @@
                 <groupId>io.oryxos</groupId>
                 <artifactId>oryxos-cli</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <!-- Apache PDFBox：文本型 PDF 解析（014 知识库，唯一新增运行时依赖） -->
+            <dependency>
+                <groupId>org.apache.pdfbox</groupId>
+                <artifactId>pdfbox</artifactId>
+                <version>${pdfbox.version}</version>
             </dependency>
 
             <!-- Picocli -->

--- a/specs/014-knowledge-base/tasks.md
+++ b/specs/014-knowledge-base/tasks.md
@@ -19,10 +19,10 @@ US5 远程桩与 US6 无 key 自测最后收口契约与 CI。
 
 **Purpose**: 新建 `oryxos-knowledge` 模块（宪法停点 1）并搭好跨故事测试地基。
 
-- [ ] T001 新建 `oryxos-knowledge/pom.xml`（对照 `oryxos-memory`：依赖 core + storage +
+- [x] T001 新建 `oryxos-knowledge/pom.xml`（对照 `oryxos-memory`：依赖 core + storage +
       spring-ai-model 取 `@Tool`；新增 Apache PDFBox），并把模块加入根 `pom.xml`、
       `oryxos-boot/pom.xml`、`oryxos-cli/pom.xml` 依赖聚合
-- [ ] T002 [P] 在 `oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeWorkspaceFixture.java`
+- [x] T002 [P] 在 `oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeWorkspaceFixture.java`
       建共享测试夹具：临时工作区内创建知识库目录（KNOWLEDGE.md 清单 + md/txt/PDF 文档）、
       Agent 目录、合法/dangling/escaped/name-mismatch 绑定软连接
 
@@ -36,31 +36,31 @@ US5 远程桩与 US6 无 key 自测最后收口契约与 CI。
 
 ### Tests
 
-- [ ] T003 [P] 在 `oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeManifestTest.java`
+- [x] T003 [P] 在 `oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeManifestTest.java`
       添加清单解析失败测试：frontmatter name/description 校验、name 与目录名不一致、
       backend 缺省 local、远程 connection 的 `${ENV_VAR}` 占位不解析明文
-- [ ] T004 [P] 在 `oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeBindingServiceTest.java`
+- [x] T004 [P] 在 `oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeBindingServiceTest.java`
       添加绑定失败测试：bind/unbind/replace/inspect/references/reconcile 全操作 +
       四类非法态检测 + 真实路径越界拒绝（复用 `RealPathBoundary`）
 
 ### Implementation
 
-- [ ] T005 [P] 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/model/` 创建不可变值对象：
+- [x] T005 [P] 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/model/` 创建不可变值对象：
       `KnowledgeQuery`、`KnowledgeHit`、`Citation`、`KnowledgeBaseInfo`、`DocumentStatus`、
       `KnowledgeCapabilities`（字段按 data-model.md §4）
-- [ ] T006 [P] 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/` 创建契约接口：
+- [x] T006 [P] 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/` 创建契约接口：
       `KnowledgeRetriever`（必选）、`KnowledgeAdmin`（可选）、`KnowledgeBackend`、
       `KnowledgeBackendRegistry`（按名注册 + localDefault）、`KnowledgeService`（门面），
       形状按 contracts/knowledge-spi.md §1，全同步签名
-- [ ] T007 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeManifest.java`
+- [x] T007 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeManifest.java`
       实现 KNOWLEDGE.md frontmatter 读取与合法性校验（T003 转绿）
-- [ ] T008 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeBindingService.java`
+- [x] T008 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeBindingService.java`
       照 `AgentSkillBindingService` 范式实现绑定 CRUD 与巡检（T004 转绿）；被引用删除抛
       `KnowledgeReferencedException`
-- [ ] T009 [P] 在 `oryxos-storage/src/main/resources/schema.sql` 末尾追加
+- [x] T009 [P] 在 `oryxos-storage/src/main/resources/schema.sql` 末尾追加
       `knowledge_documents` / `knowledge_chunks` DDL（data-model.md §2：中文块注释 +
       `IF NOT EXISTS` + `idx_` 索引 + generation 双缓冲列 + dim/embedding_model 列）
-- [ ] T010 [P] 在 `oryxos-storage/src/main/java/io/oryxos/storage/` 创建
+- [x] T010 [P] 在 `oryxos-storage/src/main/java/io/oryxos/storage/` 创建
       `KnowledgeDocumentEntity.java`、`KnowledgeChunkEntity.java`、
       `KnowledgeDocumentRepository.java`、`KnowledgeChunkRepository.java`（平铺包，随现状）
 
@@ -74,38 +74,38 @@ US5 远程桩与 US6 无 key 自测最后收口契约与 CI。
 
 ### Tests
 
-- [ ] T011 [P] 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/index/DocumentParserTest.java`
+- [x] T011 [P] 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/index/DocumentParserTest.java`
       添加解析失败测试：md/txt 片段序号、文本型 PDF 页码出处、扫描件（无文本层）拒绝、
       空文档跳过、>10MB 拒绝、二进制忽略告警
-- [ ] T012 [P] 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/index/ChunkerTest.java`
+- [x] T012 [P] 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/index/ChunkerTest.java`
       添加切分失败测试：标题边界优先 + 长度上限、不跨文档、位置可回溯（行为契约 2）
-- [ ] T013 [P] 在 `oryxos-provider/src/test/java/io/oryxos/provider/MockEmbeddingModelTest.java`
+- [x] T013 [P] 在 `oryxos-provider/src/test/java/io/oryxos/provider/MockEmbeddingModelTest.java`
       添加确定性测试：同文本恒同向量、单位向量、不同文本可区分（行为契约 6 / SC-004）
-- [ ] T014 [P] 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/retrieve/RetrievalPipelineTest.java`
+- [x] T014 [P] 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/retrieve/RetrievalPipelineTest.java`
       添加流水线失败测试：双路召回并行、RRF 名次融合、精排槽位直通、embedding 不可用走
       关键词降级并标注（行为契约 4）、维度/模型不一致拒绝混比（行为契约 5）
 
 ### Implementation
 
-- [ ] T015 [P] 在 `oryxos-provider/src/main/java/io/oryxos/provider/ProviderEmbeddingModelFactory.java`
+- [x] T015 [P] 在 `oryxos-provider/src/main/java/io/oryxos/provider/ProviderEmbeddingModelFactory.java`
       复用 `OpenAiApi` 构建链（stripTrailingV1/HTTP1.1/超时工厂）按名构建 EmbeddingModel；
       `knowledge.embedding.provider` 未配置 ⇒ 显式不可用（可读报错，不静默回退，plan 停点 3）
-- [ ] T016 [P] 在 `oryxos-provider/src/main/java/io/oryxos/provider/MockEmbeddingModel.java`
+- [x] T016 [P] 在 `oryxos-provider/src/main/java/io/oryxos/provider/MockEmbeddingModel.java`
       实现文本哈希播种的确定性伪随机单位向量（T013 转绿）
-- [ ] T017 [P] 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/` 实现
+- [x] T017 [P] 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/` 实现
       `DocumentParser` SPI + `MarkdownParser`/`TextParser`/`PdfParser`（PDFBox）+ `Chunker`
       （T011/T012 转绿）
-- [ ] T018 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/store/SqliteVectorIndexStore.java`
+- [x] T018 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/store/SqliteVectorIndexStore.java`
       实现 chunk/向量 BLOB 存取与按库全量加载（float32 编解码；接口形状不带 knowledge
       语义，FR-016；配置键 `knowledge.store` 默认 sqlite）
-- [ ] T019 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/retrieve/RetrievalPipeline.java`
+- [x] T019 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/retrieve/RetrievalPipeline.java`
       实现双路召回（纯 Java 余弦暴力 ∥ 关键词 LIKE）→ RRF 融合 → 精排槽位（T014 转绿）
-- [ ] T020 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/KnowledgeIndexService.java`
+- [x] T020 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/KnowledgeIndexService.java`
       实现导入流水线：SHA-256 指纹变更检测、文档状态机（PENDING→INDEXING→READY/FAILED
       + 可读失败原因）、虚拟线程后台推进、失败可重试不静默丢弃
-- [ ] T021 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/LocalKnowledgeBackend.java`
+- [x] T021 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/LocalKnowledgeBackend.java`
       组装为全能力后端插件（capabilities 全 true、rerank false）并实现 `KnowledgeAdmin`
-- [ ] T022 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/contract/KnowledgeBackendContractTest.java`
+- [x] T022 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/contract/KnowledgeBackendContractTest.java`
       建参数化契约测试骨架：8 条行为契约逐条断言，先只挂 `LocalKnowledgeBackend`
       （US5 阶段挂远程桩），mock 向量下全部转绿
 

--- a/specs/014-knowledge-base/tasks.md
+++ b/specs/014-knowledge-base/tasks.md
@@ -1,0 +1,321 @@
+# Tasks: 知识库（Knowledge Base）
+
+**Input**: `spec.md`、`plan.md`、`research.md`（D1~D11）、`data-model.md`、
+`contracts/knowledge-spi.md`、`contracts/rest-api.md`、`quickstart.md`
+
+**Tests**: spec 要求以参数化契约测试钉死 8 条行为契约（contracts/knowledge-spi.md §2），
+且 SC-004 要求 mock 环境 CI 可稳定断言；所有故事按「先写失败测试，再实现」执行。
+
+**Organization**: 任务按 User Story 分组。Phase 1~3 是共享地基（契约 → 存储 → 本地后端
+引擎）；US1 是运行时 MVP；US2/US3 管理面、US4 GitOps、US7 看板在地基完成后可并行推进；
+US5 远程桩与 US6 无 key 自测最后收口契约与 CI。
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: 可与同阶段其它标记任务并行（不同文件、无未完成依赖）。
+- **[Story]**: 对应 `spec.md` 的 US1~US7。
+
+## Phase 1: Setup — 模块骨架与测试夹具
+
+**Purpose**: 新建 `oryxos-knowledge` 模块（宪法停点 1）并搭好跨故事测试地基。
+
+- [ ] T001 新建 `oryxos-knowledge/pom.xml`（对照 `oryxos-memory`：依赖 core + storage +
+      spring-ai-model 取 `@Tool`；新增 Apache PDFBox），并把模块加入根 `pom.xml`、
+      `oryxos-boot/pom.xml`、`oryxos-cli/pom.xml` 依赖聚合
+- [ ] T002 [P] 在 `oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeWorkspaceFixture.java`
+      建共享测试夹具：临时工作区内创建知识库目录（KNOWLEDGE.md 清单 + md/txt/PDF 文档）、
+      Agent 目录、合法/dangling/escaped/name-mismatch 绑定软连接
+
+---
+
+## Phase 2: Foundational A — 契约与存储（阻塞所有故事）
+
+**Purpose**: 宪法停点 2/3 落地——core 契约面 + schema.sql 两表 + 存储实体。
+
+**⚠️ CRITICAL**: 本阶段完成前不得开始任何 User Story 实现。
+
+### Tests
+
+- [ ] T003 [P] 在 `oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeManifestTest.java`
+      添加清单解析失败测试：frontmatter name/description 校验、name 与目录名不一致、
+      backend 缺省 local、远程 connection 的 `${ENV_VAR}` 占位不解析明文
+- [ ] T004 [P] 在 `oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeBindingServiceTest.java`
+      添加绑定失败测试：bind/unbind/replace/inspect/references/reconcile 全操作 +
+      四类非法态检测 + 真实路径越界拒绝（复用 `RealPathBoundary`）
+
+### Implementation
+
+- [ ] T005 [P] 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/model/` 创建不可变值对象：
+      `KnowledgeQuery`、`KnowledgeHit`、`Citation`、`KnowledgeBaseInfo`、`DocumentStatus`、
+      `KnowledgeCapabilities`（字段按 data-model.md §4）
+- [ ] T006 [P] 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/` 创建契约接口：
+      `KnowledgeRetriever`（必选）、`KnowledgeAdmin`（可选）、`KnowledgeBackend`、
+      `KnowledgeBackendRegistry`（按名注册 + localDefault）、`KnowledgeService`（门面），
+      形状按 contracts/knowledge-spi.md §1，全同步签名
+- [ ] T007 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeManifest.java`
+      实现 KNOWLEDGE.md frontmatter 读取与合法性校验（T003 转绿）
+- [ ] T008 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeBindingService.java`
+      照 `AgentSkillBindingService` 范式实现绑定 CRUD 与巡检（T004 转绿）；被引用删除抛
+      `KnowledgeReferencedException`
+- [ ] T009 [P] 在 `oryxos-storage/src/main/resources/schema.sql` 末尾追加
+      `knowledge_documents` / `knowledge_chunks` DDL（data-model.md §2：中文块注释 +
+      `IF NOT EXISTS` + `idx_` 索引 + generation 双缓冲列 + dim/embedding_model 列）
+- [ ] T010 [P] 在 `oryxos-storage/src/main/java/io/oryxos/storage/` 创建
+      `KnowledgeDocumentEntity.java`、`KnowledgeChunkEntity.java`、
+      `KnowledgeDocumentRepository.java`、`KnowledgeChunkRepository.java`（平铺包，随现状）
+
+**Checkpoint**: 契约面可编译、绑定可建可检、两表可建——引擎与故事实现可以开始。
+
+---
+
+## Phase 3: Foundational B — 本地后端引擎（阻塞所有故事）
+
+**Purpose**: 第一个插件 `LocalKnowledgeBackend`：解析 → 切分 → 向量化 → 存取 → 检索流水线。
+
+### Tests
+
+- [ ] T011 [P] 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/index/DocumentParserTest.java`
+      添加解析失败测试：md/txt 片段序号、文本型 PDF 页码出处、扫描件（无文本层）拒绝、
+      空文档跳过、>10MB 拒绝、二进制忽略告警
+- [ ] T012 [P] 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/index/ChunkerTest.java`
+      添加切分失败测试：标题边界优先 + 长度上限、不跨文档、位置可回溯（行为契约 2）
+- [ ] T013 [P] 在 `oryxos-provider/src/test/java/io/oryxos/provider/MockEmbeddingModelTest.java`
+      添加确定性测试：同文本恒同向量、单位向量、不同文本可区分（行为契约 6 / SC-004）
+- [ ] T014 [P] 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/retrieve/RetrievalPipelineTest.java`
+      添加流水线失败测试：双路召回并行、RRF 名次融合、精排槽位直通、embedding 不可用走
+      关键词降级并标注（行为契约 4）、维度/模型不一致拒绝混比（行为契约 5）
+
+### Implementation
+
+- [ ] T015 [P] 在 `oryxos-provider/src/main/java/io/oryxos/provider/ProviderEmbeddingModelFactory.java`
+      复用 `OpenAiApi` 构建链（stripTrailingV1/HTTP1.1/超时工厂）按名构建 EmbeddingModel；
+      `knowledge.embedding.provider` 未配置 ⇒ 显式不可用（可读报错，不静默回退，plan 停点 3）
+- [ ] T016 [P] 在 `oryxos-provider/src/main/java/io/oryxos/provider/MockEmbeddingModel.java`
+      实现文本哈希播种的确定性伪随机单位向量（T013 转绿）
+- [ ] T017 [P] 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/` 实现
+      `DocumentParser` SPI + `MarkdownParser`/`TextParser`/`PdfParser`（PDFBox）+ `Chunker`
+      （T011/T012 转绿）
+- [ ] T018 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/store/SqliteVectorIndexStore.java`
+      实现 chunk/向量 BLOB 存取与按库全量加载（float32 编解码；接口形状不带 knowledge
+      语义，FR-016；配置键 `knowledge.store` 默认 sqlite）
+- [ ] T019 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/retrieve/RetrievalPipeline.java`
+      实现双路召回（纯 Java 余弦暴力 ∥ 关键词 LIKE）→ RRF 融合 → 精排槽位（T014 转绿）
+- [ ] T020 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/KnowledgeIndexService.java`
+      实现导入流水线：SHA-256 指纹变更检测、文档状态机（PENDING→INDEXING→READY/FAILED
+      + 可读失败原因）、虚拟线程后台推进、失败可重试不静默丢弃
+- [ ] T021 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/LocalKnowledgeBackend.java`
+      组装为全能力后端插件（capabilities 全 true、rerank false）并实现 `KnowledgeAdmin`
+- [ ] T022 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/contract/KnowledgeBackendContractTest.java`
+      建参数化契约测试骨架：8 条行为契约逐条断言，先只挂 `LocalKnowledgeBackend`
+      （US5 阶段挂远程桩），mock 向量下全部转绿
+
+**Checkpoint**: 手工构造目录可完成「导入 → 索引 → 检索命中带出处」，全部契约测试绿。
+
+---
+
+## Phase 4: User Story 1 — 终端用户带出处回答 (Priority: P1) 🎯 MVP
+
+**Goal**: Agent 自主检索绑定库、按出处跟读原文、回答带出处；未绑定零注入零干扰。
+
+**Independent Test**: 手工构造知识库目录与绑定链接（不依赖管理台），CLI chat / REST 对话验证
+（spec US1 场景 1~6）。
+
+### Tests
+
+- [ ] T023 [P] [US1] 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/builtin/KnowledgeToolsTest.java`
+      添加失败测试：schema 两必一选（query/limit/knowledge_base）、绑定范围圈定、多库聚合
+      全局 top-K、限定未绑定库可读错误、零绑定可读错误、结果 JSON 含埋点字段（FR-022）
+- [ ] T024 [P] [US1] 在 `oryxos-core/src/test/java/io/oryxos/core/context/ContextLoaderKnowledgeTest.java`
+      添加失败测试：每轮注入绑定库 name+description+检索指引、零绑定零注入、正文永不预载
+
+### Implementation
+
+- [ ] T025 [US1] 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/DefaultKnowledgeService.java`
+      实现门面：经 `KnowledgeBindingService` 圈定绑定库 → 逐库路由后端 → 跨库融合取全局
+      top-K（Clarify-Q2）
+- [ ] T026 [US1] 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/builtin/KnowledgeTools.java`
+      实现 `@Tool retrieve_knowledge`（经 `ToolExecutionContext` 取 agentName；结果为
+      contracts §3 的结构化 JSON 埋点载体）（T023 转绿）
+- [ ] T027 [US1] 在 `oryxos-core/src/main/java/io/oryxos/core/context/ContextLoader.java`
+      新增 `appendKnowledge()`（对照 `appendSkills()`；按 `profile.tools()` 含
+      `retrieve_knowledge` 联动）（T024 转绿）
+- [ ] T028 [US1] 在 `oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java` 装配：
+      backend registry、`LocalKnowledgeBackend`、`KnowledgeService`、
+      `registry.registerAnnotated(new KnowledgeTools(...))`，并同步
+      `OryxToolContractTest` 参数化注册面
+- [ ] T029 [US1] 本地库文档目录自动纳入 `read_file` 白名单（FR-017）：沿用 `oryxos.root`
+      换根自动纳入机制 + `RealPathBoundary` 校验；远程命中标注不可跟读；补
+      `oryxos-tool/src/test/java/io/oryxos/tool/sandbox/` 白名单联动测试
+- [ ] T030 [US1] 端到端验证 quickstart §C：命中带出处 / 原文跟读 / 无关问题不干扰 /
+      检索入 `tool_invocations` 审计（US1 场景 6），修复暴露的问题
+
+**Checkpoint**: MVP 达成——mock 环境下 US1 六个验收场景全部通过。
+
+---
+
+## Phase 5: User Story 2 — 管理台全生命周期 (Priority: P1)
+
+**Goal**: 非技术管理员在管理台完成建库→传文档→绑定→验证→维护→删除闭环。
+
+**Independent Test**: 仅通过管理台完成闭环（spec US2 场景 1~6），计时验收 SC-001（≤5 分钟）。
+
+### Tests
+
+- [ ] T031 [P] [US2] 在 `oryxos-web/src/test/java/io/oryxos/web/controller/KnowledgeApiControllerTest.java`
+      添加 MockMvc 失败测试：CRUD、两段式上传（不支持类型/扫描件/超限 4xx 当场拒绝）、
+      状态查询、重建、重名 409、被引用删除 409 + Agent 名单、能力门禁 400
+      （contracts/rest-api.md 全表）
+
+### Implementation
+
+- [ ] T032 [US2] 在 `oryxos-web/src/main/java/io/oryxos/web/controller/KnowledgeApiController.java`
+      + `controller/dto/` record DTO 实现 REST 全生命周期端点（T031 转绿）；
+      `GlobalExceptionHandler` 新增 `KnowledgeReferencedException` → 409
+- [ ] T033 [US2] 在 `oryxos-knowledge/.../index/KnowledgeIndexService.java` 补双缓冲重建
+      （FR-024）：generation+1 后台构建、同步临界区原子切换、失败保留旧代与原因；
+      补重建期间并发检索不中断的测试
+- [ ] T034 [US2] 在 `oryxos-web/src/main/frontend/src/App.vue` 落地知识库页（TOP_NAV 占位
+      已存在）：列表（名称/描述/后端/文档数/片段数/状态）、详情（文档清单 + 单文档删除 +
+      重建 + 上传）、创建/删除；操作按钮按能力集渲染（FR-009）；`npm run build` 通过
+
+**Checkpoint**: US2 六个验收场景通过，SC-001 计时达标。
+
+---
+
+## Phase 6: User Story 3 — 创建 Agent 三路径关联 (Priority: P2)
+
+**Goal**: 新建表单多选、一句话生成绑定建议、编辑增改，三路径绑定一致。
+
+**Independent Test**: 已有知识库前提下分别走三条路径，验证绑定生效且三界面一致（SC-007）。
+
+### Tests
+
+- [ ] T035 [P] [US3] 在 `oryxos-web/src/test/java/io/oryxos/web/controller/AgentApiControllerTest.java`
+      补绑定三件套失败测试（GET/PUT/DELETE `/agents/{name}/knowledge`，非法链接 4xx）与
+      Agent 创建/编辑请求 `knowledgeBindings` 字段测试
+
+### Implementation
+
+- [ ] T036 [US3] 在 `oryxos-web/src/main/java/io/oryxos/web/controller/AgentApiController.java`
+      实现绑定三件套（照 skills 三件套先例）+ 创建/编辑端点接受 `knowledgeBindings`
+      并经 `KnowledgeBindingService` 落软连接（T035 转绿）
+- [ ] T037 [US3] 「一句话生成 Agent」起草上下文注入现有知识库名单（name+description，与
+      工具/渠道候选同等待遇，FR-018）；草稿含 `knowledgeBindings` 建议、保存时后端重新
+      校验（照 Skill 建议流程：草稿不是持久绑定索引）
+- [ ] T038 [US3] `App.vue` Agent 详情页绑定管理视图 + 新建/编辑表单知识库多选（SC-007
+      三界面一致）
+
+**Checkpoint**: US3 三条路径验收通过，SC-008 留人工评审。
+
+---
+
+## Phase 7: User Story 4 — GitOps 热加载 + CLI (Priority: P2)
+
+**Goal**: 纯文件系统上线知识库，运行中自动发现索引，CLI 可查。
+
+**Independent Test**: 服务运行中纯文件操作 + `oryxos knowledge list`（spec US4 场景 1~5，
+SC-006 30 秒窗口）。
+
+### Tests
+
+- [ ] T039 [P] [US4] 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/watch/KnowledgeWatcherTest.java`
+      添加失败测试：新目录发现、文档改删触发重索引、非法目录不注册 + 告警不影响他库、
+      启动 reconcile 对账
+
+### Implementation
+
+- [ ] T040 [US4] 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/watch/KnowledgeWatcher.java`
+      照 `WorkspaceWatcher` 非递归补挂骨架实现热加载 + 启动对账（T039 转绿），接入
+      `OryxOsRuntime` 启动顺序
+- [ ] T041 [P] [US4] 在 `oryxos-cli/src/main/java/io/oryxos/cli/command/KnowledgeCommand.java`
+      实现 `oryxos knowledge list`（与 `provider list` 同族输出）；`InitCommand.DIRS`
+      加 `"knowledge"`；注册到 `OryxOsCli` 子命令表
+
+**Checkpoint**: US4 五个验收场景通过（含停服改目录后对账）。
+
+---
+
+## Phase 8: User Story 7 — 使用效果看板 (Priority: P2)
+
+**Goal**: 管理台回答「这个库被用得怎么样、该补什么文档」，指标与审计可核对。
+
+**Independent Test**: 制造命中/零结果/降级三类调用后看板核对（spec US7 场景 1~3，SC-009）。
+
+### Tests
+
+- [ ] T042 [P] [US7] 在 `KnowledgeApiControllerTest.java` 补 metrics 端点失败测试：
+      检索次数/零结果率/降级率/命中文档分布/出处引用率、时间过滤、零结果查询原文列表、
+      与 `tool_invocations` 数据一致
+
+### Implementation
+
+- [ ] T043 [US7] 在 `KnowledgeApiController` 实现 `GET /knowledge/{name}/metrics`：只聚合
+      `tool_invocations`（FR-023 不另建统计路径）；出处引用率关联会话最终回答文本近似计算
+      （T042 转绿）
+- [ ] T044 [US7] `App.vue` 库详情使用看板视图（指标卡 + 时间过滤 + 零结果列表）
+
+**Checkpoint**: US7 三个验收场景通过，看板逐项与审计 SQL 核对一致。
+
+---
+
+## Phase 9: User Story 5 — 远程后端桩与能力门禁 (Priority: P3)
+
+**Goal**: 用「仅检索能力」测试桩证明插件契约：三同（同工具/同出处契约/同审计）+ 门禁。
+
+**Independent Test**: spec US5 场景 1~3 + SC-011 逐项核验。
+
+- [ ] T045 [P] [US5] 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/contract/StubRemoteBackend.java`
+      实现测试桩（仅声明 retrieve；可配置返回无出处命中、模拟不可达），挂入 T022 参数化
+      契约测试并全部转绿
+- [ ] T046 [US5] 端到端核验：`backend: stub` 清单库绑定检索三同、缺出处显式标注「出处
+      不可用」且不可跟读、管理端点 400 门禁、管理台不渲染入口、不可达可读错误入审计
+      （quickstart §E）
+
+**Checkpoint**: SC-011 三同逐项通过。
+
+---
+
+## Phase 10: User Story 6 — 无 key 环境 CI 自测 (Priority: P3)
+
+**Goal**: mock provider 下 REST 全流程确定可重复，CI 稳定断言。
+
+- [ ] T047 [US6] 在 `oryxos-boot`（或 `oryxos-web`）新增端到端集成测试：仅 mock provider
+      走通 quickstart §A 全流程（建库→上传→轮询 READY→绑定→invoke 命中带出处→审计核对→
+      引用保护 409→解绑删除），重复执行结果一致（SC-004）
+
+**Checkpoint**: CI 无凭证全绿。
+
+---
+
+## Phase 11: Polish — 文档同步与全量验收
+
+- [ ] T048 [P] 同步 `CLAUDE.md` 模块表 + `docs/TechnicalSolution.md` §10 新增
+      `oryxos-knowledge` 模块（宪法停点 1 的文档义务）；`website/zh/docs/architecture.md:80`
+      「知识库（占位）」落地
+- [ ] T049 [P] `README.md` 能力清单与 CLI 命令表补知识库；`config/application.yml.example`
+      （如有）补 `knowledge.*` 配置段示例
+- [ ] T050 跑满 quickstart §A~G 全量验收 + `mvn verify` 全绿（Spotless/P3C/Checkstyle/
+      SpotBugs/OWASP）+ 前端 `npm run build`；SC-001~SC-011 逐条勾验
+
+---
+
+## Dependencies & Execution Order
+
+- **Phase 1 → 2 → 3 严格串行**（模块骨架 → 契约存储 → 引擎），是所有故事的地基。
+- **Phase 4（US1）** 依赖 Phase 3；**Phase 5（US2）** 依赖 Phase 3 + T032 依赖 T025 门面。
+- **Phase 6（US3）/ 7（US4）/ 8（US7）** 依赖 Phase 4~5 的服务与端点，三者互相独立可并行。
+- **Phase 9（US5）** 依赖 T022 契约测试骨架与 Phase 5 能力门禁；**Phase 10（US6）** 依赖
+  Phase 4~5 全链路；**Phase 11** 最后。
+
+### 对应实现 PR 切分（plan「Delivery Order」）
+
+| PR | 内容 | 任务 |
+|----|------|------|
+| impl-1 契约骨架 | Phase 1 + Phase 2（含 CLAUDE.md 模块表同步提前到此 PR） | T001~T010, T048 前半 |
+| impl-2 本地后端 | Phase 3 | T011~T022 |
+| impl-3 运行时 MVP | Phase 4 | T023~T030 |
+| impl-4 管理面 | Phase 5 + Phase 6 | T031~T038 |
+| impl-5 GitOps | Phase 7 | T039~T041 |
+| impl-6 观测与收口 | Phase 8~11 | T042~T050 |
+
+每个 PR 合并前：新增测试全绿 + `mvn verify` 通过 + PR 描述标注对应 FR/SC 编号。


### PR DESCRIPTION
## 概要

014 知识库的第一个实现 PR(3 个实现 PR 中的 impl-A):**契约骨架 + 本地后端引擎**,对应 tasks.md T001~T022 与 plan Delivery Order 前两段。含 tasks.md(接续 #195,任务清单并入本 PR 评审,替代已关闭的 #197)。纯后端,不含运行时接线与 UI——`retrieve_knowledge` 工具注册、ContextLoader 注入、REST/管理台在 impl-B。

## 宪法停点落地(plan 已声明,#195 已过评审)

1. **新建 `oryxos-knowledge` 模块**(依赖 core + storage;PDFBox 为唯一新增运行时依赖)——CLAUDE.md 模块表与 TechnicalSolution §10 已在本 PR 同步
2. **契约上移 `oryxos-core/knowledge/`**:检索必选(`KnowledgeRetriever`)+ 管理可选(`KnowledgeAdmin`)+ 能力声明 + 按名注册表;`TextEmbedder` 向量化端口在 `core/embedding/`(FR-016 通用基建)
3. **新表** `knowledge_documents` / `knowledge_chunks`(schema.sql 手工 DDL,generation 双缓冲列 + dim/embedding_model 一致性列)

## 主要内容

| 块 | 内容 | FR |
|---|---|---|
| 契约与值对象 | 出处(Citation)一等公民、payload 逃生舱、能力声明 | FR-004/006 |
| 绑定服务 | `agents/<a>/knowledge/<kb>` 相对软连接唯一真相源,四类非法态 + RealPathBoundary 真实路径门禁,删除引用保护 | FR-002/011/019 |
| 索引流水线 | 两段式导入(同步校验入口即拒 + 后台虚拟线程 + 状态机)、SHA-256 指纹、双缓冲重建(失败弃新代) | FR-003/008/024 |
| 解析层 SPI | md/txt/文本型 PDF(页码出处);扫描件/二进制/超限/空文档可读拒绝 | FR-003 |
| 检索 | 双路召回(余弦 ∥ 关键词)→ RRF 名次融合 → 精排槽位;跨库聚合全局 top-K;降级标注;向量模型不一致拒绝混比 | FR-004/013/014/020 |
| embedding | 复用 OpenAiApi 构建链按名构造;未配置**不静默回退**(可读报错);mock 确定性单位向量 | FR-007 |

## 验证

- **32 个新增测试全绿**,含 8 条行为契约的参数化契约测试骨架(impl-C 挂远程桩后覆盖 SC-011)
- `mvn verify` **全 reactor 11 模块通过**(Spotless / Checkstyle / P3C / SpotBugs / 全部存量测试无回归)
- 过程中修复的门禁问题:P3C 魔法值与事务 rollbackFor、SpotBugs 构造注入告警(按仓库既有 SuppressFBWarnings 惯例)、指纹比较改 `MessageDigest.isEqual`

## 评审重点建议

1. core 契约面的形状(接口 + 值对象)——合并后 impl-B/C 都建立在它之上;
2. `KnowledgeBindingService` 与 `AgentSkillBindingService` 的同构性(安全门禁是否等强);
3. schema.sql 两表 DDL 与双缓冲 generation 语义;
4. `LocalKnowledgeBackend.retrieveOne` 的降级与一致性拒绝路径。

## 后续

- impl-B(运行时 MVP + 管理面):T023~T038,US1/US2/US3
- impl-C(GitOps + 观测 + 远程桩收口):T039~T050