### PR TITLE
fix(web): reject workspace writes to MEMORY.md

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/memory/MemoryMdGuard.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/memory/MemoryMdGuard.java
@@ -1,13 +1,13 @@
-package io.oryxos.tool.builtin;
+package io.oryxos.core.memory;
 
 import java.nio.file.Path;
 import java.util.Locale;
 
 /**
  * 长期记忆文件只能经 {@code save_memory} 写入——{@code MarkdownMemoryStore#sanitizeEntryContent}
- * 只覆盖那条路径；文件工具直写会绕过分区头消毒（#163），污染核心/归档召回。
+ * 只覆盖那条路径；其它入口直写会绕过分区头消毒（#163），污染核心/归档召回。
  */
-final class MemoryMdGuard {
+public final class MemoryMdGuard {
 
   /** 小写文件名；比较时用 {@link Locale#ROOT}。 */
   private static final String MEMORY_FILE_LOWER = "memory.md";
@@ -18,7 +18,7 @@ final class MemoryMdGuard {
       value = "IMPROPER_UNICODE",
       justification =
           "文件名是 ASCII「MEMORY.md」；Locale.ROOT 大小写折叠仅用于 Windows 大小写不敏感路径，非安全边界上的任意 Unicode 文本")
-  static void rejectMutation(String path) {
+  public static void rejectMutation(String path) {
     if (path == null || path.isBlank()) {
       return;
     }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -1,5 +1,6 @@
 package io.oryxos.tool.builtin;
 
+import io.oryxos.core.memory.MemoryMdGuard;
 import io.oryxos.tool.sandbox.ActionType;
 import io.oryxos.tool.sandbox.Sandbox;
 import io.oryxos.tool.sandbox.SandboxAction;

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -1,5 +1,6 @@
 package io.oryxos.tool.builtin;
 
+import io.oryxos.core.memory.MemoryMdGuard;
 import io.oryxos.tool.sandbox.ActionType;
 import io.oryxos.tool.sandbox.Sandbox;
 import io.oryxos.tool.sandbox.SandboxAction;

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
@@ -2,6 +2,7 @@ package io.oryxos.web.controller;
 
 import io.oryxos.core.agent.AgentLifecycleService;
 import io.oryxos.core.fs.RealPathBoundary;
+import io.oryxos.core.memory.MemoryMdGuard;
 import io.oryxos.web.common.ApiResponse;
 import io.oryxos.web.controller.dto.FileNode;
 import io.oryxos.web.controller.dto.WriteFileRequest;
@@ -135,6 +136,7 @@ public class WorkspaceApiController {
     if (path == null || path.isBlank()) {
       throw new IllegalArgumentException("path 为空"); // → 400
     }
+    MemoryMdGuard.rejectMutation(path);
     Path target = resolveWithinRoot(path);
     if (isAgentSkillsPath(target)) {
       throw new IllegalArgumentException("Agent skills/ 是绑定视图，禁止从工作区入口写入");

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
@@ -122,6 +122,23 @@ class WorkspaceApiControllerTest {
   }
 
   @Test
+  @DisplayName("工作区写入口禁止直写 MEMORY.md（须走 save_memory）")
+  void writeMemoryMdIsRejected() throws Exception {
+    Path memory = Files.createDirectories(oryxosRoot.resolve("agents/demo"));
+    Files.writeString(memory.resolve("MEMORY.md"), "## 核心记忆\n- keep\n## 归档记忆\n");
+
+    mvc.perform(
+            post("/api/v1/workspace/file")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"path\":\"agents/demo/MEMORY.md\",\"content\":\"## 核心记忆\\n## 归档记忆\\n- hijack\"}"))
+        .andExpect(status().isBadRequest());
+    org.junit.jupiter.api.Assertions.assertEquals(
+        "## 核心记忆\n- keep\n## 归档记忆\n",
+        Files.readString(oryxosRoot.resolve("agents/demo/MEMORY.md")));
+  }
+
+  @Test
   @DisplayName("工作区写入口禁止写 Agent skills 绑定视图")
   void writeThroughAgentSkillsIsRejected() throws Exception {
     mvc.perform(


### PR DESCRIPTION
Fixes #222

## Summary
- Move MemoryMdGuard to oryxos-core for shared use
- Reject MEMORY.md writes from workspace POST /file

## Test plan
- [x] WorkspaceApiControllerTest#writeMemoryMdIsRejected