### PR TITLE
fix(tool): reject make_dir on MEMORY.md path

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -239,6 +239,7 @@ public class FileTools {
 
   @Tool(name = "make_dir", description = "创建目录（含父目录，幂等）")
   public String makeDir(@ToolParam(description = "要创建的目录路径") String path) {
+    MemoryMdGuard.rejectMutation(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     try {
       Files.createDirectories(Path.of(path));

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -194,6 +194,7 @@ class FileToolsTest {
     assertThrows(IllegalArgumentException.class, () -> tools.editFile(path, "keep", "hijack"));
     assertThrows(IllegalArgumentException.class, () -> tools.appendFile(path, "hijack\n"));
     assertThrows(IllegalArgumentException.class, () -> tools.deleteFile(path));
+    assertThrows(IllegalArgumentException.class, () -> tools.makeDir(path));
     assertThrows(
         IllegalArgumentException.class, () -> tools.moveFile(path, dir.resolve("x.md").toString()));
     assertThrows(IllegalArgumentException.class, () -> tools.copyFile(other.toString(), path));


### PR DESCRIPTION
## Summary
- Call `MemoryMdGuard.rejectMutation(path)` at the start of `make_dir`, matching other file mutation tools from #214
- Prevents creating a directory at the `MEMORY.md` path that would block subsequent `save_memory` writes
- Extends existing MEMORY.md guard unit test to cover `make_dir`

Fixes #224

## Test plan
- [x] `FileToolsTest#fileToolsRejectDirectMemoryMdMutation` (includes `make_dir`)
- [x] `FileToolsTest#makeDirRechecksPathAfterCreateDirectories`
- [ ] CI green on this PR