### PR TITLE
fix(memory): enqueue append return value instead of getLast

### DIFF
--- a/oryxos-memory/src/main/java/io/oryxos/memory/InMemoryMemoryStore.java
+++ b/oryxos-memory/src/main/java/io/oryxos/memory/InMemoryMemoryStore.java
@@ -21,8 +21,9 @@ public class InMemoryMemoryStore implements LongTermMemoryStore {
   private final List<String> archive = new ArrayList<>();
 
   @Override
-  public void append(String content, MemoryScope scope) {
+  public MemoryEntryView append(String content, MemoryScope scope) {
     (scope == MemoryScope.CORE ? core : archive).add(content);
+    return new MemoryEntryView(content, java.time.Instant.now());
   }
 
   @Override

--- a/oryxos-memory/src/main/java/io/oryxos/memory/LongTermMemoryStore.java
+++ b/oryxos-memory/src/main/java/io/oryxos/memory/LongTermMemoryStore.java
@@ -18,7 +18,8 @@ import java.util.List;
  */
 public interface LongTermMemoryStore {
 
-  void append(String content, MemoryScope scope);
+  /** 追加一条记忆；返回刚写入的条目视图（供索引入队，避免并发下再读 {@link #archivalEntries()}{@code .getLast()} 错绑）。 */
+  MemoryEntryView append(String content, MemoryScope scope);
 
   /** 核心区全量 + 归档区（截断后）。 */
   String load();

--- a/oryxos-memory/src/main/java/io/oryxos/memory/MarkdownMemoryStore.java
+++ b/oryxos-memory/src/main/java/io/oryxos/memory/MarkdownMemoryStore.java
@@ -74,9 +74,9 @@ public class MarkdownMemoryStore implements LongTermMemoryStore {
   }
 
   @Override
-  public void append(String content, MemoryScope scope) {
-    String entry =
-        "- [" + LocalDateTime.now().format(TIMESTAMP) + "] " + sanitizeEntryContent(content);
+  public MemoryEntryView append(String content, MemoryScope scope) {
+    LocalDateTime now = LocalDateTime.now();
+    String entry = "- [" + now.format(TIMESTAMP) + "] " + sanitizeEntryContent(content);
     Path file = memoryFile();
     // 读-改-写必须整段互斥：并发会话/定时任务同时 append 时，不加锁会互相覆盖对方刚写的条目。
     synchronized (lockFor(file)) {
@@ -90,6 +90,7 @@ public class MarkdownMemoryStore implements LongTermMemoryStore {
       }
       write(file, CORE_HEADER + "\n" + core + "\n" + ARCHIVE_HEADER + "\n" + archive);
     }
+    return new MemoryEntryView(entry, now.atZone(ZoneId.systemDefault()).toInstant());
   }
 
   /**

--- a/oryxos-memory/src/main/java/io/oryxos/memory/Mem0MemoryStore.java
+++ b/oryxos-memory/src/main/java/io/oryxos/memory/Mem0MemoryStore.java
@@ -66,7 +66,7 @@ public class Mem0MemoryStore implements LongTermMemoryStore {
   }
 
   @Override
-  public void append(String content, MemoryScope scope) {
+  public MemoryEntryView append(String content, MemoryScope scope) {
     // core 必须原文保真（infer:false）；archival 交 mem0 提炼与冲突消解（infer:true）
     Map<String, Object> body = new HashMap<>(8);
     body.put("messages", List.of(Map.of("role", "user", "content", content)));
@@ -83,6 +83,7 @@ public class Mem0MemoryStore implements LongTermMemoryStore {
                 .body(body)
                 .retrieve()
                 .toBodilessEntity());
+    return new MemoryEntryView(content, java.time.Instant.now());
   }
 
   @Override

--- a/oryxos-memory/src/main/java/io/oryxos/memory/MemoryServiceImpl.java
+++ b/oryxos-memory/src/main/java/io/oryxos/memory/MemoryServiceImpl.java
@@ -60,17 +60,15 @@ public class MemoryServiceImpl implements MemoryService {
       value = "CRLF_INJECTION_LOGS",
       justification = "日志中的异常消息已经 sanitize() 消去 CR/LF；taint 分析不跨方法追踪该消毒，故局部抑制")
   public void remember(String content, MemoryScope scope) {
-    store.append(content, scope);
+    MemoryEntryView written = store.append(content, scope);
     if (scope != MemoryScope.ARCHIVAL
         || index == null
         || store.capabilities() != MemoryRecallCapability.HYBRID_BUILTIN) {
       return; // core 不入索引（FR-005）；DELEGATED 档索引归外部服务
     }
     try {
-      List<MemoryEntryView> entries = store.archivalEntries();
-      if (!entries.isEmpty()) {
-        index.enqueue(currentAgent(), entries.getLast());
-      }
+      // 用 append 返回值入队——勿再 archivalEntries().getLast()（并发会话会错绑/漏记）
+      index.enqueue(currentAgent(), written);
     } catch (RuntimeException e) {
       log.warn("记忆索引入队失败（本体已落库，随对账补齐）: {}", sanitize(e.getMessage()));
     }

--- a/oryxos-memory/src/main/java/io/oryxos/memory/SqliteMemoryStore.java
+++ b/oryxos-memory/src/main/java/io/oryxos/memory/SqliteMemoryStore.java
@@ -38,12 +38,16 @@ public class SqliteMemoryStore implements LongTermMemoryStore {
   }
 
   @Override
-  public void append(String content, MemoryScope scope) {
+  public MemoryEntryView append(String content, MemoryScope scope) {
     MemoryEntry entry = new MemoryEntry();
     entry.setAgentName(agentName());
     entry.setScope(scope.name());
     entry.setContent(content);
     repository.save(entry);
+    // 不依赖 save 返回值（测试 mock 可能返回 null）；createdAt 未填时用 now，对账不依赖精确时刻
+    java.time.Instant time =
+        entry.getCreatedAt() != null ? entry.getCreatedAt() : java.time.Instant.now();
+    return new MemoryEntryView(entry.getContent(), time);
   }
 
   @Override

--- a/oryxos-memory/src/test/java/io/oryxos/memory/MemoryRecallEngineTest.java
+++ b/oryxos-memory/src/test/java/io/oryxos/memory/MemoryRecallEngineTest.java
@@ -66,8 +66,10 @@ class MemoryRecallEngineTest {
     }
 
     @Override
-    public void append(String content, MemoryScope scope) {
-      archival.add(new MemoryEntryView(content, Instant.now()));
+    public MemoryEntryView append(String content, MemoryScope scope) {
+      MemoryEntryView view = new MemoryEntryView(content, Instant.now());
+      archival.add(view);
+      return view;
     }
 
     @Override

--- a/oryxos-memory/src/test/java/io/oryxos/memory/MemoryServiceImplTest.java
+++ b/oryxos-memory/src/test/java/io/oryxos/memory/MemoryServiceImplTest.java
@@ -106,6 +106,50 @@ class MemoryServiceImplTest {
   }
 
   @Test
+  @DisplayName("并发 remember 各自入队自己的条目（不依赖 getLast）")
+  void concurrentRememberEnqueuesOwnEntries() throws Exception {
+    MemoryVectorIndex index = mock(MemoryVectorIndex.class);
+    MemoryServiceImpl service = new MemoryServiceImpl(new MarkdownMemoryStore(root), null, index);
+    int n = 20;
+    java.util.concurrent.CountDownLatch start = new java.util.concurrent.CountDownLatch(1);
+    java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(n);
+    java.util.concurrent.ExecutorService pool =
+        java.util.concurrent.Executors.newFixedThreadPool(8);
+    try {
+      for (int i = 0; i < n; i++) {
+        final String marker = "concurrent-entry-" + i;
+        pool.execute(
+            () -> {
+              try {
+                start.await();
+                service.remember(marker, MemoryScope.ARCHIVAL);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              } finally {
+                done.countDown();
+              }
+            });
+      }
+      start.countDown();
+      assertTrue(done.await(10, java.util.concurrent.TimeUnit.SECONDS));
+    } finally {
+      pool.shutdownNow();
+    }
+    ArgumentCaptor<io.oryxos.core.memory.MemoryEntryView> entry =
+        ArgumentCaptor.forClass(io.oryxos.core.memory.MemoryEntryView.class);
+    verify(index, org.mockito.Mockito.times(n)).enqueue(anyString(), entry.capture());
+    java.util.Set<String> markers = new java.util.HashSet<>();
+    for (io.oryxos.core.memory.MemoryEntryView view : entry.getAllValues()) {
+      for (int i = 0; i < n; i++) {
+        if (view.content().contains("concurrent-entry-" + i)) {
+          markers.add("concurrent-entry-" + i);
+        }
+      }
+    }
+    assertEquals(n, markers.size(), "每个并发写入都应入队自己的条目，不得互相覆盖 getLast");
+  }
+
+  @Test
   @DisplayName("reconcileIndex 委托索引对账_DELEGATED 档为 no-op")
   void reconcileIndexDelegatesAndSkipsDelegated() {
     MemoryVectorIndex index = mock(MemoryVectorIndex.class);

--- a/oryxos-memory/src/test/java/io/oryxos/memory/contract/MemoryBackendContractTest.java
+++ b/oryxos-memory/src/test/java/io/oryxos/memory/contract/MemoryBackendContractTest.java
@@ -239,9 +239,10 @@ class MemoryBackendContractTest {
     }
 
     @Override
-    public void append(String content, MemoryScope scope) {
+    public MemoryEntryView append(String content, MemoryScope scope) {
       Map<String, List<String>> target = scope == MemoryScope.CORE ? coreByAgent : archiveByAgent;
       target.computeIfAbsent(agent(), key -> new ArrayList<>()).add(content);
+      return new MemoryEntryView(content, java.time.Instant.now());
     }
 
     @Override


### PR DESCRIPTION
Fixes #217

## Summary
- LongTermMemoryStore.append returns the MemoryEntryView just written
- remember enqueues that value instead of archivalEntries().getLast()
- Concurrent remember test asserts each marker is enqueued

## Test plan
- [x] MemoryServiceImplTest (incl. concurrent enqueue)
- [x] MemoryRecallEngineTest / MemoryBackendContractTest / SqliteMemoryStoreTest