### PR TITLE
fix(tool): keep live tool registry so MCP admin changes take effect

### DIFF
--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -513,7 +513,8 @@ public class OryxOsRuntime {
 
   @Bean
   Map<String, OryxTool> tools(ToolRegistry toolRegistry) {
-    // 20 节起：全部来源统一经 ToolRegistry 供给（PromptBuilder 按 Profile.tools 过滤）
+    // 20 节起：全部来源统一经 ToolRegistry 供给（PromptBuilder 按 Profile.tools 过滤）。
+    // 活视图：管理台 MCP CRUD「立即生效」必须打到同一份 Map，不能 copyOf 冻在启动瞬间。
     return toolRegistry.asMap();
   }
 
@@ -531,7 +532,7 @@ public class OryxOsRuntime {
       ToolRegistry toolRegistry,
       ProfileRegistry profileRegistry,
       ToolInvocationAuditor auditor) {
-    // 31 节：mcp_servers 白名单在此接线——Agent 只能调它声明过的 server 提供的工具
+    // 31 节：mcp_servers 白名单在此接线。mcpToolOwners() 是活视图，与 tools bean 一样不能在构造时 copyOf。
     return new ToolExecutor(tools, toolRegistry.mcpToolOwners(), profileRegistry, auditor);
   }
 

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/PromptBuilder.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/PromptBuilder.java
@@ -23,7 +23,7 @@ import java.util.Map;
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",
-    justification = "contextLoader 是 Spring 注入的共享单例，构造注入共享同一引用正是意图。")
+    justification = "contextLoader / tools 都是运行时共享引用：工具表必须随 MCP 增删更新，copyOf 会让模型侧永远只看到启动快照。")
 public class PromptBuilder {
 
   private static final DateTimeFormatter DATE_TIME =
@@ -49,7 +49,7 @@ public class PromptBuilder {
       MemoryService memoryService,
       Clock clock) {
     this.contextLoader = contextLoader;
-    this.tools = Map.copyOf(tools);
+    this.tools = tools;
     this.memoryService = memoryService;
     this.clock = clock;
   }

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/ToolExecutor.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/ToolExecutor.java
@@ -23,7 +23,8 @@ import org.slf4j.LoggerFactory;
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",
-    justification = "profileRegistry 是 Spring 注入的共享单例，构造注入共享同一引用正是意图（无法也不应防御性拷贝）。")
+    justification =
+        "tools / mcpToolOwners / profileRegistry 都是运行时共享索引：MCP 增删必须立刻可见，copyOf 会把执行面冻在装配瞬间。")
 public class ToolExecutor {
 
   private static final Logger LOG = LoggerFactory.getLogger(ToolExecutor.class);
@@ -45,8 +46,8 @@ public class ToolExecutor {
       Map<String, String> mcpToolOwners,
       ProfileRegistry profileRegistry,
       ToolInvocationAuditor auditor) {
-    this.tools = Map.copyOf(tools);
-    this.mcpToolOwners = Map.copyOf(mcpToolOwners);
+    this.tools = tools;
+    this.mcpToolOwners = mcpToolOwners;
     this.profileRegistry = profileRegistry;
     this.auditor = auditor;
   }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/McpAuthorizationToolExecutorTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/McpAuthorizationToolExecutorTest.java
@@ -10,6 +10,7 @@ import io.oryxos.core.ToolResult;
 import io.oryxos.core.profile.Profile;
 import io.oryxos.core.profile.ProfileRegistry;
 import io.oryxos.core.provider.ToolCallRequest;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -89,5 +90,28 @@ class McpAuthorizationToolExecutorTest {
         legacy.execute("s-1", "agent-anything", new ToolCallRequest("github_search_issues", "{}"));
 
     assertTrue(result.success());
+  }
+
+  @Test
+  @DisplayName("构造后才写入的 mcp 归属立刻生效")
+  void ownersAddedAfterConstructionAreEnforced() {
+    Map<String, OryxTool> tools = new HashMap<>();
+    tools.put("github_search_issues", githubTool);
+    Map<String, String> owners = new HashMap<>();
+    ToolExecutor executor = new ToolExecutor(tools, owners, profileRegistry, auditor);
+    profileRegistry.register(profileWithMcpServers("agent-b", List.of()));
+
+    assertTrue(
+        executor
+            .execute("s-1", "agent-b", new ToolCallRequest("github_search_issues", "{}"))
+            .success(),
+        "尚无归属时不当成 MCP 工具拦截");
+
+    owners.put("github_search_issues", "github");
+
+    ToolResult denied =
+        executor.execute("s-1", "agent-b", new ToolCallRequest("github_search_issues", "{}"));
+    assertFalse(denied.success());
+    assertTrue(denied.errorMessage().contains("mcp_servers"));
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/PromptBuilderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/PromptBuilderTest.java
@@ -15,6 +15,7 @@ import io.oryxos.core.session.Session;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -131,6 +132,19 @@ class PromptBuilderTest {
     assertFalse(hasMsg(request, "结果1"), "轮内工具消息随轮整体截掉，不撕裂");
     assertTrue(hasMsg(request, "问题2") && hasMsg(request, "结果2"));
     assertTrue(hasMsg(request, "问题3") && hasMsg(request, "结果3"));
+  }
+
+  @Test
+  @DisplayName("构造后才注册的工具立刻进 availableTools")
+  void toolsRegisteredAfterConstructionAppearInAvailableTools() {
+    Map<String, OryxTool> live = new HashMap<>();
+    PromptBuilder liveBuilder = new PromptBuilder(contextLoader, live, FIXED_CLOCK);
+    live.put("http_get", httpGetTool);
+
+    ProviderRequest request =
+        liveBuilder.build(sessionWithTurns(1), profile(20, List.of("http_get")));
+
+    assertEquals(List.of(httpGetTool), request.availableTools());
   }
 
   /** 结构化历史里是否有一条消息的 content 含 sub（替代旧的 request.content() 文本包含判断）。 */

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/ToolExecutorTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/ToolExecutorTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 import io.oryxos.core.OryxTool;
 import io.oryxos.core.ToolResult;
 import io.oryxos.core.provider.ToolCallRequest;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -156,6 +157,24 @@ class ToolExecutorTest {
             eq(false),
             contains("no_such_tool"),
             anyLong());
+  }
+
+  @Test
+  @DisplayName("构造后才注册的工具立刻可执行（管理台 MCP 立即生效）")
+  void toolsRegisteredAfterConstructionAreExecutable() {
+    Map<String, OryxTool> live = new HashMap<>();
+    ToolExecutor liveExecutor = new ToolExecutor(live, auditor);
+    live.put("http_get", httpGet);
+    when(httpGet.execute(any())).thenReturn(ToolResult.ok("ok"));
+
+    ToolResult result =
+        liveExecutor.execute("s-1", "agent-x", new ToolCallRequest("http_get", "{}"));
+
+    assertTrue(result.success());
+    live.remove("http_get");
+    ToolResult gone = liveExecutor.execute("s-1", "agent-x", new ToolCallRequest("http_get", "{}"));
+    assertFalse(gone.success());
+    assertTrue(gone.errorMessage().contains("未注册"));
   }
 
   @Test

--- a/oryxos-tool/src/main/java/io/oryxos/tool/ToolRegistry.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/ToolRegistry.java
@@ -3,10 +3,11 @@ package io.oryxos.tool;
 import io.oryxos.core.OryxTool;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.ai.support.ToolCallbacks;
 import org.springframework.ai.tool.ToolCallback;
 
@@ -16,18 +17,21 @@ import org.springframework.ai.tool.ToolCallback;
  *
  * <p>两条注册路径：{@link #register}（直接实现 / MCP adapter）与 {@link #registerAnnotated} （@Tool 注解扫描——schema
  * 自动生成，宪法 II 第二件事）。重名拒绝：静默覆盖会让两个来源打架且难查。
+ *
+ * <p>{@link #asMap()}/{@link #mcpToolOwners()} 返回活视图，不 snapshot——管理台增删 MCP 必须立刻反映到 Prompt / 执行 /
+ * {@code GET /api/v1/tools}，否则会出现「status 已连接、模型侧仍是开机那一版」。
  */
 public class ToolRegistry {
 
-  private final Map<String, OryxTool> tools = new LinkedHashMap<>();
+  private final Map<String, OryxTool> tools = new ConcurrentHashMap<>();
   // 工具名 -> 提供它的 MCP server 名（仅 MCP 来源的工具在此有记录）；ToolExecutor 据此校验 Agent 的 mcp_servers 声明。
-  private final Map<String, String> mcpToolOwners = new LinkedHashMap<>();
+  private final Map<String, String> mcpToolOwners = new ConcurrentHashMap<>();
 
   public void register(OryxTool tool) {
-    if (tools.containsKey(tool.getName())) {
+    OryxTool previous = tools.putIfAbsent(tool.getName(), tool);
+    if (previous != null) {
       throw new IllegalStateException("工具重名，拒绝注册: " + tool.getName());
     }
-    tools.put(tool.getName(), tool);
   }
 
   /** MCP 工具注册：额外记录"这个工具名属于哪个 server"，供运行时 mcp_servers 白名单校验。 */
@@ -43,8 +47,11 @@ public class ToolRegistry {
   }
 
   /** 工具名 -> 所属 MCP server 名（仅 MCP 来源的工具在内）；供 {@code ToolExecutor} 做 mcp_servers 白名单校验。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "必须返回活视图：MCP 增删后 ToolExecutor 才能看到新的归属，copyOf 会把白名单冻在启动瞬间")
   public Map<String, String> mcpToolOwners() {
-    return Map.copyOf(mcpToolOwners);
+    return Collections.unmodifiableMap(mcpToolOwners);
   }
 
   /**
@@ -68,9 +75,12 @@ public class ToolRegistry {
     return List.copyOf(tools.values());
   }
 
-  /** 供 OryxOsRuntime 的 tools() bean——ToolExecutor/PromptBuilder 消费的既有形态。 */
+  /** 供 OryxOsRuntime 的 tools() bean——活视图，PromptBuilder/ToolExecutor/管理台列表共用同一份。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "必须返回活视图：MCP connect/disconnect 后 ReAct 与 GET /tools 才能看到同一份注册表")
   public Map<String, OryxTool> asMap() {
-    return Map.copyOf(tools);
+    return Collections.unmodifiableMap(tools);
   }
 
   /** 按 Profile 的 tools 字段过滤：结果 = 声明列表中存在于注册表的项，不多不少；未知名跳过。 */

--- a/oryxos-tool/src/test/java/io/oryxos/tool/ToolRegistryTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/ToolRegistryTest.java
@@ -12,6 +12,7 @@ import io.oryxos.core.OryxTool;
 import io.oryxos.core.ToolResult;
 import io.oryxos.tool.mcp.McpToolAdapter;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.tool.annotation.Tool;
@@ -105,5 +106,23 @@ class ToolRegistryTest {
     // 不多（shell 没混进来）不少（两个声明的都在）；未知名跳过不报错
     assertEquals(
         List.of("read_file", "http_get"), filtered.stream().map(OryxTool::getName).toList());
+  }
+
+  @Test
+  @DisplayName("asMap/mcpToolOwners 是活视图：事后注册立刻可见")
+  void asMapAndOwnersStayLiveAfterRegister() {
+    ToolRegistry registry = new ToolRegistry();
+    Map<String, OryxTool> view = registry.asMap();
+    Map<String, String> owners = registry.mcpToolOwners();
+
+    registry.registerMcpTool("github", mcpTool("github_search"));
+
+    assertTrue(view.containsKey("github_search"));
+    assertEquals("github", owners.get("github_search"));
+
+    registry.unregister("github_search");
+
+    assertTrue(view.isEmpty());
+    assertTrue(owners.isEmpty());
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/ToolApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/ToolApiController.java
@@ -15,9 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
  * bean"的自动装配歧义）；OryxTool 是 core 类型，web 无需依赖 oryxos-tool 模块。
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-    value = "SPRING_ENDPOINT",
+    value = {"SPRING_ENDPOINT", "EI_EXPOSE_REP2"},
     justification =
-        "core-stage web API is unauthenticated by design (internal network + gateway); auth is extension-phase")
+        "core-stage web API is unauthenticated by design (internal network + gateway); auth is extension-phase。"
+            + "tools 必须是活视图：GET /api/v1/tools 要反映管理台刚连上/断开的 MCP 工具。")
 @RestController
 @RequestMapping("/api/v1/tools")
 public class ToolApiController {
@@ -25,7 +26,7 @@ public class ToolApiController {
   private final Map<String, OryxTool> tools;
 
   public ToolApiController(@Qualifier("tools") Map<String, OryxTool> tools) {
-    this.tools = Map.copyOf(tools);
+    this.tools = tools;
   }
 
   @GetMapping

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/ToolApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/ToolApiControllerTest.java
@@ -1,0 +1,62 @@
+package io.oryxos.web.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.oryxos.core.OryxTool;
+import io.oryxos.core.ToolResult;
+import io.oryxos.web.GlobalExceptionHandler;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class ToolApiControllerTest {
+
+  @Test
+  @DisplayName("GET /tools 看到构造后才放进 Map 的工具")
+  void listReflectsToolsAddedAfterConstruction() throws Exception {
+    Map<String, OryxTool> live = new HashMap<>();
+    MockMvc mvc =
+        MockMvcBuilders.standaloneSetup(new ToolApiController(live))
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+
+    mvc.perform(get("/api/v1/tools"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data").isEmpty());
+
+    live.put("github_search", stub("github_search"));
+
+    mvc.perform(get("/api/v1/tools"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].name").value("github_search"));
+  }
+
+  private static OryxTool stub(String name) {
+    return new OryxTool() {
+      @Override
+      public String getName() {
+        return name;
+      }
+
+      @Override
+      public String getDescription() {
+        return name;
+      }
+
+      @Override
+      public String getInputSchema() {
+        return "{}";
+      }
+
+      @Override
+      public ToolResult execute(com.fasterxml.jackson.databind.JsonNode input) {
+        return ToolResult.ok("ok");
+      }
+    };
+  }
+}


### PR DESCRIPTION
Fixes #201

## Summary
- `ToolRegistry.asMap()` / `mcpToolOwners()` return a live view instead of `Map.copyOf`
- Stop snapshotting the tool map in `ToolExecutor`, `PromptBuilder`, and `GET /api/v1/tools`
- MCP connect/disconnect is visible to ReAct and the tools API without restart

## Test plan
- [x] Registry view sees register/unregister immediately
- [x] ToolExecutor can run tools added after construction; removed tools fail as unregistered
- [x] PromptBuilder `availableTools` and MCP owner checks follow the live maps
- [x] `GET /api/v1/tools` lists tools added after controller construction