### PR TITLE
fix(tool): recheck make_dir after createDirectories

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -238,8 +238,9 @@ public class FileTools {
   public String makeDir(@ToolParam(description = "要创建的目录路径") String path) {
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     try {
-      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
       Files.createDirectories(Path.of(path));
+      // 建目录后复检：与 write_file / download_file 同款——防首次校验到 createDirectories 间路径被换成外向软链
+      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
       return "已创建目录: " + path;
     } catch (IOException e) {
       throw new UncheckedIOException("创建目录失败: " + path, e);

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -200,6 +200,28 @@ class FileToolsTest {
   }
 
   @Test
+  @DisplayName("make_dir 建目录后复检 FILE_WRITE（防校验窗口内路径逃逸）")
+  void makeDirRechecksPathAfterCreateDirectories() {
+    AtomicInteger fileWrites = new AtomicInteger();
+    Path nested = dir.resolve("nested");
+    Sandbox sandbox =
+        action -> {
+          if (action.type() == ActionType.FILE_WRITE) {
+            int n = fileWrites.incrementAndGet();
+            if (n >= 2) {
+              // 复检必须在 createDirectories 之后：此时目标目录应已存在
+              assertTrue(Files.isDirectory(nested), "复检应发生在 createDirectories 之后");
+              throw new SandboxViolationException("复检拒绝: " + action.target());
+            }
+          }
+        };
+    FileTools guarded = new FileTools(sandbox);
+
+    assertThrows(SandboxViolationException.class, () -> guarded.makeDir(nested.toString()));
+    assertEquals(2, fileWrites.get(), "应在建目录前与 createDirectories 后各 enforce 一次 FILE_WRITE");
+  }
+
+  @Test
   @DisplayName("read_file 读取前复检 FILE_READ")
   void readFileRechecksPathBeforeRead() throws IOException {
     Path target = dir.resolve("secret.txt");


### PR DESCRIPTION
Fixes #210

## Summary
- Run FILE_WRITE recheck after Files.createDirectories (align with write_file / download_file)
- Add FileToolsTest asserting post-create recheck

## Test plan
- [x] FileToolsTest