### PR TITLE
fix(yaml): reject Boolean coercion on Channel/MCP/Profile string fiel…

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/channel/ChannelConfigLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/ChannelConfigLoader.java
@@ -169,7 +169,15 @@ public class ChannelConfigLoader {
   }
 
   private static String asString(Object value) {
-    return value == null ? null : String.valueOf(value);
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof String text) {
+      return text;
+    }
+    // YAML 1.1：裸 yes/on/null 会变成 Boolean/null；String.valueOf(true)→"true" 会静默改名（对齐 #198）
+    throw new IllegalArgumentException(
+        "期望 YAML 字符串（yes/on/null 等请加引号），实际是 " + value.getClass().getSimpleName() + ": " + value);
   }
 
   private static String sanitize(String value) {

--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -172,7 +172,7 @@ public class ProfileLoader {
       Map<String, String> config = new LinkedHashMap<>();
       for (Map.Entry<String, Object> kv : entry.entrySet()) {
         if (!"type".equals(kv.getKey()) && kv.getValue() != null) {
-          config.put(kv.getKey(), String.valueOf(kv.getValue()));
+          config.put(kv.getKey(), asString(kv.getValue()));
         }
       }
       channels.add(new Profile.NotifyChannel(type, config));
@@ -285,7 +285,15 @@ public class ProfileLoader {
   }
 
   private static String asString(Object value) {
-    return value == null ? null : String.valueOf(value);
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof String text) {
+      return text;
+    }
+    // YAML 1.1：裸 yes/on/null 会变成 Boolean/null；String.valueOf(true)→"true" 会静默改名（对齐 #198）
+    throw new ProfileValidationException(
+        "期望 YAML 字符串（yes/on/null 等请加引号），实际是 " + value.getClass().getSimpleName() + ": " + value);
   }
 
   private static Double asDouble(Object value) {
@@ -311,7 +319,11 @@ public class ProfileLoader {
     if (list == null) {
       return List.of();
     }
-    return list.stream().map(String::valueOf).toList();
+    List<String> out = new ArrayList<>();
+    for (Object item : list) {
+      out.add(asString(item));
+    }
+    return out;
   }
 
   /** 日志参数消毒：去掉换行，防日志伪造（CRLF injection）。 */

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/ChannelConfigLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/ChannelConfigLoaderTest.java
@@ -143,4 +143,48 @@ class ChannelConfigLoaderTest {
         """);
     assertEquals(false, new ChannelConfigLoader(configFile()).loadRaw().get(0).enabled());
   }
+
+  @Test
+  @DisplayName("YAML 1.1 布尔词 yes/on 不得被 String.valueOf 改成 true（须加引号）")
+  void rejectsYamlBooleanWordsAsStringFields() throws Exception {
+    write(
+        """
+        channels:
+          - name: yes
+            type: feishu
+            app_id: a
+            app_secret: b
+            agent: ops
+        """);
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class, () -> new ChannelConfigLoader(configFile()).loadRaw());
+    assertTrue(e.getMessage().contains("字符串") || e.getMessage().contains("Boolean"));
+
+    write(
+        """
+        channels:
+          - name: ops
+            type: feishu
+            app_id: a
+            app_secret: b
+            agent: on
+        """);
+    assertThrows(
+        IllegalArgumentException.class, () -> new ChannelConfigLoader(configFile()).loadRaw());
+
+    write(
+        """
+        channels:
+          - name: "yes"
+            type: feishu
+            app_id: a
+            app_secret: b
+            agent: "on"
+        """);
+    List<ChannelConfig> ok = new ChannelConfigLoader(configFile()).loadRaw();
+    assertEquals(1, ok.size());
+    assertEquals("yes", ok.get(0).name());
+    assertEquals("on", ok.get(0).agent());
+  }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
@@ -359,4 +359,48 @@ class ProfileLoaderTest {
 
     assertTrue(exception.getMessage().contains("name"));
   }
+
+  @Test
+  void scheduleKeyYamlBooleanWordRejected() throws IOException {
+    write(
+        "bool-schedule-key.yaml",
+        """
+        name: bool-schedule-key
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - key: on
+            name: morning
+            cron: "0 0 8 * * *"
+        """);
+
+    ProfileValidationException exception =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("bool-schedule-key.yaml")));
+
+    assertTrue(
+        exception.getMessage().contains("字符串") || exception.getMessage().contains("Boolean"));
+  }
+
+  @Test
+  void scheduleKeyQuotedYesOk() throws IOException {
+    write(
+        "quoted-yes-key.yaml",
+        """
+        name: quoted-yes-key
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - key: "yes"
+            name: yes-job
+            cron: "0 0 8 * * *"
+            message: hi
+        """);
+
+    Profile profile = loader().parse(profilesDir.resolve("quoted-yes-key.yaml"));
+    assertEquals("yes", profile.schedules().get(0).key());
+  }
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/mcp/McpConfigLoader.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/mcp/McpConfigLoader.java
@@ -159,7 +159,10 @@ public class McpConfigLoader {
     }
     Map<String, String> out = new LinkedHashMap<>();
     for (Map.Entry<String, Object> entry : ((Map<String, Object>) value).entrySet()) {
-      out.put(entry.getKey(), String.valueOf(entry.getValue()));
+      if (entry.getValue() == null) {
+        continue;
+      }
+      out.put(entry.getKey(), asString(entry.getValue()));
     }
     return out;
   }
@@ -180,7 +183,15 @@ public class McpConfigLoader {
   }
 
   private static String asString(Object value) {
-    return value == null ? null : String.valueOf(value);
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof String text) {
+      return text;
+    }
+    // YAML 1.1：裸 yes/on/null 会变成 Boolean/null；String.valueOf(true)→"true" 会静默改名（对齐 #198）
+    throw new IllegalArgumentException(
+        "期望 YAML 字符串（yes/on/null 等请加引号），实际是 " + value.getClass().getSimpleName() + ": " + value);
   }
 
   private static String sanitize(String value) {

--- a/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpConfigLoaderTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpConfigLoaderTest.java
@@ -1,0 +1,46 @@
+package io.oryxos.tool.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class McpConfigLoaderTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  @DisplayName("YAML 1.1 布尔词 yes 不得被 String.valueOf 改成 name=true")
+  void rejectsYamlBooleanWordAsName() throws Exception {
+    Path file = tempDir.resolve("mcp_servers.yaml");
+    Files.writeString(
+        file,
+        """
+        servers:
+          - name: yes
+            transport: stdio
+            command: echo
+        """);
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> new McpConfigLoader(file).loadRaw());
+    assertTrue(e.getMessage().contains("字符串") || e.getMessage().contains("Boolean"));
+
+    Files.writeString(
+        file,
+        """
+        servers:
+          - name: "yes"
+            transport: stdio
+            command: echo
+        """);
+    List<io.oryxos.core.mcp.McpServerConfig> ok = new McpConfigLoader(file).loadRaw();
+    assertEquals(1, ok.size());
+    assertEquals("yes", ok.get(0).name());
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #244
- `asString` (and list/map helpers) in Channel/MCP/Profile loaders accept only real `String` values
- Bare YAML 1.1 `yes`/`on` no longer become `"true"`; quoted `"yes"` still works

## Test plan
- [ ] `ChannelConfigLoaderTest#rejectsYamlBooleanWordsAsStringFields`
- [ ] `McpConfigLoaderTest#rejectsYamlBooleanWordAsName`
- [ ] `ProfileLoaderTest#scheduleKeyYamlBooleanWordRejected` / `scheduleKeyQuotedYesOk`