### PR TITLE
fix(cli): disable tool RestClient auto-redirects (SSRF)

### DIFF
--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -545,6 +545,9 @@ public class OryxOsRuntime {
    *
    * <p>提取为 static 方法便于单测直接验证超时行为（无需启 Spring 容器），模式同 {@code
    * ProviderChatModelFactory.timeoutFactory()}。
+   *
+   * <p>同时 {@code followRedirects(NEVER)}：默认 NORMAL 会跟随 302；Mem0 等客户端会附带 {@code
+   * Authorization}/{@code X-API-Key}，恶意或被劫持的 {@code memory.mem0.base-url} 可把请求拐到内网/元数据。
    */
   static JdkClientHttpRequestFactory toolHttpRequestFactory() {
     Duration connectTimeout =
@@ -556,7 +559,10 @@ public class OryxOsRuntime {
             Long.getLong(TOOL_HTTP_READ_TIMEOUT_PROP, DEFAULT_TOOL_HTTP_READ_TIMEOUT_SECONDS));
     JdkClientHttpRequestFactory factory =
         new JdkClientHttpRequestFactory(
-            HttpClient.newBuilder().connectTimeout(connectTimeout).build());
+            HttpClient.newBuilder()
+                .connectTimeout(connectTimeout)
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build());
     factory.setReadTimeout(readTimeout);
     return factory;
   }

--- a/oryxos-cli/src/test/java/io/oryxos/cli/OryxOsRuntimeTimeoutTest.java
+++ b/oryxos-cli/src/test/java/io/oryxos/cli/OryxOsRuntimeTimeoutTest.java
@@ -1,13 +1,17 @@
 package io.oryxos.cli;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.sun.net.httpserver.HttpServer;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -75,5 +79,49 @@ class OryxOsRuntimeTimeoutTest {
                         .body("{\"city\":\"beijing\"}")
                         .retrieve()
                         .toEntity(String.class)));
+  }
+
+  @Test
+  @DisplayName("工具 RestClient 遇到 302 不得自动跟随（防恶意 Mem0 base-url SSRF）")
+  void toolRestClientDoesNotFollowRedirects() throws Exception {
+    AtomicInteger sinkHits = new AtomicInteger();
+    HttpServer entry = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    HttpServer sink = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    try {
+      sink.createContext(
+          "/",
+          exchange -> {
+            sinkHits.incrementAndGet();
+            byte[] body = "stolen".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+          });
+      sink.start();
+      String sinkUrl = "http://127.0.0.1:" + sink.getAddress().getPort() + "/sink";
+      entry.createContext(
+          "/",
+          exchange -> {
+            exchange.getResponseHeaders().add("Location", sinkUrl);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+          });
+      entry.start();
+
+      RestClient client =
+          RestClient.builder().requestFactory(OryxOsRuntime.toolHttpRequestFactory()).build();
+      String start = "http://127.0.0.1:" + entry.getAddress().getPort() + "/";
+
+      try {
+        String body = client.get().uri(start).retrieve().body(String.class);
+        assertTrue(body == null || !body.contains("stolen"), "即便不抛错也不得返回重定向目标体");
+      } catch (Exception expected) {
+        // 3xx 被 RestClient 当成错误也算 fail-closed，可接受
+      }
+      assertEquals(0, sinkHits.get(), "不得跟随 Location 访问下一跳");
+    } finally {
+      entry.stop(0);
+      sink.stop(0);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Set `followRedirects(NEVER)` on the JDK `HttpClient` used by `OryxOsRuntime.toolHttpRequestFactory()` (Mem0 / shared tool RestClient)
- Same hardening as provider #221; prevents credentialed 302 SSRF via malicious `memory.mem0.base-url`
- Add RestClient 302 regression test

Fixes #227

## Test plan
- [x] `OryxOsRuntimeTimeoutTest` (timeout + no-follow-redirect)
- [ ] CI green on this PR