### PR TITLE
fix(fs): reject direct writes to channels.yaml and mcp_servers.yaml

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/fs/AdminConfigFileGuard.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/fs/AdminConfigFileGuard.java
@@ -1,0 +1,35 @@
+package io.oryxos.core.fs;
+
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * 管理台热更配置只能经 AdminService 落盘——文件工具 / Workspace / download_file 直写会绕过校验与断连重连。
+ *
+ * <p>覆盖 {@code channels.yaml}（{@code ChannelAdminService}）与 {@code mcp_servers.yaml}（{@code
+ * McpServerAdminService}）。
+ */
+public final class AdminConfigFileGuard {
+
+  private static final Set<String> RESERVED_LOWER = Set.of("channels.yaml", "mcp_servers.yaml");
+
+  private AdminConfigFileGuard() {}
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "Reserved filenames are ASCII; Locale.ROOT fold matches case-insensitive filesystems.")
+  public static void rejectMutation(String path) {
+    if (path == null || path.isBlank()) {
+      return;
+    }
+    // 任意路径段命中即可：write_file("…/channels.yaml/x") 会 createDirectories 把配置名建成目录
+    for (Path segment : Path.of(path)) {
+      String lower = segment.toString().toLowerCase(Locale.ROOT);
+      if (RESERVED_LOWER.contains(lower)) {
+        throw new IllegalArgumentException("拒绝直接改写管理配置（请用 Channel / MCP 管理入口）: " + path);
+      }
+    }
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/fs/AdminConfigFileGuardTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/fs/AdminConfigFileGuardTest.java
@@ -1,0 +1,46 @@
+package io.oryxos.core.fs;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AdminConfigFileGuardTest {
+
+  @Test
+  @DisplayName("拒绝 channels.yaml / mcp_servers.yaml 直写（大小写不敏感）")
+  void rejectsReservedConfigFiles() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AdminConfigFileGuard.rejectMutation(".oryxos/channels.yaml"));
+    assertThrows(
+        IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectMutation("Channels.YAML"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AdminConfigFileGuard.rejectMutation(".oryxos/mcp_servers.yaml"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AdminConfigFileGuard.rejectMutation("MCP_SERVERS.yaml"));
+  }
+
+  @Test
+  @DisplayName("拒绝经保留文件名建子路径（防目录占位）")
+  void rejectsAncestorPathViaReservedName() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AdminConfigFileGuard.rejectMutation(".oryxos/channels.yaml/child.txt"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AdminConfigFileGuard.rejectMutation("mcp_servers.yaml/nested/x.yml"));
+  }
+
+  @Test
+  @DisplayName("普通路径放行")
+  void allowsOrdinaryPaths() {
+    assertDoesNotThrow(() -> AdminConfigFileGuard.rejectMutation("agents/demo/notes.md"));
+    assertDoesNotThrow(() -> AdminConfigFileGuard.rejectMutation("channels.yaml.bak"));
+    assertDoesNotThrow(() -> AdminConfigFileGuard.rejectMutation(null));
+    assertDoesNotThrow(() -> AdminConfigFileGuard.rejectMutation("  "));
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -1,5 +1,6 @@
 package io.oryxos.tool.builtin;
 
+import io.oryxos.core.fs.AdminConfigFileGuard;
 import io.oryxos.core.fs.WorkspaceMutationGuard;
 import io.oryxos.core.memory.MemoryMdGuard;
 import io.oryxos.tool.sandbox.ActionType;
@@ -62,6 +63,7 @@ public class FileTools {
       @ToolParam(description = "要写入的文件路径") String path,
       @ToolParam(description = "要写入的内容") String content) {
     MemoryMdGuard.rejectMutation(path);
+    AdminConfigFileGuard.rejectMutation(path);
     WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
     WorkspaceMutationGuard.rejectAgentMdDirectWrite(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
@@ -107,6 +109,7 @@ public class FileTools {
       @ToolParam(description = "要被替换的原文本（必须在文件中唯一出现）") String oldString,
       @ToolParam(description = "替换后的新文本") String newString) {
     MemoryMdGuard.rejectMutation(path);
+    AdminConfigFileGuard.rejectMutation(path);
     WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
     WorkspaceMutationGuard.rejectAgentMdDirectWrite(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
@@ -245,6 +248,7 @@ public class FileTools {
   @Tool(name = "make_dir", description = "创建目录（含父目录，幂等）")
   public String makeDir(@ToolParam(description = "要创建的目录路径") String path) {
     MemoryMdGuard.rejectMutation(path);
+    AdminConfigFileGuard.rejectMutation(path);
     WorkspaceMutationGuard.rejectBindSlotCreate(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     try {
@@ -262,6 +266,7 @@ public class FileTools {
       @ToolParam(description = "文件路径") String path,
       @ToolParam(description = "要追加的内容") String content) {
     MemoryMdGuard.rejectMutation(path);
+    AdminConfigFileGuard.rejectMutation(path);
     WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
     WorkspaceMutationGuard.rejectAgentMdDirectWrite(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
@@ -282,6 +287,7 @@ public class FileTools {
   @Tool(name = "delete_file", description = "删除一个文件（拒绝删除目录）")
   public String deleteFile(@ToolParam(description = "要删除的文件路径") String path) {
     MemoryMdGuard.rejectMutation(path);
+    AdminConfigFileGuard.rejectMutation(path);
     WorkspaceMutationGuard.rejectBindLinkDetach(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     Path file = Path.of(path);
@@ -302,8 +308,10 @@ public class FileTools {
   public String moveFile(
       @ToolParam(description = "源路径") String from, @ToolParam(description = "目标路径") String to) {
     MemoryMdGuard.rejectMutation(from);
-    MemoryMdGuard.rejectMutation(to);
+    AdminConfigFileGuard.rejectMutation(from);
     WorkspaceMutationGuard.rejectBindLinkDetach(from);
+    MemoryMdGuard.rejectMutation(to);
+    AdminConfigFileGuard.rejectMutation(to);
     WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(to);
     WorkspaceMutationGuard.rejectAgentMdDirectWrite(to);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, from));
@@ -338,6 +346,7 @@ public class FileTools {
   public String copyFile(
       @ToolParam(description = "源路径") String from, @ToolParam(description = "目标路径") String to) {
     MemoryMdGuard.rejectMutation(to);
+    AdminConfigFileGuard.rejectMutation(to);
     WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(to);
     WorkspaceMutationGuard.rejectAgentMdDirectWrite(to);
     sandbox.enforce(new SandboxAction(ActionType.FILE_READ, from));

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -1,5 +1,6 @@
 package io.oryxos.tool.builtin;
 
+import io.oryxos.core.fs.AdminConfigFileGuard;
 import io.oryxos.core.fs.WorkspaceMutationGuard;
 import io.oryxos.core.memory.MemoryMdGuard;
 import io.oryxos.tool.sandbox.ActionType;
@@ -303,6 +304,7 @@ public class HttpTools {
       @ToolParam(description = "要下载的 URL") String url,
       @ToolParam(description = "保存到的本地文件路径") String path) {
     MemoryMdGuard.rejectMutation(path);
+    AdminConfigFileGuard.rejectMutation(path);
     WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
     WorkspaceMutationGuard.rejectAgentMdDirectWrite(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path)); // 先校验落盘路径

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -271,6 +271,31 @@ class FileToolsTest {
   }
 
   @Test
+  @DisplayName("文件工具拒绝直写 channels.yaml / mcp_servers.yaml")
+  void fileToolsRejectAdminConfigFiles() throws IOException {
+    Path channels = dir.resolve("channels.yaml");
+    Path mcp = dir.resolve("mcp_servers.yaml");
+    Path other = dir.resolve("other.txt");
+    Files.writeString(channels, "channels: []\n");
+    Files.writeString(mcp, "servers: []\n");
+    Files.writeString(other, "x");
+    assertThrows(
+        IllegalArgumentException.class, () -> tools.writeFile(channels.toString(), "hijack"));
+    assertThrows(IllegalArgumentException.class, () -> tools.editFile(mcp.toString(), "[]", "x"));
+    assertThrows(
+        IllegalArgumentException.class, () -> tools.appendFile(channels.toString(), "x\n"));
+    assertThrows(IllegalArgumentException.class, () -> tools.deleteFile(channels.toString()));
+    assertThrows(IllegalArgumentException.class, () -> tools.makeDir(channels.toString()));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> tools.moveFile(channels.toString(), dir.resolve("x.yaml").toString()));
+    assertThrows(
+        IllegalArgumentException.class, () -> tools.copyFile(other.toString(), mcp.toString()));
+    assertEquals("channels: []\n", Files.readString(channels));
+    assertEquals("servers: []\n", Files.readString(mcp));
+  }
+
+  @Test
   @DisplayName("write_file 落盘前复检 FILE_WRITE（防校验窗口内路径逃逸）")
   void writeFileRechecksPathBeforeWrite() {
     AtomicInteger fileWrites = new AtomicInteger();

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
@@ -1,6 +1,7 @@
 package io.oryxos.web.controller;
 
 import io.oryxos.core.agent.AgentLifecycleService;
+import io.oryxos.core.fs.AdminConfigFileGuard;
 import io.oryxos.core.fs.RealPathBoundary;
 import io.oryxos.core.fs.WorkspaceMutationGuard;
 import io.oryxos.core.memory.MemoryMdGuard;
@@ -140,6 +141,7 @@ public class WorkspaceApiController {
     }
     // 先词法拦直写；再投影真实路径后复检——notes.md→MEMORY.md 软链只在投影后能看见
     MemoryMdGuard.rejectMutation(path);
+    AdminConfigFileGuard.rejectMutation(path);
     WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
     Path target = resolveWithinRoot(path);
     MemoryMdGuard.rejectMutation(target);

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
@@ -162,6 +162,27 @@ class WorkspaceApiControllerTest {
   }
 
   @Test
+  @DisplayName("工作区写入口禁止直写 channels.yaml / mcp_servers.yaml")
+  void writeAdminConfigFilesIsRejected() throws Exception {
+    Path channels = Files.writeString(oryxosRoot.resolve("channels.yaml"), "channels: []\n");
+    Path mcp = Files.writeString(oryxosRoot.resolve("mcp_servers.yaml"), "servers: []\n");
+    mvc.perform(
+            post("/api/v1/workspace/file")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"path\":\"channels.yaml\",\"content\":\"channels: [{hijack: true}]\\n\"}"))
+        .andExpect(status().isBadRequest());
+    mvc.perform(
+            post("/api/v1/workspace/file")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"path\":\"mcp_servers.yaml\",\"content\":\"servers: [{hijack: true}]\\n\"}"))
+        .andExpect(status().isBadRequest());
+    org.junit.jupiter.api.Assertions.assertEquals("channels: []\n", Files.readString(channels));
+    org.junit.jupiter.api.Assertions.assertEquals("servers: []\n", Files.readString(mcp));
+  }
+
+  @Test
   @DisplayName("工作区写入口禁止写 Agent skills 绑定视图")
   void writeThroughAgentSkillsIsRejected() throws Exception {
     mvc.perform(


### PR DESCRIPTION
## Summary
- Closes #238
- Add `AdminConfigFileGuard` to block direct mutation of `channels.yaml` and `mcp_servers.yaml`
- Wire into `FileTools`, `HttpTools.downloadFile`, and `WorkspaceApiController.writeFile`

## Test plan
- [ ] `AdminConfigFileGuardTest`
- [ ] `FileToolsTest#fileToolsRejectAdminConfigFiles`
- [ ] `WorkspaceApiControllerTest#writeAdminConfigFilesIsRejected`
- [ ] Manual: `write_file(".oryxos/channels.yaml", ...)` rejected; Channel admin API still works