### PR TITLE
fix(http): strip bare Api-Key on cross-origin redirects

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -210,8 +210,8 @@ public class HttpTools {
   }
 
   /**
-   * 去掉跨源重定向不应转发的头（Authorization / Proxy-Authorization / Cookie / Cookie2 / X-API-Key）。
-   * 同浏览器对跨站重定向的凭证剥离习惯。
+   * 去掉跨源重定向不应转发的头（Authorization / Proxy-Authorization / Cookie / Cookie2 / X-API-Key /
+   * Api-Key）。同浏览器对跨站重定向的凭证剥离习惯。
    */
   static String stripSensitiveHeaders(String headers) {
     if (headers == null || headers.isBlank()) {
@@ -238,14 +238,15 @@ public class HttpTools {
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",
       justification =
-          "HTTP header names are ASCII tokens; Locale.ROOT lowercasing is the correct case-fold for Authorization/Cookie/X-API-Key matching.")
+          "HTTP header names are ASCII tokens; Locale.ROOT lowercasing is the correct case-fold for Authorization/Cookie/X-API-Key/Api-Key matching.")
   private static boolean isSensitiveHeaderName(String name) {
     String n = name.toLowerCase(Locale.ROOT);
     return "authorization".equals(n)
         || "proxy-authorization".equals(n)
         || "cookie".equals(n)
         || "cookie2".equals(n)
-        || "x-api-key".equals(n);
+        || "x-api-key".equals(n)
+        || "api-key".equals(n);
   }
 
   @Tool(name = "http_get", description = "发起一个 HTTP GET 请求，返回响应体")

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
@@ -304,6 +304,55 @@ class HttpToolsTest {
   }
 
   @Test
+  @DisplayName("http_request 跨源 302 不得把裸 Api-Key 带到下一跳")
+  void httpRequestCrossOriginRedirectStripsBareApiKey() throws IOException {
+    HttpServer entry = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    HttpServer sink = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    List<String> sinkApiKeys = new ArrayList<>();
+    try {
+      sink.createContext(
+          "/",
+          exchange -> {
+            String apiKey = exchange.getRequestHeaders().getFirst("Api-Key");
+            if (apiKey != null) {
+              sinkApiKeys.add(apiKey);
+            }
+            byte[] response = "ok".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+          });
+      String sinkUrl = "http://127.0.0.1:" + sink.getAddress().getPort() + "/sink";
+      entry.createContext(
+          "/",
+          exchange -> {
+            exchange.getResponseHeaders().add("Location", sinkUrl);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+          });
+      entry.start();
+      sink.start();
+
+      Sandbox whitelist =
+          new WhitelistSandbox(
+              new FileSandboxProperties(List.of()),
+              new ShellSandboxProperties(List.of()),
+              new HttpSandboxProperties(List.of("localhost", "127.0.0.1")));
+      HttpTools guarded = new HttpTools(whitelist, RestClient.create());
+      String start = "http://localhost:" + entry.getAddress().getPort() + "/";
+
+      String body =
+          guarded.httpRequest("POST", start, "Api-Key: bare-secret\nX-Trace-Id: keep-me", "{}");
+
+      assertEquals("ok", body);
+      assertTrue(sinkApiKeys.isEmpty(), "跨源重定向不得转发裸 Api-Key");
+    } finally {
+      entry.stop(0);
+      sink.stop(0);
+    }
+  }
+
+  @Test
   @DisplayName("http_request 跨源 302 不得把 POST body 带到下一跳（改 GET）")
   void httpRequest302DoesNotReplayPostBody() throws IOException {
     HttpServer entry = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);


### PR DESCRIPTION
## Summary
- Closes #240
- Treat bare `Api-Key` as sensitive on cross-origin redirects (alongside `X-API-Key` from #232)
- Add `HttpToolsTest#httpRequestCrossOriginRedirectStripsBareApiKey`

## Test plan
- [ ] `HttpToolsTest#httpRequestCrossOriginRedirectStripsBareApiKey`
- [ ] `HttpToolsTest#httpRequestCrossOriginRedirectStripsXApiKey` still passes