### PR TITLE
fix(tool): strip X-API-Key on cross-origin HTTP redirects

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -209,7 +209,10 @@ public class HttpTools {
     return -1;
   }
 
-  /** 去掉跨源重定向不应转发的头（Authorization / Proxy-Authorization / Cookie / Cookie2）。 同浏览器对跨站重定向的凭证剥离习惯。 */
+  /**
+   * 去掉跨源重定向不应转发的头（Authorization / Proxy-Authorization / Cookie / Cookie2 / X-API-Key）。
+   * 同浏览器对跨站重定向的凭证剥离习惯。
+   */
   static String stripSensitiveHeaders(String headers) {
     if (headers == null || headers.isBlank()) {
       return headers;
@@ -235,13 +238,14 @@ public class HttpTools {
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",
       justification =
-          "HTTP header names are ASCII tokens; Locale.ROOT lowercasing is the correct case-fold for Authorization/Cookie matching.")
+          "HTTP header names are ASCII tokens; Locale.ROOT lowercasing is the correct case-fold for Authorization/Cookie/X-API-Key matching.")
   private static boolean isSensitiveHeaderName(String name) {
     String n = name.toLowerCase(Locale.ROOT);
     return "authorization".equals(n)
         || "proxy-authorization".equals(n)
         || "cookie".equals(n)
-        || "cookie2".equals(n);
+        || "cookie2".equals(n)
+        || "x-api-key".equals(n);
   }
 
   @Tool(name = "http_get", description = "发起一个 HTTP GET 请求，返回响应体")

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
@@ -245,6 +245,65 @@ class HttpToolsTest {
   }
 
   @Test
+  @DisplayName("http_request 跨源 302 不得把 X-API-Key 带到下一跳（白名单内主机亦然）")
+  void httpRequestCrossOriginRedirectStripsXApiKey() throws IOException {
+    HttpServer entry = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    HttpServer sink = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    AtomicInteger sinkHits = new AtomicInteger();
+    List<String> sinkApiKeys = new ArrayList<>();
+    List<String> sinkTrace = new ArrayList<>();
+    try {
+      sink.createContext(
+          "/",
+          exchange -> {
+            sinkHits.incrementAndGet();
+            String apiKey = exchange.getRequestHeaders().getFirst("X-API-Key");
+            if (apiKey != null) {
+              sinkApiKeys.add(apiKey);
+            }
+            String trace = exchange.getRequestHeaders().getFirst("X-Trace-Id");
+            if (trace != null) {
+              sinkTrace.add(trace);
+            }
+            byte[] response = "ok".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+          });
+      String sinkUrl = "http://127.0.0.1:" + sink.getAddress().getPort() + "/sink";
+      entry.createContext(
+          "/",
+          exchange -> {
+            exchange.getResponseHeaders().add("Location", sinkUrl);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+          });
+      entry.start();
+      sink.start();
+
+      Sandbox whitelist =
+          new WhitelistSandbox(
+              new FileSandboxProperties(List.of()),
+              new ShellSandboxProperties(List.of()),
+              new HttpSandboxProperties(List.of("localhost", "127.0.0.1")));
+      HttpTools guarded = new HttpTools(whitelist, RestClient.create());
+      String start = "http://localhost:" + entry.getAddress().getPort() + "/";
+
+      String body =
+          guarded.httpRequest(
+              "POST", start, "X-API-Key: secret-api-key\nX-Trace-Id: keep-me", "{\"x\":1}");
+
+      assertEquals("ok", body);
+      assertEquals(1, sinkHits.get());
+      assertTrue(sinkApiKeys.isEmpty(), "跨源重定向不得转发 X-API-Key");
+      assertEquals(List.of("keep-me"), sinkTrace, "非敏感自定义头仍可转发");
+    } finally {
+      entry.stop(0);
+      sink.stop(0);
+    }
+  }
+
+  @Test
   @DisplayName("http_request 跨源 302 不得把 POST body 带到下一跳（改 GET）")
   void httpRequest302DoesNotReplayPostBody() throws IOException {
     HttpServer entry = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);


### PR DESCRIPTION
## Summary
- Extend `HttpTools.isSensitiveHeaderName` to treat `X-API-Key` as sensitive
- Strip it on cross-origin redirects (same path as Authorization/Cookie from #182)
- Add regression test mirroring the Authorization case

Fixes #231

## Test plan
- [x] `HttpToolsTest#httpRequestCrossOriginRedirectStripsXApiKey`
- [ ] CI green on this PR