### PR TITLE
fix(provider): disable HttpClient auto-redirects (SSRF)

### DIFF
--- a/oryxos-provider/src/main/java/io/oryxos/provider/ProviderChatModelFactory.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ProviderChatModelFactory.java
@@ -80,11 +80,15 @@ public class ProviderChatModelFactory {
   /**
    * 构造带连接超时的 {@link HttpClient}，强制 HTTP/1.1：JDK 21 HttpClient 默认尝试 HTTP/2 升级（Upgrade: h2c +
    * Transfer-Encoding: chunked），vLLM/Ollama（uvicorn）不认 h2c 升级，导致请求体丢失（'input': None）、服务端返回 400。
+   *
+   * <p>同时 {@code followRedirects(NEVER)}：默认 NORMAL 会跟随 302，恶意 provider baseUrl 可把管理台 /models 或
+   * ReAct chat 请求拐到元数据/内网（与 Skill import、HttpTools 策略对齐）。
    */
   static HttpClient httpClient(Duration connectTimeout) {
     return HttpClient.newBuilder()
         .connectTimeout(connectTimeout)
         .version(HttpClient.Version.HTTP_1_1)
+        .followRedirects(HttpClient.Redirect.NEVER)
         .build();
   }
 

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ProviderChatModelFactoryHttpVersionTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ProviderChatModelFactoryHttpVersionTest.java
@@ -19,4 +19,11 @@ class ProviderChatModelFactoryHttpVersionTest {
     HttpClient client = ProviderChatModelFactory.httpClient(Duration.ofSeconds(10));
     assertEquals(HttpClient.Version.HTTP_1_1, client.version());
   }
+
+  @Test
+  @DisplayName("工厂构造的HttpClient禁止自动跟随重定向（防恶意baseUrl SSRF）")
+  void httpClientDisablesAutoRedirects() {
+    HttpClient client = ProviderChatModelFactory.httpClient(Duration.ofSeconds(10));
+    assertEquals(HttpClient.Redirect.NEVER, client.followRedirects());
+  }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/provider/ProviderModelsService.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/provider/ProviderModelsService.java
@@ -99,6 +99,8 @@ public class ProviderModelsService {
             HttpClient.newBuilder()
                 .connectTimeout(connectTimeout)
                 .version(HttpClient.Version.HTTP_1_1)
+                // 禁自动重定向：与 Skill import / HttpTools 同款——防恶意 baseUrl 302→元数据/内网（SSRF）
+                .followRedirects(HttpClient.Redirect.NEVER)
                 .build());
     factory.setReadTimeout(readTimeout);
     return factory;

--- a/oryxos-web/src/test/java/io/oryxos/web/provider/ProviderModelsServiceTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/provider/ProviderModelsServiceTest.java
@@ -3,6 +3,7 @@ package io.oryxos.web.provider;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -152,5 +153,46 @@ class ProviderModelsServiceTest {
     assertTimeoutPreemptively(
         Duration.ofSeconds(10),
         () -> assertThrows(ProviderUnavailableException.class, () -> timed.listModels("hang")));
+  }
+
+  @Test
+  @DisplayName("/models 遇到 302 不得自动跟随（防恶意 baseUrl 拐到内网/元数据）")
+  void modelsDoesNotFollowRedirects() throws Exception {
+    java.util.concurrent.atomic.AtomicInteger sinkHits =
+        new java.util.concurrent.atomic.AtomicInteger();
+    HttpServer sink = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    try {
+      sink.createContext(
+          "/v1/models",
+          exchange -> {
+            sinkHits.incrementAndGet();
+            byte[] body = "{\"data\":[{\"id\":\"stolen\"}]}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+          });
+      sink.start();
+      String sinkModels = "http://127.0.0.1:" + sink.getAddress().getPort() + "/v1/models";
+      server.createContext(
+          "/v1/models",
+          exchange -> {
+            exchange.getResponseHeaders().add("Location", sinkModels);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+          });
+      when(registry.find("evil"))
+          .thenReturn(Optional.of(new ProviderDef("evil", "sk-x", baseUrl, null)));
+
+      try {
+        List<String> models = service.listModels("evil");
+        assertTrue(models.stream().noneMatch(id -> id.contains("stolen")), "即便不抛错也不得返回重定向目标体");
+      } catch (ProviderUnavailableException expected) {
+        // 3xx 被 RestClient 当成错误也算 fail-closed，可接受
+      }
+      assertEquals(0, sinkHits.get(), "不得跟随 Location 访问下一跳");
+    } finally {
+      sink.stop(0);
+    }
   }
 }


### PR DESCRIPTION
Fixes #220

## Summary
- Disable HttpClient auto-redirects in ProviderModelsService and ProviderChatModelFactory
- Align with Skill import / HttpTools (fail closed on 302)

## Test plan
- [x] ProviderModelsServiceTest (302 must not hit redirect sink)
- [x] ProviderChatModelFactoryHttpVersionTest (Redirect.NEVER)