### PR TITLE
fix(memory): reject MEMORY.md in any path segment

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/memory/MemoryMdGuard.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/memory/MemoryMdGuard.java
@@ -22,9 +22,11 @@ public final class MemoryMdGuard {
     if (path == null || path.isBlank()) {
       return;
     }
-    Path name = Path.of(path).getFileName();
-    if (name != null && MEMORY_FILE_LOWER.equals(name.toString().toLowerCase(Locale.ROOT))) {
-      throw new IllegalArgumentException("拒绝直接改写 MEMORY.md，请使用 save_memory: " + path);
+    // 任意路径段命中即可：write_file("…/MEMORY.md/x.txt") 会 createDirectories 把 MEMORY.md 建成目录
+    for (Path segment : Path.of(path)) {
+      if (MEMORY_FILE_LOWER.equals(segment.toString().toLowerCase(Locale.ROOT))) {
+        throw new IllegalArgumentException("拒绝直接改写 MEMORY.md，请使用 save_memory: " + path);
+      }
     }
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/memory/MemoryMdGuardTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/memory/MemoryMdGuardTest.java
@@ -1,0 +1,41 @@
+package io.oryxos.core.memory;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemoryMdGuardTest {
+
+  @Test
+  @DisplayName("叶子名为 MEMORY.md 时拒绝")
+  void rejectsLeafMemoryMd() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> MemoryMdGuard.rejectMutation(".oryxos/agents/demo/MEMORY.md"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> MemoryMdGuard.rejectMutation("agents/demo/memory.md"));
+  }
+
+  @Test
+  @DisplayName("中间路径段为 MEMORY.md 时也拒绝（防建成目录）")
+  void rejectsMemoryMdAsAncestorSegment() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> MemoryMdGuard.rejectMutation(".oryxos/agents/demo/MEMORY.md/child.txt"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> MemoryMdGuard.rejectMutation("agents/demo/Memory.md/nested/x.md"));
+  }
+
+  @Test
+  @DisplayName("普通路径放行")
+  void allowsOrdinaryPaths() {
+    assertDoesNotThrow(() -> MemoryMdGuard.rejectMutation("agents/demo/notes.md"));
+    assertDoesNotThrow(() -> MemoryMdGuard.rejectMutation("memory/backup.txt"));
+    assertDoesNotThrow(() -> MemoryMdGuard.rejectMutation(null));
+    assertDoesNotThrow(() -> MemoryMdGuard.rejectMutation("  "));
+  }
+}

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -204,6 +204,18 @@ class FileToolsTest {
   }
 
   @Test
+  @DisplayName("文件工具拒绝经 MEMORY.md 子路径建目录（防 DoS save_memory）")
+  void fileToolsRejectMemoryMdAncestorPath() throws IOException {
+    Path agentDir = dir.resolve("agents/fresh");
+    Files.createDirectories(agentDir);
+    Path underMemory = agentDir.resolve("MEMORY.md/child.txt");
+
+    assertThrows(
+        IllegalArgumentException.class, () -> tools.writeFile(underMemory.toString(), "hijack"));
+    assertTrue(Files.notExists(agentDir.resolve("MEMORY.md")), "拒绝后不得把 MEMORY.md 建成目录");
+  }
+
+  @Test
   @DisplayName("write_file 落盘前复检 FILE_WRITE（防校验窗口内路径逃逸）")
   void writeFileRechecksPathBeforeWrite() {
     AtomicInteger fileWrites = new AtomicInteger();


### PR DESCRIPTION
## Summary
- Strengthen `MemoryMdGuard.rejectMutation` to reject if **any** path segment equals `memory.md` (case-insensitive), not only the leaf
- Blocks `write_file("…/MEMORY.md/child.txt")` / workspace `POST /file` from materializing `MEMORY.md` as a directory via `createDirectories`
- Add `MemoryMdGuardTest` + FileTools regression for ancestor-path bypass

Fixes #229

## Test plan
- [x] `MemoryMdGuardTest`
- [x] `FileToolsTest#fileToolsRejectDirectMemoryMdMutation`
- [x] `FileToolsTest#fileToolsRejectMemoryMdAncestorPath`
- [ ] CI green on this PR