### PR TITLE
feat(knowledge): 运行时 MVP 与管理面（014 impl-B）

### DIFF
--- a/oryxos-cli/pom.xml
+++ b/oryxos-cli/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>oryxos-memory</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-knowledge</artifactId>
+        </dependency>
+        <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
         </dependency>

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -246,6 +246,7 @@ public class OryxOsRuntime {
       SkillRegistry skillRegistry,
       AgentSkillBindingService skillBindings,
       SkillCatalog skillCatalog,
+      io.oryxos.core.knowledge.KnowledgeService knowledgeService,
       @Value("${oryxos.author.provider:}") String authorProvider,
       @Value("${oryxos.author.model:}") String authorModel) {
     String defaultProvider =
@@ -260,6 +261,7 @@ public class OryxOsRuntime {
         authorProvider == null || authorProvider.isBlank() ? defaultProvider : authorProvider;
     // 30 节：把真实工具清单 + notify 渠道注入作者提示词，让"一句话生成"只用真实能力、可直接运行
     // 31 节：再把已连接 MCP server 目录也喂给它，生成的 AGENT.md 才可能正确带上 mcp_servers
+    // 014：再把已有知识库名单（name → description）也喂给它，生成的草稿才可能带出正确的绑定建议（FR-018）
     return new AgentLifecycleService(
         agentLoader,
         profileRegistry,
@@ -274,7 +276,15 @@ public class OryxOsRuntime {
         mcpServerAdmin,
         skillRegistry,
         skillBindings,
-        skillCatalog);
+        skillCatalog,
+        () ->
+            knowledgeService.listBases().stream()
+                .collect(
+                    java.util.stream.Collectors.toMap(
+                        io.oryxos.core.knowledge.model.KnowledgeBaseInfo::name,
+                        io.oryxos.core.knowledge.model.KnowledgeBaseInfo::description,
+                        (a, b) -> a,
+                        java.util.LinkedHashMap::new)));
   }
 
   /** 30 节 WorkspaceWatcher 专用守护线程执行器（跟 25 节调度线程池同类，不手工 new Thread）。 */
@@ -298,8 +308,112 @@ public class OryxOsRuntime {
   }
 
   @Bean
-  ContextLoader contextLoader(AgentSkillBindingService skillBindings) {
-    return new ContextLoader(oryxosRoot(), skillBindings);
+  ContextLoader contextLoader(
+      AgentSkillBindingService skillBindings,
+      io.oryxos.core.knowledge.KnowledgeBindingService knowledgeBindings) {
+    return new ContextLoader(oryxosRoot(), skillBindings, knowledgeBindings);
+  }
+
+  // ---- 014 知识库：契约在 core、实现经 oryxos-knowledge、按名注册（宪法 III 同款哲学）----
+
+  @Bean
+  io.oryxos.core.knowledge.KnowledgeBindingService knowledgeBindingService() {
+    return new io.oryxos.core.knowledge.KnowledgeBindingService(oryxosRoot());
+  }
+
+  /** 向量索引存储可插拔位（research D1）：默认 sqlite；未知档位明确报错不静默降级。 */
+  @Bean
+  io.oryxos.knowledge.store.ChunkStore chunkStore(
+      @Value("${knowledge.store:sqlite}") String store,
+      io.oryxos.storage.KnowledgeDocumentRepository documentRepository,
+      io.oryxos.storage.KnowledgeChunkRepository chunkRepository) {
+    return switch (store) {
+      case "sqlite" ->
+          new io.oryxos.knowledge.store.SqliteChunkStore(documentRepository, chunkRepository);
+      case "memory" -> new io.oryxos.knowledge.store.InMemoryChunkStore(); // 测试/演示档，重启即失
+      default ->
+          throw new IllegalStateException("未知的 knowledge.store: " + store + "（支持 sqlite / memory）");
+    };
+  }
+
+  /**
+   * embedding 供给者：按名从 Provider 注册表取凭证即时构造并缓存（FR-007 复用同一套凭证）。 未配置不静默回退（plan 停点 3）——lazy
+   * 抛可读异常，由检索降级/导入报错消化（FR-013）。
+   */
+  @Bean
+  java.util.function.Supplier<io.oryxos.core.embedding.TextEmbedder> knowledgeEmbedderSupplier(
+      ProviderRegistry providerRegistry,
+      @Value("${knowledge.embedding.provider:}") String embeddingProvider,
+      @Value("${knowledge.embedding.model:}") String embeddingModel) {
+    io.oryxos.provider.ProviderEmbeddingModelFactory factory =
+        new io.oryxos.provider.ProviderEmbeddingModelFactory();
+    java.util.concurrent.atomic.AtomicReference<io.oryxos.core.embedding.TextEmbedder> cache =
+        new java.util.concurrent.atomic.AtomicReference<>();
+    return () -> {
+      io.oryxos.core.embedding.TextEmbedder cached = cache.get();
+      if (cached != null) {
+        return cached;
+      }
+      if (embeddingProvider == null || embeddingProvider.isBlank()) {
+        throw new IllegalArgumentException(
+            "未配置 embedding provider（knowledge.embedding.provider）：向量化不可用，"
+                + "请配置支持 embedding 端点的 provider（如 qwen）或 mock");
+      }
+      ProviderDef def =
+          providerRegistry
+              .find(embeddingProvider)
+              .orElseThrow(
+                  () ->
+                      new IllegalArgumentException(
+                          "embedding provider 不存在于 Provider 注册表: " + embeddingProvider));
+      io.oryxos.core.embedding.TextEmbedder built =
+          factory.buildOne(def.name(), def.apiKey(), def.baseUrl(), embeddingModel);
+      cache.set(built);
+      return built;
+    };
+  }
+
+  @Bean
+  io.oryxos.knowledge.index.KnowledgeIndexService knowledgeIndexService(
+      io.oryxos.knowledge.store.ChunkStore chunkStore,
+      java.util.function.Supplier<io.oryxos.core.embedding.TextEmbedder> knowledgeEmbedderSupplier,
+      ExecutorService agentExecutionExecutor) {
+    // 两段式导入的后台段跑在虚拟线程执行器上（宪法 VII：同步代码 + 虚拟线程，无异步编程模型）
+    return new io.oryxos.knowledge.index.KnowledgeIndexService(
+        oryxosRoot().resolve("knowledge"),
+        chunkStore,
+        knowledgeEmbedderSupplier,
+        agentExecutionExecutor);
+  }
+
+  @Bean
+  io.oryxos.knowledge.LocalKnowledgeBackend localKnowledgeBackend(
+      io.oryxos.knowledge.store.ChunkStore chunkStore,
+      io.oryxos.knowledge.index.KnowledgeIndexService knowledgeIndexService,
+      java.util.function.Supplier<io.oryxos.core.embedding.TextEmbedder>
+          knowledgeEmbedderSupplier) {
+    return new io.oryxos.knowledge.LocalKnowledgeBackend(
+        oryxosRoot().resolve("knowledge"),
+        chunkStore,
+        knowledgeIndexService,
+        knowledgeEmbedderSupplier);
+  }
+
+  @Bean
+  io.oryxos.core.knowledge.KnowledgeBackendRegistry knowledgeBackendRegistry(
+      io.oryxos.knowledge.LocalKnowledgeBackend localKnowledgeBackend) {
+    io.oryxos.core.knowledge.KnowledgeBackendRegistry registry =
+        new io.oryxos.core.knowledge.KnowledgeBackendRegistry();
+    registry.register(localKnowledgeBackend);
+    return registry;
+  }
+
+  @Bean
+  io.oryxos.core.knowledge.KnowledgeService knowledgeService(
+      io.oryxos.core.knowledge.KnowledgeBindingService knowledgeBindingService,
+      io.oryxos.core.knowledge.KnowledgeBackendRegistry knowledgeBackendRegistry) {
+    return new io.oryxos.core.knowledge.KnowledgeServiceImpl(
+        oryxosRoot().resolve("knowledge"), knowledgeBindingService, knowledgeBackendRegistry);
   }
 
   @Bean
@@ -472,7 +586,8 @@ public class OryxOsRuntime {
       MemoryService memoryService,
       NotifyChannelRegistry notifyChannelRegistry,
       McpClientService mcpClientService,
-      UserInteraction userInteraction) {
+      UserInteraction userInteraction,
+      io.oryxos.core.knowledge.KnowledgeService knowledgeService) {
     ToolRegistry registry = new ToolRegistry();
     // 内置工具走 @Tool 注解管道（schema 自动生成，宪法 II 第二件事）
     registry.registerAnnotated(new FileTools(sandbox)); // read/write/list/edit/grep/glob
@@ -496,6 +611,10 @@ public class OryxOsRuntime {
     registry.register(new NotifyTools(notifyAdapters, sandbox, notifyChannelRegistry));
     // 记忆工具：save_memory / recall_memory（补齐 20 节预留的两工具面），只认门面对后端无感
     registry.registerAnnotated(new MemoryTools(memoryService));
+    // 知识检索工具（014）：retrieve_knowledge——只认门面，范围由门面按发起 Agent 的绑定圈定
+    registry.registerAnnotated(
+        new io.oryxos.knowledge.builtin.KnowledgeTools(
+            knowledgeService, oryxosRoot().resolve("knowledge")));
     // MCP：失联的 server 只 WARN 跳过，不拖垮启动；31 节起走长驻 bean，管理台 CRUD 复用同一份连接状态
     mcpClientService.connectAll(registry);
     return registry;

--- a/oryxos-cli/src/main/java/io/oryxos/cli/command/InitCommand.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/command/InitCommand.java
@@ -15,7 +15,7 @@ import picocli.CommandLine.Command;
 public class InitCommand implements Runnable {
 
   private static final List<String> DIRS =
-      List.of("agents", "skills", "output", "memory", "sessions", "logs");
+      List.of("agents", "skills", "knowledge", "output", "memory", "sessions", "logs");
   private static final List<String> BOOTSTRAP_FILES = List.of("AGENTS.md", "SOUL.md", "USER.md");
 
   @Override

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
@@ -105,6 +105,10 @@ public class AgentLifecycleService {
       例如需要抓 GitHub 榜单，就写一个 scripts/xxx.py 并在 AGENT.md 正文里用 shell 调它。
       9. 输出格式：多个文件时，每个文件前**单独一行**写分隔符 `===FILE: <相对路径>===`（第一个必须是 AGENT.md）；\
       若只需要 AGENT.md 可不用分隔符直接输出它。不要用 Markdown 代码围栏（```）包整个输出，也不要任何额外解释。
+      10. 知识库：下面【已有知识库】是本底座已创建的知识库清单。若需求与某个库的描述明确相关，允许在本次生成的 AGENT.md \
+      frontmatter 暂时输出顶层 knowledge 列表作为**生成建议 sidecar**（如 knowledge: [ops-manual]），并把 retrieve_knowledge \
+      加进 tools（前提是它在【可用工具】里）；后端会立即移除该字段，最终 AGENT.md 绝不保存 knowledge。需求无关就不要输出 \
+      knowledge 字段。**绝不编造清单外名称**。
 
       【可用工具】（tools 只能从这里选，禁止编造）
       {tools}
@@ -114,6 +118,9 @@ public class AgentLifecycleService {
 
       【可用 Skill】（仅用于生成建议 sidecar，禁止编造）
       {skills}
+
+      【已有知识库】（仅用于生成建议 sidecar，禁止编造）
+      {knowledge}
 
       【正确示例（仅示范字段与工具用法，name/provider 以上面规则为准）】
       {example}
@@ -177,6 +184,8 @@ public class AgentLifecycleService {
   private final SkillRegistry skillRegistry;
   private final AgentSkillBindingService skillBindings;
   private final SkillCatalog skillCatalog;
+  // 014：生成时把已有知识库名单（name → description）喂给作者模型（FR-018）；可空——旧调用方不带这个能力。
+  private final java.util.function.Supplier<Map<String, String>> knowledgeCandidates;
 
   public AgentLifecycleService(
       AgentLoader agentLoader,
@@ -277,6 +286,41 @@ public class AgentLifecycleService {
       SkillRegistry skillRegistry,
       AgentSkillBindingService skillBindings,
       SkillCatalog skillCatalog) {
+    this(
+        agentLoader,
+        profileRegistry,
+        agentScheduler,
+        agentStore,
+        providerService,
+        defaultProvider,
+        authorProvider,
+        authorModel,
+        tools,
+        notifyChannels,
+        mcpServerAdmin,
+        skillRegistry,
+        skillBindings,
+        skillCatalog,
+        null);
+  }
+
+  /** 014：注入知识库名单供给者，生成提示词里补上真实的「已有知识库」清单（FR-018）。 */
+  public AgentLifecycleService(
+      AgentLoader agentLoader,
+      ProfileRegistry profileRegistry,
+      AgentScheduler agentScheduler,
+      AgentStore agentStore,
+      ProviderService providerService,
+      String defaultProvider,
+      String authorProvider,
+      String authorModel,
+      Map<String, OryxTool> tools,
+      NotifyChannelRegistry notifyChannels,
+      McpServerAdmin mcpServerAdmin,
+      SkillRegistry skillRegistry,
+      AgentSkillBindingService skillBindings,
+      SkillCatalog skillCatalog,
+      java.util.function.Supplier<Map<String, String>> knowledgeCandidates) {
     this.agentLoader = agentLoader;
     this.profileRegistry = profileRegistry;
     this.agentScheduler = agentScheduler;
@@ -291,6 +335,7 @@ public class AgentLifecycleService {
     this.skillRegistry = skillRegistry;
     this.skillBindings = skillBindings;
     this.skillCatalog = skillCatalog;
+    this.knowledgeCandidates = knowledgeCandidates;
   }
 
   /**
@@ -566,6 +611,8 @@ public class AgentLifecycleService {
             List.of(),
             List.of(),
             Profile.Settings.defaults());
+    Map<String, String> knowledgeBases =
+        knowledgeCandidates == null ? Map.of() : knowledgeCandidates.get();
     String prompt =
         AGENT_AUTHOR_PROMPT
                 .replace("{name}", name)
@@ -574,6 +621,7 @@ public class AgentLifecycleService {
                 .replace("{tools}", describeTools())
                 .replace("{mcp_servers}", describeMcpServers())
                 .replace("{skills}", describeSkills(candidates))
+                .replace("{knowledge}", describeKnowledge(knowledgeBases))
                 .replace("{required_skills}", requiredSkillsDirective(required))
                 .replace("{notify}", notifyDirective(channel))
                 .replace("{example}", AUTHOR_EXAMPLE)
@@ -583,11 +631,27 @@ public class AgentLifecycleService {
     if (text == null || text.isBlank()) {
       throw new IllegalStateException("模型未返回内容"); // → 503
     }
-    return parseGeneratedDraft(text, name, required, candidateNames);
+    return parseGeneratedDraft(text, name, required, candidateNames, knowledgeBases.keySet());
+  }
+
+  /** 已有知识库清单（name → description）注入生成提示词；空清单明确告知，避免模型猜测。 */
+  private static String describeKnowledge(Map<String, String> knowledgeBases) {
+    if (knowledgeBases.isEmpty()) {
+      return "（当前没有知识库，不要输出 knowledge 字段）";
+    }
+    StringBuilder text = new StringBuilder();
+    knowledgeBases.forEach(
+        (name, description) ->
+            text.append("- ").append(name).append("：").append(description).append('\n'));
+    return text.toString().strip();
   }
 
   private GeneratedAgentDraft parseGeneratedDraft(
-      String text, String name, List<String> required, Set<String> candidateNames) {
+      String text,
+      String name,
+      List<String> required,
+      Set<String> candidateNames,
+      Set<String> knowledgeNames) {
     // 多文件解析（模型自己决定要不要脚本/子指令）：按 ===FILE: path=== 切分；无分隔符则整段当 AGENT.md
     Map<String, String> files = parseGeneratedFiles(text);
     for (String path : files.keySet()) {
@@ -610,11 +674,24 @@ public class AgentLifecycleService {
     if (AgentMarkdown.hasLegacySkills(agentMarkdown)) {
       throw new IllegalArgumentException("生成结果中的顶层 skills 未能安全移除");
     }
+    // 014：knowledge 建议同为 sidecar——校验在清单内、随即从 AGENT.md 移除（frontmatter 不声明知识库，FR-002）
+    List<String> suggestedKnowledge =
+        AgentMarkdown.knowledgeSidecar(agentMarkdown).stream().distinct().toList();
+    for (String kb : suggestedKnowledge) {
+      if (!knowledgeNames.contains(kb)) {
+        throw new IllegalArgumentException("作者模型建议了不存在的知识库: " + kb);
+      }
+    }
+    agentMarkdown = AgentMarkdown.removeKnowledgeSidecar(agentMarkdown);
+    if (AgentMarkdown.hasKnowledgeSidecar(agentMarkdown)) {
+      throw new IllegalArgumentException("生成结果中的顶层 knowledge 未能安全移除");
+    }
     files.put("AGENT.md", agentMarkdown);
     agentLoader.parse(agentMarkdown, name); // 校验：解析不成合法定义就抛 ProfileValidationException（→400）
     Set<String> bindingSet = new java.util.TreeSet<>(required);
     bindingSet.addAll(suggested);
-    return new GeneratedAgentDraft(files, required, suggested, List.copyOf(bindingSet));
+    return new GeneratedAgentDraft(
+        files, required, suggested, List.copyOf(bindingSet), suggestedKnowledge);
   }
 
   private static boolean isIllegalGeneratedPath(Path relative) {

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentMarkdown.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentMarkdown.java
@@ -122,6 +122,73 @@ public final class AgentMarkdown {
     return split(content).frontmatter().containsKey("skills");
   }
 
+  /** 生成建议 sidecar：读取顶层 knowledge 列表（FR-018）；frontmatter 永不持久化该字段（FR-002）。 */
+  public static List<String> knowledgeSidecar(String content) {
+    Object value = split(content).frontmatter().get("knowledge");
+    if (value == null) {
+      return List.of();
+    }
+    if (!(value instanceof List<?> list)) {
+      throw new IllegalArgumentException("顶层 knowledge 必须是字符串列表");
+    }
+    List<String> names = new ArrayList<>();
+    for (Object item : list) {
+      if (!(item instanceof String name) || name.isBlank()) {
+        throw new IllegalArgumentException("顶层 knowledge 必须是非空字符串列表");
+      }
+      names.add(name);
+    }
+    return List.copyOf(names);
+  }
+
+  /** 移除顶层 knowledge sidecar 块，保留其余行与换行风格（与 removeLegacySkills 同构）。 */
+  public static String removeKnowledgeSidecar(String content) {
+    if (content == null || content.isEmpty()) {
+      return content;
+    }
+    String newline = content.contains("\r\n") ? "\r\n" : "\n";
+    String normalized = content.replace("\r\n", "\n").replace('\r', '\n');
+    String[] lines = normalized.split("\n", -1);
+    if (lines.length == 0 || !FENCE.equals(lines[0].strip())) {
+      return content;
+    }
+    int close = -1;
+    for (int i = 1; i < lines.length; i++) {
+      if (FENCE.equals(lines[i].strip())) {
+        close = i;
+        break;
+      }
+    }
+    if (close < 0) {
+      return content;
+    }
+    List<String> kept = new ArrayList<>();
+    kept.add(lines[0]);
+    boolean removed = false;
+    for (int i = 1; i < close; i++) {
+      String line = lines[i];
+      if (isTopLevelKey(line, "knowledge")) {
+        removed = true;
+        while (i + 1 < close && isLegacyValueLine(lines[i + 1])) {
+          i++;
+        }
+        continue;
+      }
+      kept.add(line);
+    }
+    if (!removed) {
+      return content;
+    }
+    for (int i = close; i < lines.length; i++) {
+      kept.add(lines[i]);
+    }
+    return String.join(newline, kept);
+  }
+
+  public static boolean hasKnowledgeSidecar(String content) {
+    return split(content).frontmatter().containsKey("knowledge");
+  }
+
   /** Replaces all matching top-level scalars, or inserts one when absent. */
   public static String replaceTopLevelScalar(String content, String key, String value) {
     if (content == null || content.isEmpty()) {

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/GeneratedAgentDraft.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/GeneratedAgentDraft.java
@@ -8,11 +8,22 @@ public record GeneratedAgentDraft(
     Map<String, String> files,
     List<String> requiredSkills,
     List<String> suggestedSkills,
-    List<String> bindingSkills) {
+    List<String> bindingSkills,
+    List<String> bindingKnowledge) {
   public GeneratedAgentDraft {
     files = files == null ? Map.of() : Map.copyOf(files);
     requiredSkills = requiredSkills == null ? List.of() : List.copyOf(requiredSkills);
     suggestedSkills = suggestedSkills == null ? List.of() : List.copyOf(suggestedSkills);
     bindingSkills = bindingSkills == null ? List.of() : List.copyOf(bindingSkills);
+    bindingKnowledge = bindingKnowledge == null ? List.of() : List.copyOf(bindingKnowledge);
+  }
+
+  /** 兼容旧调用方（无知识库建议）。 */
+  public GeneratedAgentDraft(
+      Map<String, String> files,
+      List<String> requiredSkills,
+      List<String> suggestedSkills,
+      List<String> bindingSkills) {
+    this(files, requiredSkills, suggestedSkills, bindingSkills, List.of());
   }
 }

--- a/oryxos-core/src/main/java/io/oryxos/core/context/ContextLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/context/ContextLoader.java
@@ -1,6 +1,10 @@
 package io.oryxos.core.context;
 
 import io.oryxos.core.agent.AgentMarkdown;
+import io.oryxos.core.knowledge.BoundKnowledgeDescriptor;
+import io.oryxos.core.knowledge.KnowledgeBindingInspection;
+import io.oryxos.core.knowledge.KnowledgeBindingIssue;
+import io.oryxos.core.knowledge.KnowledgeBindingService;
 import io.oryxos.core.profile.Profile;
 import io.oryxos.core.skill.AgentSkillBindingReader;
 import io.oryxos.core.skill.BindingInspection;
@@ -38,12 +42,24 @@ public class ContextLoader {
   private static final Set<String> FILE_WRITE_TOOLS =
       Set.of("write_file", "append_file", "edit_file", "make_dir", "download_file");
 
+  /** 检索工具名：Profile 声明了它才注入知识库元数据（对照 FILE_WRITE_TOOLS 的按需注入模式）。 */
+  private static final String RETRIEVE_KNOWLEDGE_TOOL = "retrieve_knowledge";
+
   private final Path oryxosRoot;
   private final AgentSkillBindingReader skillBindings;
+  private final KnowledgeBindingService knowledgeBindings;
 
   public ContextLoader(Path oryxosRoot, AgentSkillBindingReader skillBindings) {
+    this(oryxosRoot, skillBindings, null);
+  }
+
+  public ContextLoader(
+      Path oryxosRoot,
+      AgentSkillBindingReader skillBindings,
+      KnowledgeBindingService knowledgeBindings) {
     this.oryxosRoot = oryxosRoot;
     this.skillBindings = skillBindings;
+    this.knowledgeBindings = knowledgeBindings;
   }
 
   public String load(Profile profile) {
@@ -61,6 +77,8 @@ public class ContextLoader {
     }
     // 当前 Agent 的有效 Skill：只注入目录元数据与读取路径，正文由 read_file 按需加载
     appendSkills(context, profile);
+    // 当前 Agent 绑定的知识库：只注入 name + description + 检索指引；零绑定零注入、正文永不预载（FR-005）
+    appendKnowledge(context, profile);
     // 告知会写盘的 Agent 它的绝对产出目录（已在文件白名单内），落盘文件有确定去处，避免它猜 ./output 撞沙箱
     appendOutputDir(context, profile);
     for (String bootstrap : profile.bootstrap()) {
@@ -105,6 +123,39 @@ public class ContextLoader {
           .append(binding.description())
           .append("\n  SKILL.md：")
           .append(binding.skillFile())
+          .append('\n');
+    }
+  }
+
+  /** 每轮重扫知识库绑定（渐进披露，FR-005）：问题项 WARN 跳过，合法项只注入元数据与检索指引。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "CRLF_INJECTION_LOGS",
+      justification = "Every untrusted issue string is passed through sanitize before logging.")
+  private void appendKnowledge(StringBuilder context, Profile profile) {
+    if (knowledgeBindings == null || !profile.tools().contains(RETRIEVE_KNOWLEDGE_TOOL)) {
+      return;
+    }
+    KnowledgeBindingInspection inspection = knowledgeBindings.inspect(profile.name());
+    for (KnowledgeBindingIssue issue : inspection.issues()) {
+      LOG.warn(
+          "Agent 知识库绑定异常 [{}]，跳过 {}/{}: {}",
+          issue.type(),
+          sanitize(issue.agentName()),
+          sanitize(issue.entryName()),
+          sanitize(issue.message()));
+    }
+    if (inspection.bindings().isEmpty()) {
+      return;
+    }
+    context.append(
+        "你绑定了以下知识库。回答涉及其中内容时，先用 retrieve_knowledge 检索（结果带出处，"
+            + "回答时给出出处）；命中的片段只是入口，不足以回答时按结果里的 file 路径用 read_file 读取原文补充：\n");
+    for (BoundKnowledgeDescriptor binding : inspection.bindings()) {
+      context
+          .append("- ")
+          .append(binding.name())
+          .append("：")
+          .append(binding.description())
           .append('\n');
     }
   }

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeAdmin.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeAdmin.java
@@ -12,6 +12,9 @@ public interface KnowledgeAdmin {
   /** 创建知识库（目录 + 清单）；重名拒绝。 */
   void createBase(String name, String description);
 
+  /** 更新库描述（只改清单 frontmatter）。 */
+  void updateBase(String name, String description);
+
   /** 删除知识库及其索引数据；引用保护（FR-011）由上层先行校验。 */
   void deleteBase(String name);
 

--- a/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeServiceImpl.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/knowledge/KnowledgeServiceImpl.java
@@ -1,0 +1,157 @@
+package io.oryxos.core.knowledge;
+
+import io.oryxos.core.knowledge.model.DocumentState;
+import io.oryxos.core.knowledge.model.DocumentStatus;
+import io.oryxos.core.knowledge.model.KnowledgeBaseInfo;
+import io.oryxos.core.knowledge.model.KnowledgeHit;
+import io.oryxos.core.knowledge.model.KnowledgeQuery;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 知识门面默认实现：检索范围 = 发起 Agent 的有效绑定（FR-004），按各库清单的 backend 声明路由插件， 跨库/跨后端融合取全局 top-K（FR-020 /
+ * Clarify-Q2）。列表投影供管理台 / CLI / REST 共用。
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "bindings/registry 为装配层注入的共享单例，构造注入存同一引用正是意图。")
+public class KnowledgeServiceImpl implements KnowledgeService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KnowledgeServiceImpl.class);
+
+  private final Path knowledgeRoot;
+  private final KnowledgeBindingService bindings;
+  private final KnowledgeBackendRegistry registry;
+
+  public KnowledgeServiceImpl(
+      Path knowledgeRoot, KnowledgeBindingService bindings, KnowledgeBackendRegistry registry) {
+    this.knowledgeRoot = knowledgeRoot.toAbsolutePath().normalize();
+    this.bindings = bindings;
+    this.registry = registry;
+  }
+
+  @Override
+  public List<KnowledgeHit> retrieveForAgent(
+      String agentName, String query, Integer topK, String kbNameOrNull) {
+    List<BoundKnowledgeDescriptor> bound = bindings.inspect(agentName).bindings();
+    if (bound.isEmpty()) {
+      throw new IllegalArgumentException("当前 Agent 未绑定任何知识库；请先在管理面完成绑定再检索");
+    }
+    Set<String> boundNames = new LinkedHashSet<>();
+    bound.forEach(binding -> boundNames.add(binding.name()));
+    List<String> targets;
+    if (kbNameOrNull == null || kbNameOrNull.isBlank()) {
+      targets = List.copyOf(boundNames);
+    } else if (boundNames.contains(kbNameOrNull)) {
+      targets = List.of(kbNameOrNull);
+    } else {
+      throw new IllegalArgumentException(
+          "知识库不存在或未绑定当前 Agent: " + kbNameOrNull + "（已绑定: " + String.join("、", boundNames) + "）");
+    }
+    int limit = topK == null || topK <= 0 ? KnowledgeQuery.DEFAULT_TOP_K : topK;
+    // 按后端声明分组路由（同一后端一次查询，内部已做跨库融合），跨后端再统一融合取全局 top-K
+    Map<String, List<String>> byBackend = new LinkedHashMap<>();
+    for (String kbName : targets) {
+      String backend = KnowledgeManifest.read(knowledgeRoot.resolve(kbName)).backend();
+      byBackend.computeIfAbsent(backend, key -> new ArrayList<>()).add(kbName);
+    }
+    List<KnowledgeHit> all = new ArrayList<>();
+    for (Map.Entry<String, List<String>> group : byBackend.entrySet()) {
+      KnowledgeBackend backend =
+          registry
+              .byName(group.getKey())
+              .orElseThrow(() -> new IllegalArgumentException("知识库后端未注册: " + group.getKey()));
+      all.addAll(backend.retrieve(new KnowledgeQuery(query, limit, group.getValue())));
+    }
+    return all.stream()
+        .sorted(Comparator.comparingDouble(KnowledgeHit::score).reversed())
+        .limit(limit)
+        .toList();
+  }
+
+  @Override
+  public List<KnowledgeBaseInfo> listBases() {
+    if (!Files.isDirectory(knowledgeRoot, LinkOption.NOFOLLOW_LINKS)) {
+      return List.of();
+    }
+    List<KnowledgeBaseInfo> bases = new ArrayList<>();
+    try (Stream<Path> dirs = Files.list(knowledgeRoot)) {
+      dirs.filter(Files::isDirectory)
+          .sorted()
+          .forEach(
+              dir -> {
+                try {
+                  bases.add(describe(KnowledgeManifest.read(dir)));
+                } catch (RuntimeException e) {
+                  // 非法目录不注册、告警、不影响其他库（US4 场景 3）
+                  LOG.warn(
+                      "跳过非法知识库目录 {}: {}",
+                      sanitize(String.valueOf(dir.getFileName())),
+                      sanitize(e.getMessage()));
+                }
+              });
+    } catch (IOException e) {
+      throw new UncheckedIOException("扫描知识库根目录失败: " + knowledgeRoot, e);
+    }
+    return List.copyOf(bases);
+  }
+
+  private KnowledgeBaseInfo describe(KnowledgeManifest manifest) {
+    List<DocumentStatus> statuses =
+        registry
+            .byName(manifest.backend())
+            .filter(backend -> backend.capabilities().status())
+            .flatMap(KnowledgeBackend::admin)
+            .map(admin -> admin.status(manifest.name()))
+            .orElse(List.of());
+    int chunkCount = statuses.stream().mapToInt(DocumentStatus::chunkCount).sum();
+    Instant lastIndexedAt =
+        statuses.stream()
+            .map(DocumentStatus::indexedAt)
+            .filter(indexedAt -> indexedAt != null)
+            .max(Comparator.naturalOrder())
+            .orElse(null);
+    return new KnowledgeBaseInfo(
+        manifest.name(),
+        manifest.description(),
+        manifest.backend(),
+        statuses.size(),
+        chunkCount,
+        aggregateStatus(statuses),
+        lastIndexedAt);
+  }
+
+  private static String aggregateStatus(List<DocumentStatus> statuses) {
+    if (statuses.isEmpty()) {
+      return "空";
+    }
+    if (statuses.stream().anyMatch(status -> status.state() == DocumentState.FAILED)) {
+      return "失败";
+    }
+    boolean inProgress =
+        statuses.stream()
+            .anyMatch(
+                status ->
+                    status.state() == DocumentState.PENDING
+                        || status.state() == DocumentState.INDEXING);
+    return inProgress ? "索引中" : "就绪";
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/context/ContextLoaderKnowledgeTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/context/ContextLoaderKnowledgeTest.java
@@ -1,0 +1,88 @@
+package io.oryxos.core.context;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.oryxos.core.knowledge.KnowledgeBindingService;
+import io.oryxos.core.knowledge.KnowledgeWorkspaceFixture;
+import io.oryxos.core.profile.Profile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** T024：渐进披露注入（FR-005）——每轮只注入绑定库元数据与检索指引，零绑定零注入、正文永不预载。 */
+class ContextLoaderKnowledgeTest {
+
+  @TempDir Path root;
+
+  private KnowledgeBindingService bindings;
+  private ContextLoader loader;
+
+  @BeforeEach
+  void setUp() {
+    KnowledgeWorkspaceFixture.workspace(root);
+    KnowledgeWorkspaceFixture.knowledgeBase(
+        root, "ops-manual", "运维手册", Map.of("disk.md", "# 磁盘告警\n\n处置步骤，正文不得出现在 prompt"));
+    KnowledgeWorkspaceFixture.agent(root, "assistant");
+    bindings = new KnowledgeBindingService(root);
+    loader = new ContextLoader(root, null, bindings);
+  }
+
+  @Test
+  void injectsOnlyMetadataAndGuidanceForBoundBases() {
+    bindings.bind("assistant", "ops-manual");
+
+    String context = loader.load(profile(List.of("retrieve_knowledge", "read_file")));
+
+    assertTrue(context.contains("ops-manual"), "注入绑定库名称");
+    assertTrue(context.contains("运维手册"), "注入绑定库描述");
+    assertTrue(context.contains("retrieve_knowledge"), "注入检索指引");
+    // 正文永不预载（FR-005）
+    assertFalse(context.contains("处置步骤"), "文档正文绝不进入 system prompt");
+  }
+
+  @Test
+  void zeroBindingMeansZeroInjection() {
+    String context = loader.load(profile(List.of("retrieve_knowledge")));
+    assertFalse(context.contains("知识库"), "未绑定 Agent 上下文零知识库注入（SC-005）");
+  }
+
+  @Test
+  void noInjectionWhenToolNotDeclared() {
+    bindings.bind("assistant", "ops-manual");
+    String context = loader.load(profile(List.of("read_file")));
+    assertFalse(context.contains("ops-manual"), "未声明检索工具的 Agent 不注入（注入了也无法使用）");
+  }
+
+  @Test
+  void brokenBindingIsSkippedWithoutFailingPromptAssembly() throws Exception {
+    bindings.bind("assistant", "ops-manual");
+    // 制造 dangling：目标库目录被移走
+    Path kbDir = root.resolve("knowledge/ops-manual");
+    Path moved = root.resolve("moved-away");
+    Files.move(kbDir, moved);
+
+    String context = loader.load(profile(List.of("retrieve_knowledge")));
+
+    assertFalse(context.contains("ops-manual"), "损坏绑定跳过注入，不炸 prompt 组装");
+  }
+
+  private static Profile profile(List<String> tools) {
+    return new Profile(
+        "assistant",
+        null,
+        null,
+        new Profile.ProviderRef("mock", "mock", null),
+        tools,
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        Profile.Settings.defaults());
+  }
+}

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/LocalKnowledgeBackend.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/LocalKnowledgeBackend.java
@@ -231,6 +231,20 @@ public class LocalKnowledgeBackend implements KnowledgeBackend, KnowledgeAdmin {
   }
 
   @Override
+  public void updateBase(String name, String description) {
+    Path dir = RealPathBoundary.requireWithin(knowledgeRoot, knowledgeRoot.resolve(name));
+    KnowledgeManifest.read(dir); // 校验存在且合法
+    String desc = description == null ? "" : description.replace('\r', ' ').replace('\n', ' ');
+    try {
+      Files.writeString(
+          dir.resolve(KnowledgeManifest.FILE),
+          "---\nname: " + name + "\ndescription: " + desc + "\nbackend: local\n---\n");
+    } catch (IOException e) {
+      throw new UncheckedIOException("更新知识库清单失败: " + name, e);
+    }
+  }
+
+  @Override
   public void deleteBase(String name) {
     Path dir = RealPathBoundary.requireWithin(knowledgeRoot, knowledgeRoot.resolve(name));
     if (!Files.isDirectory(dir)) {

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/builtin/KnowledgeTools.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/builtin/KnowledgeTools.java
@@ -1,0 +1,97 @@
+package io.oryxos.knowledge.builtin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.agent.ProfileContext;
+import io.oryxos.core.knowledge.KnowledgeService;
+import io.oryxos.core.knowledge.model.KnowledgeHit;
+import io.oryxos.core.profile.Profile;
+import java.nio.file.Path;
+import java.util.List;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+/**
+ * 内置检索工具 {@code retrieve_knowledge}（FR-004）：只认 {@link KnowledgeService} 门面，检索范围由门面按 发起 Agent
+ * 的绑定圈定（经 {@link ProfileContext}，MemoryTools 同款模式）。
+ *
+ * <p>工具结果是结构化 JSON——同时是 FR-022 的前瞻埋点载体（命中明细 + 分数 + 零结果/降级标记 + 查询原文 + 耗时），随 {@code tool_invocations}
+ * 审计落库，后续评测集/优化建议直接消费，无需二次埋点。 检索范围类错误返回可读文本（不抛栈），对话不中断（SC-005）。
+ */
+public class KnowledgeTools {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final KnowledgeService knowledgeService;
+  private final Path knowledgeRoot;
+
+  public KnowledgeTools(KnowledgeService knowledgeService, Path knowledgeRoot) {
+    this.knowledgeService = knowledgeService;
+    this.knowledgeRoot = knowledgeRoot.toAbsolutePath().normalize();
+  }
+
+  @Tool(
+      name = "retrieve_knowledge",
+      description =
+          "在当前 Agent 绑定的知识库中检索企业知识，返回带出处的片段。片段是入口：不足以回答时按结果里的 file 绝对路径用 read_file 读取原文补充")
+  public String retrieveKnowledge(
+      @ToolParam(description = "检索查询（可对用户原话改写）") String query,
+      @ToolParam(required = false, description = "返回片段数上限，默认 5") Integer limit,
+      @ToolParam(required = false, description = "限定单个知识库名；缺省聚合全部绑定库") String knowledgeBase) {
+    long start = System.currentTimeMillis();
+    Profile profile = ProfileContext.current();
+    if (profile == null) {
+      return "检索失败: 无法确定当前 Agent（缺少运行上下文）";
+    }
+    String kbFilter = knowledgeBase == null || knowledgeBase.isBlank() ? null : knowledgeBase;
+    List<KnowledgeHit> hits;
+    try {
+      hits = knowledgeService.retrieveForAgent(profile.name(), query, limit, kbFilter);
+    } catch (IllegalArgumentException e) {
+      // 零绑定 / 限定未绑定库等范围错误：可读文本返回，不中断对话（FR-020 / SC-005）
+      return "检索失败: " + e.getMessage();
+    }
+    return render(query, hits, System.currentTimeMillis() - start);
+  }
+
+  /** contracts/knowledge-spi.md §3 的结构化结果（同时是 FR-022 埋点结构，一次设计到位）。 */
+  private String render(String query, List<KnowledgeHit> hits, long durationMs) {
+    ObjectNode root = MAPPER.createObjectNode();
+    root.put("query", query);
+    ArrayNode hitNodes = root.putArray("hits");
+    boolean anyDegraded = false;
+    for (KnowledgeHit hit : hits) {
+      anyDegraded |= hit.degraded();
+      ObjectNode node = hitNodes.addObject();
+      node.put("kb", hit.citation().kbName());
+      node.put("path", hit.citation().relPath());
+      node.put("position", hit.citation().position());
+      node.put("citation", hit.citation().display());
+      node.put("readable", hit.citation().readable());
+      if (hit.citation().readable() && !hit.citation().relPath().isBlank()) {
+        node.put(
+            "file",
+            knowledgeRoot
+                .resolve(hit.citation().kbName())
+                .resolve(hit.citation().relPath())
+                .toString());
+      }
+      node.put("score", hit.score());
+      node.put("degraded", hit.degraded());
+      node.put("content", hit.content());
+      Object reason = hit.payload().get("degraded_reason");
+      if (reason != null) {
+        node.put("degraded_reason", String.valueOf(reason));
+      }
+    }
+    root.put("zero_result", hits.isEmpty());
+    root.put("degraded", anyDegraded);
+    root.put("duration_ms", durationMs);
+    try {
+      return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(root);
+    } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+      throw new IllegalStateException("检索结果序列化失败", e);
+    }
+  }
+}

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/store/InMemoryChunkStore.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/store/InMemoryChunkStore.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-/** 引擎单测用的内存实现：与 SqliteChunkStore 同语义，免 Spring/SQLite 起箱。 */
+/** 内存档（knowledge.store=memory）：与 SqliteChunkStore 同语义，重启即失——测试与演示用。 */
 public final class InMemoryChunkStore implements ChunkStore {
 
   private final AtomicLong ids = new AtomicLong();

--- a/oryxos-knowledge/src/test/java/io/oryxos/knowledge/builtin/KnowledgeToolsTest.java
+++ b/oryxos-knowledge/src/test/java/io/oryxos/knowledge/builtin/KnowledgeToolsTest.java
@@ -1,0 +1,149 @@
+package io.oryxos.knowledge.builtin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.core.agent.ProfileContext;
+import io.oryxos.core.knowledge.KnowledgeService;
+import io.oryxos.core.knowledge.model.Citation;
+import io.oryxos.core.knowledge.model.KnowledgeBaseInfo;
+import io.oryxos.core.knowledge.model.KnowledgeHit;
+import io.oryxos.core.profile.Profile;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** T023：retrieve_knowledge——绑定范围经 ProfileContext 圈定、结果为 FR-022 埋点结构、范围错误可读返回。 */
+class KnowledgeToolsTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @TempDir Path knowledgeRoot;
+
+  private String lastAgent;
+  private Integer lastTopK;
+  private String lastKbFilter;
+
+  @AfterEach
+  void tearDown() {
+    ProfileContext.clear();
+  }
+
+  @Test
+  void scopesByCurrentAgentAndEmitsStructuredAuditPayload() throws Exception {
+    KnowledgeHit hit =
+        new KnowledgeHit(
+            new Citation("ops-manual", "disk.md", "3", true), "处置步骤", 0.42, false, Map.of());
+    KnowledgeTools tools = new KnowledgeTools(service(List.of(hit)), knowledgeRoot);
+    ProfileContext.set(profile("ops-agent"));
+
+    String result = tools.retrieveKnowledge("磁盘告警", 3, "ops-manual");
+
+    assertEquals("ops-agent", lastAgent, "检索范围 = 发起 Agent 的绑定（FR-004）");
+    assertEquals(3, lastTopK);
+    assertEquals("ops-manual", lastKbFilter, "工具参数可限定单库（FR-020）");
+    JsonNode json = MAPPER.readTree(result);
+    // FR-022 埋点一次到位：查询原文 + 命中明细（库/文档/位置/分数）+ 标记 + 耗时
+    assertEquals("磁盘告警", json.get("query").asText());
+    JsonNode first = json.get("hits").get(0);
+    assertEquals("ops-manual", first.get("kb").asText());
+    assertEquals("disk.md", first.get("path").asText());
+    assertEquals("3", first.get("position").asText());
+    assertEquals("[ops-manual] disk.md #3", first.get("citation").asText());
+    assertTrue(first.get("file").asText().endsWith("ops-manual/disk.md"), "本地命中给出可跟读绝对路径（FR-017）");
+    assertFalse(json.get("zero_result").asBoolean());
+    assertFalse(json.get("degraded").asBoolean());
+    assertTrue(json.has("duration_ms"));
+  }
+
+  @Test
+  void degradedHitsAreFlaggedAndUnreadableCitationHasNoFilePath() throws Exception {
+    KnowledgeHit degraded =
+        new KnowledgeHit(
+            new Citation("remote-kb", "", "出处不可用", false),
+            "远程片段",
+            0.2,
+            true,
+            Map.of("degraded_reason", "向量化服务不可用"));
+    KnowledgeTools tools = new KnowledgeTools(service(List.of(degraded)), knowledgeRoot);
+    ProfileContext.set(profile("ops-agent"));
+
+    JsonNode json = MAPPER.readTree(tools.retrieveKnowledge("查询", null, null));
+
+    JsonNode first = json.get("hits").get(0);
+    assertTrue(first.get("degraded").asBoolean());
+    assertTrue(json.get("degraded").asBoolean());
+    assertFalse(first.has("file"), "不可跟读命中绝不返回不可用路径（FR-017）");
+    assertTrue(first.get("degraded_reason").asText().contains("向量化"));
+  }
+
+  @Test
+  void scopeErrorsReturnReadableTextWithoutBreakingConversation() {
+    KnowledgeService failing =
+        new KnowledgeService() {
+          @Override
+          public List<KnowledgeHit> retrieveForAgent(
+              String agentName, String query, Integer topK, String kbNameOrNull) {
+            throw new IllegalArgumentException("当前 Agent 未绑定任何知识库");
+          }
+
+          @Override
+          public List<KnowledgeBaseInfo> listBases() {
+            return List.of();
+          }
+        };
+    KnowledgeTools tools = new KnowledgeTools(failing, knowledgeRoot);
+    ProfileContext.set(profile("lonely"));
+
+    String result = tools.retrieveKnowledge("任何查询", null, null);
+
+    assertTrue(result.startsWith("检索失败:"), "零绑定误调返回可读错误（SC-005），不抛栈");
+    assertTrue(result.contains("未绑定"));
+  }
+
+  @Test
+  void missingProfileContextIsReadablyRejected() {
+    KnowledgeTools tools = new KnowledgeTools(service(List.of()), knowledgeRoot);
+    ProfileContext.clear();
+    assertTrue(tools.retrieveKnowledge("查询", null, null).contains("无法确定当前 Agent"));
+  }
+
+  private KnowledgeService service(List<KnowledgeHit> hits) {
+    return new KnowledgeService() {
+      @Override
+      public List<KnowledgeHit> retrieveForAgent(
+          String agentName, String query, Integer topK, String kbNameOrNull) {
+        lastAgent = agentName;
+        lastTopK = topK;
+        lastKbFilter = kbNameOrNull;
+        return hits;
+      }
+
+      @Override
+      public List<KnowledgeBaseInfo> listBases() {
+        return List.of();
+      }
+    };
+  }
+
+  private static Profile profile(String name) {
+    return new Profile(
+        name,
+        null,
+        null,
+        new Profile.ProviderRef("mock", "mock", null),
+        List.of("retrieve_knowledge"),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        Profile.Settings.defaults());
+  }
+}

--- a/oryxos-web/pom.xml
+++ b/oryxos-web/pom.xml
@@ -59,6 +59,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- 知识库端点测试用真实本地后端（内存存储档），只进测试路径 -->
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-knowledge</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -198,6 +198,7 @@ function select(key) {
   if (key === 'whitelist') { cancelWl(); loadWhitelist() }
   if (key === 'mcp') { cancelMcp(); loadMcp(); loadMcpCatalog() }
   if (key === 'skills') { cancelSkill(); closeSkillDetail(); loadSkills() }
+  if (key === 'knowledge') { cancelKb(); closeKbDetail(); loadKnowledge() }
   if (key === 'overview') { loadOverviewStats() }
 }
 
@@ -210,8 +211,97 @@ function refresh() {
   if (key === 'whitelist') { loadWhitelist(); return }
   if (key === 'mcp') { loadMcp(); return }
   if (key === 'skills') { loadSkills(); return }
+  if (key === 'knowledge') { kbDetail.value ? refreshKbDetail(kbDetail.value.name) : loadKnowledge(); return }
   if (key === 'overview') { loadOverviewStats(); return }
   if (NAV.find((n) => n.key === key)?.path) load(key)
+}
+
+// —— 知识库（014）：列表/详情/创建/上传/重建/删除；管理操作按后端能力集渲染（FR-009）——
+const kb = ref({ loading: false, error: null, data: [] })
+const kbDetail = ref(null) // { name, base, documents, loading, error, busy }
+const kbForm = reactive({ open: false, name: '', description: '', busy: false, error: '' })
+async function loadKnowledge() {
+  kb.value = { loading: true, error: null, data: [] }
+  try {
+    const res = await fetch('/api/v1/knowledge')
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '加载失败')
+    kb.value = { loading: false, error: null, data: body.data || [] }
+  } catch (e) { kb.value = { loading: false, error: e.message, data: [] } }
+}
+function cancelKb() { kbForm.open = false; kbForm.name = ''; kbForm.description = ''; kbForm.busy = false; kbForm.error = '' }
+function closeKbDetail() { kbDetail.value = null }
+async function refreshKbDetail(name) {
+  kbDetail.value = { ...(kbDetail.value || { name }), name, loading: true, error: null, busy: false }
+  try {
+    const res = await fetch(`/api/v1/knowledge/${encodeURIComponent(name)}`)
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '加载失败')
+    kbDetail.value = { name, base: body.data.base, documents: body.data.documents || [], loading: false, error: null, busy: false }
+  } catch (e) { kbDetail.value = { name, base: null, documents: [], loading: false, error: e.message, busy: false } }
+}
+async function createKb() {
+  kbForm.busy = true; kbForm.error = ''
+  try {
+    const res = await fetch('/api/v1/knowledge', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: kbForm.name.trim(), description: kbForm.description.trim() }),
+    })
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '创建失败')
+    cancelKb(); await loadKnowledge()
+  } catch (e) { kbForm.error = e.message } finally { kbForm.busy = false }
+}
+async function deleteKb(name) {
+  if (!confirm(`删除知识库「${name}」？（目录与索引一并删除）`)) return
+  try {
+    const res = await fetch(`/api/v1/knowledge/${encodeURIComponent(name)}`, { method: 'DELETE' })
+    const body = await res.json()
+    if (body.code !== 0) {
+      // 409：被 Agent 引用——点名引用方（FR-011）
+      const refs = (body.data?.references || []).map((r) => r.agentName).join('、')
+      throw new Error(refs ? `${body.message}（引用方：${refs}）` : (body.message || '删除失败'))
+    }
+    if (kbDetail.value?.name === name) closeKbDetail()
+    await loadKnowledge()
+  } catch (e) { kb.value = { ...kb.value, error: e.message } }
+}
+async function uploadKbDoc(event) {
+  const file = event.target.files?.[0]
+  event.target.value = '' // 允许重复选同一文件
+  if (!file || !kbDetail.value) return
+  const name = kbDetail.value.name
+  kbDetail.value = { ...kbDetail.value, busy: true, error: null }
+  try {
+    const form = new FormData()
+    form.append('file', file)
+    const res = await fetch(`/api/v1/knowledge/${encodeURIComponent(name)}/documents`, { method: 'POST', body: form })
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '上传失败')
+    await refreshKbDetail(name)
+  } catch (e) { kbDetail.value = { ...kbDetail.value, busy: false, error: e.message } }
+}
+async function reindexKb() {
+  if (!kbDetail.value) return
+  const name = kbDetail.value.name
+  kbDetail.value = { ...kbDetail.value, busy: true, error: null }
+  try {
+    const res = await fetch(`/api/v1/knowledge/${encodeURIComponent(name)}/reindex`, { method: 'POST' })
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '重建失败')
+    await refreshKbDetail(name)
+  } catch (e) { kbDetail.value = { ...kbDetail.value, busy: false, error: e.message } }
+}
+async function deleteKbDoc(relPath) {
+  if (!kbDetail.value) return
+  if (!confirm(`删除文档「${relPath}」？（源文件与索引片段一并删除）`)) return
+  const name = kbDetail.value.name
+  try {
+    const res = await fetch(`/api/v1/knowledge/${encodeURIComponent(name)}/documents?path=${encodeURIComponent(relPath)}`, { method: 'DELETE' })
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '删除失败')
+    await refreshKbDetail(name)
+  } catch (e) { kbDetail.value = { ...kbDetail.value, error: e.message } }
 }
 
 // —— Skill CRUD：.oryxos/skills/<name>/ 存在即已安装，Agent 通过本地相对软连接绑定。——
@@ -435,7 +525,8 @@ async function loadAgents() {
 // 只填 name + description 可直接按模板脚手架；也可先「用大模型生成」各文件、编辑后再创建。
 const agentCreate = reactive({
   open: false, name: '', description: '', provider: '', model: '', notifyChannel: '', skills: [],
-  requiredSkills: [], suggestedSkills: [], files: null, busy: false, error: '',
+  requiredSkills: [], suggestedSkills: [], knowledge: [], suggestedKnowledge: [],
+  files: null, busy: false, error: '',
 })
 
 // 新建页用的 provider / model 下拉数据源：provider 来自 GET /providers；model 来自 GET /providers/{name}/models（服务端代理）
@@ -473,11 +564,14 @@ function openCreate() {
   agentCreate.skills = []
   agentCreate.requiredSkills = []
   agentCreate.suggestedSkills = []
+  agentCreate.knowledge = []
+  agentCreate.suggestedKnowledge = []
   agentCreate.files = null
   agentCreate.busy = false
   agentCreate.error = ''
   loadNotifyChannels()
   loadSkills() // Skill 选择器的数据源（可手动指定必启用的 Skill；不选则由作者模型自动选）
+  loadKnowledge() // 知识库多选的数据源（FR-018 关联入口之一）
   loadCreateProviders() // provider 下拉数据源
 }
 
@@ -498,6 +592,9 @@ async function generateFiles() {
     agentCreate.requiredSkills = body.data.requiredSkills || []
     agentCreate.suggestedSkills = body.data.suggestedSkills || []
     agentCreate.skills = body.data.bindingSkills || []
+    // 一句话生成的知识库绑定建议（FR-018）：合并进选择器，作者确认后随创建生效
+    agentCreate.suggestedKnowledge = body.data.bindingKnowledge || []
+    agentCreate.knowledge = Array.from(new Set([...agentCreate.knowledge, ...agentCreate.suggestedKnowledge]))
   } catch (e) { agentCreate.error = e.message } finally { agentCreate.busy = false }
 }
 
@@ -509,11 +606,11 @@ async function submitCreate() {
     const res = agentCreate.files
       ? await fetch(`/api/v1/agents/${encodeURIComponent(agentCreate.name)}/files`, {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ files: agentCreate.files, skillBindings: agentCreate.skills }),
+          body: JSON.stringify({ files: agentCreate.files, skillBindings: agentCreate.skills, knowledgeBindings: agentCreate.knowledge }),
         })
         : await fetch('/api/v1/agents', {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: agentCreate.name, description: agentCreate.description, provider: agentCreate.provider || undefined, model: agentCreate.model || undefined, skillBindings: agentCreate.skills }),
+          body: JSON.stringify({ name: agentCreate.name, description: agentCreate.description, provider: agentCreate.provider || undefined, model: agentCreate.model || undefined, skillBindings: agentCreate.skills, knowledgeBindings: agentCreate.knowledge }),
         })
     const body = await res.json()
     if (body.code !== 0) throw new Error(body.message || '创建失败')
@@ -891,6 +988,7 @@ async function deleteWhitelist(category, value) {
 // —— Agent 详情：Tab 切换（基本信息 / 文件 / 会话 / 记忆）——
 const agentDetail = ref(null) // { name, agent, tab, loading, error, node, editing }
 const agentBinding = reactive({ selected: [], saving: false, error: null, issues: [] })
+const agentKb = reactive({ selected: [], saving: false, error: null, issues: [] })
 const fileView = ref(null) // { path, loading, error, content, saving, saved }
 // 详情页「编辑基本信息」表单态 + 编辑态的 model 下拉数据源（与新建页的 createModels 分开，避免串台）
 const editBasic = reactive({ description: '', provider: '', model: '' })
@@ -988,19 +1086,28 @@ async function openAgent(agent) {
   agentBinding.selected = [...(agent.skills || [])]
   agentBinding.error = null
   agentBinding.issues = []
+  agentKb.selected = []
+  agentKb.error = null
+  agentKb.issues = []
   fileView.value = null
   resetChat()
   resetAgentMemory()
   try {
-    const [treeRes, bindingRes] = await Promise.all([
+    const [treeRes, bindingRes, kbRes] = await Promise.all([
       fetch('/api/v1/workspace/tree'),
       fetch(`/api/v1/agents/${encodeURIComponent(agent.name)}/skills`),
+      fetch(`/api/v1/agents/${encodeURIComponent(agent.name)}/knowledge`),
       loadSkills(), // Skill 绑定选择器的数据源：存在即已安装
+      loadKnowledge(), // 知识库绑定选择器的数据源
     ])
     const body = await treeRes.json()
     const bindingBody = await bindingRes.json()
+    const kbBody = await kbRes.json()
     if (body.code !== 0) throw new Error(body.message || '加载失败')
     if (bindingBody.code !== 0) throw new Error(bindingBody.message || '绑定加载失败')
+    if (kbBody.code !== 0) throw new Error(kbBody.message || '知识库绑定加载失败')
+    agentKb.selected = (kbBody.data.bindings || []).map((b) => b.name)
+    agentKb.issues = kbBody.data.issues || []
     const agentsNode = (body.data.children || []).find((c) => c.name === 'agents')
     const node = (agentsNode?.children || []).find((c) => c.name === agent.name) || null
     const outputTree = (body.data.children || []).find((c) => c.name === 'output') || null
@@ -1030,6 +1137,21 @@ async function saveAgentBindings() {
     }
     await loadAgents()
   } catch (e) { agentBinding.error = e.message } finally { agentBinding.saving = false }
+}
+
+async function saveAgentKnowledge() {
+  if (!agentDetail.value) return
+  agentKb.saving = true; agentKb.error = null
+  try {
+    const res = await fetch(`/api/v1/agents/${encodeURIComponent(agentDetail.value.name)}/knowledge`, {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ knowledge: agentKb.selected }),
+    })
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '保存知识库绑定失败')
+    agentKb.selected = (body.data.bindings || []).map((b) => b.name)
+    agentKb.issues = body.data.issues || []
+  } catch (e) { agentKb.error = e.message } finally { agentKb.saving = false }
 }
 
 // 重新拉取当前 Agent 的元数据 + 文件树（保存文件后刷新基本信息）
@@ -1526,11 +1648,81 @@ const outputRows = computed(() =>
             </div>
           </div>
 
-          <!-- 知识库：占位空列表（待接入知识库端点） -->
-          <table v-else-if="active === 'knowledge'">
-            <thead><tr><th>名称</th><th>描述</th></tr></thead>
-            <tbody><tr><td colspan="2" class="empty">（暂无知识库条目 · 待接入知识库端点）</td></tr></tbody>
-          </table>
+          <!-- 知识库（014）：列表 + 详情（文档清单/上传/重建/单文档删除）；管理操作按后端能力集渲染 -->
+          <div v-else-if="active === 'knowledge'">
+            <!-- 列表视图 -->
+            <template v-if="!kbDetail">
+              <div class="toolbar">
+                <button class="btn btn-primary" @click="kbForm.open = true">+ 新建知识库</button>
+              </div>
+              <div v-if="kbForm.open" class="modal-overlay" @click.self="cancelKb()">
+                <div class="modal-card">
+                  <div class="modal-head"><h3>新建知识库</h3><button class="modal-x" @click="cancelKb()">✕</button></div>
+                  <div class="modal-body">
+                    <input v-model="kbForm.name" class="gen-input" placeholder="库名（字母/数字/下划线/连字符，即目录名）" />
+                    <textarea v-model="kbForm.description" class="gen-input" rows="2" placeholder="描述（会注入 Agent 上下文，写清这库装什么知识）"></textarea>
+                    <p v-if="kbForm.error" class="error">{{ kbForm.error }}</p>
+                  </div>
+                  <div class="modal-foot">
+                    <button class="btn" @click="cancelKb">取消</button>
+                    <button class="btn btn-primary" :disabled="kbForm.busy || !kbForm.name.trim() || !kbForm.description.trim()" @click="createKb">创建</button>
+                  </div>
+                </div>
+              </div>
+              <p v-if="kb.loading" class="empty">加载中…</p>
+              <p v-else-if="kb.error" class="error">出错：{{ kb.error }}</p>
+              <table v-else>
+                <thead><tr><th>名称</th><th>描述</th><th>后端</th><th>文档数</th><th>片段数</th><th>索引状态</th><th style="width:160px">操作</th></tr></thead>
+                <tbody>
+                  <tr v-if="!kb.data.length"><td colspan="7" class="empty">（暂无知识库，点右上「新建知识库」或向 .oryxos/knowledge/ 放入目录）</td></tr>
+                  <tr v-for="b in kb.data" :key="b.name">
+                    <td class="mono">{{ b.name }}</td>
+                    <td>{{ b.description }}</td>
+                    <td class="mono">{{ b.backend }}</td>
+                    <td>{{ b.documentCount }}</td>
+                    <td>{{ b.chunkCount }}</td>
+                    <td>{{ b.indexStatus }}</td>
+                    <td class="ops">
+                      <button class="btn" @click="refreshKbDetail(b.name)">详情</button>
+                      <button v-if="b.capabilities?.createDelete" class="btn" @click="deleteKb(b.name)">删除</button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </template>
+            <!-- 详情视图：文档清单 + 上传 + 重建（能力感知：只读后端不出上传/重建入口，FR-009） -->
+            <div v-else>
+              <button class="btn back" @click="closeKbDetail">← 返回知识库列表</button>
+              <div class="sess-meta"><span>知识库</span><span class="mono">{{ kbDetail.name }}</span></div>
+              <p v-if="kbDetail.loading" class="empty">加载中…</p>
+              <template v-else>
+                <p class="empty">{{ kbDetail.base?.description || '—' }}（后端：{{ kbDetail.base?.backend || '—' }} · 状态：{{ kbDetail.base?.indexStatus || '—' }} · 片段 {{ kbDetail.base?.chunkCount ?? '—' }}）</p>
+                <div class="ops" style="margin:8px 0">
+                  <label v-if="kbDetail.base?.capabilities?.importDocs" class="btn" style="cursor:pointer">
+                    上传文档（md / txt / 文本型 PDF）
+                    <input type="file" accept=".md,.markdown,.txt,.pdf" style="display:none" @change="uploadKbDoc" />
+                  </label>
+                  <button v-if="kbDetail.base?.capabilities?.rebuild" class="btn" :disabled="kbDetail.busy" @click="reindexKb">重建索引</button>
+                  <button class="btn" :disabled="kbDetail.busy" @click="refreshKbDetail(kbDetail.name)">刷新状态</button>
+                </div>
+                <p v-if="kbDetail.busy" class="empty">处理中…（切分向量化在后台推进，可点「刷新状态」跟进）</p>
+                <p v-if="kbDetail.error" class="error">{{ kbDetail.error }}</p>
+                <table>
+                  <thead><tr><th>文档</th><th>状态</th><th>片段数</th><th>最近索引</th><th style="width:90px">操作</th></tr></thead>
+                  <tbody>
+                    <tr v-if="!kbDetail.documents.length"><td colspan="5" class="empty">（暂无文档）</td></tr>
+                    <tr v-for="d in kbDetail.documents" :key="d.relPath">
+                      <td class="mono">{{ d.relPath }}</td>
+                      <td>{{ d.state }}<span v-if="d.failureReason" class="error">：{{ d.failureReason }}</span></td>
+                      <td>{{ d.chunkCount }}</td>
+                      <td class="mono">{{ d.indexedAt ? new Date(d.indexedAt).toLocaleString() : '—' }}</td>
+                      <td class="ops"><button v-if="kbDetail.base?.capabilities?.importDocs" class="btn" @click="deleteKbDoc(d.relPath)">删除</button></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </template>
+            </div>
+          </div>
 
           <!-- Sandbox 白名单：三类 file/shell/http 的 CRUD（新增走弹框 / 逐行删除） -->
           <div v-else-if="active === 'whitelist'">
@@ -1616,6 +1808,15 @@ const outputRows = computed(() =>
                 </div>
                 <p v-if="agentCreate.suggestedSkills.length" class="empty">作者建议：{{ agentCreate.suggestedSkills.join('、') }}；已合并到最终绑定，可在创建前取消。</p>
                 <p class="empty">绑定保存为 agents/&lt;name&gt;/skills/&lt;skill&gt; 固定相对软连接；AGENT.md 不保存 skills 字段，也不预载正文。</p>
+                <label class="empty" style="display:block;margin:6px 0 2px">知识库绑定（可多选；「用大模型生成」会按需求给出建议）</label>
+                <div class="skill-picker">
+                  <span v-if="!kb.data.length" class="empty">（暂无知识库，可先到「知识库」页新建）</span>
+                  <label v-for="b in kb.data" :key="b.name" class="skill-opt" :title="b.description">
+                    <input type="checkbox" :value="b.name" v-model="agentCreate.knowledge" />
+                    <span class="mono">{{ b.name }}</span>
+                  </label>
+                </div>
+                <p v-if="agentCreate.suggestedKnowledge.length" class="empty">作者建议知识库：{{ agentCreate.suggestedKnowledge.join('、') }}；已合并到选择，可在创建前取消。</p>
                 <div class="ops">
                   <button class="btn" :disabled="agentCreate.busy || !agentCreate.name.trim()" @click="generateFiles">用大模型生成</button>
                   <button class="btn btn-primary" :disabled="agentCreate.busy || !agentCreate.name.trim()" @click="submitCreate">创建</button>
@@ -1695,6 +1896,20 @@ const outputRows = computed(() =>
                       <div class="ops"><button class="btn" :disabled="agentBinding.saving" @click="saveAgentBindings">{{ agentBinding.saving ? '保存中…' : '保存绑定' }}</button></div>
                       <p v-if="agentBinding.error" class="error">{{ agentBinding.error }}</p>
                       <p v-for="(issue, i) in agentBinding.issues" :key="i" class="error">{{ issue.type }}：{{ issue.message }}</p>
+                    </div>
+                  </div>
+                  <div class="info-row"><span class="k">knowledge</span>
+                    <div>
+                      <div class="skill-picker">
+                        <span v-if="!kb.data.length" class="empty">（暂无知识库）</span>
+                        <label v-for="b in kb.data" :key="b.name" class="skill-opt" :title="b.description">
+                          <input type="checkbox" :value="b.name" v-model="agentKb.selected" />
+                          <span class="mono">{{ b.name }}</span>
+                        </label>
+                      </div>
+                      <div class="ops"><button class="btn" :disabled="agentKb.saving" @click="saveAgentKnowledge">{{ agentKb.saving ? '保存中…' : '保存知识库绑定' }}</button></div>
+                      <p v-if="agentKb.error" class="error">{{ agentKb.error }}</p>
+                      <p v-for="(issue, i) in agentKb.issues" :key="'kb'+i" class="error">{{ issue.type }}：{{ issue.message }}</p>
                     </div>
                   </div>
                   <div class="info-row"><span class="k">定时</span><span class="mono">{{ (agentDetail.agent.schedules || []).map((s) => s.cron + ' (' + s.zone + ')').join('；') || '—' }}</span></div>

--- a/oryxos-web/src/main/java/io/oryxos/web/GlobalExceptionHandler.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/GlobalExceptionHandler.java
@@ -27,8 +27,15 @@ public class GlobalExceptionHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-  /** 400 — malformed or invalid request arguments（含 AGENT.md 定义非法：ProfileValidationException）。 */
-  @ExceptionHandler({IllegalArgumentException.class, ProfileValidationException.class})
+  /**
+   * 400 — malformed or invalid request arguments（含 AGENT.md
+   * 定义非法：ProfileValidationException；文档导入同步校验失败：KnowledgeImportException）。
+   */
+  @ExceptionHandler({
+    IllegalArgumentException.class,
+    ProfileValidationException.class,
+    io.oryxos.core.knowledge.KnowledgeImportException.class
+  })
   public ResponseEntity<ApiResponse<Void>> handleBadRequest(RuntimeException ex) {
     LOG.warn("Bad request: {}", sanitize(ex.getMessage()));
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -57,6 +64,17 @@ public class GlobalExceptionHandler {
     LOG.error("Service unavailable: {}", sanitize(ex.getMessage()));
     return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
         .body(ApiResponse.error(HttpStatus.SERVICE_UNAVAILABLE.value(), ex.getMessage()));
+  }
+
+  /** 409 — 删除知识库被 Agent 引用保护拦下（FR-011）：携带引用 Agent 清单。 */
+  @ExceptionHandler(io.oryxos.core.knowledge.KnowledgeReferencedException.class)
+  public ResponseEntity<ApiResponse<io.oryxos.web.controller.dto.KnowledgeReferenceConflictView>>
+      handleKnowledgeReferenced(io.oryxos.core.knowledge.KnowledgeReferencedException ex) {
+    io.oryxos.web.controller.dto.KnowledgeReferenceConflictView data =
+        io.oryxos.web.controller.dto.KnowledgeReferenceConflictView.from(
+            ex.kbName(), ex.references());
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(new ApiResponse<>(HttpStatus.CONFLICT.value(), ex.getMessage(), data));
   }
 
   /** 409 — Skill archive is blocked by active or archived Agent references. */

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/AgentApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/AgentApiController.java
@@ -3,6 +3,7 @@ package io.oryxos.web.controller;
 import io.oryxos.core.agent.AgentExecutionService;
 import io.oryxos.core.agent.AgentLifecycleService;
 import io.oryxos.core.agent.AgentService;
+import io.oryxos.core.knowledge.KnowledgeBindingService;
 import io.oryxos.core.memory.MemoryService;
 import io.oryxos.core.profile.ProfileRegistry;
 import io.oryxos.core.session.Message;
@@ -14,6 +15,7 @@ import io.oryxos.core.skill.SkillCatalog;
 import io.oryxos.core.skill.SkillCatalogEntry;
 import io.oryxos.web.common.ApiResponse;
 import io.oryxos.web.controller.dto.AgentExecutionView;
+import io.oryxos.web.controller.dto.AgentKnowledgeBindingsView;
 import io.oryxos.web.controller.dto.AgentSkillBindingsView;
 import io.oryxos.web.controller.dto.AgentView;
 import io.oryxos.web.controller.dto.CreateAgentRequest;
@@ -21,6 +23,7 @@ import io.oryxos.web.controller.dto.GenerateFilesRequest;
 import io.oryxos.web.controller.dto.GeneratedFilesView;
 import io.oryxos.web.controller.dto.MessageRequest;
 import io.oryxos.web.controller.dto.MessageResponse;
+import io.oryxos.web.controller.dto.ReplaceKnowledgeBindingsRequest;
 import io.oryxos.web.controller.dto.ReplaceSkillBindingsRequest;
 import io.oryxos.web.controller.dto.SaveFilesRequest;
 import io.oryxos.web.controller.dto.SessionView;
@@ -74,6 +77,7 @@ public class AgentApiController {
   private final AgentExecutionService executionService;
   private final AgentSkillBindingService skillBindings;
   private final SkillCatalog skillCatalog;
+  private final KnowledgeBindingService knowledgeBindings;
 
   public AgentApiController(
       AgentLifecycleService lifecycle,
@@ -89,6 +93,7 @@ public class AgentApiController {
         profileRegistry,
         memoryService,
         executionService,
+        null,
         null,
         null);
   }
@@ -109,6 +114,28 @@ public class AgentApiController {
         memoryService,
         executionService,
         skillBindings,
+        null,
+        null);
+  }
+
+  public AgentApiController(
+      AgentLifecycleService lifecycle,
+      AgentService agentService,
+      SessionManager sessionManager,
+      ProfileRegistry profileRegistry,
+      MemoryService memoryService,
+      AgentExecutionService executionService,
+      AgentSkillBindingService skillBindings,
+      SkillCatalog skillCatalog) {
+    this(
+        lifecycle,
+        agentService,
+        sessionManager,
+        profileRegistry,
+        memoryService,
+        executionService,
+        skillBindings,
+        skillCatalog,
         null);
   }
 
@@ -121,7 +148,8 @@ public class AgentApiController {
       MemoryService memoryService,
       AgentExecutionService executionService,
       AgentSkillBindingService skillBindings,
-      SkillCatalog skillCatalog) {
+      SkillCatalog skillCatalog,
+      KnowledgeBindingService knowledgeBindings) {
     this.lifecycle = lifecycle;
     this.agentService = agentService;
     this.sessionManager = sessionManager;
@@ -130,6 +158,7 @@ public class AgentApiController {
     this.executionService = executionService;
     this.skillBindings = skillBindings;
     this.skillCatalog = skillCatalog;
+    this.knowledgeBindings = knowledgeBindings;
   }
 
   /** 创建：只需 name + description，后台按模板脚手架出完整目录 + 派生注册（失败回滚）。 */
@@ -138,10 +167,14 @@ public class AgentApiController {
     if (req == null || req.name() == null || req.name().isBlank()) {
       throw new IllegalArgumentException("Agent 名为空");
     }
-    return ApiResponse.ok(
-        view(
-            lifecycle.create(
-                req.name(), req.description(), req.provider(), req.model(), req.skillBindings())));
+    io.oryxos.core.profile.Profile created =
+        lifecycle.create(
+            req.name(), req.description(), req.provider(), req.model(), req.skillBindings());
+    // 014 FR-018：新建表单的知识库多选在此落软连接（绑定仅管理面动作；失败时 Agent 已建、错误可读可重试）
+    if (!req.knowledgeBindings().isEmpty()) {
+      requireKnowledgeBindings().replaceBindings(req.name(), req.knowledgeBindings());
+    }
+    return ApiResponse.ok(view(created));
   }
 
   @GetMapping
@@ -289,10 +322,49 @@ public class AgentApiController {
   @PostMapping("/{name}/files")
   public ApiResponse<AgentView> saveFiles(
       @PathVariable String name, @RequestBody SaveFilesRequest req) {
+    io.oryxos.core.profile.Profile saved =
+        lifecycle.saveFiles(
+            name, req == null ? null : req.files(), req == null ? null : req.skillBindings());
+    // 014 FR-018：生成/编辑保存时同步知识库绑定（null = 不改动）
+    if (req != null && req.knowledgeBindings() != null) {
+      requireKnowledgeBindings().replaceBindings(name, req.knowledgeBindings());
+    }
+    return ApiResponse.ok(view(saved));
+  }
+
+  // ---- 知识库绑定三件套 + 整体替换（014 FR-002/018/019：绑定仅管理面动作，运行时无自改工具）----
+
+  @GetMapping("/{name}/knowledge")
+  public ApiResponse<AgentKnowledgeBindingsView> knowledge(@PathVariable String name) {
+    requireAgent(name);
     return ApiResponse.ok(
-        view(
-            lifecycle.saveFiles(
-                name, req == null ? null : req.files(), req == null ? null : req.skillBindings())));
+        AgentKnowledgeBindingsView.from(requireKnowledgeBindings().inspect(name)));
+  }
+
+  @PutMapping("/{name}/knowledge/{kb}")
+  public ApiResponse<AgentKnowledgeBindingsView> bindKnowledge(
+      @PathVariable String name, @PathVariable String kb) {
+    requireAgent(name);
+    requireKnowledgeBindings().bind(name, kb);
+    return knowledge(name);
+  }
+
+  @DeleteMapping("/{name}/knowledge/{kb}")
+  public ApiResponse<AgentKnowledgeBindingsView> unbindKnowledge(
+      @PathVariable String name, @PathVariable String kb) {
+    requireAgent(name);
+    requireKnowledgeBindings().unbind(name, kb);
+    return knowledge(name);
+  }
+
+  @PutMapping("/{name}/knowledge")
+  public ApiResponse<AgentKnowledgeBindingsView> replaceKnowledge(
+      @PathVariable String name, @RequestBody ReplaceKnowledgeBindingsRequest request) {
+    requireAgent(name);
+    return ApiResponse.ok(
+        AgentKnowledgeBindingsView.from(
+            requireKnowledgeBindings()
+                .replaceBindings(name, request == null ? List.of() : request.knowledge())));
   }
 
   @GetMapping("/{name}/skills")
@@ -351,6 +423,13 @@ public class AgentApiController {
       throw new IllegalStateException("Agent Skill 绑定服务未装配");
     }
     return skillBindings;
+  }
+
+  private KnowledgeBindingService requireKnowledgeBindings() {
+    if (knowledgeBindings == null) {
+      throw new IllegalStateException("Agent 知识库绑定服务未装配");
+    }
+    return knowledgeBindings;
   }
 
   private void requireSkillsExist(List<String> names) {

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/KnowledgeApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/KnowledgeApiController.java
@@ -1,0 +1,253 @@
+package io.oryxos.web.controller;
+
+import io.oryxos.core.fs.RealPathBoundary;
+import io.oryxos.core.knowledge.KnowledgeAdmin;
+import io.oryxos.core.knowledge.KnowledgeBackend;
+import io.oryxos.core.knowledge.KnowledgeBackendRegistry;
+import io.oryxos.core.knowledge.KnowledgeBindingService;
+import io.oryxos.core.knowledge.KnowledgeImportException;
+import io.oryxos.core.knowledge.KnowledgeManifest;
+import io.oryxos.core.knowledge.KnowledgeService;
+import io.oryxos.core.knowledge.model.KnowledgeBaseInfo;
+import io.oryxos.core.knowledge.model.KnowledgeCapabilities;
+import io.oryxos.web.common.ApiResponse;
+import io.oryxos.web.controller.dto.CreateKnowledgeBaseRequest;
+import io.oryxos.web.controller.dto.KnowledgeBaseDetailView;
+import io.oryxos.web.controller.dto.KnowledgeBaseView;
+import io.oryxos.web.controller.dto.KnowledgeDocumentView;
+import io.oryxos.web.controller.dto.UpdateKnowledgeBaseRequest;
+import io.oryxos.web.error.ResourceNotFoundException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 知识库 REST 端点（FR-008）：全生命周期 + 两段式上传 + 索引状态 + 双缓冲重建。 管理类操作进入时按目标库后端的能力声明门禁——未声明能力 → 400
+ * 可读拒绝，绝不半执行（FR-006 / SC-011）； 删除受 Agent 引用保护 → 409 + 引用清单（FR-011）。
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = {"SPRING_ENDPOINT", "EI_EXPOSE_REP2"},
+    justification =
+        "core-stage web API is unauthenticated by design (internal network + gateway); auth is extension-phase. 协作者是 Spring 注入的共享单例，构造注入共享同一引用正是意图。")
+@RestController
+@RequestMapping("/api/v1/knowledge")
+public class KnowledgeApiController {
+
+  /** 上传文件名白名单：库内相对文件名，不允许路径分隔符（路径遍历在入口挡掉）。 */
+  private static final Pattern SAFE_FILE_NAME = Pattern.compile("[A-Za-z0-9\\u4e00-\\u9fa5._-]+");
+
+  private final KnowledgeService knowledgeService;
+  private final KnowledgeBackendRegistry backendRegistry;
+  private final KnowledgeBindingService bindingService;
+  private final Path knowledgeRoot;
+
+  public KnowledgeApiController(
+      KnowledgeService knowledgeService,
+      KnowledgeBackendRegistry backendRegistry,
+      KnowledgeBindingService bindingService,
+      @Value("${oryxos.root:.oryxos}") String oryxosRoot) {
+    this.knowledgeService = knowledgeService;
+    this.backendRegistry = backendRegistry;
+    this.bindingService = bindingService;
+    this.knowledgeRoot = Path.of(oryxosRoot).resolve("knowledge").toAbsolutePath().normalize();
+  }
+
+  @GetMapping
+  public ApiResponse<List<KnowledgeBaseView>> list() {
+    return ApiResponse.ok(knowledgeService.listBases().stream().map(this::view).toList());
+  }
+
+  @PostMapping
+  public ApiResponse<KnowledgeBaseView> create(@RequestBody CreateKnowledgeBaseRequest req) {
+    if (req == null || req.name() == null || req.name().isBlank()) {
+      throw new IllegalArgumentException("知识库名为空");
+    }
+    if (req.description() == null || req.description().isBlank()) {
+      throw new IllegalArgumentException("知识库描述为空（描述会注入 Agent 上下文，必填）");
+    }
+    String backendName =
+        req.backend() == null || req.backend().isBlank()
+            ? KnowledgeBackendRegistry.LOCAL
+            : req.backend();
+    KnowledgeBackend backend = requireBackend(backendName);
+    admin(backend, KnowledgeCapabilities::createDelete, "创建")
+        .createBase(req.name(), req.description());
+    return ApiResponse.ok(
+        knowledgeService.listBases().stream()
+            .filter(info -> info.name().equals(req.name()))
+            .findFirst()
+            .map(this::view)
+            .orElseThrow(() -> new IllegalStateException("知识库创建后未出现在清单中: " + req.name())));
+  }
+
+  @GetMapping("/{name}")
+  public ApiResponse<KnowledgeBaseDetailView> detail(@PathVariable String name) {
+    KnowledgeManifest manifest = requireBase(name);
+    KnowledgeBackend backend = requireBackend(manifest.backend());
+    List<KnowledgeDocumentView> documents =
+        backend.capabilities().status()
+            ? backend.admin().orElseThrow().status(name).stream()
+                .map(KnowledgeDocumentView::from)
+                .toList()
+            : List.of();
+    KnowledgeBaseView base =
+        knowledgeService.listBases().stream()
+            .filter(info -> info.name().equals(name))
+            .findFirst()
+            .map(this::view)
+            .orElseThrow(() -> new ResourceNotFoundException("知识库不存在: " + name));
+    return ApiResponse.ok(new KnowledgeBaseDetailView(base, documents));
+  }
+
+  @PatchMapping("/{name}")
+  public ApiResponse<KnowledgeBaseView> update(
+      @PathVariable String name, @RequestBody UpdateKnowledgeBaseRequest req) {
+    if (req == null || req.description() == null || req.description().isBlank()) {
+      throw new IllegalArgumentException("知识库描述为空");
+    }
+    KnowledgeManifest manifest = requireBase(name);
+    KnowledgeBackend backend = requireBackend(manifest.backend());
+    admin(backend, KnowledgeCapabilities::createDelete, "修改").updateBase(name, req.description());
+    return ApiResponse.ok(
+        knowledgeService.listBases().stream()
+            .filter(info -> info.name().equals(name))
+            .findFirst()
+            .map(this::view)
+            .orElseThrow(() -> new ResourceNotFoundException("知识库不存在: " + name)));
+  }
+
+  /** 删除：引用保护先行（409 + 引用 Agent 清单），再按能力门禁与后端执行。 */
+  @DeleteMapping("/{name}")
+  public ApiResponse<Void> delete(@PathVariable String name) {
+    KnowledgeManifest manifest = requireBase(name);
+    bindingService.ensureDeletable(name); // 被引用 → KnowledgeReferencedException → 409
+    KnowledgeBackend backend = requireBackend(manifest.backend());
+    admin(backend, KnowledgeCapabilities::createDelete, "删除").deleteBase(name);
+    return ApiResponse.ok(null);
+  }
+
+  /**
+   * 两段式上传（Clarify-Q3）：同步段落盘 + 解析校验——不支持类型/扫描件/超限当场 400（含原因），
+   * 校验失败即清理落盘文件不留半成品；切分向量化由后台虚拟线程推进，状态可随时查。
+   */
+  @PostMapping("/{name}/documents")
+  public ApiResponse<KnowledgeDocumentView> upload(
+      @PathVariable String name, @RequestParam("file") MultipartFile file) {
+    KnowledgeManifest manifest = requireBase(name);
+    KnowledgeBackend backend = requireBackend(manifest.backend());
+    KnowledgeAdmin admin = admin(backend, KnowledgeCapabilities::importDocs, "上传文档");
+    if (file == null || file.isEmpty()) {
+      throw new IllegalArgumentException("上传文件为空");
+    }
+    String fileName = safeFileName(file.getOriginalFilename());
+    Path target =
+        RealPathBoundary.requireWithin(
+            knowledgeRoot, knowledgeRoot.resolve(name).resolve(fileName));
+    try {
+      Files.write(target, file.getBytes());
+    } catch (IOException e) {
+      throw new UncheckedIOException("文档落盘失败: " + fileName, e);
+    }
+    try {
+      return ApiResponse.ok(KnowledgeDocumentView.from(admin.importDocument(name, fileName)));
+    } catch (KnowledgeImportException e) {
+      deleteQuietly(target); // 入口即拒绝：不留半完成文件（Edge Cases）
+      throw e;
+    }
+  }
+
+  /** 删单个文档：索引片段级联清理 + 源文件一并删除（管理台视角文档即文件）。 */
+  @DeleteMapping("/{name}/documents")
+  public ApiResponse<Void> deleteDocument(
+      @PathVariable String name, @RequestParam("path") String relPath) {
+    KnowledgeManifest manifest = requireBase(name);
+    KnowledgeBackend backend = requireBackend(manifest.backend());
+    KnowledgeAdmin admin = admin(backend, KnowledgeCapabilities::importDocs, "删除文档");
+    Path target =
+        RealPathBoundary.requireWithin(knowledgeRoot, knowledgeRoot.resolve(name).resolve(relPath));
+    admin.deleteDocument(name, relPath);
+    deleteQuietly(target);
+    return ApiResponse.ok(null);
+  }
+
+  @GetMapping("/{name}/status")
+  public ApiResponse<List<KnowledgeDocumentView>> status(@PathVariable String name) {
+    KnowledgeManifest manifest = requireBase(name);
+    KnowledgeBackend backend = requireBackend(manifest.backend());
+    return ApiResponse.ok(
+        admin(backend, KnowledgeCapabilities::status, "查询索引状态").status(name).stream()
+            .map(KnowledgeDocumentView::from)
+            .toList());
+  }
+
+  /** 双缓冲重建（FR-024）：旧索引持续服务，新索引就绪原子切换；失败旧索引不受影响（503 + 可读原因）。 */
+  @PostMapping("/{name}/reindex")
+  public ApiResponse<List<KnowledgeDocumentView>> reindex(@PathVariable String name) {
+    KnowledgeManifest manifest = requireBase(name);
+    KnowledgeBackend backend = requireBackend(manifest.backend());
+    KnowledgeAdmin admin = admin(backend, KnowledgeCapabilities::rebuild, "重建索引");
+    admin.rebuild(name);
+    return status(name);
+  }
+
+  private KnowledgeBaseView view(KnowledgeBaseInfo info) {
+    KnowledgeCapabilities capabilities =
+        backendRegistry.byName(info.backend()).map(KnowledgeBackend::capabilities).orElse(null);
+    return KnowledgeBaseView.from(info, capabilities);
+  }
+
+  private KnowledgeManifest requireBase(String name) {
+    Path dir = knowledgeRoot.resolve(name);
+    if (!Files.isDirectory(dir)) {
+      throw new ResourceNotFoundException("知识库不存在: " + name);
+    }
+    return KnowledgeManifest.read(dir);
+  }
+
+  private KnowledgeBackend requireBackend(String backendName) {
+    return backendRegistry
+        .byName(backendName)
+        .orElseThrow(() -> new IllegalArgumentException("知识库后端未注册: " + backendName));
+  }
+
+  /** 能力门禁（FR-006）：未声明能力在入口可读拒绝，不落到后端实现。 */
+  private static KnowledgeAdmin admin(
+      KnowledgeBackend backend, Predicate<KnowledgeCapabilities> capability, String operation) {
+    if (!capability.test(backend.capabilities()) || backend.admin().isEmpty()) {
+      throw new IllegalArgumentException("该知识库后端不支持此操作（" + operation + "）: " + backend.name());
+    }
+    return backend.admin().orElseThrow();
+  }
+
+  private static String safeFileName(String original) {
+    java.nio.file.Path leaf = original == null ? null : Path.of(original).getFileName();
+    String fileName = leaf == null ? "" : leaf.toString();
+    if (fileName.isBlank() || !SAFE_FILE_NAME.matcher(fileName).matches()) {
+      throw new IllegalArgumentException("非法文件名（只允许中英文/数字/点/下划线/连字符）: " + original);
+    }
+    return fileName;
+  }
+
+  private static void deleteQuietly(Path target) {
+    try {
+      Files.deleteIfExists(target);
+    } catch (IOException ignored) {
+      // 清理失败不影响主流程；对账与重建可收敛
+    }
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/AgentKnowledgeBindingsView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/AgentKnowledgeBindingsView.java
@@ -1,0 +1,27 @@
+package io.oryxos.web.controller.dto;
+
+import io.oryxos.core.knowledge.KnowledgeBindingInspection;
+import java.util.List;
+
+/** Agent 知识库绑定视图（含链接合法性状态，SC-007 三界面一致的对账面）。 */
+public record AgentKnowledgeBindingsView(List<BindingView> bindings, List<IssueView> issues) {
+
+  public AgentKnowledgeBindingsView {
+    bindings = bindings == null ? List.of() : List.copyOf(bindings);
+    issues = issues == null ? List.of() : List.copyOf(issues);
+  }
+
+  public static AgentKnowledgeBindingsView from(KnowledgeBindingInspection inspection) {
+    return new AgentKnowledgeBindingsView(
+        inspection.bindings().stream()
+            .map(binding -> new BindingView(binding.name(), binding.description()))
+            .toList(),
+        inspection.issues().stream()
+            .map(issue -> new IssueView(issue.entryName(), issue.type().name(), issue.message()))
+            .toList());
+  }
+
+  public record BindingView(String name, String description) {}
+
+  public record IssueView(String entryName, String type, String message) {}
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/CreateAgentRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/CreateAgentRequest.java
@@ -2,14 +2,25 @@ package io.oryxos.web.controller.dto;
 
 import java.util.List;
 
-/** POST /agents request: Agent metadata, selected provider/model, and initial Skill bindings. */
+/** POST /agents request: Agent metadata, selected provider/model, and initial bindings. */
 public record CreateAgentRequest(
-    String name, String description, String provider, String model, List<String> skillBindings) {
+    String name,
+    String description,
+    String provider,
+    String model,
+    List<String> skillBindings,
+    List<String> knowledgeBindings) {
   public CreateAgentRequest {
     skillBindings = skillBindings == null ? List.of() : List.copyOf(skillBindings);
+    knowledgeBindings = knowledgeBindings == null ? List.of() : List.copyOf(knowledgeBindings);
+  }
+
+  public CreateAgentRequest(
+      String name, String description, String provider, String model, List<String> skillBindings) {
+    this(name, description, provider, model, skillBindings, List.of());
   }
 
   public CreateAgentRequest(String name, String description) {
-    this(name, description, null, null, List.of());
+    this(name, description, null, null, List.of(), List.of());
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/CreateKnowledgeBaseRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/CreateKnowledgeBaseRequest.java
@@ -1,0 +1,4 @@
+package io.oryxos.web.controller.dto;
+
+/** POST /knowledge 请求体；backend 缺省 local（FR-015）。 */
+public record CreateKnowledgeBaseRequest(String name, String description, String backend) {}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/GeneratedFilesView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/GeneratedFilesView.java
@@ -9,17 +9,23 @@ public record GeneratedFilesView(
     Map<String, String> files,
     List<String> requiredSkills,
     List<String> suggestedSkills,
-    List<String> bindingSkills) {
+    List<String> bindingSkills,
+    List<String> bindingKnowledge) {
 
   public GeneratedFilesView {
     files = files == null ? Map.of() : Map.copyOf(files);
     requiredSkills = requiredSkills == null ? List.of() : List.copyOf(requiredSkills);
     suggestedSkills = suggestedSkills == null ? List.of() : List.copyOf(suggestedSkills);
     bindingSkills = bindingSkills == null ? List.of() : List.copyOf(bindingSkills);
+    bindingKnowledge = bindingKnowledge == null ? List.of() : List.copyOf(bindingKnowledge);
   }
 
   public static GeneratedFilesView from(GeneratedAgentDraft draft) {
     return new GeneratedFilesView(
-        draft.files(), draft.requiredSkills(), draft.suggestedSkills(), draft.bindingSkills());
+        draft.files(),
+        draft.requiredSkills(),
+        draft.suggestedSkills(),
+        draft.bindingSkills(),
+        draft.bindingKnowledge());
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/KnowledgeBaseDetailView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/KnowledgeBaseDetailView.java
@@ -1,0 +1,11 @@
+package io.oryxos.web.controller.dto;
+
+import java.util.List;
+
+/** 知识库详情：库信息 + 文档清单。 */
+public record KnowledgeBaseDetailView(
+    KnowledgeBaseView base, List<KnowledgeDocumentView> documents) {
+  public KnowledgeBaseDetailView {
+    documents = documents == null ? List.of() : List.copyOf(documents);
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/KnowledgeBaseView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/KnowledgeBaseView.java
@@ -1,0 +1,43 @@
+package io.oryxos.web.controller.dto;
+
+import io.oryxos.core.knowledge.model.KnowledgeBaseInfo;
+import io.oryxos.core.knowledge.model.KnowledgeCapabilities;
+import java.time.Instant;
+
+/** 知识库列表/详情行：投影 + 后端能力集（管理台按能力渲染操作入口，FR-009）。 */
+public record KnowledgeBaseView(
+    String name,
+    String description,
+    String backend,
+    int documentCount,
+    int chunkCount,
+    String indexStatus,
+    Instant lastIndexedAt,
+    CapabilitiesView capabilities) {
+
+  public static KnowledgeBaseView from(KnowledgeBaseInfo info, KnowledgeCapabilities capabilities) {
+    return new KnowledgeBaseView(
+        info.name(),
+        info.description(),
+        info.backend(),
+        info.documentCount(),
+        info.chunkCount(),
+        info.indexStatus(),
+        info.lastIndexedAt(),
+        capabilities == null ? null : CapabilitiesView.from(capabilities));
+  }
+
+  /** 能力声明视图：未注册后端返回 null（前端按只读渲染）。 */
+  public record CapabilitiesView(
+      boolean createDelete, boolean importDocs, boolean rebuild, boolean status, boolean rerank) {
+
+    public static CapabilitiesView from(KnowledgeCapabilities capabilities) {
+      return new CapabilitiesView(
+          capabilities.createDelete(),
+          capabilities.importDocs(),
+          capabilities.rebuild(),
+          capabilities.status(),
+          capabilities.rerank());
+    }
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/KnowledgeDocumentView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/KnowledgeDocumentView.java
@@ -1,0 +1,18 @@
+package io.oryxos.web.controller.dto;
+
+import io.oryxos.core.knowledge.model.DocumentStatus;
+import java.time.Instant;
+
+/** 库详情的文档清单行（状态机可随时查询，FR-008）。 */
+public record KnowledgeDocumentView(
+    String relPath, String state, int chunkCount, String failureReason, Instant indexedAt) {
+
+  public static KnowledgeDocumentView from(DocumentStatus status) {
+    return new KnowledgeDocumentView(
+        status.relPath(),
+        status.state().name(),
+        status.chunkCount(),
+        status.failureReason(),
+        status.indexedAt());
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/KnowledgeReferenceConflictView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/KnowledgeReferenceConflictView.java
@@ -1,0 +1,26 @@
+package io.oryxos.web.controller.dto;
+
+import io.oryxos.core.knowledge.KnowledgeReference;
+import java.util.List;
+
+/** 删除被引用知识库的 409 冲突载荷：点名引用它的 Agent（FR-011）。 */
+public record KnowledgeReferenceConflictView(String kbName, List<ReferenceView> references) {
+
+  public KnowledgeReferenceConflictView {
+    references = references == null ? List.of() : List.copyOf(references);
+  }
+
+  public static KnowledgeReferenceConflictView from(
+      String kbName, List<KnowledgeReference> references) {
+    return new KnowledgeReferenceConflictView(
+        kbName,
+        references.stream()
+            .map(
+                reference ->
+                    new ReferenceView(
+                        reference.agentName(), reference.state().name(), reference.directoryName()))
+            .toList());
+  }
+
+  public record ReferenceView(String agentName, String state, String directoryName) {}
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ReplaceKnowledgeBindingsRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ReplaceKnowledgeBindingsRequest.java
@@ -1,0 +1,10 @@
+package io.oryxos.web.controller.dto;
+
+import java.util.List;
+
+/** PUT /agents/{name}/knowledge 请求体：整体替换该 Agent 的知识库绑定集合。 */
+public record ReplaceKnowledgeBindingsRequest(List<String> knowledge) {
+  public ReplaceKnowledgeBindingsRequest {
+    knowledge = knowledge == null ? List.of() : List.copyOf(knowledge);
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/SaveFilesRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/SaveFilesRequest.java
@@ -4,14 +4,20 @@ import java.util.List;
 import java.util.Map;
 
 /** POST /agents/{name}/files 请求体：保存（可能被用户改过的）一组 Agent 文件，写入即生效。 */
-public record SaveFilesRequest(Map<String, String> files, List<String> skillBindings) {
+public record SaveFilesRequest(
+    Map<String, String> files, List<String> skillBindings, List<String> knowledgeBindings) {
 
   public SaveFilesRequest {
     files = files == null ? Map.of() : Map.copyOf(files);
     skillBindings = skillBindings == null ? null : List.copyOf(skillBindings);
+    knowledgeBindings = knowledgeBindings == null ? null : List.copyOf(knowledgeBindings);
+  }
+
+  public SaveFilesRequest(Map<String, String> files, List<String> skillBindings) {
+    this(files, skillBindings, null);
   }
 
   public SaveFilesRequest(Map<String, String> files) {
-    this(files, null);
+    this(files, null, null);
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/UpdateKnowledgeBaseRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/UpdateKnowledgeBaseRequest.java
@@ -1,0 +1,4 @@
+package io.oryxos.web.controller.dto;
+
+/** PATCH /knowledge/{name} 请求体：只改描述。 */
+public record UpdateKnowledgeBaseRequest(String description) {}

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/AgentKnowledgeBindingApiTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/AgentKnowledgeBindingApiTest.java
@@ -1,0 +1,136 @@
+package io.oryxos.web.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.oryxos.core.agent.AgentExecutionService;
+import io.oryxos.core.agent.AgentLifecycleService;
+import io.oryxos.core.agent.AgentService;
+import io.oryxos.core.knowledge.KnowledgeBindingService;
+import io.oryxos.core.memory.MemoryService;
+import io.oryxos.core.profile.Profile;
+import io.oryxos.core.profile.ProfileRegistry;
+import io.oryxos.core.session.SessionManager;
+import io.oryxos.web.GlobalExceptionHandler;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/** T035：Agent 知识库绑定三件套 + 整体替换 + 创建入口的 knowledgeBindings（FR-002/018/019）。 */
+class AgentKnowledgeBindingApiTest {
+
+  @TempDir Path root;
+
+  private AgentLifecycleService lifecycle;
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    Files.createDirectories(root.resolve("agents/ops"));
+    Files.writeString(root.resolve("agents/ops/AGENT.md"), "---\nname: ops\n---\nbody");
+    knowledgeBase("ops-manual", "运维手册");
+    knowledgeBase("faq", "产品FAQ");
+    KnowledgeBindingService bindings = new KnowledgeBindingService(root);
+    Profile profile = profile("ops");
+    ProfileRegistry profiles = new ProfileRegistry(Map.of("ops", profile));
+    lifecycle = mock(AgentLifecycleService.class);
+    when(lifecycle.create(eq("ops"), any(), any(), any(), any())).thenReturn(profile);
+    mvc =
+        MockMvcBuilders.standaloneSetup(
+                new AgentApiController(
+                    lifecycle,
+                    mock(AgentService.class),
+                    mock(SessionManager.class),
+                    profiles,
+                    mock(MemoryService.class),
+                    mock(AgentExecutionService.class),
+                    null,
+                    null,
+                    bindings))
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+  }
+
+  @Test
+  @DisplayName("bind → get 可见；unbind → 清空；replace 整体替换")
+  void bindingCrudAndReplace() throws Exception {
+    mvc.perform(put("/api/v1/agents/ops/knowledge/ops-manual"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.bindings[0].name").value("ops-manual"))
+        .andExpect(jsonPath("$.data.bindings[0].description").value("运维手册"));
+
+    mvc.perform(get("/api/v1/agents/ops/knowledge"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.bindings.length()").value(1));
+
+    mvc.perform(
+            put("/api/v1/agents/ops/knowledge")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"knowledge\":[\"faq\"]}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.bindings[0].name").value("faq"));
+
+    mvc.perform(delete("/api/v1/agents/ops/knowledge/faq"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.bindings.length()").value(0));
+  }
+
+  @Test
+  @DisplayName("绑定不存在的库 → 400；不存在的 Agent → 404")
+  void errorsAreReadable() throws Exception {
+    mvc.perform(put("/api/v1/agents/ops/knowledge/nope")).andExpect(status().isBadRequest());
+    mvc.perform(get("/api/v1/agents/ghost/knowledge")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("创建 Agent 携带 knowledgeBindings → 绑定同步建立（FR-018 路径一）")
+  void createWithKnowledgeBindings() throws Exception {
+    mvc.perform(
+            post("/api/v1/agents")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"name\":\"ops\",\"description\":\"x\",\"knowledgeBindings\":[\"ops-manual\"]}"))
+        .andExpect(status().isOk());
+
+    mvc.perform(get("/api/v1/agents/ops/knowledge"))
+        .andExpect(jsonPath("$.data.bindings[0].name").value("ops-manual"));
+  }
+
+  private void knowledgeBase(String name, String description) throws Exception {
+    Path dir = Files.createDirectories(root.resolve("knowledge").resolve(name));
+    Files.writeString(
+        dir.resolve("KNOWLEDGE.md"),
+        "---\nname: " + name + "\ndescription: " + description + "\n---\n");
+  }
+
+  private static Profile profile(String name) {
+    return new Profile(
+        name,
+        null,
+        null,
+        new Profile.ProviderRef("mock", "mock", null),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        Profile.Settings.defaults());
+  }
+}

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/KnowledgeApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/KnowledgeApiControllerTest.java
@@ -1,0 +1,243 @@
+package io.oryxos.web.controller;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.oryxos.core.embedding.TextEmbedder;
+import io.oryxos.core.knowledge.KnowledgeAdmin;
+import io.oryxos.core.knowledge.KnowledgeBackend;
+import io.oryxos.core.knowledge.KnowledgeBackendRegistry;
+import io.oryxos.core.knowledge.KnowledgeBindingService;
+import io.oryxos.core.knowledge.KnowledgeService;
+import io.oryxos.core.knowledge.KnowledgeServiceImpl;
+import io.oryxos.core.knowledge.model.KnowledgeCapabilities;
+import io.oryxos.core.knowledge.model.KnowledgeHit;
+import io.oryxos.core.knowledge.model.KnowledgeQuery;
+import io.oryxos.knowledge.LocalKnowledgeBackend;
+import io.oryxos.knowledge.index.KnowledgeIndexService;
+import io.oryxos.knowledge.store.InMemoryChunkStore;
+import io.oryxos.web.GlobalExceptionHandler;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * T031：知识库 REST 全生命周期（FR-008）——两段式上传当场拒绝、能力门禁 400、引用保护 409、重名 409/400。 用真实本地后端（内存存储档）+
+ * 仅检索测试桩，同一套端点核验能力感知（SC-011 门禁面）。
+ */
+class KnowledgeApiControllerTest {
+
+  @TempDir Path root;
+
+  private Path kbRoot;
+  private KnowledgeBindingService bindings;
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    kbRoot = Files.createDirectories(root.resolve("knowledge"));
+    Files.createDirectories(root.resolve("agents"));
+    Supplier<TextEmbedder> embedder = () -> new HashEmbedder();
+    InMemoryChunkStore store = new InMemoryChunkStore();
+    KnowledgeIndexService indexService =
+        new KnowledgeIndexService(kbRoot, store, embedder, Runnable::run);
+    LocalKnowledgeBackend local = new LocalKnowledgeBackend(kbRoot, store, indexService, embedder);
+    KnowledgeBackendRegistry registry = new KnowledgeBackendRegistry();
+    registry.register(local);
+    registry.register(retrieveOnlyStub());
+    bindings = new KnowledgeBindingService(root);
+    KnowledgeService service = new KnowledgeServiceImpl(kbRoot, bindings, registry);
+    mvc =
+        MockMvcBuilders.standaloneSetup(
+                new KnowledgeApiController(service, registry, bindings, root.toString()))
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+  }
+
+  @Test
+  @DisplayName("建库 → 列表可见（含能力集）；重名 → 400")
+  void createThenListWithCapabilities() throws Exception {
+    createBase("ops-manual", "运维手册");
+
+    mvc.perform(get("/api/v1/knowledge"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].name").value("ops-manual"))
+        .andExpect(jsonPath("$.data[0].backend").value("local"))
+        .andExpect(jsonPath("$.data[0].indexStatus").value("空"))
+        .andExpect(jsonPath("$.data[0].capabilities.importDocs").value(true))
+        .andExpect(jsonPath("$.data[0].capabilities.rerank").value(false));
+
+    mvc.perform(
+            post("/api/v1/knowledge")
+                .contentType("application/json")
+                .content("{\"name\":\"ops-manual\",\"description\":\"重名\"}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("两段式上传：md 落盘校验通过 → 后台索引 READY；扫描外类型当场 400 且不留半成品")
+  void twoPhaseUploadAndEntryRejection() throws Exception {
+    createBase("ops-manual", "运维手册");
+
+    mvc.perform(
+            multipart("/api/v1/knowledge/ops-manual/documents")
+                .file(new MockMultipartFile("file", "disk.md", null, "# 磁盘告警\n\n处置步骤".getBytes())))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.relPath").value("disk.md"));
+
+    // 直接执行器：后台段已同步完成 → 状态机推进到 READY（Clarify-Q3 可随时查询）
+    mvc.perform(get("/api/v1/knowledge/ops-manual/status"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].state").value("READY"))
+        .andExpect(jsonPath("$.data[0].chunkCount").value(1));
+
+    // 不支持类型：当场 400 + 可读原因，且落盘文件被清理（入口即拒绝不留半完成状态）
+    mvc.perform(
+            multipart("/api/v1/knowledge/ops-manual/documents")
+                .file(new MockMultipartFile("file", "report.docx", null, "x".getBytes())))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("不支持")));
+    assertFalse(Files.exists(kbRoot.resolve("ops-manual/report.docx")), "校验失败的落盘文件必须清理");
+  }
+
+  @Test
+  @DisplayName("详情/改描述/删文档/重建")
+  void detailUpdateDeleteDocReindex() throws Exception {
+    createBase("ops-manual", "运维手册");
+    mvc.perform(
+            multipart("/api/v1/knowledge/ops-manual/documents")
+                .file(new MockMultipartFile("file", "disk.md", null, "# 内容".getBytes())))
+        .andExpect(status().isOk());
+
+    mvc.perform(get("/api/v1/knowledge/ops-manual"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.base.indexStatus").value("就绪"))
+        .andExpect(jsonPath("$.data.documents[0].relPath").value("disk.md"));
+
+    mvc.perform(
+            patch("/api/v1/knowledge/ops-manual")
+                .contentType("application/json")
+                .content("{\"description\":\"新描述\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.description").value("新描述"));
+
+    mvc.perform(post("/api/v1/knowledge/ops-manual/reindex"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].state").value("READY"));
+
+    mvc.perform(delete("/api/v1/knowledge/ops-manual/documents").param("path", "disk.md"))
+        .andExpect(status().isOk());
+    assertFalse(Files.exists(kbRoot.resolve("ops-manual/disk.md")));
+  }
+
+  @Test
+  @DisplayName("删除被 Agent 引用的库 → 409 + 引用清单；解绑后可删（FR-011）")
+  void deleteIsReferenceProtected() throws Exception {
+    createBase("ops-manual", "运维手册");
+    Files.writeString(
+        Files.createDirectories(root.resolve("agents/ops")).resolve("AGENT.md"),
+        "---\nname: ops\n---\nbody");
+    bindings.bind("ops", "ops-manual");
+
+    mvc.perform(delete("/api/v1/knowledge/ops-manual"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.data.references[0].agentName").value("ops"));
+
+    bindings.unbind("ops", "ops-manual");
+    mvc.perform(delete("/api/v1/knowledge/ops-manual")).andExpect(status().isOk());
+    assertFalse(Files.exists(kbRoot.resolve("ops-manual")));
+  }
+
+  @Test
+  @DisplayName("能力门禁：仅检索后端的管理操作入口即 400 可读拒绝（FR-006 / SC-011）；不存在 → 404")
+  void capabilityGateAndNotFound() throws Exception {
+    Path remote = Files.createDirectories(kbRoot.resolve("remote-kb"));
+    Files.writeString(
+        remote.resolve("KNOWLEDGE.md"),
+        "---\nname: remote-kb\ndescription: 远程库\nbackend: stub\n---\n");
+
+    mvc.perform(post("/api/v1/knowledge/remote-kb/reindex"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("不支持此操作")));
+    mvc.perform(
+            multipart("/api/v1/knowledge/remote-kb/documents")
+                .file(new MockMultipartFile("file", "a.md", null, "x".getBytes())))
+        .andExpect(status().isBadRequest());
+    // 列表照常展示（能力集为仅检索，前端据此不渲染入口）
+    mvc.perform(get("/api/v1/knowledge"))
+        .andExpect(jsonPath("$.data[0].capabilities.importDocs").value(false));
+
+    mvc.perform(get("/api/v1/knowledge/nope")).andExpect(status().isNotFound());
+  }
+
+  private void createBase(String name, String description) throws Exception {
+    mvc.perform(
+            post("/api/v1/knowledge")
+                .contentType("application/json")
+                .content("{\"name\":\"" + name + "\",\"description\":\"" + description + "\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(0));
+  }
+
+  /** 仅声明检索能力的远程测试桩（US5 门禁面先行核验；契约三同在 impl-C 契约测试收口）。 */
+  private static KnowledgeBackend retrieveOnlyStub() {
+    return new KnowledgeBackend() {
+      @Override
+      public String name() {
+        return "stub";
+      }
+
+      @Override
+      public KnowledgeCapabilities capabilities() {
+        return KnowledgeCapabilities.retrieveOnly();
+      }
+
+      @Override
+      public Optional<KnowledgeAdmin> admin() {
+        return Optional.empty();
+      }
+
+      @Override
+      public List<KnowledgeHit> retrieve(KnowledgeQuery query) {
+        return List.of();
+      }
+    };
+  }
+
+  /** 确定性字符直方图向量（测试用）。 */
+  private static final class HashEmbedder implements TextEmbedder {
+    @Override
+    public float[] embed(String text) {
+      float[] vector = new float[8];
+      for (int i = 0; i < text.length(); i++) {
+        vector[text.charAt(i) % 8] += 1;
+      }
+      return vector;
+    }
+
+    @Override
+    public String modelId() {
+      return "test/v1";
+    }
+
+    @Override
+    public int dimensions() {
+      return 8;
+    }
+  }
+}

--- a/specs/014-knowledge-base/tasks.md
+++ b/specs/014-knowledge-base/tasks.md
@@ -122,28 +122,28 @@ US5 远程桩与 US6 无 key 自测最后收口契约与 CI。
 
 ### Tests
 
-- [ ] T023 [P] [US1] 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/builtin/KnowledgeToolsTest.java`
+- [x] T023 [P] [US1] 在 `oryxos-knowledge/src/test/java/io/oryxos/knowledge/builtin/KnowledgeToolsTest.java`
       添加失败测试：schema 两必一选（query/limit/knowledge_base）、绑定范围圈定、多库聚合
       全局 top-K、限定未绑定库可读错误、零绑定可读错误、结果 JSON 含埋点字段（FR-022）
-- [ ] T024 [P] [US1] 在 `oryxos-core/src/test/java/io/oryxos/core/context/ContextLoaderKnowledgeTest.java`
+- [x] T024 [P] [US1] 在 `oryxos-core/src/test/java/io/oryxos/core/context/ContextLoaderKnowledgeTest.java`
       添加失败测试：每轮注入绑定库 name+description+检索指引、零绑定零注入、正文永不预载
 
 ### Implementation
 
-- [ ] T025 [US1] 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/DefaultKnowledgeService.java`
+- [x] T025 [US1] 在 `oryxos-core/src/main/java/io/oryxos/core/knowledge/DefaultKnowledgeService.java`
       实现门面：经 `KnowledgeBindingService` 圈定绑定库 → 逐库路由后端 → 跨库融合取全局
       top-K（Clarify-Q2）
-- [ ] T026 [US1] 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/builtin/KnowledgeTools.java`
+- [x] T026 [US1] 在 `oryxos-knowledge/src/main/java/io/oryxos/knowledge/builtin/KnowledgeTools.java`
       实现 `@Tool retrieve_knowledge`（经 `ToolExecutionContext` 取 agentName；结果为
       contracts §3 的结构化 JSON 埋点载体）（T023 转绿）
-- [ ] T027 [US1] 在 `oryxos-core/src/main/java/io/oryxos/core/context/ContextLoader.java`
+- [x] T027 [US1] 在 `oryxos-core/src/main/java/io/oryxos/core/context/ContextLoader.java`
       新增 `appendKnowledge()`（对照 `appendSkills()`；按 `profile.tools()` 含
       `retrieve_knowledge` 联动）（T024 转绿）
-- [ ] T028 [US1] 在 `oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java` 装配：
+- [x] T028 [US1] 在 `oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java` 装配：
       backend registry、`LocalKnowledgeBackend`、`KnowledgeService`、
       `registry.registerAnnotated(new KnowledgeTools(...))`，并同步
       `OryxToolContractTest` 参数化注册面
-- [ ] T029 [US1] 本地库文档目录自动纳入 `read_file` 白名单（FR-017）：沿用 `oryxos.root`
+- [x] T029 [US1] 本地库文档目录自动纳入 `read_file` 白名单（FR-017）：沿用 `oryxos.root`
       换根自动纳入机制 + `RealPathBoundary` 校验；远程命中标注不可跟读；补
       `oryxos-tool/src/test/java/io/oryxos/tool/sandbox/` 白名单联动测试
 - [ ] T030 [US1] 端到端验证 quickstart §C：命中带出处 / 原文跟读 / 无关问题不干扰 /
@@ -161,20 +161,20 @@ US5 远程桩与 US6 无 key 自测最后收口契约与 CI。
 
 ### Tests
 
-- [ ] T031 [P] [US2] 在 `oryxos-web/src/test/java/io/oryxos/web/controller/KnowledgeApiControllerTest.java`
+- [x] T031 [P] [US2] 在 `oryxos-web/src/test/java/io/oryxos/web/controller/KnowledgeApiControllerTest.java`
       添加 MockMvc 失败测试：CRUD、两段式上传（不支持类型/扫描件/超限 4xx 当场拒绝）、
       状态查询、重建、重名 409、被引用删除 409 + Agent 名单、能力门禁 400
       （contracts/rest-api.md 全表）
 
 ### Implementation
 
-- [ ] T032 [US2] 在 `oryxos-web/src/main/java/io/oryxos/web/controller/KnowledgeApiController.java`
+- [x] T032 [US2] 在 `oryxos-web/src/main/java/io/oryxos/web/controller/KnowledgeApiController.java`
       + `controller/dto/` record DTO 实现 REST 全生命周期端点（T031 转绿）；
       `GlobalExceptionHandler` 新增 `KnowledgeReferencedException` → 409
-- [ ] T033 [US2] 在 `oryxos-knowledge/.../index/KnowledgeIndexService.java` 补双缓冲重建
+- [x] T033 [US2] 在 `oryxos-knowledge/.../index/KnowledgeIndexService.java` 补双缓冲重建
       （FR-024）：generation+1 后台构建、同步临界区原子切换、失败保留旧代与原因；
       补重建期间并发检索不中断的测试
-- [ ] T034 [US2] 在 `oryxos-web/src/main/frontend/src/App.vue` 落地知识库页（TOP_NAV 占位
+- [x] T034 [US2] 在 `oryxos-web/src/main/frontend/src/App.vue` 落地知识库页（TOP_NAV 占位
       已存在）：列表（名称/描述/后端/文档数/片段数/状态）、详情（文档清单 + 单文档删除 +
       重建 + 上传）、创建/删除；操作按钮按能力集渲染（FR-009）；`npm run build` 通过
 
@@ -190,19 +190,19 @@ US5 远程桩与 US6 无 key 自测最后收口契约与 CI。
 
 ### Tests
 
-- [ ] T035 [P] [US3] 在 `oryxos-web/src/test/java/io/oryxos/web/controller/AgentApiControllerTest.java`
+- [x] T035 [P] [US3] 在 `oryxos-web/src/test/java/io/oryxos/web/controller/AgentApiControllerTest.java`
       补绑定三件套失败测试（GET/PUT/DELETE `/agents/{name}/knowledge`，非法链接 4xx）与
       Agent 创建/编辑请求 `knowledgeBindings` 字段测试
 
 ### Implementation
 
-- [ ] T036 [US3] 在 `oryxos-web/src/main/java/io/oryxos/web/controller/AgentApiController.java`
+- [x] T036 [US3] 在 `oryxos-web/src/main/java/io/oryxos/web/controller/AgentApiController.java`
       实现绑定三件套（照 skills 三件套先例）+ 创建/编辑端点接受 `knowledgeBindings`
       并经 `KnowledgeBindingService` 落软连接（T035 转绿）
-- [ ] T037 [US3] 「一句话生成 Agent」起草上下文注入现有知识库名单（name+description，与
+- [x] T037 [US3] 「一句话生成 Agent」起草上下文注入现有知识库名单（name+description，与
       工具/渠道候选同等待遇，FR-018）；草稿含 `knowledgeBindings` 建议、保存时后端重新
       校验（照 Skill 建议流程：草稿不是持久绑定索引）
-- [ ] T038 [US3] `App.vue` Agent 详情页绑定管理视图 + 新建/编辑表单知识库多选（SC-007
+- [x] T038 [US3] `App.vue` Agent 详情页绑定管理视图 + 新建/编辑表单知识库多选（SC-007
       三界面一致）
 
 **Checkpoint**: US3 三条路径验收通过，SC-008 留人工评审。


### PR DESCRIPTION
## 概要

014 知识库第二个实现 PR(impl-B,接 #202):**运行时 MVP + 管理面**,对应 tasks.md T023~T029、T031~T038。合并后 US1(终端用户带出处回答)、US2(管理台全生命周期)、US3(三路径关联)可用。

## 运行时(US1)

| 块 | 说明 | FR |
|---|---|---|
| `retrieve_knowledge` 工具 | 两必一选 schema(query/limit/knowledge_base),经 ProfileContext 圈定发起 Agent 绑定范围;范围错误可读返回不中断对话 | FR-004/019/020 |
| 埋点一次到位 | 工具结果 = 结构化 JSON(查询原文+命中明细+分数+零结果/降级标记+耗时),随 `tool_invocations` 落库,评测集直接消费 | FR-012/022 |
| `KnowledgeServiceImpl` 门面 | 绑定圈定 → 按清单 backend 路由插件 → 跨库/跨后端融合全局 top-K | FR-020 |
| 渐进披露注入 | `ContextLoader.appendKnowledge`:只注入 name+description+指引,零绑定零注入、正文永不预载 | FR-005 |
| 原文跟读 | 命中带可跟读绝对路径(`file` 字段,工作区根已在 read_file 白名单);不可跟读绝不返回路径 | FR-017 |
| 装配 | 存储档位 sqlite/memory、embedding 供给者(注册表按名取凭证+缓存,未配置可读报错**不静默回退**)、`init` 建 knowledge 目录 | FR-007 |

## 管理面(US2/US3)

- **REST 全生命周期**:列表(含能力集)/创建/详情/改描述/删除、两段式上传(不支持类型/扫描件当场 400 且清理落盘文件)、状态查询、双缓冲重建;**能力门禁入口即 400**(FR-006);**删除引用保护 409 + 引用 Agent 清单**(FR-011)
- **绑定三件套** + 整体替换;创建/保存文件携带 `knowledgeBindings`
- **一句话生成**(FR-018):作者提示词注入已有知识库名单,草稿以顶层 `knowledge` sidecar 给出建议——校验在清单内、随即从 AGENT.md 移除(frontmatter 不声明知识库,FR-002)
- **管理台**:知识库页落地(列表/详情/上传/重建/删除,操作按能力集渲染 FR-009)、Agent 详情绑定视图、新建表单多选+生成建议合并

## 验证

- 新增 16 个测试全绿(ContextLoader 注入 4 / KnowledgeTools 4 / REST 端点 5 / 绑定 API 3),存量零回归
- `mvn verify` 全 reactor 11 模块通过(Spotless/Checkstyle/P3C/SpotBugs);前端 `npm run build` 通过
- 门禁修掉的问题:P3C 实现类命名(→ KnowledgeServiceImpl)、SpotBugs getFileName 空指针路径

## 评审重点建议

1. `ContextLoader.appendKnowledge` 的注入门槛(按 profile.tools 含 retrieve_knowledge 联动)与指引文案;
2. `AgentLifecycleService` 的 knowledge sidecar 解析/移除路径(与 skills sidecar 同构);
3. `KnowledgeApiController` 上传的文件名白名单与 RealPathBoundary 边界;
4. App.vue 知识库页与绑定视图(建议本地跑 serve 点一遍)。

## 后续

impl-C(收口):GitOps 热加载 + `oryxos knowledge list` CLI + 使用看板 + 远程桩契约参数化 + mock E2E + 文档同步,T039~T050。