### PR TITLE
fix(notify): add DingTalk/Feishu rich text and card formats

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
@@ -75,7 +75,7 @@ public class NotifyTools implements OryxTool {
           "properties": {
             "content": {"type": "string", "description": "要推送的内容"},
             "channel": {"type": "string", "description": "渠道名（全局 Notify 注册表中的 name）；缺省或 default 用注册表第一个渠道"},
-            "format": {"type": "string", "description": "消息格式：text（默认）或 markdown（企微群机器人等已支持的渠道）；未知值由对应 Adapter 拒绝"}
+            "format": {"type": "string", "description": "消息格式：text（默认）；企微 markdown；钉钉 markdown/actionCard；飞书 post/markdown/interactive/card；未知值由对应 Adapter 拒绝"}
           },
           "required": ["content"]
         }""";

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/DingTalkNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/DingTalkNotifyAdapter.java
@@ -4,6 +4,8 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -11,13 +13,32 @@ import javax.crypto.spec.SecretKeySpec;
 /**
  * 钉钉自定义机器人（type: dingtalk）。
  *
- * <p>body 格式：{@code {"msgtype":"text","text":{"content":"..."}}}。钉钉机器人必须启用一种安全设置：
- * "自定义关键词"最省事（把关键词写进 Skill 输出要求即可，本实现零处理）；若群里开的是"加签"， 在 config 里配 {@code secret}（走 ${ENV}
- * 占位），发送时按官方算法拼 timestamp+sign 到 URL。
+ * <p>默认 body：{@code {"msgtype":"text","text":{"content":"..."}}}。 {@code config.format=markdown}（或
+ * {@code msgtype=markdown}）时改为官方 markdown： {@code
+ * {"msgtype":"markdown","markdown":{"title":"...","text":"..."}}}。 {@code format=actionCard}（或
+ * {@code action_card}）时发整体跳转卡片，需渠道 config 提供 {@code single_url}（可选 {@code single_title}）。
+ *
+ * <p>钉钉机器人必须启用一种安全设置："自定义关键词"最省事（把关键词写进 Skill 输出要求即可，本实现零处理）；若群里开的是"加签"， 在 config 里配 {@code
+ * secret}（走 ${ENV} 占位），发送时按官方算法拼 timestamp+sign 到 URL。
  *
  * <p>出网经 {@link NotifyPoster}：禁自动重定向并每跳复检域名白名单。
  */
 public class DingTalkNotifyAdapter implements NotifyChannelAdapter {
+
+  private static final String FORMAT_TEXT = "text";
+  private static final String FORMAT_MARKDOWN = "markdown";
+  private static final String FORMAT_ACTION_CARD = "actioncard";
+  private static final String FORMAT_ACTION_CARD_SNAKE = "action_card";
+  private static final String MSGTYPE_ACTION_CARD = "actionCard";
+  private static final String CONFIG_FORMAT = "format";
+  private static final String CONFIG_MSGTYPE = "msgtype";
+  private static final String CONFIG_TITLE = "title";
+  private static final String CONFIG_SINGLE_TITLE = "single_title";
+  private static final String CONFIG_SINGLE_URL = "single_url";
+  private static final String DEFAULT_TITLE = "notify";
+  private static final String DEFAULT_SINGLE_TITLE = "查看详情";
+  private static final String MARKDOWN_HEADING_PREFIX = "#";
+  private static final int TITLE_MAX_LEN = 64;
 
   private final NotifyPoster poster;
 
@@ -35,7 +56,91 @@ public class DingTalkNotifyAdapter implements NotifyChannelAdapter {
     if (secret != null && !secret.isBlank()) {
       url = appendSignature(url, secret);
     }
-    poster.postJson(url, Map.of("msgtype", "text", "text", Map.of("content", content)));
+    String format = resolveFormat(target.config());
+    if (FORMAT_MARKDOWN.equals(format)) {
+      String title = resolveTitle(target.config(), content);
+      poster.postJson(
+          url,
+          Map.of(
+              CONFIG_MSGTYPE,
+              FORMAT_MARKDOWN,
+              FORMAT_MARKDOWN,
+              Map.of(CONFIG_TITLE, title, "text", content)));
+      return;
+    }
+    if (FORMAT_ACTION_CARD.equals(format)) {
+      poster.postJson(url, buildActionCardBody(target.config(), content));
+      return;
+    }
+    if (!FORMAT_TEXT.equals(format)) {
+      throw new IllegalArgumentException(
+          "dingtalk 不支持 format/msgtype=" + format + "（当前支持: text, markdown, actionCard）");
+    }
+    poster.postJson(
+        url, Map.of(CONFIG_MSGTYPE, FORMAT_TEXT, FORMAT_TEXT, Map.of("content", content)));
+  }
+
+  private static Map<String, Object> buildActionCardBody(
+      Map<String, String> config, String content) {
+    String singleUrl = config.get(CONFIG_SINGLE_URL);
+    if (singleUrl == null || singleUrl.isBlank()) {
+      throw new IllegalArgumentException(
+          "dingtalk format=actionCard 需要渠道 config.single_url（整体跳转卡片）");
+    }
+    String singleTitle = config.get(CONFIG_SINGLE_TITLE);
+    if (singleTitle == null || singleTitle.isBlank()) {
+      singleTitle = DEFAULT_SINGLE_TITLE;
+    }
+    Map<String, Object> actionCard = new LinkedHashMap<>();
+    actionCard.put(CONFIG_TITLE, resolveTitle(config, content));
+    actionCard.put("text", content);
+    actionCard.put("singleTitle", singleTitle.strip());
+    actionCard.put("singleURL", singleUrl.strip());
+    return Map.of(CONFIG_MSGTYPE, MSGTYPE_ACTION_CARD, MSGTYPE_ACTION_CARD, actionCard);
+  }
+
+  /** {@code format} 优先，其次兼容 {@code msgtype}；缺省 text。比较用 Locale.ROOT 小写。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "format/msgtype are ASCII protocol tokens; Locale.ROOT lowercasing is the correct case-fold.")
+  private static String resolveFormat(Map<String, String> config) {
+    String format = config.get(CONFIG_FORMAT);
+    if (format == null || format.isBlank()) {
+      format = config.get(CONFIG_MSGTYPE);
+    }
+    if (format == null || format.isBlank()) {
+      return FORMAT_TEXT;
+    }
+    String normalized = format.toLowerCase(Locale.ROOT).strip();
+    if (FORMAT_ACTION_CARD_SNAKE.equals(normalized)
+        || MSGTYPE_ACTION_CARD.toLowerCase(Locale.ROOT).equals(normalized)) {
+      return FORMAT_ACTION_CARD;
+    }
+    return normalized;
+  }
+
+  /** 优先 config.title；否则取正文首行（去 markdown 标题标记），再截断。 */
+  private static String resolveTitle(Map<String, String> config, String content) {
+    String title = config.get(CONFIG_TITLE);
+    if (title != null && !title.isBlank()) {
+      return truncate(title.strip(), TITLE_MAX_LEN);
+    }
+    if (content == null || content.isBlank()) {
+      return DEFAULT_TITLE;
+    }
+    String firstLine = content.strip().lines().findFirst().orElse(DEFAULT_TITLE).strip();
+    while (firstLine.startsWith(MARKDOWN_HEADING_PREFIX)) {
+      firstLine = firstLine.substring(MARKDOWN_HEADING_PREFIX.length()).strip();
+    }
+    if (firstLine.isBlank()) {
+      return DEFAULT_TITLE;
+    }
+    return truncate(firstLine, TITLE_MAX_LEN);
+  }
+
+  private static String truncate(String s, int max) {
+    return s.length() <= max ? s : s.substring(0, max);
   }
 
   /** 钉钉"加签"安全设置：sign = urlEncode(base64(HmacSHA256(timestamp + "\n" + secret, secret)))。 */

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/FeishuNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/FeishuNotifyAdapter.java
@@ -1,16 +1,42 @@
 package io.oryxos.tool.notify;
 
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 /**
  * 飞书 / Lark 自定义机器人（type: feishu）。
  *
- * <p>二者协议相同、仅域名不同（open.feishu.cn / open.larksuite.com），URL 来自配置故一个实现覆盖两者。 body 格式：{@code
- * {"msg_type":"text","content":{"text":"..."}}}；签名校验为可选项，未开启时拿 URL 即可推。
+ * <p>二者协议相同、仅域名不同（open.feishu.cn / open.larksuite.com），URL 来自配置故一个实现覆盖两者。
+ *
+ * <p>默认 body：{@code {"msg_type":"text","content":{"text":"..."}}}。 {@code
+ * config.format=post}/{@code markdown} 时发官方富文本 post（把 content 整段放入 text 节点）。 {@code
+ * format=interactive}/{@code card} 时发简易互动卡片（header + lark_md 正文）。
+ *
+ * <p>签名校验为可选项：config 含 {@code secret} 时按官方算法把 {@code timestamp}+{@code sign} 写入 JSON 体（秒级时间戳；
+ * 与钉钉「拼到 URL」不同）。
  *
  * <p>出网经 {@link NotifyPoster}：禁自动重定向并每跳复检域名白名单。
  */
 public class FeishuNotifyAdapter implements NotifyChannelAdapter {
+
+  private static final String FORMAT_TEXT = "text";
+  private static final String FORMAT_POST = "post";
+  private static final String FORMAT_MARKDOWN = "markdown";
+  private static final String FORMAT_INTERACTIVE = "interactive";
+  private static final String FORMAT_CARD = "card";
+  private static final String CONFIG_FORMAT = "format";
+  private static final String CONFIG_MSG_TYPE = "msg_type";
+  private static final String CONFIG_TITLE = "title";
+  private static final String DEFAULT_TITLE = "notify";
+  private static final String MARKDOWN_HEADING_PREFIX = "#";
+  private static final int TITLE_MAX_LEN = 64;
 
   private final NotifyPoster poster;
 
@@ -24,6 +50,108 @@ public class FeishuNotifyAdapter implements NotifyChannelAdapter {
     if (url == null || url.isBlank()) {
       throw new IllegalArgumentException("feishu 渠道缺少 url 配置（notify_channels 条目需要 url 键）");
     }
-    poster.postJson(url, Map.of("msg_type", "text", "content", Map.of("text", content)));
+    String format = resolveFormat(target.config());
+    Map<String, Object> body;
+    if (FORMAT_POST.equals(format) || FORMAT_MARKDOWN.equals(format)) {
+      body = buildPostBody(target.config(), content);
+    } else if (FORMAT_INTERACTIVE.equals(format) || FORMAT_CARD.equals(format)) {
+      body = buildInteractiveBody(target.config(), content);
+    } else if (FORMAT_TEXT.equals(format)) {
+      body = new LinkedHashMap<>();
+      body.put(CONFIG_MSG_TYPE, FORMAT_TEXT);
+      body.put("content", Map.of("text", content));
+    } else {
+      throw new IllegalArgumentException(
+          "feishu 不支持 format/msg_type="
+              + format
+              + "（当前支持: text, post, markdown, interactive, card）");
+    }
+    maybeSign(body, target.config().get("secret"));
+    poster.postJson(url, body);
+  }
+
+  private static Map<String, Object> buildPostBody(Map<String, String> config, String content) {
+    String title = resolveTitle(config, content);
+    Map<String, Object> zhCn = new LinkedHashMap<>();
+    zhCn.put(CONFIG_TITLE, title);
+    zhCn.put("content", List.of(List.of(Map.of("tag", "text", "text", content))));
+    Map<String, Object> post = Map.of("zh_cn", zhCn);
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put(CONFIG_MSG_TYPE, FORMAT_POST);
+    body.put("content", Map.of(FORMAT_POST, post));
+    return body;
+  }
+
+  private static Map<String, Object> buildInteractiveBody(
+      Map<String, String> config, String content) {
+    String title = resolveTitle(config, content);
+    Map<String, Object> card = new LinkedHashMap<>();
+    card.put("header", Map.of("title", Map.of("tag", "plain_text", "content", title)));
+    card.put(
+        "elements",
+        List.of(Map.of("tag", "div", "text", Map.of("tag", "lark_md", "content", content))));
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put(CONFIG_MSG_TYPE, FORMAT_INTERACTIVE);
+    body.put("card", card);
+    return body;
+  }
+
+  /**
+   * 飞书自定义机器人加签：timestamp（秒）+ sign 写入 JSON 体。sign = Base64(HmacSHA256(key=timestamp+"\\n"+secret,
+   * data=空字节))。
+   */
+  private static void maybeSign(Map<String, Object> body, String secret) {
+    if (secret == null || secret.isBlank()) {
+      return;
+    }
+    long timestampSec = System.currentTimeMillis() / 1000L;
+    String stringToSign = timestampSec + "\n" + secret;
+    try {
+      Mac mac = Mac.getInstance("HmacSHA256");
+      mac.init(new SecretKeySpec(stringToSign.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+      String sign = Base64.getEncoder().encodeToString(mac.doFinal(new byte[0]));
+      body.put("timestamp", String.valueOf(timestampSec));
+      body.put("sign", sign);
+    } catch (GeneralSecurityException e) {
+      throw new IllegalStateException("飞书加签计算失败", e);
+    }
+  }
+
+  /** {@code format} 优先，其次兼容 {@code msg_type}；缺省 text。比较用 Locale.ROOT 小写。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "format/msg_type are ASCII protocol tokens; Locale.ROOT lowercasing is the correct case-fold.")
+  private static String resolveFormat(Map<String, String> config) {
+    String format = config.get(CONFIG_FORMAT);
+    if (format == null || format.isBlank()) {
+      format = config.get(CONFIG_MSG_TYPE);
+    }
+    if (format == null || format.isBlank()) {
+      return FORMAT_TEXT;
+    }
+    return format.toLowerCase(Locale.ROOT).strip();
+  }
+
+  private static String resolveTitle(Map<String, String> config, String content) {
+    String title = config.get(CONFIG_TITLE);
+    if (title != null && !title.isBlank()) {
+      return truncate(title.strip(), TITLE_MAX_LEN);
+    }
+    if (content == null || content.isBlank()) {
+      return DEFAULT_TITLE;
+    }
+    String firstLine = content.strip().lines().findFirst().orElse(DEFAULT_TITLE).strip();
+    while (firstLine.startsWith(MARKDOWN_HEADING_PREFIX)) {
+      firstLine = firstLine.substring(MARKDOWN_HEADING_PREFIX.length()).strip();
+    }
+    if (firstLine.isBlank()) {
+      return DEFAULT_TITLE;
+    }
+    return truncate(firstLine, TITLE_MAX_LEN);
+  }
+
+  private static String truncate(String s, int max) {
+    return s.length() <= max ? s : s.substring(0, max);
   }
 }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
@@ -117,6 +117,84 @@ class VendorNotifyAdapterTest {
   }
 
   @Test
+  @DisplayName("飞书：format=post 发官方富文本体")
+  void feishuPostFormatMatchesVendorContract() throws IOException {
+    new FeishuNotifyAdapter(poster)
+        .send(
+            new NotifyTarget("feishu", Map.of("url", url(), "format", "post", "title", "更新")),
+            "项目已更新");
+
+    JsonNode body = lastBody();
+    assertEquals("post", body.get("msg_type").asText());
+    assertEquals("更新", body.get("content").get("post").get("zh_cn").get("title").asText());
+    assertEquals(
+        "项目已更新",
+        body.get("content")
+            .get("post")
+            .get("zh_cn")
+            .get("content")
+            .get(0)
+            .get(0)
+            .get("text")
+            .asText());
+  }
+
+  @Test
+  @DisplayName("飞书：format=markdown 走 post 富文本（与企微同参）")
+  void feishuMarkdownAliasUsesPostBody() throws IOException {
+    new FeishuNotifyAdapter(poster)
+        .send(
+            new NotifyTarget("feishu", Map.of("url", url(), "format", "markdown")),
+            "## 告警\nCPU 90%");
+
+    JsonNode body = lastBody();
+    assertEquals("post", body.get("msg_type").asText());
+    assertEquals("告警", body.get("content").get("post").get("zh_cn").get("title").asText());
+  }
+
+  @Test
+  @DisplayName("飞书：format=interactive 发简易卡片")
+  void feishuInteractiveFormatMatchesVendorContract() throws IOException {
+    new FeishuNotifyAdapter(poster)
+        .send(
+            new NotifyTarget(
+                "feishu", Map.of("url", url(), "format", "interactive", "title", "告警")),
+            "**CPU** 90%");
+
+    JsonNode body = lastBody();
+    assertEquals("interactive", body.get("msg_type").asText());
+    assertEquals("告警", body.get("card").get("header").get("title").get("content").asText());
+    assertEquals(
+        "lark_md", body.get("card").get("elements").get(0).get("text").get("tag").asText());
+    assertEquals(
+        "**CPU** 90%", body.get("card").get("elements").get(0).get("text").get("content").asText());
+  }
+
+  @Test
+  @DisplayName("飞书加签：config 含 secret 时 body 带 timestamp+sign")
+  void feishuSignedBodyCarriesTimestampAndSign() throws IOException {
+    new FeishuNotifyAdapter(poster)
+        .send(new NotifyTarget("feishu", Map.of("url", url(), "secret", "test-secret")), "hi");
+
+    JsonNode body = lastBody();
+    assertTrue(body.hasNonNull("timestamp"), "加签模式必须带 timestamp");
+    assertTrue(body.hasNonNull("sign"), "加签模式必须带 sign");
+    assertEquals(null, received.get(0).query(), "飞书签名在 body，不拼 URL");
+  }
+
+  @Test
+  @DisplayName("飞书：未知 format 点名拒绝且零请求")
+  void feishuRejectsUnknownFormat() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new FeishuNotifyAdapter(poster)
+                .send(
+                    new NotifyTarget("feishu", Map.of("url", url(), "format", "share_chat")), "x"));
+    assertEquals(0, received.size());
+  }
+
+  @Test
   @DisplayName("钉钉：msgtype/text.content 格式（关键词模式，无签名参数）")
   void dingTalkBodyMatchesVendorContract() throws IOException {
     new DingTalkNotifyAdapter(poster)
@@ -126,6 +204,74 @@ class VendorNotifyAdapterTest {
     assertEquals("text", body.get("msgtype").asText());
     assertEquals("OryxOS日报来了", body.get("text").get("content").asText());
     assertEquals(null, received.get(0).query(), "关键词模式不拼签名参数");
+  }
+
+  @Test
+  @DisplayName("钉钉：format=markdown 发官方 markdown 体")
+  void dingTalkMarkdownFormatMatchesVendorContract() throws IOException {
+    new DingTalkNotifyAdapter(poster)
+        .send(
+            new NotifyTarget(
+                "dingtalk", Map.of("url", url(), "format", "markdown", "title", "杭州天气")),
+            "#### 杭州天气\n> 9度");
+
+    JsonNode body = lastBody();
+    assertEquals("markdown", body.get("msgtype").asText());
+    assertEquals("杭州天气", body.get("markdown").get("title").asText());
+    assertEquals("#### 杭州天气\n> 9度", body.get("markdown").get("text").asText());
+  }
+
+  @Test
+  @DisplayName("钉钉：format=actionCard 发整体跳转卡片")
+  void dingTalkActionCardFormatMatchesVendorContract() throws IOException {
+    new DingTalkNotifyAdapter(poster)
+        .send(
+            new NotifyTarget(
+                "dingtalk",
+                Map.of(
+                    "url",
+                    url(),
+                    "format",
+                    "actionCard",
+                    "title",
+                    "告警",
+                    "single_url",
+                    "https://example.com/alert",
+                    "single_title",
+                    "查看")),
+            "### CPU 过高");
+
+    JsonNode body = lastBody();
+    assertEquals("actionCard", body.get("msgtype").asText());
+    assertEquals("告警", body.get("actionCard").get("title").asText());
+    assertEquals("### CPU 过高", body.get("actionCard").get("text").asText());
+    assertEquals("查看", body.get("actionCard").get("singleTitle").asText());
+    assertEquals("https://example.com/alert", body.get("actionCard").get("singleURL").asText());
+  }
+
+  @Test
+  @DisplayName("钉钉：actionCard 缺 single_url 点名拒绝且零请求")
+  void dingTalkActionCardRequiresSingleUrl() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new DingTalkNotifyAdapter(poster)
+                .send(
+                    new NotifyTarget("dingtalk", Map.of("url", url(), "format", "actionCard")),
+                    "x"));
+    assertEquals(0, received.size());
+  }
+
+  @Test
+  @DisplayName("钉钉：未知 format 点名拒绝且零请求")
+  void dingTalkRejectsUnknownFormat() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new DingTalkNotifyAdapter(poster)
+                .send(
+                    new NotifyTarget("dingtalk", Map.of("url", url(), "format", "feedCard")), "x"));
+    assertEquals(0, received.size());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- DingTalk: `format=markdown` / `actionCard` (requires `single_url`)
- Feishu: `format=post` / `markdown` / `interactive` / `card`; optional webhook `secret` → body `timestamp` + `sign`
- Unit tests for bodies, unknown format reject, Feishu sign-in-body
- `NotifyTools` schema description updated

Fixes #247

## Test plan
- [x] `VendorNotifyAdapterTest` (DingTalk markdown/actionCard; Feishu post/interactive/sign)
- [x] `NotifyToolsTest` still green
- [ ] CI green on this PR