### PR TITLE
fix(notify): add WeCom markdown format support

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
@@ -74,7 +74,8 @@ public class NotifyTools implements OryxTool {
           "type": "object",
           "properties": {
             "content": {"type": "string", "description": "要推送的内容"},
-            "channel": {"type": "string", "description": "渠道名（全局 Notify 注册表中的 name）；缺省或 default 用注册表第一个渠道"}
+            "channel": {"type": "string", "description": "渠道名（全局 Notify 注册表中的 name）；缺省或 default 用注册表第一个渠道"},
+            "format": {"type": "string", "description": "消息格式：text（默认）或 markdown（企微群机器人等已支持的渠道）；未知值由对应 Adapter 拒绝"}
           },
           "required": ["content"]
         }""";
@@ -88,18 +89,19 @@ public class NotifyTools implements OryxTool {
     }
     String content = contentNode.asText();
     String channel = input.hasNonNull("channel") ? input.get("channel").asText() : null;
+    String format = input.hasNonNull("format") ? input.get("format").asText() : null;
     boolean useDefault = channel == null || channel.isBlank() || DEFAULT_CHANNEL.equals(channel);
 
     // 新模型（31 节）：注册表优先——缺省取第一个；显式名则 find
     if (useDefault) {
       List<NotifyChannelDef> registered = channelRegistry.list();
       if (!registered.isEmpty()) {
-        return sendRegistered(registered.get(0), content);
+        return sendRegistered(registered.get(0), content, format);
       }
     } else {
       Optional<NotifyChannelDef> registered = channelRegistry.find(channel);
       if (registered.isPresent()) {
-        return sendRegistered(registered.get(), content);
+        return sendRegistered(registered.get(), content, format);
       }
       // 名字不在注册表 → 落到下面的兼容路径（按 type 匹配 Agent 内联渠道）
     }
@@ -124,15 +126,15 @@ public class NotifyTools implements OryxTool {
     NotifyChannelAdapter adapter = adapters.get(resolved.type());
     if (adapter == null) {
       return ToolResult.error(
-          "渠道类型 " + resolved.type() + " 没有对应的通知实现（已装配: " + adapters.keySet() + "）", false);
+          "渠道类型 " + resolved.type() + " 没有对应实现（已装配: " + adapters.keySet() + "）", false);
     }
-    NotifyTarget target = new NotifyTarget(resolved.type(), resolved.config());
+    NotifyTarget target = new NotifyTarget(resolved.type(), withFormat(resolved.config(), format));
     sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, resolved.config().get("url")));
     adapter.send(target, content);
     return ToolResult.ok("已推送");
   }
 
-  private ToolResult sendRegistered(NotifyChannelDef def, String content) {
+  private ToolResult sendRegistered(NotifyChannelDef def, String content, String format) {
     NotifyChannelAdapter adapter = adapters.get(def.type());
     if (adapter == null) {
       return ToolResult.error(
@@ -140,8 +142,19 @@ public class NotifyTools implements OryxTool {
           false);
     }
     sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, def.url()));
-    adapter.send(new NotifyTarget(def.type(), Map.of("url", def.url())), content);
+    adapter.send(
+        new NotifyTarget(def.type(), withFormat(Map.of("url", def.url()), format)), content);
     return ToolResult.ok("已推送");
+  }
+
+  /** 把可选 format 写入渠道 config（不覆盖已有 format 键，除非调用方显式传入非空）。 */
+  private static Map<String, String> withFormat(Map<String, String> base, String format) {
+    if (format == null || format.isBlank()) {
+      return base;
+    }
+    java.util.HashMap<String, String> merged = new java.util.HashMap<>(base);
+    merged.put("format", format.strip());
+    return Map.copyOf(merged);
   }
 
   /** channel 空白或 "default" → 第一个渠道；否则按 NotifyChannel.type 匹配（clarify 1）。 */

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/WeComNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/WeComNotifyAdapter.java
@@ -5,8 +5,12 @@ import java.util.Map;
 /**
  * 企业微信群机器人（type: wecom）。
  *
- * <p>webhook 形态与通用档相同，仅 body 格式不同：{@code {"msgtype":"text","text":{"content":"..."}}}。
- * 注意这是"群机器人"档——"应用消息"（corpid/corpsecret 换 AccessToken）属扩展阶段，不在此。
+ * <p>默认 body：{@code {"msgtype":"text","text":{"content":"..."}}}。 {@code config.format=markdown}（或
+ * {@code msgtype=markdown}）时改为官方 markdown： {@code
+ * {"msgtype":"markdown","markdown":{"content":"..."}}}。
+ *
+ * <p>注意这是"群机器人"档——"应用消息"（corpid/corpsecret 换 AccessToken）属扩展阶段，不在此。 {@code template_card}/{@code
+ * news} 等留给后续 PR。
  *
  * <p>出网经 {@link NotifyPoster}：禁自动重定向并每跳复检域名白名单。
  */
@@ -24,6 +28,31 @@ public class WeComNotifyAdapter implements NotifyChannelAdapter {
     if (url == null || url.isBlank()) {
       throw new IllegalArgumentException("wecom 渠道缺少 url 配置（notify_channels 条目需要 url 键）");
     }
+    String format = resolveFormat(target.config());
+    if ("markdown".equals(format)) {
+      poster.postJson(url, Map.of("msgtype", "markdown", "markdown", Map.of("content", content)));
+      return;
+    }
+    if (!"text".equals(format)) {
+      throw new IllegalArgumentException(
+          "wecom 不支持 format/msgtype=" + format + "（当前支持: text, markdown）");
+    }
     poster.postJson(url, Map.of("msgtype", "text", "text", Map.of("content", content)));
+  }
+
+  /** {@code format} 优先，其次兼容 {@code msgtype}；缺省 text。比较用 Locale.ROOT 小写。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "format/msgtype are ASCII protocol tokens; Locale.ROOT lowercasing is the correct case-fold.")
+  private static String resolveFormat(Map<String, String> config) {
+    String format = config.get("format");
+    if (format == null || format.isBlank()) {
+      format = config.get("msgtype");
+    }
+    if (format == null || format.isBlank()) {
+      return "text";
+    }
+    return format.toLowerCase(java.util.Locale.ROOT).strip();
   }
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/WeComNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/WeComNotifyAdapter.java
@@ -1,5 +1,6 @@
 package io.oryxos.tool.notify;
 
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -16,6 +17,11 @@ import java.util.Map;
  */
 public class WeComNotifyAdapter implements NotifyChannelAdapter {
 
+  private static final String FORMAT_TEXT = "text";
+  private static final String FORMAT_MARKDOWN = "markdown";
+  private static final String CONFIG_FORMAT = "format";
+  private static final String CONFIG_MSGTYPE = "msgtype";
+
   private final NotifyPoster poster;
 
   public WeComNotifyAdapter(NotifyPoster poster) {
@@ -29,15 +35,18 @@ public class WeComNotifyAdapter implements NotifyChannelAdapter {
       throw new IllegalArgumentException("wecom 渠道缺少 url 配置（notify_channels 条目需要 url 键）");
     }
     String format = resolveFormat(target.config());
-    if ("markdown".equals(format)) {
-      poster.postJson(url, Map.of("msgtype", "markdown", "markdown", Map.of("content", content)));
+    if (FORMAT_MARKDOWN.equals(format)) {
+      poster.postJson(
+          url,
+          Map.of(CONFIG_MSGTYPE, FORMAT_MARKDOWN, FORMAT_MARKDOWN, Map.of("content", content)));
       return;
     }
-    if (!"text".equals(format)) {
+    if (!FORMAT_TEXT.equals(format)) {
       throw new IllegalArgumentException(
           "wecom 不支持 format/msgtype=" + format + "（当前支持: text, markdown）");
     }
-    poster.postJson(url, Map.of("msgtype", "text", "text", Map.of("content", content)));
+    poster.postJson(
+        url, Map.of(CONFIG_MSGTYPE, FORMAT_TEXT, FORMAT_TEXT, Map.of("content", content)));
   }
 
   /** {@code format} 优先，其次兼容 {@code msgtype}；缺省 text。比较用 Locale.ROOT 小写。 */
@@ -46,13 +55,13 @@ public class WeComNotifyAdapter implements NotifyChannelAdapter {
       justification =
           "format/msgtype are ASCII protocol tokens; Locale.ROOT lowercasing is the correct case-fold.")
   private static String resolveFormat(Map<String, String> config) {
-    String format = config.get("format");
+    String format = config.get(CONFIG_FORMAT);
     if (format == null || format.isBlank()) {
-      format = config.get("msgtype");
+      format = config.get(CONFIG_MSGTYPE);
     }
     if (format == null || format.isBlank()) {
-      return "text";
+      return FORMAT_TEXT;
     }
-    return format.toLowerCase(java.util.Locale.ROOT).strip();
+    return format.toLowerCase(Locale.ROOT).strip();
   }
 }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/NotifyToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/NotifyToolsTest.java
@@ -100,6 +100,38 @@ class NotifyToolsTest {
   }
 
   @Test
+  @DisplayName("format=markdown 写入 NotifyTarget.config 供 Adapter 解释（企微等）")
+  void formatPropagatesIntoNotifyTargetConfig() {
+    NotifyChannelRegistry registry = mock(NotifyChannelRegistry.class);
+    when(registry.find("ops-wecom"))
+        .thenReturn(
+            java.util.Optional.of(
+                new NotifyChannelDef(
+                    "ops-wecom",
+                    "wecom",
+                    "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=x",
+                    null)));
+    NotifyTools tools =
+        new NotifyTools(Map.of("wecom", adapter), new PermissiveSandbox(), registry);
+    var input = MAPPER.createObjectNode();
+    input.put("content", "**告警**");
+    input.put("channel", "ops-wecom");
+    input.put("format", "markdown");
+
+    ToolResult result = tools.execute(input);
+
+    assertTrue(result.success());
+    verify(adapter)
+        .send(
+            argThat(
+                t ->
+                    "wecom".equals(t.channelType())
+                        && "markdown".equals(t.config().get("format"))
+                        && t.config().get("url").contains("qyapi.weixin.qq.com")),
+            eq("**告警**"));
+  }
+
+  @Test
   @DisplayName("channel 缺省且注册表非空_取注册表第一个（不依赖 Profile 内联）")
   void omittedChannelUsesFirstRegistryEntry() {
     NotifyChannelRegistry registry = mock(NotifyChannelRegistry.class);

--- a/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
@@ -80,6 +80,33 @@ class VendorNotifyAdapterTest {
   }
 
   @Test
+  @DisplayName("企业微信：format=markdown 发官方 markdown 体")
+  void wecomMarkdownFormatMatchesVendorContract() throws IOException {
+    new WeComNotifyAdapter(poster)
+        .send(
+            new NotifyTarget("wecom", Map.of("url", url(), "format", "markdown")),
+            "**告警** <font color=\"warning\">1</font>");
+
+    JsonNode body = lastBody();
+    assertEquals("markdown", body.get("msgtype").asText());
+    assertEquals(
+        "**告警** <font color=\"warning\">1</font>", body.get("markdown").get("content").asText());
+  }
+
+  @Test
+  @DisplayName("企业微信：未知 format 点名拒绝且零请求")
+  void wecomRejectsUnknownFormat() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new WeComNotifyAdapter(poster)
+                .send(
+                    new NotifyTarget("wecom", Map.of("url", url(), "format", "template_card")),
+                    "x"));
+    assertEquals(0, received.size());
+  }
+
+  @Test
   @DisplayName("飞书/Lark：msg_type/content.text 格式")
   void feishuBodyMatchesVendorContract() throws IOException {
     new FeishuNotifyAdapter(poster).send(new NotifyTarget("feishu", Map.of("url", url())), "日报来了");


### PR DESCRIPTION
## Summary
- Add optional `format` on `notify` tool (default `text`), passed via `NotifyTarget.config`
- `WeComNotifyAdapter` supports `format=markdown` → official `msgtype: markdown` body
- Unit tests for markdown body, unknown format reject, and format propagation

Fixes #233

## Test plan
- [x] `VendorNotifyAdapterTest` (WeCom text + markdown + unknown format)
- [x] `NotifyToolsTest#formatPropagatesIntoNotifyTargetConfig`
- [ ] CI green on this PR