### PR TITLE
fix(agent): treat AGENT.md case-insensitively in WorkspaceWatcher (#242)

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/agent/WorkspaceWatcher.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/WorkspaceWatcher.java
@@ -112,6 +112,10 @@ public class WorkspaceWatcher {
   //  - 根目录事件：只认直接子目录的新增（补挂监听 + 试登记）与删除（注销）；
   //  - 子 Agent 目录事件：只认 AGENT.md 的增/改（登记或刷新）与删（注销）。
   /** 把一个目录事件翻成对某个 Agent 的登记/刷新/注销。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "AGENT.md is an ASCII reserved filename; equalsIgnoreCase matches case-insensitive filesystems.")
   void dispatch(WatchService watchService, Path dir, Path changed, WatchEvent.Kind<?> kind) {
     if (agentsDir.equals(dir)) {
       if (kind == ENTRY_CREATE && Files.isDirectory(changed)) {
@@ -123,7 +127,8 @@ public class WorkspaceWatcher {
       // 根目录层的 MODIFY 不处理：AGENT.md 变更由子目录自己的 watch 捕获
       return;
     }
-    if (!AGENT_FILE.equals(String.valueOf(changed.getFileName()))) {
+    // 大小写不敏感：macOS/Windows 上编辑器或 WatchService 可能上报 agent.md，须与 Workspace 写入口一致
+    if (!AGENT_FILE.equalsIgnoreCase(String.valueOf(changed.getFileName()))) {
       return; // 子目录里只有 AGENT.md 的变更牵动注册
     }
     if (kind == ENTRY_DELETE) {

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/WorkspaceWatcherTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/WorkspaceWatcherTest.java
@@ -119,6 +119,21 @@ class WorkspaceWatcherTest {
   }
 
   @Test
+  @DisplayName("子目录 agent.md 大小写不同仍触发登记/注销（与 Workspace 写入口一致）")
+  void dispatch_agentFileWrongCase_stillRegisters() throws IOException {
+    Path dir = writeAgent("demo", "name: demo\nprovider:\n  name: deepseek\n  model: m");
+    // 模拟 WatchService 上报 agent.md（大小写敏感比较会漏；FS 上常与 AGENT.md 同一文件）
+    Path wrongCase = dir.resolve("agent.md");
+    try (WatchService ws = agentsDir.getFileSystem().newWatchService()) {
+      watcher.dispatch(ws, dir, wrongCase, ENTRY_MODIFY);
+      assertTrue(registry.exists("demo"), "agent.md 事件须刷新登记");
+
+      watcher.dispatch(ws, dir, wrongCase, ENTRY_DELETE);
+      assertFalse(registry.exists("demo"), "agent.md 删除事件须注销");
+    }
+  }
+
+  @Test
   @DisplayName("issue #61：新建 Agent 目录（AGENT.md 已就位）在根事件中即登记并补挂监听")
   void dispatch_newAgentDirAtRoot_registersAndWatches() throws IOException {
     Path dir = writeAgent("demo", "name: demo\nprovider:\n  name: deepseek\n  model: m");


### PR DESCRIPTION
## Summary
- Closes #242
- `WorkspaceWatcher.dispatch` uses `equalsIgnoreCase` for `AGENT.md` (align with Workspace write path)
- Add test for `agent.md` FS events refreshing/unregistering schedules

## Test plan
- [ ] `WorkspaceWatcherTest#dispatch_agentFileWrongCase_stillRegisters`
- [ ] Existing `WorkspaceWatcherTest` still pass