### PR TITLE
feat(notify): SMTP email notification channel + SMTP endpoint allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ Map<String, ChatModel> providerMap = Map.of(
 - 文件操作：路径白名单（`file.allowed_paths`）
 - Shell：可执行文件精确白名单（`shell.allowed_commands`）；参数以 argv 直传，不解释 Shell 语法。将解释器列入白名单是管理员对本机代码执行权限的显式授予，不构成隔离
 - HTTP：域名通配符白名单（`http.allowed_domains`）
+- SMTP：端点白名单（`smtp.allowed_endpoints`，按 `host:port` 精确放行，端口缺省=任意，空=deny-all）
 
 文件目标存在时必须用 `toRealPath()` 校验真实路径仍位于白名单根；新建路径校验最近存在父目录的真实路径。Agent Skill 绑定只允许指向 `.oryxos/skills/` 的相对软连接，拒绝绝对链接和越界链接。
 
@@ -291,7 +292,7 @@ interface OryxTool {
 | `http_post` | `HttpTools` | POST 请求，域名通配符白名单 |
 | `save_memory` | `MemoryTools` | 追加到长期记忆（core/archival 分区显式指定） |
 | `recall_memory` | `MemoryTools` | 检索归档记忆；配置全局 `embedding.*` 后为语义+关键词+时间三路加权融合（015），未配置保持关键词行为 |
-| `notify` | `NotifyTools` | 推送到 Profile 的 `notify_channels`，核心阶段走 `WebhookNotifyAdapter` |
+| `notify` | `NotifyTools` | 推送到全局注册表按名引用的通知渠道；webhook/feishu/wecom/dingtalk 走 `WebhookNotifyAdapter`，email 走 `EmailNotifyAdapter`（`config` 多字段 + SMTP 端点白名单） |
 
 ### Plugin Tool 三档
 

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -92,6 +92,9 @@ http:
     - api.open-meteo.com        # 天气 Agent 免 key 天气源（31 节 Demo 一）
     - hn.algolia.com            # 科技日报 Agent 新闻源（31 节 Demo 二）
     - api.github.com            # GitHub 日报脚本子进程网络（31 节 Demo 三）
+smtp:
+  allowed_endpoints: []         # 邮件通知（EmailNotifyAdapter）出站 SMTP 端点白名单，格式 host[:port]
+                                # （端口缺省=任意端口；空 = 不发任何邮件）。例：smtp.gmail.com:465
 
 # ── 日志级别（格式 / appender 在 logback-spring.xml）──────
 logging:

--- a/docs/TechnicalSolution.md
+++ b/docs/TechnicalSolution.md
@@ -332,11 +332,12 @@ ActionType     = FILE_READ | FILE_WRITE | SHELL_COMMAND | HTTP_REQUEST
 
 接口签名里不出现"白名单""容器镜像""VM 配置"这类某一档实现特有的词——用最重的 microVM 实现去反向套这个签名，也应该能干净套入，这是校验接口是否中立的办法。
 
-**`WhitelistSandbox`（核心阶段唯一实现）。** 配置在 `application.yaml`（`file.allowed_paths`、`shell.allowed_commands`、`http.allowed_domains`），内部按 `ActionType` 路由到三个私有校验方法：
+**`WhitelistSandbox`（核心阶段唯一实现）。** 配置在 `application.yaml`（`file.allowed_paths`、`shell.allowed_commands`、`http.allowed_domains`、`smtp.allowed_endpoints`），内部按 `ActionType` 路由到四个私有校验方法：
 
 - `checkFilePath`（路径标准化后比对白名单，需处理 `../` 路径穿越）
 - `checkShellCommand`（精确比对可执行文件白名单；解释器仅在管理员显式列入时允许，并授予宿主机进程权限）
 - `checkHttpUrl`（解析 host 后做通配符匹配）
+- `checkSmtpEndpoint`（按 `host:port` 精确放行 SMTP 端点，端口缺省=任意）
 
 任意校验失败抛 `SandboxViolationException`，Tool 执行终止；异常信息直接复用 `ToolExecutor` 已有的失败审计路径写入 `tool_invocations`（`success=false`、`error_message`），不需要为 Sandbox 单独新增审计逻辑。
 
@@ -372,7 +373,9 @@ NotifyChannelAdapter.send(NotifyTarget target, String content)
 NotifyTarget = { channelType: String, config: Map<String, String> }
 ```
 
-**`WebhookNotifyAdapter`（核心阶段唯一实现）。** 用通用 HTTP webhook 承接所有场景——企业微信、飞书、钉钉的群机器人都提供 webhook 地址，核心阶段不用逐家接它们的专用 API（签名算法、AccessToken 刷新这些认证细节核心阶段不做），直接把 `content` 包成对方 webhook 约定的 JSON 格式发一次 POST。发送前一样要过 `Sandbox.enforce(new SandboxAction(HTTP_REQUEST, url))` 域名白名单校验，跟 `http_post` 共享同一份 `http.allowed_domains` 配置，不新增 Sandbox 逻辑。
+**`WebhookNotifyAdapter`（核心阶段 HTTP 类实现）。** 用通用 HTTP webhook 承接 HTTP 类场景——企业微信、飞书、钉钉的群机器人都提供 webhook 地址，核心阶段不用逐家接它们的专用 API（签名算法、AccessToken 刷新这些认证细节核心阶段不做），直接把 `content` 包成对方 webhook 约定的 JSON 格式发一次 POST。发送前一样要过 `Sandbox.enforce(new SandboxAction(HTTP_REQUEST, url))` 域名白名单校验，跟 `http_post` 共享同一份 `http.allowed_domains` 配置，不新增 Sandbox 逻辑。
+
+**`EmailNotifyAdapter`（扩展阶段 SMTP 专用实现）。** email 类型渠道不走 webhook，而是经 jakarta.mail 直连 SMTP 发送。其 `config` 多字段承载 `host`/`port`/`from`/`to`/`username`/`password`/`subject`/`encryption`（凭证可用 `${ENV_VAR}` 占位符在发送时从环境变量解析，不明文落库）；出站端点走独立的 `smtp.allowed_endpoints`（`host:port`）白名单，与 HTTP 域名白名单分离。
 
 **`NotifyTools`（内置 Tool，归 `oryxos-tool`）：**
 
@@ -380,7 +383,7 @@ NotifyTarget = { channelType: String, config: Map<String, String> }
 @Tool notify(content: String, channel: String = 默认渠道)
 ```
 
-`channel` 参数是通知渠道的全局注册名。通知渠道通过 Web 管理台或 `/api/v1/notify-channels` 做 CRUD，持久化在 SQLite 的 `notify_channels` 表；每项包含 `name`、`type`、`url` 和可选的 `description`。Agent 在 `AGENT.md` 正文中用自然语言按名引用渠道，LLM 调用时传 `channel` 和 `content`，`NotifyTools` 再从注册表解析适配器和 URL。具体 webhook 地址不进入对话，增加或修改渠道也无需改 Agent；`AGENT.md` frontmatter 不包含 `notify_channels` 字段。
+`channel` 参数是通知渠道的全局注册名。通知渠道通过 Web 管理台或 `/api/v1/notify-channels` 做 CRUD，持久化在 SQLite 的 `notify_channels` 表；每项包含 `name`、`type`、`url` 和可选的 `description`，以及承载类型相关多字段的 `config`（webhook/feishu 等 HTTP 类继续用 `url`，email 用 `config` 的 host/port/from/to 等）。Agent 在 `AGENT.md` 正文中用自然语言按名引用渠道，LLM 调用时传 `channel` 和 `content`，`NotifyTools` 再从注册表解析适配器和 URL。具体 webhook 地址不进入对话，增加或修改渠道也无需改 Agent；`AGENT.md` frontmatter 不包含 `notify_channels` 字段。
 
 ![NotifyTools 设计：接口先行，核心阶段只实现 WebhookNotifyAdapter，扩展阶段新增专用渠道 Adapter](../website/public/images/docs-notify.svg)
 

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -88,6 +88,7 @@ import io.oryxos.tool.interaction.UserInteraction;
 import io.oryxos.tool.mcp.McpClientService;
 import io.oryxos.tool.mcp.McpConfigLoader;
 import io.oryxos.tool.notify.DingTalkNotifyAdapter;
+import io.oryxos.tool.notify.EmailNotifyAdapter;
 import io.oryxos.tool.notify.FeishuNotifyAdapter;
 import io.oryxos.tool.notify.NotifyChannelAdapter;
 import io.oryxos.tool.notify.NotifyPoster;
@@ -97,6 +98,7 @@ import io.oryxos.tool.sandbox.FileSandboxProperties;
 import io.oryxos.tool.sandbox.HttpSandboxProperties;
 import io.oryxos.tool.sandbox.Sandbox;
 import io.oryxos.tool.sandbox.ShellSandboxProperties;
+import io.oryxos.tool.sandbox.SmtpSandboxProperties;
 import io.oryxos.tool.sandbox.WhitelistSandbox;
 import io.oryxos.tool.web.DuckDuckGoSearchProvider;
 import java.net.http.HttpClient;
@@ -139,7 +141,8 @@ import org.springframework.web.context.WebApplicationContext;
   ProvidersProperties.class,
   FileSandboxProperties.class,
   ShellSandboxProperties.class,
-  HttpSandboxProperties.class
+  HttpSandboxProperties.class,
+  SmtpSandboxProperties.class
 })
 public class OryxOsRuntime {
 
@@ -511,7 +514,8 @@ public class OryxOsRuntime {
       SandboxWhitelistStore whitelistStore,
       FileSandboxProperties fileProps,
       ShellSandboxProperties shellProps,
-      HttpSandboxProperties httpProps) {
+      HttpSandboxProperties httpProps,
+      SmtpSandboxProperties smtpProps) {
     // 24 节：真正的白名单校验（宪法 VI 第一档）。空列表 = deny-all。
     // 返回具体类型（而非 Sandbox 接口）：同一实例既是校验墙 Sandbox 又是可管理白名单 SandboxWhitelist，
     // 具体类型让 Spring 同时按两个接口装配（工具注 Sandbox，Web 管理端点注 SandboxWhitelist）。
@@ -522,6 +526,7 @@ public class OryxOsRuntime {
     nullToEmpty(fileProps.allowedPaths()).forEach(p -> whitelist.add(Category.FILE, p));
     nullToEmpty(shellProps.allowedCommands()).forEach(c -> whitelist.add(Category.SHELL, c));
     nullToEmpty(httpProps.allowedDomains()).forEach(d -> whitelist.add(Category.HTTP, d));
+    nullToEmpty(smtpProps.allowedEndpoints()).forEach(e -> whitelist.add(Category.SMTP, e));
     // 工作区根永远是 Agent 的家：随 oryxos.root 自动纳入文件白名单（幂等 + 落库）。
     whitelist.add(Category.FILE, oryxosRootProp);
     return whitelist;
@@ -717,7 +722,8 @@ public class OryxOsRuntime {
             "webhook", new WebhookNotifyAdapter(notifyPoster),
             "wecom", new WeComNotifyAdapter(notifyPoster),
             "feishu", new FeishuNotifyAdapter(notifyPoster),
-            "dingtalk", new DingTalkNotifyAdapter(notifyPoster));
+            "dingtalk", new DingTalkNotifyAdapter(notifyPoster),
+            "email", new EmailNotifyAdapter(sandbox));
     registry.register(new NotifyTools(notifyAdapters, sandbox, notifyChannelRegistry));
     // 记忆工具：save_memory / recall_memory（补齐 20 节预留的两工具面），只认门面对后端无感
     registry.registerAnnotated(new MemoryTools(memoryService));

--- a/oryxos-core/src/main/java/io/oryxos/core/notify/NotifyChannelDef.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/notify/NotifyChannelDef.java
@@ -1,10 +1,25 @@
 package io.oryxos.core.notify;
 
+import java.util.Map;
+
 /**
  * 通知渠道定义（跨模块值对象，31 节）：一个全局命名的通知出口。
  *
  * <p>{@code name} 全局唯一、Agent 按它引用；{@code type} 决定用哪个 {@code NotifyChannelAdapter}
- * （feishu/wecom/dingtalk/webhook）；{@code url} 是该渠道的 webhook 地址。放 core 是因为
+ * （webhook/feishu/wecom/dingtalk/email）；{@code url} 是 HTTP 类渠道的 webhook 地址；{@code config}
+ * 承载该类型所需的额外字段（如 email 的 host/port/from/to/username/password/subject/encryption）。放 core 是因为
  * web（CRUD）、oryxos-tool（notify 工具按名解析）、oryxos-storage（JPA 实现）三边都要认它，而三者都已依赖 core。
  */
-public record NotifyChannelDef(String name, String type, String url, String description) {}
+public record NotifyChannelDef(
+    String name, String type, String url, String description, Map<String, String> config) {
+
+  /** 向后兼容 4 参构造：{@code config} 置空 map（旧调用点免改，HTTP 类渠道用 {@code url} 即可）。 */
+  public NotifyChannelDef(String name, String type, String url, String description) {
+    this(name, type, url, description, Map.of());
+  }
+
+  /** 防御性拷贝：config 是可变 Map，暴露前固化不可变（SpotBugs EI_EXPOSE_REP / EI_EXPOSE_REP2）。 */
+  public NotifyChannelDef {
+    config = config == null ? Map.of() : Map.copyOf(config);
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/sandbox/SandboxWhitelist.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/sandbox/SandboxWhitelist.java
@@ -11,11 +11,12 @@ import java.util.List;
  */
 public interface SandboxWhitelist {
 
-  /** 三类白名单：文件路径 / Shell 命令 / HTTP 域名。 */
+  /** 四类白名单：文件路径 / Shell 命令 / HTTP 域名 / SMTP 端点。 */
   enum Category {
     FILE,
     SHELL,
-    HTTP
+    HTTP,
+    SMTP
   }
 
   /** 列出某类当前的全部白名单条目（文件类返回归一后的绝对路径）。 */

--- a/oryxos-storage/src/main/java/io/oryxos/storage/JpaNotifyChannelRegistry.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/JpaNotifyChannelRegistry.java
@@ -1,16 +1,23 @@
 package io.oryxos.storage;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.oryxos.core.notify.NotifyChannelDef;
 import io.oryxos.core.notify.NotifyChannelRegistry;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
  * {@link NotifyChannelRegistry} 的 SQLite/JPA 实现：notify_channels 表 ↔ {@link NotifyChannelDef} 互转。
+ * {@code config} 列是 JSON 文本，序列化沿用 {@link JpaSessionManager} 的手工 ObjectMapper 模式。
  */
 public class JpaNotifyChannelRegistry implements NotifyChannelRegistry {
 
   private final NotifyChannelRepository repository;
+
+  private final ObjectMapper mapper = new ObjectMapper();
 
   public JpaNotifyChannelRegistry(NotifyChannelRepository repository) {
     this.repository = repository;
@@ -18,12 +25,12 @@ public class JpaNotifyChannelRegistry implements NotifyChannelRegistry {
 
   @Override
   public List<NotifyChannelDef> list() {
-    return repository.findAll().stream().map(JpaNotifyChannelRegistry::toDef).toList();
+    return repository.findAll().stream().map(this::toDef).toList();
   }
 
   @Override
   public Optional<NotifyChannelDef> find(String name) {
-    return repository.findById(name).map(JpaNotifyChannelRegistry::toDef);
+    return repository.findById(name).map(this::toDef);
   }
 
   @Override
@@ -38,6 +45,7 @@ public class JpaNotifyChannelRegistry implements NotifyChannelRegistry {
     entity.setType(channel.type());
     entity.setUrl(channel.url());
     entity.setDescription(channel.description());
+    entity.setConfig(writeConfig(channel.config()));
     return toDef(repository.save(entity));
   }
 
@@ -46,7 +54,31 @@ public class JpaNotifyChannelRegistry implements NotifyChannelRegistry {
     repository.deleteById(name);
   }
 
-  private static NotifyChannelDef toDef(NotifyChannel e) {
-    return new NotifyChannelDef(e.getName(), e.getType(), e.getUrl(), e.getDescription());
+  private NotifyChannelDef toDef(NotifyChannel e) {
+    return new NotifyChannelDef(
+        e.getName(), e.getType(), e.getUrl(), e.getDescription(), readConfig(e.getConfig()));
+  }
+
+  private String writeConfig(Map<String, String> config) {
+    if (config == null || config.isEmpty()) {
+      return null;
+    }
+    try {
+      return mapper.writeValueAsString(config);
+    } catch (JsonProcessingException ex) {
+      // config 写不进去等于渠道配置丢失，显式失败而非静默存空
+      throw new IllegalStateException("通知渠道 config 序列化失败: " + ex.getOriginalMessage(), ex);
+    }
+  }
+
+  private Map<String, String> readConfig(String configJson) {
+    if (configJson == null || configJson.isBlank()) {
+      return Map.of();
+    }
+    try {
+      return mapper.readValue(configJson, new TypeReference<Map<String, String>>() {});
+    } catch (JsonProcessingException ex) {
+      throw new IllegalStateException("通知渠道 config 反序列化失败: " + ex.getOriginalMessage(), ex);
+    }
   }
 }

--- a/oryxos-storage/src/main/java/io/oryxos/storage/NotifyChannel.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/NotifyChannel.java
@@ -21,6 +21,9 @@ public class NotifyChannel {
   @Column(nullable = false)
   private String url;
 
+  /** 类型相关的额外配置（JSON 文本，如 email 的 host/port/from/to/username/password/…）；null 视为空。 */
+  private String config;
+
   private String description;
 
   @Column(name = "created_at", nullable = false)
@@ -65,6 +68,14 @@ public class NotifyChannel {
 
   public void setUrl(String url) {
     this.url = url;
+  }
+
+  public String getConfig() {
+    return config;
+  }
+
+  public void setConfig(String config) {
+    this.config = config;
   }
 
   public String getDescription() {

--- a/oryxos-storage/src/main/java/io/oryxos/storage/NotifyChannelSchemaMigration.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/NotifyChannelSchemaMigration.java
@@ -1,0 +1,52 @@
+package io.oryxos.storage;
+
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * SQLite 表结构增量迁移：给已存在的 {@code notify_channels} 补 {@code config} 列。
+ *
+ * <p>背景：表结构唯一权威是手工 {@code schema.sql}（{@code ddl-auto: none}），而 {@code CREATE TABLE IF NOT EXISTS}
+ * 不会给旧库加新列、SQLite 又无 {@code ADD COLUMN IF NOT EXISTS}，故用一个幂等的 {@link CommandLineRunner} 在启动时按
+ * {@code PRAGMA table_info} 探测缺列再 {@code ALTER TABLE ... ADD COLUMN}。新库由 schema.sql 直接建含该列，此处探测后空转。
+ */
+@Component
+public class NotifyChannelSchemaMigration implements CommandLineRunner {
+
+  private static final Logger log = LoggerFactory.getLogger(NotifyChannelSchemaMigration.class);
+
+  private static final String TABLE = "notify_channels";
+  private static final String COLUMN = "config";
+
+  private final JdbcTemplate jdbc;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "注入的 JdbcTemplate 是 Spring 共享 Bean（连接工厂），本就不应防御性拷贝。")
+  public NotifyChannelSchemaMigration(JdbcTemplate jdbc) {
+    this.jdbc = jdbc;
+  }
+
+  @Override
+  public void run(String... args) {
+    if (!hasColumn()) {
+      jdbc.execute("ALTER TABLE " + TABLE + " ADD COLUMN " + COLUMN + " TEXT");
+      log.info("已迁移 {}：新增 {} 列", TABLE, COLUMN);
+    }
+  }
+
+  private boolean hasColumn() {
+    List<Map<String, Object>> columns = jdbc.queryForList("PRAGMA table_info(" + TABLE + ")");
+    for (Map<String, Object> row : columns) {
+      if (COLUMN.equals(row.get("name"))) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/oryxos-storage/src/main/resources/schema.sql
+++ b/oryxos-storage/src/main/resources/schema.sql
@@ -131,12 +131,14 @@ CREATE TABLE IF NOT EXISTS memory_vectors (
 );
 CREATE INDEX IF NOT EXISTS idx_memvec_agent ON memory_vectors (agent_name);
 
--- notify_channels：全局通知渠道注册表（31 节）——name → type + url + 描述；管理台可 CRUD、Agent 按名字引用
--- （notify 工具的 channel 参数）。新表，CREATE TABLE IF NOT EXISTS，非 ALTER，无迁移风险。
+-- notify_channels：全局通知渠道注册表（31 节）——name → type + url + config + 描述；管理台可 CRUD、Agent 按名字引用
+-- （notify 工具的 channel 参数）。config 为类型相关多字段的 JSON 文本（如 email 的 host/port/from/to）。
+-- 新表，CREATE TABLE IF NOT EXISTS，非 ALTER，无迁移风险。
 CREATE TABLE IF NOT EXISTS notify_channels (
     name VARCHAR(128) PRIMARY KEY,
     type VARCHAR(32) NOT NULL,
     url TEXT NOT NULL,
+    config TEXT,
     description TEXT,
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL

--- a/oryxos-tool/pom.xml
+++ b/oryxos-tool/pom.xml
@@ -42,6 +42,11 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
         </dependency>
+        <!-- 邮件通知渠道（EmailNotifyAdapter）出站 SMTP——版本由 Boot BOM 管理（Angus Mail + jakarta.mail-api） -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
@@ -13,6 +13,7 @@ import io.oryxos.tool.notify.NotifyTarget;
 import io.oryxos.tool.sandbox.ActionType;
 import io.oryxos.tool.sandbox.Sandbox;
 import io.oryxos.tool.sandbox.SandboxAction;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,6 +29,15 @@ public class NotifyTools implements OryxTool {
 
   /** channel 参数的"用默认渠道"字面量（课件示例用词）。 */
   private static final String DEFAULT_CHANNEL = "default";
+
+  /** config 里存 HTTP 类渠道 webhook 地址的键（email 渠道无 url，走 SMTP）。 */
+  private static final String KEY_URL = "url";
+
+  /** 渠道类型字面量 email（走 SMTP，而非 HTTP webhook）。 */
+  private static final String TYPE_EMAIL = "email";
+
+  /** email 渠道 config 里收件人地址的键（描述里露出，模型才知道发给谁）。 */
+  private static final String KEY_TO = "to";
 
   /** channelType → 实现（webhook/wecom/feishu/dingtalk…）；多档并存按 type 路由（课件 6.4 路一）。 */
   private final Map<String, NotifyChannelAdapter> adapters;
@@ -57,14 +67,27 @@ public class NotifyTools implements OryxTool {
 
   @Override
   public String getDescription() {
-    // 动态列出当前已注册的渠道名，模型据此选 channel（31 节：出口全局管理、按名引用）
+    // 动态列出当前已注册的渠道名 + 类型，模型据此选 channel 并判断是 email / webhook（31 节：出口全局管理、按名引用）。
+    // email 渠道额外露出收件人（config.to），否则模型只看到"test"会误判"非邮件"。
     List<NotifyChannelDef> registered = channelRegistry.list();
     if (registered.isEmpty()) {
       return "把一条消息推送到指定通知渠道。channel 传渠道名；当前无已注册渠道——去管理台「Notify 渠道」里新建。";
     }
     String names =
-        registered.stream().map(NotifyChannelDef::name).collect(Collectors.joining(", "));
+        registered.stream().map(NotifyTools::describe).collect(Collectors.joining(", "));
     return "把一条消息推送到指定通知渠道。channel 传渠道名，当前可用：" + names;
+  }
+
+  /** 渠道名(type)；email 再加 →收件人，让模型一眼看出这是发往哪个邮箱的 SMTP 渠道。 */
+  private static String describe(NotifyChannelDef def) {
+    String base = def.name() + "(" + def.type() + ")";
+    if (TYPE_EMAIL.equals(def.type())) {
+      String to = def.config().get(KEY_TO);
+      if (to != null && !to.isBlank()) {
+        return def.name() + "(" + def.type() + "→" + to + ")";
+      }
+    }
+    return base;
   }
 
   @Override
@@ -129,7 +152,11 @@ public class NotifyTools implements OryxTool {
           "渠道类型 " + resolved.type() + " 没有对应实现（已装配: " + adapters.keySet() + "）", false);
     }
     NotifyTarget target = new NotifyTarget(resolved.type(), withFormat(resolved.config(), format));
-    sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, resolved.config().get("url")));
+    // 内联渠道有 url 才做 HTTP 预检；无 url 的渠道（如 email 走 SMTP）由适配器在 send 首行自行过沙箱
+    String url = resolved.config().get(KEY_URL);
+    if (url != null && !url.isBlank()) {
+      sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, url));
+    }
     adapter.send(target, content);
     return ToolResult.ok("已推送");
   }
@@ -141,9 +168,18 @@ public class NotifyTools implements OryxTool {
           "渠道 " + def.name() + " 的类型 " + def.type() + " 没有对应实现（已装配: " + adapters.keySet() + "）",
           false);
     }
-    sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, def.url()));
-    adapter.send(
-        new NotifyTarget(def.type(), withFormat(Map.of("url", def.url()), format)), content);
+    // 全量 config：email 用多字段、HTTP 类靠 url 回填（兼容旧行无 config 列）；与内联路径同策略。
+    // （def.config() 经 NotifyChannelDef 紧凑构造器固化非空，无需判空）
+    Map<String, String> config = new HashMap<>(def.config());
+    if (!config.containsKey(KEY_URL) && def.url() != null && !def.url().isBlank()) {
+      config.put(KEY_URL, def.url());
+    }
+    config = withFormat(config, format);
+    String url = config.get(KEY_URL);
+    if (url != null && !url.isBlank()) {
+      sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, url)); // email 无 url，SMTP 由适配器自检
+    }
+    adapter.send(new NotifyTarget(def.type(), config), content);
     return ToolResult.ok("已推送");
   }
 

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
@@ -73,8 +73,7 @@ public class NotifyTools implements OryxTool {
     if (registered.isEmpty()) {
       return "把一条消息推送到指定通知渠道。channel 传渠道名；当前无已注册渠道——去管理台「Notify 渠道」里新建。";
     }
-    String names =
-        registered.stream().map(NotifyTools::describe).collect(Collectors.joining(", "));
+    String names = registered.stream().map(NotifyTools::describe).collect(Collectors.joining(", "));
     return "把一条消息推送到指定通知渠道。channel 传渠道名，当前可用：" + names;
   }
 

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/EmailNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/EmailNotifyAdapter.java
@@ -1,0 +1,186 @@
+package io.oryxos.tool.notify;
+
+import io.oryxos.tool.sandbox.ActionType;
+import io.oryxos.tool.sandbox.Sandbox;
+import io.oryxos.tool.sandbox.SandboxAction;
+import jakarta.mail.Authenticator;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.PasswordAuthentication;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * 邮件通知渠道：把一条内容作为邮件正文发出（第 5 个 {@link NotifyChannelAdapter}，第 19 节预留的「扩展阶段 SMTP 专用 Adapter」）。
+ *
+ * <p>配置可走两条路径：内联 Profile 的 {@code notify_channels}（{@code type: email}），或全局注册表 {@code
+ * NotifyChannelDef} 的 {@code config}（多字段）。凭证（password/username）支持 {@code ${VAR}} 环境变量占位，由本 adapter
+ * 在发送时解析，绝不落明文（宪法明文）；内联路径另经 {@code ProfileLoader} 先行解析，两者兼容。
+ *
+ * <p>出站先过沙箱 {@link ActionType#SMTP_SEND}（按 host:port 精确放行，区别于 HTTP 只校验域名）；SMTP 用 Jakarta Mail 同步阻塞
+ * 发送，契合宪法 VII（virtual thread 扛 IO）。
+ */
+public final class EmailNotifyAdapter implements NotifyChannelAdapter {
+
+  private static final String KEY_HOST = "host";
+  private static final String KEY_PORT = "port";
+  private static final String KEY_FROM = "from";
+  private static final String KEY_TO = "to";
+  private static final String KEY_USERNAME = "username";
+  private static final String KEY_PASSWORD = "password";
+  private static final String KEY_SUBJECT = "subject";
+  private static final String KEY_ENCRYPTION = "encryption";
+
+  private static final String DEFAULT_SUBJECT = "OryxOS 通知";
+
+  private static final String ENCRYPTION_SSL = "ssl";
+  private static final String ENCRYPTION_STARTTLS = "starttls";
+  private static final String ENCRYPTION_NONE = "none";
+
+  private static final int MAX_PORT = 65535;
+  private static final int DEFAULT_SSL_PORT = 465;
+  private static final int DEFAULT_STARTTLS_PORT = 587;
+
+  /** 凭证环境变量占位的包裹符：{@code ${VAR}} → 读取环境变量 VAR。 */
+  private static final String ENV_PREFIX = "${";
+
+  private static final String ENV_SUFFIX = "}";
+
+  private final Sandbox sandbox;
+
+  public EmailNotifyAdapter(Sandbox sandbox) {
+    this.sandbox = sandbox;
+  }
+
+  @Override
+  public void send(NotifyTarget target, String content) {
+    Map<String, String> config = target.config();
+    String host = require(config, KEY_HOST);
+    int port = parsePort(require(config, KEY_PORT));
+    String from = require(config, KEY_FROM);
+    String to = require(config, KEY_TO);
+    String username = resolveEnv(config.get(KEY_USERNAME));
+    String password = resolveEnv(config.get(KEY_PASSWORD));
+    String subject = config.getOrDefault(KEY_SUBJECT, DEFAULT_SUBJECT);
+    String encryption = resolveEncryption(config.get(KEY_ENCRYPTION), port);
+
+    // 涉外 IO 前过沙箱（宪法 VI / H4 不变量①）：SMTP 出站按 host:port 精确放行
+    sandbox.enforce(new SandboxAction(ActionType.SMTP_SEND, host + ":" + port));
+
+    Properties props = new Properties();
+    props.put("mail.smtp.host", host);
+    props.put("mail.smtp.port", String.valueOf(port));
+    if (ENCRYPTION_SSL.equals(encryption)) {
+      props.put("mail.smtp.ssl.enable", "true");
+    } else if (ENCRYPTION_STARTTLS.equals(encryption)) {
+      props.put("mail.smtp.starttls.enable", "true");
+    }
+    boolean auth = username != null && !username.isBlank();
+    if (auth) {
+      // 认证必需显式打开 mail.smtp.auth：缺省 false 时 Transport.send 不发 AUTH 命令，服务器回 530「Client was not
+      // authenticated」。
+      props.put("mail.smtp.auth", "true");
+    }
+    Session session =
+        auth
+            ? Session.getInstance(
+                props, new SmtpAuthenticator(username, password == null ? "" : password))
+            : Session.getInstance(props);
+
+    try {
+      MimeMessage message = new MimeMessage(session);
+      message.setFrom(new InternetAddress(from));
+      message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(to));
+      message.setSubject(subject, "UTF-8");
+      message.setText(content, "UTF-8");
+      Transport.send(message);
+    } catch (MessagingException e) {
+      throw new IllegalStateException("邮件发送失败: " + e.getMessage(), e);
+    }
+  }
+
+  private static String require(Map<String, String> config, String key) {
+    String value = config.get(key);
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(
+          "email 渠道缺少配置键 " + key + "（notify_channels 的 email 条目需要 host/port/from/to）");
+    }
+    return value.strip();
+  }
+
+  private static int parsePort(String raw) {
+    int port;
+    try {
+      port = Integer.parseInt(raw.strip());
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("email 渠道 port 不是整数: " + raw);
+    }
+    if (port < 1 || port > MAX_PORT) {
+      throw new IllegalArgumentException("email 渠道 port 非法（须 1~" + MAX_PORT + "）: " + raw);
+    }
+    return port;
+  }
+
+  /** 解析 {@code ${VAR}} 环境变量占位（凭证走环境变量，注册表 config 不落明文）；非占位值原样返回。 */
+  static String resolveEnv(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.strip();
+    if (trimmed.startsWith(ENV_PREFIX) && trimmed.endsWith(ENV_SUFFIX)) {
+      return System.getenv(
+          trimmed.substring(ENV_PREFIX.length(), trimmed.length() - ENV_SUFFIX.length()));
+    }
+    return value;
+  }
+
+  /** 缺省按端口推断加密（465→ssl、587→starttls、其余→none）；显式值优先，非法值报错（不静默明文）。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "encryption 是受限 ASCII 令牌（ssl/starttls/none），大小写不敏感比对是安全且意图明确的；不涉及会因 unicode 折叠改变语义的字段")
+  private static String resolveEncryption(String explicit, int port) {
+    if (explicit == null || explicit.isBlank()) {
+      if (port == DEFAULT_SSL_PORT) {
+        return ENCRYPTION_SSL;
+      }
+      if (port == DEFAULT_STARTTLS_PORT) {
+        return ENCRYPTION_STARTTLS;
+      }
+      return ENCRYPTION_NONE;
+    }
+    String value = explicit.strip();
+    if (ENCRYPTION_SSL.equalsIgnoreCase(value)) {
+      return ENCRYPTION_SSL;
+    }
+    if (ENCRYPTION_STARTTLS.equalsIgnoreCase(value)) {
+      return ENCRYPTION_STARTTLS;
+    }
+    if (ENCRYPTION_NONE.equalsIgnoreCase(value)) {
+      return ENCRYPTION_NONE;
+    }
+    throw new IllegalArgumentException(
+        "email 渠道 encryption 非法: " + explicit + "（可选 ssl / starttls / none）");
+  }
+
+  /** SMTP 认证凭证：只在配置了 username 时启用；密码缺省传空串（某些服务器允许空口令）。 */
+  private static final class SmtpAuthenticator extends Authenticator {
+
+    private final String username;
+    private final String password;
+
+    SmtpAuthenticator(String username, String password) {
+      this.username = username;
+      this.password = password;
+    }
+
+    @Override
+    protected PasswordAuthentication getPasswordAuthentication() {
+      return new PasswordAuthentication(username, password);
+    }
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/ActionType.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/ActionType.java
@@ -1,10 +1,11 @@
 package io.oryxos.tool.sandbox;
 
 /**
- * 涉外动作类型（24 节起）：文件读 / 文件写 / Shell 命令 / HTTP 读 / HTTP 写。
+ * 涉外动作类型（24 节起）：文件读 / 文件写 / Shell 命令 / HTTP 读 / HTTP 写 / SMTP 发信。
  *
  * <p>HTTP 分读写（第 32 节）：{@code HTTP_READ}（GET/抓网页/下载/搜索）默认放行——只挡内网/回环/云元数据等 SSRF 目标，让研究型 Agent
- * 自由取数；{@code HTTP_REQUEST}（POST/PUT/… 写请求）仍走域名白名单——防止把数据外发到任意端点。file/shell 一律白名单不放宽。
+ * 自由取数；{@code HTTP_REQUEST}（POST/PUT/… 写请求）仍走域名白名单——防止把数据外发到任意端点。file/shell 一律白名单不放宽。 SMTP
+ * 发信（邮件通知扩展）：走 {@code host[:port]} 白名单，端口不被忽略（区别于 HTTP 域名只校验 host）。
  */
 public enum ActionType {
   FILE_READ,
@@ -13,5 +14,7 @@ public enum ActionType {
   /** HTTP 读（GET 类）：默认放行 + 内网/SSRF 黑名单兜底。 */
   HTTP_READ,
   /** HTTP 写（POST/PUT/PATCH/DELETE）：域名白名单（写路径不再叠加 SSRF；内网目标需运营者显式加白）。 */
-  HTTP_REQUEST
+  HTTP_REQUEST,
+  /** SMTP 发信（邮件通知）：按 host[:port] 白名单放行，防数据外发（非 HTTP 出站）。 */
+  SMTP_SEND
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/SmtpSandboxProperties.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/SmtpSandboxProperties.java
@@ -1,0 +1,17 @@
+package io.oryxos.tool.sandbox;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * SMTP 出站端点白名单配置（键 {@code smtp.allowed_endpoints}）。条目形如 {@code host} 或 {@code
+ * host:port}（端口缺省=任意端口），支持 {@code *.} 通配；空列表 = deny-all。
+ */
+@ConfigurationProperties(prefix = "smtp")
+public record SmtpSandboxProperties(List<String> allowedEndpoints) {
+
+  public SmtpSandboxProperties {
+    // null = deny-all；copyOf 固化不可变（SpotBugs EI_EXPOSE）
+    allowedEndpoints = allowedEndpoints == null ? List.of() : List.copyOf(allowedEndpoints);
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -17,17 +17,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * 核心阶段唯一的 {@link Sandbox} 实现：应用层白名单校验（宪法 VI 第一档）。按 {@link ActionType} 路由到文件路径 / 可执行文件 / HTTP
- * 域名三类校验，任一不过抛 {@link SandboxViolationException}、动作零发生。
+ * 核心阶段唯一的 {@link Sandbox} 实现：应用层白名单校验（宪法 VI 第一档）。按 {@link ActionType} 路由到文件路径 / 可执行文件 / HTTP 域名 /
+ * SMTP 端点四类校验，任一不过抛 {@link SandboxViolationException}、动作零发生。
  *
- * <p>三块白名单初始来自配置（{@code file.allowed_paths} / {@code shell.allowed_commands} / {@code
- * http.allowed_domains}）。空列表天然 deny-all（{@code anyMatch} 对空流恒 false），配置缺失绝不退化为放行。
+ * <p>四块白名单初始来自配置（{@code file.allowed_paths} / {@code shell.allowed_commands} / {@code
+ * http.allowed_domains} / {@code smtp.allowed_endpoints}）。空列表天然 deny-all（{@code anyMatch} 对空流恒
+ * false），配置缺失绝不退化为放行。
  *
  * <p>同时实现 {@link SandboxWhitelist}：管理员可经 Web 端点运行时查询 / 增删白名单。存储用并发集合 （{@link CopyOnWriteArrayList}
  * / {@link ConcurrentHashMap#newKeySet()}）——校验读路径无锁（热路径）， 管理写路径极少发生、拷贝开销可接受；非异步编程模型，符合宪法 VII。每次改动落
  * INFO 日志留痕。
  *
- * <p>三个 {@code check*} 与 {@code matchesDomain} 均 {@code private}——对外只暴露 {@code enforce} 与管理三方法。 若把
+ * <p>四个 {@code check*} 与 {@code matchesDomain} 均 {@code private}——对外只暴露 {@code enforce} 与管理三方法。 若把
  * check* public 暴露到 {@code Sandbox} 接口上，接口就被这一档实现带偏了。
  */
 // final：构造器会因非法配置抛异常（normalizeRoot/requireNonBlank），禁止子类化以杜绝 finalizer attack（CT_CONSTRUCTOR_THROW）
@@ -57,6 +58,7 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   private final CopyOnWriteArrayList<Path> allowedRoots = new CopyOnWriteArrayList<>();
   private final Set<String> allowedCommands = ConcurrentHashMap.newKeySet();
   private final CopyOnWriteArrayList<String> allowedDomainPatterns = new CopyOnWriteArrayList<>();
+  private final CopyOnWriteArrayList<String> allowedSmtpEndpoints = new CopyOnWriteArrayList<>();
 
   // 持久化后端（31 节）：非空则 add/remove 写穿落库、构造时从库恢复；为 null 时纯内存（单测 / 无库场景）。
   private final SandboxWhitelistStore store;
@@ -97,8 +99,10 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
       allowedRoots.addIfAbsent(normalizeRoot(value));
     } else if (category == Category.SHELL) {
       allowedCommands.add(requireNonBlank(value));
-    } else {
+    } else if (category == Category.HTTP) {
       allowedDomainPatterns.addIfAbsent(value);
+    } else if (category == Category.SMTP) {
+      allowedSmtpEndpoints.addIfAbsent(value);
     }
   }
 
@@ -137,6 +141,9 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
         break;
       case HTTP_REQUEST:
         checkHttpWrite(action.target());
+        break;
+      case SMTP_SEND:
+        checkSmtpEndpoint(action.target());
         break;
       default:
         // 安全默认：未来若新增未覆盖的动作类型，deny 而非静默放行（宪法 VI）
@@ -230,6 +237,37 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
               + host
               + "。这是安全策略（防数据外发），请勿反复重试；确需向该地址发送数据，请在管理台「SandBox 列表」把该域名加入 http 白名单后再试。");
     }
+  }
+
+  /**
+   * SMTP 发信（非 HTTP 出站）：过端点白名单——按 host[:port] 精确放行，端口不被忽略（区别于 {@link #checkHttpWrite} 只校验域名）。
+   * 白名单条目形如 {@code host}（任意端口）或 {@code host:port}（指定端口），域名部分支持 {@code *.} 通配。
+   */
+  private void checkSmtpEndpoint(String hostPort) {
+    int colon = hostPort == null ? -1 : hostPort.lastIndexOf(':');
+    String host = colon < 0 ? hostPort : hostPort.substring(0, colon);
+    String port = colon < 0 ? null : hostPort.substring(colon + 1);
+    if (host == null || host.isBlank()) {
+      throw new SandboxViolationException("SMTP 目标缺少主机名，拒绝: " + hostPort);
+    }
+    boolean allowed = allowedSmtpEndpoints.stream().anyMatch(p -> matchesSmtp(p, host, port));
+    if (!allowed) {
+      throw new SandboxViolationException(
+          "SMTP 目标不在出网白名单: "
+              + hostPort
+              + "。这是安全策略（防数据外发），请勿反复重试；确需向该邮件服务器发信，请在管理台「SandBox 列表」把该 smtp 端点（host[:port]）加入 smtp 白名单后再试。");
+    }
+  }
+
+  /** 端点匹配：域名部分复用 {@link #matchesDomain}（大小写不敏感 + {@code *.} 通配）；带端口的条目还需端口相等。 */
+  private boolean matchesSmtp(String pattern, String host, String targetPort) {
+    int colon = pattern.lastIndexOf(':');
+    String patternHost = colon < 0 ? pattern : pattern.substring(0, colon);
+    String patternPort = colon < 0 ? null : pattern.substring(colon + 1);
+    if (!matchesDomain(host, patternHost)) {
+      return false;
+    }
+    return patternPort == null || patternPort.equals(targetPort);
   }
 
   /** SSRF 兜底：拒绝主机解析到回环/任意本地/链路本地(含云元数据 169.254.169.254)/站点内网/组播/CGNAT，及 localhost、*.internal。 */
@@ -386,7 +424,10 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
     if (category == Category.SHELL) {
       return List.copyOf(allowedCommands);
     }
-    return List.copyOf(allowedDomainPatterns);
+    if (category == Category.HTTP) {
+      return List.copyOf(allowedDomainPatterns);
+    }
+    return List.copyOf(allowedSmtpEndpoints);
   }
 
   @Override
@@ -412,9 +453,12 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
     } else if (category == Category.SHELL) {
       canonical = entry;
       changed = allowedCommands.add(canonical);
-    } else {
+    } else if (category == Category.HTTP) {
       canonical = entry;
       changed = allowedDomainPatterns.addIfAbsent(entry);
+    } else {
+      canonical = entry;
+      changed = allowedSmtpEndpoints.addIfAbsent(entry);
     }
     // 写穿：只有内存确有变更才落库（幂等，避免重复写；启动播种重复调用不会重复插入）
     if (changed && store != null) {
@@ -443,9 +487,12 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
     } else if (category == Category.SHELL) {
       canonical = entry;
       changed = allowedCommands.remove(entry);
-    } else {
+    } else if (category == Category.HTTP) {
       canonical = entry;
       changed = allowedDomainPatterns.remove(entry);
+    } else {
+      canonical = entry;
+      changed = allowedSmtpEndpoints.remove(entry);
     }
     if (changed && store != null) {
       store.remove(category, canonical);

--- a/oryxos-tool/src/test/java/io/oryxos/tool/notify/EmailNotifyAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/notify/EmailNotifyAdapterTest.java
@@ -1,0 +1,199 @@
+package io.oryxos.tool.notify;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+
+import io.oryxos.tool.sandbox.FileSandboxProperties;
+import io.oryxos.tool.sandbox.HttpSandboxProperties;
+import io.oryxos.tool.sandbox.PermissiveSandbox;
+import io.oryxos.tool.sandbox.SandboxViolationException;
+import io.oryxos.tool.sandbox.ShellSandboxProperties;
+import io.oryxos.tool.sandbox.WhitelistSandbox;
+import jakarta.mail.Message;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+/**
+ * 课件《第19节》扩展阶段 SMTP 专用 Adapter：EmailNotifyAdapterTest。
+ *
+ * <p>不接真 SMTP 服务器（沿用课件"假服务用本地桩"思路）：正常路径用 Mockito 5 内联 mockmaker {@code mockStatic(Transport.class)}
+ * 拦下静态 {@code Transport.send(Message)}，断言消息与 Session 属性组装正确；沙箱拦截用真 {@link WhitelistSandbox}（SMTP
+ * 白名单空 → deny-all）。
+ */
+class EmailNotifyAdapterTest {
+
+  private static final Map<String, String> BASE_CONFIG =
+      Map.of(
+          "host", "smtp.example.com",
+          "port", "587",
+          "from", "ops@corp.com",
+          "to", "admin@corp.com");
+
+  private static NotifyTarget target(Map<String, String> overrides) {
+    Map<String, String> config = new HashMap<>(BASE_CONFIG);
+    config.putAll(overrides);
+    return new NotifyTarget("email", config);
+  }
+
+  private static WhitelistSandbox emptySmtpSandbox() {
+    return new WhitelistSandbox(
+        new FileSandboxProperties(List.of()),
+        new ShellSandboxProperties(List.of()),
+        new HttpSandboxProperties(List.of()));
+  }
+
+  @Test
+  @DisplayName("正常路径：Transport.send 恰好一次，发件人/收件人/主题/正文正确")
+  void sendBuildsAndDeliversMessage() throws Exception {
+    EmailNotifyAdapter adapter = new EmailNotifyAdapter(new PermissiveSandbox());
+
+    try (MockedStatic<Transport> transport = mockStatic(Transport.class)) {
+      adapter.send(target(Map.of("subject", "告警")), "磁盘 90%");
+      ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+      transport.verify(() -> Transport.send(captor.capture()), times(1));
+
+      MimeMessage message = captor.getValue();
+      assertEquals("ops@corp.com", ((InternetAddress) message.getFrom()[0]).getAddress(), "发件人");
+      assertEquals(
+          "admin@corp.com",
+          ((InternetAddress) message.getRecipients(Message.RecipientType.TO)[0]).getAddress(),
+          "收件人");
+      assertEquals("告警", message.getSubject());
+      assertEquals("磁盘 90%", message.getContent());
+    }
+  }
+
+  @Test
+  @DisplayName("Session 属性：host/port 映射，587 默认 starttls")
+  void sessionPropertiesMapHostPortEncryption() throws Exception {
+    EmailNotifyAdapter adapter = new EmailNotifyAdapter(new PermissiveSandbox());
+
+    try (MockedStatic<Transport> transport = mockStatic(Transport.class)) {
+      adapter.send(target(Map.of()), "hello");
+      ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+      transport.verify(() -> Transport.send(captor.capture()));
+
+      Properties props = captor.getValue().getSession().getProperties();
+      assertEquals("smtp.example.com", props.getProperty("mail.smtp.host"));
+      assertEquals("587", props.getProperty("mail.smtp.port"));
+      assertEquals("true", props.getProperty("mail.smtp.starttls.enable"));
+    }
+  }
+
+  @Test
+  @DisplayName("认证：配置 username 时显式开启 mail.smtp.auth（否则不发 AUTH → 530 未认证）")
+  void authEnabledWhenUsernamePresent() throws Exception {
+    EmailNotifyAdapter adapter = new EmailNotifyAdapter(new PermissiveSandbox());
+
+    try (MockedStatic<Transport> transport = mockStatic(Transport.class)) {
+      adapter.send(target(Map.of("username", "ops", "password", "s3cret")), "hello");
+      ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+      transport.verify(() -> Transport.send(captor.capture()));
+
+      Properties props = captor.getValue().getSession().getProperties();
+      assertEquals("true", props.getProperty("mail.smtp.auth"));
+    }
+  }
+
+  @Test
+  @DisplayName("encryption 推断：465→ssl、其余→none，显式值优先")
+  void encryptionInferredFromPort() throws Exception {
+    EmailNotifyAdapter adapter = new EmailNotifyAdapter(new PermissiveSandbox());
+
+    // 465 → ssl
+    try (MockedStatic<Transport> transport = mockStatic(Transport.class)) {
+      adapter.send(target(Map.of("port", "465")), "hello");
+      ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+      transport.verify(() -> Transport.send(captor.capture()));
+      Properties props = captor.getValue().getSession().getProperties();
+      assertEquals("true", props.getProperty("mail.smtp.ssl.enable"));
+    }
+
+    // 25 → none（不设 ssl/starttls）
+    try (MockedStatic<Transport> transport = mockStatic(Transport.class)) {
+      adapter.send(target(Map.of("port", "25")), "hello");
+      ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+      transport.verify(() -> Transport.send(captor.capture()));
+      Properties props = captor.getValue().getSession().getProperties();
+      assertNull(props.getProperty("mail.smtp.ssl.enable"));
+      assertNull(props.getProperty("mail.smtp.starttls.enable"));
+    }
+
+    // 显式值优先：端口 25 + encryption=ssl → ssl
+    try (MockedStatic<Transport> transport = mockStatic(Transport.class)) {
+      adapter.send(target(Map.of("port", "25", "encryption", "ssl")), "hello");
+      ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+      transport.verify(() -> Transport.send(captor.capture()));
+      Properties props = captor.getValue().getSession().getProperties();
+      assertEquals("true", props.getProperty("mail.smtp.ssl.enable"));
+    }
+  }
+
+  @Test
+  @DisplayName("白名单拦截：SMTP 白名单空，抛 SandboxViolationException 且未触达 Transport")
+  void unlistedEndpointBlockedBeforeSend() {
+    EmailNotifyAdapter adapter = new EmailNotifyAdapter(emptySmtpSandbox());
+
+    try (MockedStatic<Transport> transport = mockStatic(Transport.class)) {
+      assertThrows(SandboxViolationException.class, () -> adapter.send(target(Map.of()), "leaked"));
+      transport.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  @DisplayName("缺必填键 host/port/from/to：报错点名且未触达 Transport")
+  void missingRequiredKeyFailsFast() {
+    EmailNotifyAdapter adapter = new EmailNotifyAdapter(new PermissiveSandbox());
+
+    for (String key : List.of("host", "port", "from", "to")) {
+      Map<String, String> config = new HashMap<>(BASE_CONFIG);
+      config.remove(key);
+      try (MockedStatic<Transport> transport = mockStatic(Transport.class)) {
+        IllegalArgumentException ex =
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> adapter.send(new NotifyTarget("email", config), "hello"));
+        assertTrue(ex.getMessage().contains("缺少配置键 " + key), "报错点名缺失键 " + key);
+        transport.verifyNoInteractions();
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("encryption 非法值报错，不静默明文")
+  void invalidEncryptionRejected() {
+    EmailNotifyAdapter adapter = new EmailNotifyAdapter(new PermissiveSandbox());
+
+    try (MockedStatic<Transport> transport = mockStatic(Transport.class)) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> adapter.send(target(Map.of("encryption", "tls1.3")), "hello"));
+      transport.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  @DisplayName("凭证占位：${VAR} 解析成环境变量，字面量原样透传")
+  void envPlaceholderResolves() {
+    assertEquals("literal-secret", EmailNotifyAdapter.resolveEnv("literal-secret"));
+    assertNull(EmailNotifyAdapter.resolveEnv(null));
+    assertNull(EmailNotifyAdapter.resolveEnv("${ORYXOS_UNSET_VAR_9f2c}"));
+    if (!System.getenv().isEmpty()) {
+      String var = System.getenv().keySet().iterator().next();
+      assertEquals(System.getenv(var), EmailNotifyAdapter.resolveEnv("${" + var + "}"));
+    }
+  }
+}

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -760,7 +760,7 @@ async function deleteAgent(name) {
   } catch (e) { agents.value = { ...agents.value, error: e.message } }
 }
 
-// —— Notify 渠道管理（CRUD /api/v1/notify-channels）：命名的通知出口，type ∈ feishu/wecom/dingtalk/webhook ——
+// —— Notify 渠道管理（CRUD /api/v1/notify-channels）：命名的通知出口，type ∈ feishu/wecom/dingtalk/webhook/email ——
 const notifyChannels = ref({ loading: false, error: null, data: [] })
 async function loadNotifyChannels() {
   notifyChannels.value = { loading: true, error: null, data: [] }
@@ -775,7 +775,7 @@ async function loadNotifyChannels() {
 }
 
 // 新建/编辑表单：editing 存被编辑渠道的 name（此时 name 只读），null 表示新建
-const nc = reactive({ open: false, editing: null, name: '', type: 'feishu', url: '', description: '', busy: false, error: null })
+const nc = reactive({ open: false, editing: null, name: '', type: 'feishu', url: '', description: '', host: '', port: '', from: '', to: '', username: '', password: '', subject: '', encryption: '', busy: false, error: null })
 
 async function saveNotifyChannel() {
   nc.busy = true; nc.error = null
@@ -783,9 +783,11 @@ async function saveNotifyChannel() {
     const url = nc.editing
       ? `/api/v1/notify-channels/${encodeURIComponent(nc.editing)}`
       : '/api/v1/notify-channels'
-    const payload = nc.editing
-      ? { type: nc.type, url: nc.url, description: nc.description }
-      : { name: nc.name, type: nc.type, url: nc.url, description: nc.description }
+    const config = nc.type === 'email' ? buildEmailConfig() : undefined
+    let payload = nc.type === 'email'
+      ? { type: nc.type, url: '', config, description: nc.description }
+      : { type: nc.type, url: nc.url, description: nc.description }
+    if (!nc.editing) payload = { name: nc.name, ...payload }
     const res = await fetch(url, {
       method: nc.editing ? 'PUT' : 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -803,12 +805,25 @@ function editNotifyChannel(row) {
   nc.type = row.type || 'feishu'
   nc.url = row.url || ''
   nc.description = row.description || ''
+  const c = row.config || {}
+  nc.host = c.host || ''; nc.port = c.port || ''; nc.from = c.from || ''; nc.to = c.to || ''
+  nc.username = c.username || ''; nc.password = c.password || ''; nc.subject = c.subject || ''; nc.encryption = c.encryption || ''
   nc.error = null
   nc.open = true
 }
 
+function buildEmailConfig() {
+  const config = {}
+  for (const k of ['host', 'port', 'from', 'to', 'username', 'password', 'subject', 'encryption']) {
+    if (nc[k]) config[k] = nc[k]
+  }
+  return config
+}
+
 function cancelNc() {
-  nc.open = false; nc.editing = null; nc.name = ''; nc.type = 'feishu'; nc.url = ''; nc.description = ''; nc.error = null
+  nc.open = false; nc.editing = null; nc.name = ''; nc.type = 'feishu'; nc.url = ''; nc.description = ''
+  nc.host = ''; nc.port = ''; nc.from = ''; nc.to = ''; nc.username = ''; nc.password = ''; nc.subject = ''; nc.encryption = ''
+  nc.error = null
 }
 
 async function deleteNotifyChannel(name) {
@@ -1100,27 +1115,28 @@ async function submitEnable() {
   } catch (e) { mcpEnable.error = e.message } finally { mcpEnable.busy = false }
 }
 
-// —— Sandbox 白名单管理（CRUD /api/v1/sandbox/whitelist）：三类 file/shell/http 的白名单条目 ——
+// —— Sandbox 白名单管理（CRUD /api/v1/sandbox/whitelist）：四类 file/shell/http/smtp 的白名单条目 ——
 const WL_CATS = [
   { key: 'file', label: '文件路径', ph: '允许访问的路径，如 /data 或 /tmp/*' },
   { key: 'shell', label: '可执行文件', ph: '允许执行的可执行文件，如 python3（授予本机代码执行权限）' },
   { key: 'http', label: 'HTTP 域名', ph: '允许访问的域名，如 *.example.com' },
+  { key: 'smtp', label: 'SMTP 端点', ph: '允许发信的邮件服务器，如 mail.example.com:25' },
 ]
-const wl = ref({ loading: false, error: null, file: [], shell: [], http: [] })
+const wl = ref({ loading: false, error: null, file: [], shell: [], http: [], smtp: [] })
 async function loadWhitelist() {
-  wl.value = { loading: true, error: null, file: [], shell: [], http: [] }
+  wl.value = { loading: true, error: null, file: [], shell: [], http: [], smtp: [] }
   try {
     const res = await fetch('/api/v1/sandbox/whitelist')
     const body = await res.json()
     if (body.code !== 0) throw new Error(body.message || '加载失败')
     const d = body.data || {}
-    wl.value = { loading: false, error: null, file: d.file || [], shell: d.shell || [], http: d.http || [] }
+    wl.value = { loading: false, error: null, file: d.file || [], shell: d.shell || [], http: d.http || [], smtp: d.smtp || [] }
   } catch (e) {
-    wl.value = { loading: false, error: e.message, file: [], shell: [], http: [] }
+    wl.value = { loading: false, error: e.message, file: [], shell: [], http: [], smtp: [] }
   }
 }
 
-// 新增白名单表单：category ∈ file/shell/http，value 为一条白名单条目
+// 新增白名单表单：category ∈ file/shell/http/smtp，value 为一条白名单条目
 const wlForm = reactive({ open: false, category: 'file', value: '', busy: false, error: null })
 const wlPlaceholder = computed(() => WL_CATS.find((c) => c.key === wlForm.category)?.ph || '')
 
@@ -2057,7 +2073,7 @@ const outputRows = computed(() =>
             </div>
           </div>
 
-          <!-- Sandbox 白名单：三类 file/shell/http 的 CRUD（新增走弹框 / 逐行删除） -->
+          <!-- Sandbox 白名单：四类 file/shell/http/smtp 的 CRUD（新增走弹框 / 逐行删除） -->
           <div v-else-if="active === 'whitelist'">
             <div class="toolbar">
               <button class="btn btn-primary" @click="wlForm.open = true">+ 新增白名单</button>
@@ -2071,9 +2087,10 @@ const outputRows = computed(() =>
                     <option value="file">文件路径</option>
                     <option value="shell">Shell 命令</option>
                     <option value="http">HTTP 域名</option>
+                    <option value="smtp">SMTP 端点</option>
                   </select>
                   <input v-model="wlForm.value" class="gen-input" :placeholder="wlPlaceholder" />
-                  <p class="empty">选择类别并填写一条白名单条目：文件路径 / 可执行文件 / HTTP 域名（支持通配，如 *.example.com）。</p>
+                  <p class="empty">选择类别并填写一条白名单条目：文件路径 / 可执行文件 / HTTP 域名 / SMTP 端点（域名支持通配，如 *.example.com）。</p>
                   <p v-if="wlForm.error" class="error">{{ wlForm.error }}</p>
                 </div>
                 <div class="modal-foot">
@@ -2502,15 +2519,31 @@ const outputRows = computed(() =>
                     <option value="wecom">wecom</option>
                     <option value="dingtalk">dingtalk</option>
                     <option value="webhook">webhook</option>
+                    <option value="email">email</option>
                   </select>
-                  <input v-model="nc.url" class="gen-input" placeholder="Webhook URL" />
+                  <input v-if="nc.type !== 'email'" v-model="nc.url" class="gen-input" placeholder="Webhook URL" />
+                  <template v-if="nc.type === 'email'">
+                    <input v-model="nc.host" class="gen-input" placeholder="SMTP host（如 smtp.example.com）" />
+                    <input v-model="nc.port" class="gen-input" placeholder="端口（465/587/25）" />
+                    <input v-model="nc.from" class="gen-input" placeholder="发件人（from）" />
+                    <input v-model="nc.to" class="gen-input" placeholder="收件人（to，逗号分隔）" />
+                    <input v-model="nc.username" class="gen-input" placeholder="用户名（可选）" />
+                    <input v-model="nc.password" class="gen-input" type="password" placeholder="密码（建议填 ${SMTP_PASSWORD}，无认证留空）" />
+                    <input v-model="nc.subject" class="gen-input" placeholder="主题（可选）" />
+                    <select v-model="nc.encryption" class="gen-input">
+                      <option value="">加密方式（自动按端口推断）</option>
+                      <option value="ssl">ssl</option>
+                      <option value="starttls">starttls</option>
+                      <option value="none">none</option>
+                    </select>
+                  </template>
                   <input v-model="nc.description" class="gen-input" placeholder="描述（可选）" />
-                  <p class="empty">{{ nc.editing ? '编辑现有渠道，渠道名不可改。' : 'type 支持 feishu / wecom / dingtalk / webhook；URL 为对应的 Webhook 地址。' }}</p>
+                  <p class="empty">{{ nc.editing ? '编辑现有渠道，渠道名不可改。' : 'type 支持 feishu / wecom / dingtalk / webhook / email；email 填 SMTP 多字段（密码建议 ${SMTP_PASSWORD} 环境变量占位），其余填 Webhook URL。' }}</p>
                   <p v-if="nc.error" class="error">{{ nc.error }}</p>
                 </div>
                 <div class="modal-foot">
                   <button class="btn" @click="cancelNc">取消</button>
-                  <button class="btn btn-primary" :disabled="nc.busy || !nc.name || !nc.url" @click="saveNotifyChannel">{{ nc.editing ? '保存修改' : '创建' }}</button>
+                  <button class="btn btn-primary" :disabled="nc.busy || !nc.name || (nc.type === 'email' ? !(nc.host && nc.port && nc.from && nc.to) : !nc.url)" @click="saveNotifyChannel">{{ nc.editing ? '保存修改' : '创建' }}</button>
                 </div>
               </div>
             </div>
@@ -2523,7 +2556,7 @@ const outputRows = computed(() =>
                 <tr v-for="c in notifyChannels.data" :key="c.name">
                   <td class="mono">{{ c.name }}</td>
                   <td>{{ c.type }}</td>
-                  <td class="mono">{{ c.url }}</td>
+                  <td class="mono">{{ c.type === 'email' ? (c.config ? c.config.host + ':' + c.config.port : '—') : c.url }}</td>
                   <td>{{ c.description || '—' }}</td>
                   <td class="ops">
                     <button class="btn" @click="editNotifyChannel(c)">编辑</button>

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/NotifyChannelApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/NotifyChannelApiController.java
@@ -9,6 +9,7 @@ import io.oryxos.web.controller.dto.NotifyChannelView;
 import io.oryxos.web.controller.dto.UpdateNotifyChannelRequest;
 import io.oryxos.web.error.ResourceNotFoundException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * <p>薄转发给 {@link NotifyChannelRegistry}。错误码沿用既有口径：名字冲突 / 定义非法 → 400 （{@code
  * IllegalArgumentException}）；不存在 → 404（{@code ResourceNotFoundException}）；统一 {@code ApiResponse}
- * 信封。type 必须是已装配的渠道实现之一（webhook/feishu/wecom/dingtalk）。
+ * 信封。type 必须是已装配的渠道实现之一（webhook/feishu/wecom/dingtalk/email）。
  */
 @SuppressFBWarnings(
     value = {"SPRING_ENDPOINT", "EI_EXPOSE_REP2"},
@@ -34,8 +35,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/notify-channels")
 public class NotifyChannelApiController {
 
+  private static final String TYPE_EMAIL = "email";
+
+  /** email 渠道 port 的合法上限（TCP 端口最大值）。 */
+  private static final int MAX_PORT = 65535;
+
   private static final Set<String> SUPPORTED_TYPES =
-      Set.of("webhook", "feishu", "wecom", "dingtalk");
+      Set.of("webhook", "feishu", "wecom", "dingtalk", TYPE_EMAIL);
 
   private final NotifyChannelRegistry registry;
 
@@ -52,9 +58,11 @@ public class NotifyChannelApiController {
     if (registry.exists(name)) {
       throw new IllegalArgumentException("通知渠道已存在: " + name); // → 400
     }
-    validate(req.type(), req.url());
+    Map<String, String> config = req.config();
+    String url = normalizeUrl(req.type(), req.url());
+    validate(req.type(), url, config);
     NotifyChannelDef saved =
-        registry.save(new NotifyChannelDef(name, req.type(), req.url(), req.description()));
+        registry.save(new NotifyChannelDef(name, req.type(), url, req.description(), config));
     return ApiResponse.ok(NotifyChannelView.from(saved));
   }
 
@@ -78,9 +86,11 @@ public class NotifyChannelApiController {
     if (!registry.exists(name)) {
       throw new ResourceNotFoundException("通知渠道不存在: " + name); // → 404
     }
-    validate(req.type(), req.url());
+    Map<String, String> config = req.config();
+    String url = normalizeUrl(req.type(), req.url());
+    validate(req.type(), url, config);
     NotifyChannelDef saved =
-        registry.save(new NotifyChannelDef(name, req.type(), req.url(), req.description()));
+        registry.save(new NotifyChannelDef(name, req.type(), url, req.description(), config));
     return ApiResponse.ok(NotifyChannelView.from(saved));
   }
 
@@ -93,12 +103,47 @@ public class NotifyChannelApiController {
     return ApiResponse.ok(null);
   }
 
-  private static void validate(String type, String url) {
+  private static void validate(String type, String url, Map<String, String> config) {
     if (type == null || !SUPPORTED_TYPES.contains(type)) {
       throw new IllegalArgumentException("不支持的渠道类型: " + type + "（支持: " + SUPPORTED_TYPES + "）");
     }
-    if (url == null || url.isBlank()) {
+    if (TYPE_EMAIL.equals(type)) {
+      validateEmail(config);
+    } else if (url == null || url.isBlank()) {
       throw new IllegalArgumentException("渠道 url 为空");
     }
+  }
+
+  private static void validateEmail(Map<String, String> config) {
+    if (config == null) {
+      throw new IllegalArgumentException("email 渠道缺少配置（需 host/port/from/to）");
+    }
+    requireConfig(config, "host");
+    requireConfig(config, "from");
+    requireConfig(config, "to");
+    String portRaw = config.get("port");
+    if (portRaw == null || portRaw.isBlank()) {
+      throw new IllegalArgumentException("email 渠道缺少配置键 port");
+    }
+    int port;
+    try {
+      port = Integer.parseInt(portRaw.strip());
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("email 渠道 port 不是整数: " + portRaw);
+    }
+    if (port < 1 || port > MAX_PORT) {
+      throw new IllegalArgumentException("email 渠道 port 非法（须 1~" + MAX_PORT + "）: " + portRaw);
+    }
+  }
+
+  private static void requireConfig(Map<String, String> config, String key) {
+    String value = config.get(key);
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("email 渠道缺少配置键 " + key);
+    }
+  }
+
+  private static String normalizeUrl(String type, String url) {
+    return TYPE_EMAIL.equals(type) ? "" : url;
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/SandboxWhitelistController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/SandboxWhitelistController.java
@@ -81,7 +81,8 @@ public class SandboxWhitelistController {
     try {
       return Category.valueOf(category.toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("未知的白名单类别: " + category + "（可选 file / shell / http）");
+      throw new IllegalArgumentException(
+          "未知的白名单类别: " + category + "（可选 file / shell / http / smtp）");
     }
   }
 

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/CreateNotifyChannelRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/CreateNotifyChannelRequest.java
@@ -1,5 +1,16 @@
 package io.oryxos.web.controller.dto;
 
-/** 新建通知渠道请求体：name 全局唯一，type∈{webhook,feishu,wecom,dingtalk}，url 为 webhook 地址。 */
+import java.util.Map;
+
+/**
+ * 新建通知渠道请求体：name 全局唯一，type∈{webhook,feishu,wecom,dingtalk,email}；url 为 HTTP 类渠道的 webhook 地址，config
+ * 承载类型相关多字段（如 email 的 host/port/from/to）。
+ */
 public record CreateNotifyChannelRequest(
-    String name, String type, String url, String description) {}
+    String name, String type, String url, String description, Map<String, String> config) {
+
+  /** 防御性拷贝：config 是可变 Map，入站前固化不可变（SpotBugs EI_EXPOSE_REP / EI_EXPOSE_REP2）。 */
+  public CreateNotifyChannelRequest {
+    config = config == null ? Map.of() : Map.copyOf(config);
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/NotifyChannelView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/NotifyChannelView.java
@@ -1,11 +1,18 @@
 package io.oryxos.web.controller.dto;
 
 import io.oryxos.core.notify.NotifyChannelDef;
+import java.util.Map;
 
 /** 通知渠道视图（列表/详情返回）。 */
-public record NotifyChannelView(String name, String type, String url, String description) {
+public record NotifyChannelView(
+    String name, String type, String url, String description, Map<String, String> config) {
+
+  /** 防御性拷贝：config 是可变 Map，出站前固化不可变（SpotBugs EI_EXPOSE_REP / EI_EXPOSE_REP2）。 */
+  public NotifyChannelView {
+    config = config == null ? Map.of() : Map.copyOf(config);
+  }
 
   public static NotifyChannelView from(NotifyChannelDef d) {
-    return new NotifyChannelView(d.name(), d.type(), d.url(), d.description());
+    return new NotifyChannelView(d.name(), d.type(), d.url(), d.description(), d.config());
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/UpdateNotifyChannelRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/UpdateNotifyChannelRequest.java
@@ -1,4 +1,13 @@
 package io.oryxos.web.controller.dto;
 
-/** 更新通知渠道请求体：name 在路径上，这里改 type / url / 描述。 */
-public record UpdateNotifyChannelRequest(String type, String url, String description) {}
+import java.util.Map;
+
+/** 更新通知渠道请求体：name 在路径上，这里改 type / url / config / 描述。 */
+public record UpdateNotifyChannelRequest(
+    String type, String url, String description, Map<String, String> config) {
+
+  /** 防御性拷贝：config 是可变 Map，入站前固化不可变（SpotBugs EI_EXPOSE_REP / EI_EXPOSE_REP2）。 */
+  public UpdateNotifyChannelRequest {
+    config = config == null ? Map.of() : Map.copyOf(config);
+  }
+}

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/SandboxWhitelistControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/SandboxWhitelistControllerTest.java
@@ -57,16 +57,17 @@ class SandboxWhitelistControllerTest {
   private final SandboxWhitelistController controller = new SandboxWhitelistController(whitelist);
 
   @Test
-  @DisplayName("查询返回三类白名单")
-  void listReturnsAllThreeCategories() {
+  @DisplayName("查询返回四类白名单")
+  void listReturnsAllFourCategories() {
     whitelist.add(SandboxWhitelist.Category.HTTP, "*.example.com");
 
     ApiResponse<Map<String, List<String>>> response = controller.list();
 
     Map<String, List<String>> data = response.getData();
-    assertEquals(3, data.size());
+    assertEquals(4, data.size());
     assertTrue(data.containsKey("file"));
     assertTrue(data.containsKey("shell"));
+    assertTrue(data.containsKey("smtp"));
     assertEquals(List.of("*.example.com"), data.get("http"));
   }
 

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/SandboxWhitelistWebMvcTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/SandboxWhitelistWebMvcTest.java
@@ -69,14 +69,15 @@ class SandboxWhitelistWebMvcTest {
   }
 
   @Test
-  @DisplayName("GET 返回三类白名单_200")
+  @DisplayName("GET 返回四类白名单_200")
   void getReturnsAllCategories() throws Exception {
     mvc.perform(get("/api/v1/sandbox/whitelist"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.code").value(0))
         .andExpect(jsonPath("$.data.file").isArray())
         .andExpect(jsonPath("$.data.shell").isArray())
-        .andExpect(jsonPath("$.data.http").isArray());
+        .andExpect(jsonPath("$.data.http").isArray())
+        .andExpect(jsonPath("$.data.smtp").isArray());
   }
 
   @Test


### PR DESCRIPTION
Summary
Adds a new email notification channel type that sends emails via direct SMTP connection using Jakarta Mail. Outbound traffic goes through an independent smtp.allowed_endpoints (host:port) allowlist, separated from the HTTP domain allowlist.

Changes

NotifyChannelDef now supports multi-field config for email (host/port/from/to/username/password/subject/encryption); HTTP-based channels continue to use url

Added EmailNotifyAdapter (new) + SmtpSandboxProperties (new) + NotifyChannelSchemaMigration (new): email type uses SMTP, credentials can use ${ENV_VAR} placeholders resolved from environment variables at send time

WhitelistSandbox / ActionType now include a new SMTP category (SMTP_SEND); smtp.allowed_endpoints allows exact matching by host:port

Notify tool description now exposes channel type and email recipients (e.g., test(email → recipient)), preventing the Agent from misinterpreting "non-email" based solely on channel names

Web admin console notify-channels CRUD now supports email type and multi-field config (DTO + App.vue form)

Documentation: CLAUDE.md / TechnicalSolution.md updated to include SMTP allowlist as the 4th tier and email channel descriptions

Validation

mvn verify fully green (SpotBugs / PMD / Checkstyle / Spotless)

Added EmailNotifyAdapterTest (8 cases, covering SMTP endpoint allowlist + authentication enabled); NotifyToolsTest / WhitelistSandboxTest fully green

Local real-device verification: email successfully sent via mail.vimicro.com:25