### PR TITLE
fix(tool): reject direct MEMORY.md mutation via file tools

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -59,6 +59,7 @@ public class FileTools {
   public String writeFile(
       @ToolParam(description = "要写入的文件路径") String path,
       @ToolParam(description = "要写入的内容") String content) {
+    MemoryMdGuard.rejectMutation(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     try {
       Path file = Path.of(path);
@@ -101,6 +102,7 @@ public class FileTools {
       @ToolParam(description = "要编辑的文件路径") String path,
       @ToolParam(description = "要被替换的原文本（必须在文件中唯一出现）") String oldString,
       @ToolParam(description = "替换后的新文本") String newString) {
+    MemoryMdGuard.rejectMutation(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     Path file = Path.of(path);
     if (!Files.isRegularFile(file)) {
@@ -250,6 +252,7 @@ public class FileTools {
   public String appendFile(
       @ToolParam(description = "文件路径") String path,
       @ToolParam(description = "要追加的内容") String content) {
+    MemoryMdGuard.rejectMutation(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     try {
       Path file = Path.of(path);
@@ -267,6 +270,7 @@ public class FileTools {
 
   @Tool(name = "delete_file", description = "删除一个文件（拒绝删除目录）")
   public String deleteFile(@ToolParam(description = "要删除的文件路径") String path) {
+    MemoryMdGuard.rejectMutation(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     Path file = Path.of(path);
     // NOFOLLOW_LINKS：只拦真实目录；指向目录的 symlink（如 Agent Skill 绑定）应删链接本身，不跟随目标
@@ -285,6 +289,8 @@ public class FileTools {
   @Tool(name = "move_file", description = "移动 / 重命名文件（源与目标都过白名单，目标已存在则覆盖）")
   public String moveFile(
       @ToolParam(description = "源路径") String from, @ToolParam(description = "目标路径") String to) {
+    MemoryMdGuard.rejectMutation(from);
+    MemoryMdGuard.rejectMutation(to);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, from));
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, to));
     Path src = Path.of(from);
@@ -316,6 +322,7 @@ public class FileTools {
   @Tool(name = "copy_file", description = "复制文件（源读 + 目标写，都过白名单，目标已存在则覆盖）")
   public String copyFile(
       @ToolParam(description = "源路径") String from, @ToolParam(description = "目标路径") String to) {
+    MemoryMdGuard.rejectMutation(to);
     sandbox.enforce(new SandboxAction(ActionType.FILE_READ, from));
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, to));
     Path src = Path.of(from);

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -270,6 +270,7 @@ public class HttpTools {
   public String downloadFile(
       @ToolParam(description = "要下载的 URL") String url,
       @ToolParam(description = "保存到的本地文件路径") String path) {
+    MemoryMdGuard.rejectMutation(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path)); // 先校验落盘路径
     byte[] data = read(url, byte[].class); // 读远端：放行 + 内网黑名单 + 逐跳重定向重校验
     byte[] bytes = data == null ? new byte[0] : data;

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/MemoryMdGuard.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/MemoryMdGuard.java
@@ -1,0 +1,24 @@
+package io.oryxos.tool.builtin;
+
+import java.nio.file.Path;
+
+/**
+ * 长期记忆文件只能经 {@code save_memory} 写入——{@code MarkdownMemoryStore#sanitizeEntryContent}
+ * 只覆盖那条路径；文件工具直写会绕过分区头消毒（#163），污染核心/归档召回。
+ */
+final class MemoryMdGuard {
+
+  private static final String MEMORY_FILE = "MEMORY.md";
+
+  private MemoryMdGuard() {}
+
+  static void rejectMutation(String path) {
+    if (path == null || path.isBlank()) {
+      return;
+    }
+    Path name = Path.of(path).getFileName();
+    if (name != null && MEMORY_FILE.equalsIgnoreCase(name.toString())) {
+      throw new IllegalArgumentException("拒绝直接改写 MEMORY.md，请使用 save_memory: " + path);
+    }
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/MemoryMdGuard.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/MemoryMdGuard.java
@@ -1,6 +1,7 @@
 package io.oryxos.tool.builtin;
 
 import java.nio.file.Path;
+import java.util.Locale;
 
 /**
  * 长期记忆文件只能经 {@code save_memory} 写入——{@code MarkdownMemoryStore#sanitizeEntryContent}
@@ -8,16 +9,21 @@ import java.nio.file.Path;
  */
 final class MemoryMdGuard {
 
-  private static final String MEMORY_FILE = "MEMORY.md";
+  /** 小写文件名；比较时用 {@link Locale#ROOT}。 */
+  private static final String MEMORY_FILE_LOWER = "memory.md";
 
   private MemoryMdGuard() {}
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "文件名是 ASCII「MEMORY.md」；Locale.ROOT 大小写折叠仅用于 Windows 大小写不敏感路径，非安全边界上的任意 Unicode 文本")
   static void rejectMutation(String path) {
     if (path == null || path.isBlank()) {
       return;
     }
     Path name = Path.of(path).getFileName();
-    if (name != null && MEMORY_FILE.equalsIgnoreCase(name.toString())) {
+    if (name != null && MEMORY_FILE_LOWER.equals(name.toString().toLowerCase(Locale.ROOT))) {
       throw new IllegalArgumentException("拒绝直接改写 MEMORY.md，请使用 save_memory: " + path);
     }
   }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -181,6 +181,29 @@ class FileToolsTest {
   }
 
   @Test
+  @DisplayName("文件工具拒绝直接改写 MEMORY.md（须走 save_memory）")
+  void fileToolsRejectDirectMemoryMdMutation() throws IOException {
+    Path memory = dir.resolve("agents/demo/MEMORY.md");
+    Files.createDirectories(memory.getParent());
+    Files.writeString(memory, "## 核心记忆\n- keep\n## 归档记忆\n");
+    String path = memory.toString();
+    Path other = dir.resolve("other.txt");
+    Files.writeString(other, "x");
+
+    assertThrows(IllegalArgumentException.class, () -> tools.writeFile(path, "hijack"));
+    assertThrows(IllegalArgumentException.class, () -> tools.editFile(path, "keep", "hijack"));
+    assertThrows(IllegalArgumentException.class, () -> tools.appendFile(path, "hijack\n"));
+    assertThrows(IllegalArgumentException.class, () -> tools.deleteFile(path));
+    assertThrows(
+        IllegalArgumentException.class, () -> tools.moveFile(path, dir.resolve("x.md").toString()));
+    assertThrows(IllegalArgumentException.class, () -> tools.copyFile(other.toString(), path));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> tools.writeFile(dir.resolve("memory.md").toString(), "case"));
+    assertEquals("## 核心记忆\n- keep\n## 归档记忆\n", Files.readString(memory), "拒绝后内容不得变");
+  }
+
+  @Test
   @DisplayName("write_file 落盘前复检 FILE_WRITE（防校验窗口内路径逃逸）")
   void writeFileRechecksPathBeforeWrite() {
     AtomicInteger fileWrites = new AtomicInteger();


### PR DESCRIPTION
Fixes #213

## Summary
- Reject mutating paths whose final segment is MEMORY.md (case-insensitive)
- Cover write/edit/append/delete/move/copy and download_file; point callers to save_memory

## Test plan
- [x] FileToolsTest (rejects direct MEMORY.md mutation)