### PR TITLE
fix(fs): guard skill/knowledge binds and AGENT.md against tool bypass…

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/fs/WorkspaceMutationGuard.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/fs/WorkspaceMutationGuard.java
@@ -17,6 +17,15 @@ public final class WorkspaceMutationGuard {
   private static final String KNOWLEDGE = "knowledge";
   private static final String AGENT_MD = "agent.md";
 
+  /** {@code agents/<name>/<kind|AGENT.md>}：相对 agents 下标再 +2。 */
+  private static final int REL_AFTER_AGENT_NAME = 2;
+
+  /** {@code agents/<name>/skills|knowledge/<leaf>}：相对 agents 下标再 +3。 */
+  private static final int REL_BIND_LEAF = 3;
+
+  /** 共享树段前若是 {@code agents/<name>/}，向前看 2 段对齐 agents。 */
+  private static final int LOOKBACK_TO_AGENTS = 2;
+
   private WorkspaceMutationGuard() {}
 
   /**
@@ -53,11 +62,12 @@ public final class WorkspaceMutationGuard {
     }
     List<String> segs = lowerSegments(path);
     int agents = indexOf(segs, AGENTS);
-    if (agents < 0 || agents + 2 >= segs.size()) {
+    int fileIdx = agents + REL_AFTER_AGENT_NAME;
+    if (agents < 0 || fileIdx >= segs.size()) {
       return;
     }
     // agents/<name>/AGENT.md 恰好三段（相对 agents）
-    if (agents + 2 == segs.size() - 1 && AGENT_MD.equals(segs.get(agents + 2))) {
+    if (fileIdx == segs.size() - 1 && AGENT_MD.equals(segs.get(fileIdx))) {
       throw new IllegalArgumentException(
           "拒绝直接改写 AGENT.md，请通过 Agent 管理 / lifecycle.update: " + path);
     }
@@ -76,15 +86,16 @@ public final class WorkspaceMutationGuard {
     }
     List<String> segs = lowerSegments(path);
     int agents = indexOf(segs, AGENTS);
-    if (agents < 0 || agents + 2 >= segs.size()) {
+    int kindIdx = agents + REL_AFTER_AGENT_NAME;
+    if (agents < 0 || kindIdx >= segs.size()) {
       return;
     }
-    String kind = segs.get(agents + 2);
+    String kind = segs.get(kindIdx);
     if (!SKILLS.equals(kind) && !KNOWLEDGE.equals(kind)) {
       return;
     }
     // agents/<name>/skills|knowledge 之后还有段 → 会占叶子槽
-    if (agents + 2 < segs.size() - 1) {
+    if (kindIdx < segs.size() - 1) {
       throw new IllegalArgumentException("拒绝在 Skill/Knowledge 绑定位建目录（请用 bind 入口）: " + path);
     }
   }
@@ -105,10 +116,11 @@ public final class WorkspaceMutationGuard {
   /** agents/name/skills|knowledge/leaf：恰好 bind 叶子（无更深子路径）。 */
   private static boolean isAgentBindLeaf(List<String> segs) {
     int agents = indexOf(segs, AGENTS);
-    if (agents < 0 || agents + 3 != segs.size() - 1) {
+    int leafIdx = agents + REL_BIND_LEAF;
+    if (agents < 0 || leafIdx != segs.size() - 1) {
       return false;
     }
-    String kind = segs.get(agents + 2);
+    String kind = segs.get(agents + REL_AFTER_AGENT_NAME);
     return SKILLS.equals(kind) || KNOWLEDGE.equals(kind);
   }
 
@@ -119,7 +131,7 @@ public final class WorkspaceMutationGuard {
       return false;
     }
     // 若是 agents/<name>/skills|knowledge，则交给 underAgentBindTree
-    if (i >= 2 && AGENTS.equals(segs.get(i - 2))) {
+    if (i >= LOOKBACK_TO_AGENTS && AGENTS.equals(segs.get(i - LOOKBACK_TO_AGENTS))) {
       return false;
     }
     return true;
@@ -128,10 +140,11 @@ public final class WorkspaceMutationGuard {
   /** agents/name/skills|knowledge/... */
   private static boolean underAgentBindTree(List<String> segs, String kind) {
     int agents = indexOf(segs, AGENTS);
-    if (agents < 0 || agents + 2 >= segs.size()) {
+    int kindIdx = agents + REL_AFTER_AGENT_NAME;
+    if (agents < 0 || kindIdx >= segs.size()) {
       return false;
     }
-    return kind.equals(segs.get(agents + 2));
+    return kind.equals(segs.get(kindIdx));
   }
 
   private static int indexOf(List<String> segs, String name) {

--- a/oryxos-core/src/main/java/io/oryxos/core/fs/WorkspaceMutationGuard.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/fs/WorkspaceMutationGuard.java
@@ -1,0 +1,153 @@
+package io.oryxos.core.fs;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * 工作区保留路径写禁：与 {@code WorkspaceApiController} 对齐，堵住文件工具 / download_file 旁路。
+ *
+ * <p>路径匹配用段扫描（大小写不敏感），不依赖 {@code oryxos.root}——工具侧多为绝对路径。
+ */
+public final class WorkspaceMutationGuard {
+
+  private static final String AGENTS = "agents";
+  private static final String SKILLS = "skills";
+  private static final String KNOWLEDGE = "knowledge";
+  private static final String AGENT_MD = "agent.md";
+
+  private WorkspaceMutationGuard() {}
+
+  /**
+   * 拒绝写入共享 Skill/Knowledge 实体或 Agent 绑定视图下的任意内容路径（共享 skills、agent 绑定 skills、共享 knowledge、agent 绑定
+   * knowledge）。
+   */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "Reserved path segments are ASCII; Locale.ROOT fold matches case-insensitive filesystems.")
+  public static void rejectSkillKnowledgeContentWrite(String path) {
+    if (path == null || path.isBlank()) {
+      return;
+    }
+    List<String> segs = lowerSegments(path);
+    if (underSharedTree(segs, SKILLS)
+        || underSharedTree(segs, KNOWLEDGE)
+        || underAgentBindTree(segs, SKILLS)
+        || underAgentBindTree(segs, KNOWLEDGE)) {
+      throw new IllegalArgumentException("拒绝写入 Skill/Knowledge 路径（请用管理台绑定入口）: " + path);
+    }
+  }
+
+  /**
+   * 拒绝文件工具直写 {@code agents/<name>/AGENT.md}——须走 {@code AgentLifecycleService.update} （校验 + 重注册
+   * schedules）。
+   */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification = "AGENT.md is ASCII; Locale.ROOT fold matches case-insensitive filesystems.")
+  public static void rejectAgentMdDirectWrite(String path) {
+    if (path == null || path.isBlank()) {
+      return;
+    }
+    List<String> segs = lowerSegments(path);
+    int agents = indexOf(segs, AGENTS);
+    if (agents < 0 || agents + 2 >= segs.size()) {
+      return;
+    }
+    // agents/<name>/AGENT.md 恰好三段（相对 agents）
+    if (agents + 2 == segs.size() - 1 && AGENT_MD.equals(segs.get(agents + 2))) {
+      throw new IllegalArgumentException(
+          "拒绝直接改写 AGENT.md，请通过 Agent 管理 / lifecycle.update: " + path);
+    }
+  }
+
+  /**
+   * 拒绝 {@code make_dir} 占用绑定槽（agents 下 skills/knowledge 叶子及其子路径）。建成真目录后 bind 无法落软链；允许只建 skills 或
+   * knowledge 父目录本身。
+   */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification = "Reserved path segments are ASCII; Locale.ROOT fold is intentional.")
+  public static void rejectBindSlotCreate(String path) {
+    if (path == null || path.isBlank()) {
+      return;
+    }
+    List<String> segs = lowerSegments(path);
+    int agents = indexOf(segs, AGENTS);
+    if (agents < 0 || agents + 2 >= segs.size()) {
+      return;
+    }
+    String kind = segs.get(agents + 2);
+    if (!SKILLS.equals(kind) && !KNOWLEDGE.equals(kind)) {
+      return;
+    }
+    // agents/<name>/skills|knowledge 之后还有段 → 会占叶子槽
+    if (agents + 2 < segs.size() - 1) {
+      throw new IllegalArgumentException("拒绝在 Skill/Knowledge 绑定位建目录（请用 bind 入口）: " + path);
+    }
+  }
+
+  /** 拒绝 {@code delete_file}/{@code move_file} 拆掉绑定叶子软链——须走 BindingService.unbind。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification = "Reserved path segments are ASCII; Locale.ROOT fold is intentional.")
+  public static void rejectBindLinkDetach(String path) {
+    if (path == null || path.isBlank()) {
+      return;
+    }
+    if (isAgentBindLeaf(lowerSegments(path))) {
+      throw new IllegalArgumentException("拒绝拆除 Skill/Knowledge 绑定链接（请用 unbind 入口）: " + path);
+    }
+  }
+
+  /** agents/name/skills|knowledge/leaf：恰好 bind 叶子（无更深子路径）。 */
+  private static boolean isAgentBindLeaf(List<String> segs) {
+    int agents = indexOf(segs, AGENTS);
+    if (agents < 0 || agents + 3 != segs.size() - 1) {
+      return false;
+    }
+    String kind = segs.get(agents + 2);
+    return SKILLS.equals(kind) || KNOWLEDGE.equals(kind);
+  }
+
+  /** 根级共享库 skills/name/... 或 knowledge/name/... */
+  private static boolean underSharedTree(List<String> segs, String rootName) {
+    int i = indexOf(segs, rootName);
+    if (i < 0 || i + 1 >= segs.size()) {
+      return false;
+    }
+    // 若是 agents/<name>/skills|knowledge，则交给 underAgentBindTree
+    if (i >= 2 && AGENTS.equals(segs.get(i - 2))) {
+      return false;
+    }
+    return true;
+  }
+
+  /** agents/name/skills|knowledge/... */
+  private static boolean underAgentBindTree(List<String> segs, String kind) {
+    int agents = indexOf(segs, AGENTS);
+    if (agents < 0 || agents + 2 >= segs.size()) {
+      return false;
+    }
+    return kind.equals(segs.get(agents + 2));
+  }
+
+  private static int indexOf(List<String> segs, String name) {
+    for (int i = 0; i < segs.size(); i++) {
+      if (name.equals(segs.get(i))) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private static List<String> lowerSegments(String path) {
+    List<String> segs = new ArrayList<>();
+    for (Path segment : Path.of(path)) {
+      segs.add(segment.toString().toLowerCase(Locale.ROOT));
+    }
+    return segs;
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/fs/WorkspaceMutationGuardTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/fs/WorkspaceMutationGuardTest.java
@@ -1,0 +1,81 @@
+package io.oryxos.core.fs;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WorkspaceMutationGuardTest {
+
+  @Test
+  @DisplayName("拒绝共享 skills/knowledge 与 Agent 绑定视图下的内容写")
+  void rejectSkillKnowledgeContentWrite() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite("skills/report/SKILL.md"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(
+                "agents/demo/skills/report/SKILL.md"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(
+                "agents/demo/Skills/report/x.md"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite("knowledge/ops/doc.md"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(
+                "agents/demo/knowledge/ops/doc.md"));
+    assertDoesNotThrow(
+        () -> WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite("agents/demo/notes.md"));
+    assertDoesNotThrow(
+        () -> WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite("output/report.md"));
+  }
+
+  @Test
+  @DisplayName("拒绝直写 agents/<name>/AGENT.md")
+  void rejectAgentMdDirectWrite() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> WorkspaceMutationGuard.rejectAgentMdDirectWrite("agents/demo/AGENT.md"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> WorkspaceMutationGuard.rejectAgentMdDirectWrite("agents/demo/agent.md"));
+    assertDoesNotThrow(
+        () -> WorkspaceMutationGuard.rejectAgentMdDirectWrite("agents/demo/notes.md"));
+    assertDoesNotThrow(
+        () -> WorkspaceMutationGuard.rejectAgentMdDirectWrite("agents/demo/skills/AGENT.md"));
+  }
+
+  @Test
+  @DisplayName("拒绝 make_dir 占用 bind 叶子；允许建 skills 目录本身")
+  void rejectBindSlotCreate() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> WorkspaceMutationGuard.rejectBindSlotCreate("agents/demo/skills/report"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> WorkspaceMutationGuard.rejectBindSlotCreate("agents/demo/knowledge/ops"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> WorkspaceMutationGuard.rejectBindSlotCreate("agents/demo/skills/report/sub"));
+    assertDoesNotThrow(() -> WorkspaceMutationGuard.rejectBindSlotCreate("agents/demo/skills"));
+    assertDoesNotThrow(() -> WorkspaceMutationGuard.rejectBindSlotCreate("agents/demo/output"));
+  }
+
+  @Test
+  @DisplayName("拒绝 delete/move 拆 bind 叶子")
+  void rejectBindLinkDetach() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> WorkspaceMutationGuard.rejectBindLinkDetach("agents/demo/skills/report"));
+    assertDoesNotThrow(
+        () -> WorkspaceMutationGuard.rejectBindLinkDetach("agents/demo/skills/report/SKILL.md"));
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -1,5 +1,6 @@
 package io.oryxos.tool.builtin;
 
+import io.oryxos.core.fs.WorkspaceMutationGuard;
 import io.oryxos.core.memory.MemoryMdGuard;
 import io.oryxos.tool.sandbox.ActionType;
 import io.oryxos.tool.sandbox.Sandbox;
@@ -61,6 +62,8 @@ public class FileTools {
       @ToolParam(description = "要写入的文件路径") String path,
       @ToolParam(description = "要写入的内容") String content) {
     MemoryMdGuard.rejectMutation(path);
+    WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
+    WorkspaceMutationGuard.rejectAgentMdDirectWrite(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     try {
       Path file = Path.of(path);
@@ -104,6 +107,8 @@ public class FileTools {
       @ToolParam(description = "要被替换的原文本（必须在文件中唯一出现）") String oldString,
       @ToolParam(description = "替换后的新文本") String newString) {
     MemoryMdGuard.rejectMutation(path);
+    WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
+    WorkspaceMutationGuard.rejectAgentMdDirectWrite(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     Path file = Path.of(path);
     if (!Files.isRegularFile(file)) {
@@ -240,6 +245,7 @@ public class FileTools {
   @Tool(name = "make_dir", description = "创建目录（含父目录，幂等）")
   public String makeDir(@ToolParam(description = "要创建的目录路径") String path) {
     MemoryMdGuard.rejectMutation(path);
+    WorkspaceMutationGuard.rejectBindSlotCreate(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     try {
       Files.createDirectories(Path.of(path));
@@ -256,6 +262,8 @@ public class FileTools {
       @ToolParam(description = "文件路径") String path,
       @ToolParam(description = "要追加的内容") String content) {
     MemoryMdGuard.rejectMutation(path);
+    WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
+    WorkspaceMutationGuard.rejectAgentMdDirectWrite(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     try {
       Path file = Path.of(path);
@@ -274,6 +282,7 @@ public class FileTools {
   @Tool(name = "delete_file", description = "删除一个文件（拒绝删除目录）")
   public String deleteFile(@ToolParam(description = "要删除的文件路径") String path) {
     MemoryMdGuard.rejectMutation(path);
+    WorkspaceMutationGuard.rejectBindLinkDetach(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     Path file = Path.of(path);
     // NOFOLLOW_LINKS：只拦真实目录；指向目录的 symlink（如 Agent Skill 绑定）应删链接本身，不跟随目标
@@ -294,6 +303,9 @@ public class FileTools {
       @ToolParam(description = "源路径") String from, @ToolParam(description = "目标路径") String to) {
     MemoryMdGuard.rejectMutation(from);
     MemoryMdGuard.rejectMutation(to);
+    WorkspaceMutationGuard.rejectBindLinkDetach(from);
+    WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(to);
+    WorkspaceMutationGuard.rejectAgentMdDirectWrite(to);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, from));
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, to));
     Path src = Path.of(from);
@@ -326,6 +338,8 @@ public class FileTools {
   public String copyFile(
       @ToolParam(description = "源路径") String from, @ToolParam(description = "目标路径") String to) {
     MemoryMdGuard.rejectMutation(to);
+    WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(to);
+    WorkspaceMutationGuard.rejectAgentMdDirectWrite(to);
     sandbox.enforce(new SandboxAction(ActionType.FILE_READ, from));
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, to));
     Path src = Path.of(from);

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -1,5 +1,6 @@
 package io.oryxos.tool.builtin;
 
+import io.oryxos.core.fs.WorkspaceMutationGuard;
 import io.oryxos.core.memory.MemoryMdGuard;
 import io.oryxos.tool.sandbox.ActionType;
 import io.oryxos.tool.sandbox.Sandbox;
@@ -291,6 +292,8 @@ public class HttpTools {
       @ToolParam(description = "要下载的 URL") String url,
       @ToolParam(description = "保存到的本地文件路径") String path) {
     MemoryMdGuard.rejectMutation(path);
+    WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
+    WorkspaceMutationGuard.rejectAgentMdDirectWrite(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path)); // 先校验落盘路径
     byte[] data = read(url, byte[].class); // 读远端：放行 + 内网黑名单 + 逐跳重定向重校验
     byte[] bytes = data == null ? new byte[0] : data;

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -181,6 +181,39 @@ class FileToolsTest {
   }
 
   @Test
+  @DisplayName("文件工具拒绝 Skill/Knowledge 内容写与 AGENT.md 直写")
+  void fileToolsRejectSkillKnowledgeAndAgentMd() throws IOException {
+    Path other = dir.resolve("other.txt");
+    Files.writeString(other, "x");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> tools.writeFile(dir.resolve("skills/report/SKILL.md").toString(), "bad"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> tools.writeFile(dir.resolve("agents/demo/skills/report/SKILL.md").toString(), "bad"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> tools.writeFile(dir.resolve("knowledge/ops/doc.md").toString(), "bad"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> tools.writeFile(dir.resolve("agents/demo/AGENT.md").toString(), "bogus"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> tools.makeDir(dir.resolve("agents/demo/skills/report").toString()));
+    Path link = dir.resolve("agents/demo/skills/report");
+    Files.createDirectories(link.getParent());
+    Path body = dir.resolve("skills/report");
+    Files.createDirectories(body);
+    try {
+      Files.createSymbolicLink(link, Path.of("../../../skills/report"));
+    } catch (IOException | UnsupportedOperationException e) {
+      Assumptions.assumeTrue(false, "本机无法创建符号链接，跳过: " + e.getMessage());
+    }
+    assertThrows(IllegalArgumentException.class, () -> tools.deleteFile(link.toString()));
+    assertTrue(Files.exists(link), "绑定叶子不得被 delete_file 拆除");
+  }
+
+  @Test
   @DisplayName("文件工具拒绝直接改写 MEMORY.md（须走 save_memory）")
   void fileToolsRejectDirectMemoryMdMutation() throws IOException {
     Path memory = dir.resolve("agents/demo/MEMORY.md");

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
@@ -2,6 +2,7 @@ package io.oryxos.web.controller;
 
 import io.oryxos.core.agent.AgentLifecycleService;
 import io.oryxos.core.fs.RealPathBoundary;
+import io.oryxos.core.fs.WorkspaceMutationGuard;
 import io.oryxos.core.memory.MemoryMdGuard;
 import io.oryxos.web.common.ApiResponse;
 import io.oryxos.web.controller.dto.FileNode;
@@ -47,6 +48,7 @@ public class WorkspaceApiController {
   private static final String AGENT_FILE = "AGENT.md";
   private static final String AGENTS_DIR = "agents";
   private static final String SKILLS_DIR = "skills";
+  private static final String KNOWLEDGE_DIR = "knowledge";
   private static final String PARENT_PATH_SEGMENT = "..";
 
   /** 相对 {@code agents/}：{@code <name>/AGENT.md} 与 {@code <name>/skills/...} 的最小段数。 */
@@ -137,12 +139,19 @@ public class WorkspaceApiController {
       throw new IllegalArgumentException("path 为空"); // → 400
     }
     MemoryMdGuard.rejectMutation(path);
+    WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
     Path target = resolveWithinRoot(path);
     if (isAgentSkillsPath(target)) {
       throw new IllegalArgumentException("Agent skills/ 是绑定视图，禁止从工作区入口写入");
     }
+    if (isAgentKnowledgePath(target)) {
+      throw new IllegalArgumentException("Agent knowledge/ 是绑定视图，禁止从工作区入口写入");
+    }
     if (RealPathBoundary.isWithin(oryxosRoot.resolve(SKILLS_DIR), target)) {
       throw new IllegalArgumentException("共享 Skill 实体只能通过 Skill 管理入口更新");
+    }
+    if (RealPathBoundary.isWithin(oryxosRoot.resolve(KNOWLEDGE_DIR), target)) {
+      throw new IllegalArgumentException("共享 Knowledge 实体只能通过 Knowledge 管理入口更新");
     }
     String content = req.content() == null ? "" : req.content();
     Path agentDir = agentDirOfAgentFile(target);
@@ -195,6 +204,18 @@ public class WorkspaceApiController {
     return relative != null
         && relative.getNameCount() >= AGENT_CHILD_SEGMENTS
         && SKILLS_DIR.equalsIgnoreCase(relative.getName(1).toString());
+  }
+
+  /** {@code agents/<name>/knowledge/**}（大小写不敏感），与 skills 绑定视图同款禁写。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "knowledge is an ASCII reserved path segment; equalsIgnoreCase matches case-insensitive filesystems.")
+  private boolean isAgentKnowledgePath(Path target) {
+    Path relative = relativeUnderAgents(target);
+    return relative != null
+        && relative.getNameCount() >= AGENT_CHILD_SEGMENTS
+        && KNOWLEDGE_DIR.equalsIgnoreCase(relative.getName(1).toString());
   }
 
   /** 相对真实 {@code agents/} 的路径；越出该目录或含 {@code ..} 则 null。 */

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
@@ -192,12 +192,12 @@ class WorkspaceApiControllerTest {
   }
 
   @Test
-  @DisplayName("工作区写入口禁止直接或经归档 Agent 软连接修改共享 Skill")
+  @DisplayName("工作区写入口禁止直接或经归档路径段修改共享 Skill")
   void writeThroughSharedSkillPathsIsRejected() throws Exception {
     Path shared = Files.createDirectories(oryxosRoot.resolve("skills/report"));
     Path skillFile = Files.writeString(shared.resolve("SKILL.md"), "original");
-    Path archivedLinks = Files.createDirectories(oryxosRoot.resolve("archive/ops-old/skills"));
-    Files.createSymbolicLink(archivedLinks.resolve("report"), Path.of("../../../skills/report"));
+    // 不建软链：路径段守卫已拒 skills/**；归档侧同名 skills 段亦拒（免 Windows 建链权限）
+    Files.createDirectories(oryxosRoot.resolve("archive/ops-old/skills"));
 
     mvc.perform(
             post("/api/v1/workspace/file")
@@ -211,6 +211,25 @@ class WorkspaceApiControllerTest {
                     "{\"path\":\"archive/ops-old/skills/report/SKILL.md\",\"content\":\"bad\"}"))
         .andExpect(status().isBadRequest());
     org.junit.jupiter.api.Assertions.assertEquals("original", Files.readString(skillFile));
+  }
+
+  @Test
+  @DisplayName("工作区写入口禁止 Knowledge 绑定视图与共享实体")
+  void writeThroughKnowledgePathsIsRejected() throws Exception {
+    Path shared = Files.createDirectories(oryxosRoot.resolve("knowledge/ops"));
+    Path doc = Files.writeString(shared.resolve("doc.md"), "original");
+
+    mvc.perform(
+            post("/api/v1/workspace/file")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"path\":\"knowledge/ops/doc.md\",\"content\":\"bad\"}"))
+        .andExpect(status().isBadRequest());
+    mvc.perform(
+            post("/api/v1/workspace/file")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"path\":\"agents/demo/knowledge/ops/doc.md\",\"content\":\"bad\"}"))
+        .andExpect(status().isBadRequest());
+    org.junit.jupiter.api.Assertions.assertEquals("original", Files.readString(doc));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Closes #236
- Add `WorkspaceMutationGuard` to reject Skill/Knowledge content writes, AGENT.md direct mutation, bind-slot `make_dir`, and bind-leaf delete/move
- Wire into `FileTools`, `HttpTools.downloadFile`, and `WorkspaceApiController` (Knowledge ban aligned with Skills)

## Test plan
- [ ] `WorkspaceMutationGuardTest`
- [ ] `FileToolsTest#fileToolsRejectSkillKnowledgeAndAgentMd`
- [ ] `WorkspaceApiControllerTest` shared Skill + Knowledge write rejection
- [ ] Manual: bind skill → `write_file` / `make_dir` / `delete_file` on bind paths rejected