### PR TITLE
feat(auth): 018 REST API Key 认证——/api/v1 机器调用门禁

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/017-feishu-im-channel"
+  "feature_directory": "specs/018-rest-api-key"
 }

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -128,3 +128,11 @@ oryxos:
   #   auth:
   #     enabled: true
   #     realm: OryxOS
+  # REST API Key 认证（018-rest-api-key）。默认关=现状不变；
+  # 开启后 /api/v1/** 需请求头带 Key（`Authorization: Bearer <key>` 或 `X-API-Key: <key>`），
+  # 豁免 /api/v1/health（探活）、/api/v1/auth/*（管理台登录）与 OPTIONS 预检；/admin/** 不受影响。
+  # 开启前先跑 `oryxos apikey add <name>` 生成 Key（明文仅显示一次）；
+  # 建议与上面的 auth 同时开启——否则管理台数据页无凭据可用（启动会告警）。
+  # web:
+  #   apikey:
+  #     enabled: true

--- a/docs/CliGuide.md
+++ b/docs/CliGuide.md
@@ -69,6 +69,9 @@ oryxos chat --profile weather      # ⑤ 开聊
 | `oryxos provider list` | 轻 | 列出实例声明的 Provider |
 | `oryxos tool list` | 轻 | 列出可用工具（20 节起为实时清单） |
 | `oryxos session list` | 轻 | 列出会话概览 |
+| `oryxos apikey add <name>` | 轻 | 生成 REST API Key（明文仅显示一次） |
+| `oryxos apikey list` | 轻 | 列出 API Key（前缀/状态/最近使用，无明文） |
+| `oryxos apikey revoke <name>` | 轻 | 吊销 API Key（即时生效） |
 
 **轻/重的区别**：轻命令直接读写文件或只读查库，**不启动 Spring**、秒级返回（实测约 0.35s）；重命令要调模型、跑引擎，才付出 2~4 秒的完整运行时启动代价。判断标准就一条：这个命令要不要调模型/跑引擎。
 
@@ -152,6 +155,27 @@ oryxos session list    # 会话概览：session_id / profile / status / last_act
 ```
 
 `session list` 直连当前目录的 `oryxos.db` 只读查询；库还没创建时提示"暂无会话"。
+
+---
+
+### 4.7 apikey 三件——REST API Key 管理（018）
+
+`oryxos.web.apikey.enabled=true` 时 `/api/v1/**` 启用机器调用认证（豁免 `/api/v1/health`、`/api/v1/auth/*`、OPTIONS 预检；`/admin/**` 不受影响）。Key 由这组命令管理：
+
+```bash
+oryxos apikey add ci-bot     # 生成 Key；明文只显示这一次，库中仅存 SHA-256 哈希
+oryxos apikey list           # NAME / PREFIX / STATUS / CREATED_AT / LAST_USED_AT（无明文）
+oryxos apikey revoke ci-bot  # 吊销，下一次请求即 401；其它 Key 不受影响
+```
+
+调用方任选一种请求头携带：
+
+```bash
+curl -H "Authorization: Bearer oryx_..." http://localhost:8080/api/v1/profiles
+curl -H "X-API-Key: oryx_..." http://localhost:8080/api/v1/profiles
+```
+
+注意：`add` 重名会报错不覆盖；`revoke` 已吊销的 Key 幂等提示；明文丢了只能吊销重发（无法找回）。建议与管理台认证（`oryxos.web.auth.enabled`）同时开启，否则管理台数据页无凭据可用（启动时会告警提示）。
 
 ---
 

--- a/oryxos-boot/src/test/java/io/oryxos/boot/ApiKeyAuthE2ETest.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/ApiKeyAuthE2ETest.java
@@ -25,10 +25,11 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
 /**
- * 018 端到端：真实 HTTP + SQLite + filter 注册链路上验证 API Key 门禁（quickstart V2~V4 主路径）——生成 Key（明文仅
- * 返回一次、库中只有哈希）→ 无 Key/错 Key 401 → Bearer 与 X-API-Key 双写法 200 → 吊销即时生效且第二把 Key 不受影响 → health
- * 豁免。管理台认证保持关闭（012 AuthStartupCheck 会因无账号 fail-fast），session 互认由 ApiKeyAuthFilterTest 单测覆盖。无
- * key、无网络、gate 内可跑。
+ * 018 端到端：真实 HTTP + SQLite + filter 注册链路上验证 API Key 门禁（quickstart V2~V5 主路径）——生成 Key（明文仅
+ * 返回一次、库中只有哈希）→ 无 Key/错 Key 401 → Bearer 与 X-API-Key 双写法 200 → 吊销即时生效且第二把 Key 不受影响 → health 豁免 →
+ * 双认证共存：建账号后运行时开启管理台认证（{@code WebAuthProperties} 为单例、filter 每请求读 {@code
+ * isEnabled()}，与生产开启态行为一致；启动时置 true 会被 012 AuthStartupCheck 无账号 fail-fast 拦下， 故账号就绪后再开），真实 HTTP 登录拿
+ * {@code oryxos_session} cookie，仅凭 session 无 Key 调 REST 通过（SC-006）。 无 key、无网络、gate 内可跑。
  */
 @SpringBootTest(
     classes = OryxOsRuntime.class,
@@ -41,6 +42,8 @@ class ApiKeyAuthE2ETest {
 
   @Autowired private TestRestTemplate rest;
   @Autowired private ApiKeyService apiKeyService;
+  @Autowired private io.oryxos.storage.WebUserService userService;
+  @Autowired private io.oryxos.web.config.WebAuthProperties authProperties;
 
   private static Path seedWorkspace() {
     try {
@@ -110,6 +113,39 @@ class ApiKeyAuthE2ETest {
     assertEquals(
         HttpStatus.OK,
         exchange("/api/v1/profiles", "X-API-Key", second.plaintext()).getStatusCode());
+  }
+
+  @Test
+  @Order(5)
+  void dualAuth_sessionInterop_consoleSessionPassesRestGate() {
+    userService.create("admin", "e2e-pass-018");
+    authProperties.setEnabled(true);
+    try {
+      // 真实 HTTP 登录（/api/v1/auth 子树豁免 Key 门禁）→ 拿 oryxos_session cookie
+      HttpHeaders loginHeaders = new HttpHeaders();
+      loginHeaders.set(HttpHeaders.CONTENT_TYPE, "application/json");
+      ResponseEntity<String> login =
+          rest.postForEntity(
+              "/api/v1/auth/login",
+              new HttpEntity<>(
+                  "{\"username\":\"admin\",\"password\":\"e2e-pass-018\"}", loginHeaders),
+              String.class);
+      assertEquals(HttpStatus.OK, login.getStatusCode());
+      String setCookie = login.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+      assertTrue(setCookie != null && setCookie.startsWith("oryxos_session="));
+      String cookie = setCookie.split(";", 2)[0];
+
+      // 仅凭管理台 session、无 API Key → REST 门禁放行（FR-011 / SC-006）
+      assertEquals(
+          HttpStatus.OK, exchange("/api/v1/profiles", HttpHeaders.COOKIE, cookie).getStatusCode());
+      // 伪造 session 且无 Key → 401
+      assertEquals(
+          HttpStatus.UNAUTHORIZED,
+          exchange("/api/v1/profiles", HttpHeaders.COOKIE, "oryxos_session=forged-id")
+              .getStatusCode());
+    } finally {
+      authProperties.setEnabled(false);
+    }
   }
 
   private ResponseEntity<String> exchange(String path, String headerName, String headerValue) {

--- a/oryxos-boot/src/test/java/io/oryxos/boot/ApiKeyAuthE2ETest.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/ApiKeyAuthE2ETest.java
@@ -1,0 +1,120 @@
+package io.oryxos.boot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.oryxos.cli.OryxOsRuntime;
+import io.oryxos.storage.ApiKeyService;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+/**
+ * 018 端到端：真实 HTTP + SQLite + filter 注册链路上验证 API Key 门禁（quickstart V2~V4 主路径）——生成 Key（明文仅
+ * 返回一次、库中只有哈希）→ 无 Key/错 Key 401 → Bearer 与 X-API-Key 双写法 200 → 吊销即时生效且第二把 Key 不受影响 → health
+ * 豁免。管理台认证保持关闭（012 AuthStartupCheck 会因无账号 fail-fast），session 互认由 ApiKeyAuthFilterTest 单测覆盖。无
+ * key、无网络、gate 内可跑。
+ */
+@SpringBootTest(
+    classes = OryxOsRuntime.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {"oryxos.providers[0].name=mock", "oryxos.web.apikey.enabled=true"})
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiKeyAuthE2ETest {
+
+  private static final Path ROOT = seedWorkspace();
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private ApiKeyService apiKeyService;
+
+  private static Path seedWorkspace() {
+    try {
+      Path root = Files.createTempDirectory("oryxos-apikey-e2e");
+      Files.createDirectories(root.resolve("memory"));
+      Files.createDirectories(root.resolve("agents"));
+      System.setProperty("oryxos.root", root.toString());
+      return root;
+    } catch (IOException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  @DynamicPropertySource
+  static void datasource(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", () -> "jdbc:sqlite:" + ROOT.resolve("apikey-e2e.db"));
+  }
+
+  @Test
+  @Order(1)
+  void healthExempt_noCredentials_ok() {
+    ResponseEntity<String> response = rest.getForEntity("/api/v1/health", String.class);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+  }
+
+  @Test
+  @Order(2)
+  void noKey_rejected401_withChallenge() {
+    ResponseEntity<String> response = rest.getForEntity("/api/v1/profiles", String.class);
+    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    assertEquals("Bearer realm=\"OryxOS\"", response.getHeaders().getFirst("WWW-Authenticate"));
+    assertTrue(response.getBody() != null && response.getBody().contains("\"code\":401"));
+  }
+
+  @Test
+  @Order(3)
+  void wrongKey_rejected401() {
+    ResponseEntity<String> response =
+        exchange("/api/v1/profiles", "X-API-Key", "oryx_" + "x".repeat(42));
+    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+  }
+
+  @Test
+  @Order(4)
+  void createdKey_bothHeaderStyles_ok_thenRevokeImmediate() {
+    ApiKeyService.CreatedKey first = apiKeyService.create("e2e-ci");
+    ApiKeyService.CreatedKey second = apiKeyService.create("e2e-report");
+
+    // 明文仅返回一次；实体上只有哈希与前缀
+    assertTrue(first.plaintext().startsWith("oryx_"));
+    assertFalse(first.key().getKeyHash().contains(first.plaintext()));
+
+    // 双写法等效（FR-003）
+    assertEquals(
+        HttpStatus.OK,
+        exchange("/api/v1/profiles", "X-API-Key", first.plaintext()).getStatusCode());
+    assertEquals(
+        HttpStatus.OK,
+        exchange("/api/v1/profiles", "Authorization", "Bearer " + first.plaintext())
+            .getStatusCode());
+
+    // 吊销即时生效（SC-004），另一把 Key 不受影响
+    assertTrue(apiKeyService.revoke("e2e-ci"));
+    assertEquals(
+        HttpStatus.UNAUTHORIZED,
+        exchange("/api/v1/profiles", "X-API-Key", first.plaintext()).getStatusCode());
+    assertEquals(
+        HttpStatus.OK,
+        exchange("/api/v1/profiles", "X-API-Key", second.plaintext()).getStatusCode());
+  }
+
+  private ResponseEntity<String> exchange(String path, String headerName, String headerValue) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set(headerName, headerValue);
+    return rest.exchange(path, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+  }
+}

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsCli.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsCli.java
@@ -36,7 +36,8 @@ import picocli.CommandLine.IVersionProvider;
       ToolListCommand.class,
       SessionListCommand.class,
       io.oryxos.cli.command.KnowledgeCommand.class,
-      UserCommand.class
+      UserCommand.class,
+      io.oryxos.cli.command.ApiKeyCommand.class
     })
 public class OryxOsCli implements Runnable {
 

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -49,6 +49,8 @@ import io.oryxos.provider.ProvidersProperties;
 import io.oryxos.provider.SpringAiProviderServiceImpl;
 import io.oryxos.provider.ToolSchemaAdapter;
 import io.oryxos.storage.AgentExecutionRepository;
+import io.oryxos.storage.ApiKeyRepository;
+import io.oryxos.storage.ApiKeyService;
 import io.oryxos.storage.AuditSchemaUpgrade;
 import io.oryxos.storage.JpaAgentExecutionStore;
 import io.oryxos.storage.JpaLlmCallAuditor;
@@ -792,6 +794,12 @@ public class OryxOsRuntime {
       @org.springframework.beans.factory.annotation.Value("${oryxos.web.auth.session-ttl:12h}")
           java.time.Duration sessionTtl) {
     return new WebSessionService(repository, sessionTtl);
+  }
+
+  /** 018-rest-api-key：REST API Key 生成/校验/吊销（只存 SHA-256 哈希，明文仅生成时返回一次）。 */
+  @Bean
+  ApiKeyService apiKeyService(ApiKeyRepository repository) {
+    return new ApiKeyService(repository);
   }
 
   @Bean

--- a/oryxos-cli/src/main/java/io/oryxos/cli/command/ApiKeyCommand.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/command/ApiKeyCommand.java
@@ -1,0 +1,112 @@
+package io.oryxos.cli.command;
+
+import io.oryxos.cli.OryxOsRuntime;
+import io.oryxos.storage.ApiKey;
+import io.oryxos.storage.ApiKeyService;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.springframework.boot.Banner;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/**
+ * 重命令组：REST API Key 管理（018-rest-api-key）。每个 leaf 自启 Spring（镜像 {@link UserCommand}），通过 {@code
+ * context.getBean(ApiKeyService.class)} 干活。明文 Key 只在 add 成功输出中出现一次，NEVER 落日志（宪法 VI）。
+ */
+@Command(
+    name = "apikey",
+    description = "管理 REST API Key（机器调用认证）",
+    mixinStandardHelpOptions = true,
+    subcommands = {
+      ApiKeyCommand.AddCommand.class,
+      ApiKeyCommand.ListCommand.class,
+      ApiKeyCommand.RevokeCommand.class
+    })
+public class ApiKeyCommand implements Runnable {
+
+  @Override
+  public void run() {
+    new picocli.CommandLine(this).usage(System.out);
+  }
+
+  /** 起一次性 Spring 上下文，跑完即退（镜像 UserCommand.withService）。 */
+  private static void withService(java.util.function.Consumer<ApiKeyService> action) {
+    try (ConfigurableApplicationContext context =
+        new SpringApplicationBuilder(OryxOsRuntime.class)
+            .web(WebApplicationType.NONE)
+            .bannerMode(Banner.Mode.OFF)
+            .run()) {
+      action.accept(context.getBean(ApiKeyService.class));
+    }
+  }
+
+  @Command(name = "add", description = "生成 API Key（明文仅显示这一次）", mixinStandardHelpOptions = true)
+  static class AddCommand implements Runnable {
+    @Parameters(index = "0", description = "Key 名称（标识调用方，≤64 字符，无空格，全局唯一）")
+    String name;
+
+    @Override
+    public void run() {
+      withService(
+          service -> {
+            ApiKeyService.CreatedKey created = service.create(name);
+            System.out.println("Created API key '" + created.key().getName() + "':");
+            System.out.println();
+            System.out.println("  " + created.plaintext());
+            System.out.println();
+            System.out.println("This is the ONLY time the key is displayed. Store it securely.");
+          });
+    }
+  }
+
+  @Command(name = "list", description = "列出 API Key（不显明文）", mixinStandardHelpOptions = true)
+  static class ListCommand implements Runnable {
+    @Override
+    public void run() {
+      withService(
+          service -> {
+            List<ApiKey> keys = service.list();
+            if (keys.isEmpty()) {
+              System.out.println(
+                  "No api keys found. Run 'oryxos apikey add <name>' to create one.");
+              return;
+            }
+            DateTimeFormatter fmt = DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.systemDefault());
+            System.out.printf(
+                "%-24s %-16s %-9s %-24s %s%n",
+                "NAME", "PREFIX", "STATUS", "CREATED_AT", "LAST_USED_AT");
+            for (ApiKey key : keys) {
+              System.out.printf(
+                  "%-24s %-16s %-9s %-24s %s%n",
+                  key.getName(),
+                  key.getKeyPrefix(),
+                  key.isActive() ? "active" : "revoked",
+                  key.getCreatedAt() == null ? "-" : fmt.format(key.getCreatedAt()),
+                  key.getLastUsedAt() == null ? "-" : fmt.format(key.getLastUsedAt()));
+            }
+          });
+    }
+  }
+
+  @Command(name = "revoke", description = "吊销 API Key（即时生效）", mixinStandardHelpOptions = true)
+  static class RevokeCommand implements Runnable {
+    @Parameters(index = "0", description = "要吊销的 Key 名称")
+    String name;
+
+    @Override
+    public void run() {
+      withService(
+          service -> {
+            if (service.revoke(name)) {
+              System.out.println("Revoked API key '" + name + "'");
+            } else {
+              System.out.println("API key '" + name + "' is already revoked");
+            }
+          });
+    }
+  }
+}

--- a/oryxos-storage/src/main/java/io/oryxos/storage/ApiKey.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/ApiKey.java
@@ -1,0 +1,98 @@
+package io.oryxos.storage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/** REST API 机器调用凭证（018-rest-api-key）——表结构以手工 schema.sql 为唯一权威。只存哈希不存明文。 */
+@Entity
+@Table(name = "api_keys")
+public class ApiKey {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "name", nullable = false, unique = true)
+  private String name;
+
+  @Column(name = "key_prefix", nullable = false)
+  private String keyPrefix;
+
+  @Column(name = "key_hash", nullable = false, unique = true)
+  private String keyHash;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @Column(name = "last_used_at")
+  private Instant lastUsedAt;
+
+  @Column(name = "revoked_at")
+  private Instant revokedAt;
+
+  @PrePersist
+  void onCreate() {
+    if (createdAt == null) {
+      createdAt = Instant.now();
+    }
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getKeyPrefix() {
+    return keyPrefix;
+  }
+
+  public void setKeyPrefix(String keyPrefix) {
+    this.keyPrefix = keyPrefix;
+  }
+
+  public String getKeyHash() {
+    return keyHash;
+  }
+
+  public void setKeyHash(String keyHash) {
+    this.keyHash = keyHash;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getLastUsedAt() {
+    return lastUsedAt;
+  }
+
+  public void setLastUsedAt(Instant lastUsedAt) {
+    this.lastUsedAt = lastUsedAt;
+  }
+
+  public Instant getRevokedAt() {
+    return revokedAt;
+  }
+
+  public void setRevokedAt(Instant revokedAt) {
+    this.revokedAt = revokedAt;
+  }
+
+  /** 是否有效（未吊销）。 */
+  public boolean isActive() {
+    return revokedAt == null;
+  }
+}

--- a/oryxos-storage/src/main/java/io/oryxos/storage/ApiKeyRepository.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/ApiKeyRepository.java
@@ -1,0 +1,14 @@
+package io.oryxos.storage;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** api_keys 表访问（018-rest-api-key）。校验按 key_hash 查（UNIQUE 隐式索引）。 */
+public interface ApiKeyRepository extends JpaRepository<ApiKey, Long> {
+
+  Optional<ApiKey> findByKeyHash(String keyHash);
+
+  Optional<ApiKey> findByName(String name);
+
+  boolean existsByName(String name);
+}

--- a/oryxos-storage/src/main/java/io/oryxos/storage/ApiKeyService.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/ApiKeyService.java
@@ -1,0 +1,203 @@
+package io.oryxos.storage;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * REST API Key 管理（018-rest-api-key）：生成/校验/吊销/盘点。
+ *
+ * <p>明文 Key = {@code oryx_} + 42 位 base62 随机串（SecureRandom，约 250 bit 熵）。持久化只存 SHA-256 hex 哈希
+ * 与可辨识前缀（{@code oryx_}+随机部分前 8 位）；明文仅 {@link #create} 返回值出现一次，NEVER 落库/日志（宪法 VI）。
+ *
+ * <p>哈希选 SHA-256 而非 BCrypt：高熵随机 Key 无需慢哈希，BCrypt 每请求 ~100ms 会击穿「认证开销无感」（research R1， 与 {@code
+ * WebUserService} 的 BCrypt 口径不同——那是给低熵人类密码的，各自正确）。
+ *
+ * <p>校验先对明文算 SHA-256 再按哈希查库（R2）：输入经单向变换，索引比较的计时信息不构成逐位 oracle；命中后 {@link MessageDigest#isEqual}
+ * 恒定时间复核兜底（FR-010）。不存在与已吊销走同一失败路径（防探测，FR-004）。
+ *
+ * <p>{@code last_used_at} 在请求线程内同步更新（宪法 VII 不引入异步），经 60s 内存节流防 SQLite 写放大；更新失败
+ * 仅记日志不阻断请求（FR-009/R6）。节流表是进程内缓存非状态，重启丢失无害。
+ *
+ * <p>plain class（非 @Service），构造注入 repository，由 {@code OryxOsRuntime} @Bean 装配。镜像 {@code
+ * WebUserService} 风格，不引 oryxos-web 类（避免 storage→web 反向依赖）。
+ */
+public class ApiKeyService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ApiKeyService.class);
+
+  /** 明文 Key 固定前缀——密钥扫描工具可辨识（业界 ghp_/sk_ 同型，R1）。 */
+  public static final String PLAINTEXT_PREFIX = "oryx_";
+
+  /** 随机部分长度（base62，42 位约 250 bit 熵）。 */
+  private static final int RANDOM_LENGTH = 42;
+
+  /** key_prefix 列存的随机部分头部位数（供 list/日志对账，不足以还原 Key）。 */
+  private static final int DISPLAY_RANDOM_CHARS = 8;
+
+  private static final String BASE62 =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+  private static final int MAX_NAME_LENGTH = 64;
+
+  /** last_used_at 落库节流窗口（秒）——分钟级治理信号，逐请求写库无必要（R6）。 */
+  private static final long LAST_USED_THROTTLE_SECONDS = 60;
+
+  private final ApiKeyRepository repository;
+  private final SecureRandom secureRandom = new SecureRandom();
+
+  /** 节流缓存：key id → 上次落库时间。进程内缓存非状态（宪法 VIII 不冲突）。 */
+  private final Map<Long, Instant> lastPersistedUse = new ConcurrentHashMap<>();
+
+  /** 创建结果：实体 + 明文（明文仅此一次，调用方负责只输出到 stdout）。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"},
+      justification =
+          "CreatedKey 是 create() 的一次性返回值载体，携带刚落库的同一 ApiKey 实体引用正是意图"
+              + "（调用方需读 name/prefix 展示）；不复制以免第二份实体状态漂移（镜像既有 SuppressFBWarnings 模式）。")
+  public record CreatedKey(ApiKey key, String plaintext) {}
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "repository 为 Spring 注入的共享单例，构造注入存同一引用正是意图（镜像既有 WebUserService 模式）。")
+  public ApiKeyService(ApiKeyRepository repository) {
+    this.repository = repository;
+  }
+
+  /** 生成新 Key；重名/名称非法抛 IllegalArgumentException。返回值含明文，仅此一次。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "CRLF_INJECTION_LOGS",
+      justification =
+          "日志变量仅 name 与 prefix：name 经 validateName 拒绝一切空白字符（含 CR/LF），prefix 为内部生成的"
+              + " oryx_+base62，均不可能携带 CRLF；误报。")
+  @Transactional(rollbackFor = Exception.class)
+  public CreatedKey create(String name) {
+    validateName(name);
+    String trimmed = name.strip();
+    if (repository.existsByName(trimmed)) {
+      throw new IllegalArgumentException("api key '" + trimmed + "' already exists");
+    }
+    String random = randomBase62();
+    String plaintext = PLAINTEXT_PREFIX + random;
+    ApiKey key = new ApiKey();
+    key.setName(trimmed);
+    key.setKeyPrefix(PLAINTEXT_PREFIX + random.substring(0, DISPLAY_RANDOM_CHARS));
+    key.setKeyHash(sha256Hex(plaintext));
+    ApiKey saved = repository.save(key);
+    LOG.info("api key created: name={}, prefix={}", saved.getName(), saved.getKeyPrefix());
+    return new CreatedKey(saved, plaintext);
+  }
+
+  /** 校验明文 Key：格式错/不存在/已吊销均返 false（同一路径同一结果，防探测）。通过后同步节流更新 last_used_at， 更新失败仅日志不影响返回值。 */
+  @Transactional(rollbackFor = Exception.class)
+  public boolean verify(String plaintext) {
+    if (plaintext == null || plaintext.isBlank() || !plaintext.startsWith(PLAINTEXT_PREFIX)) {
+      return false;
+    }
+    String presentedHash = sha256Hex(plaintext);
+    ApiKey key = repository.findByKeyHash(presentedHash).orElse(null);
+    if (key == null || !key.isActive()) {
+      return false;
+    }
+    // 恒定时间复核兜底（FR-010）；hex 均为本地计算的规范形式
+    if (!MessageDigest.isEqual(
+        presentedHash.getBytes(StandardCharsets.US_ASCII),
+        key.getKeyHash().getBytes(StandardCharsets.US_ASCII))) {
+      return false;
+    }
+    touchLastUsed(key);
+    return true;
+  }
+
+  /** 吊销；不存在抛 IllegalArgumentException。已吊销幂等返 false，新吊销返 true。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "CRLF_INJECTION_LOGS",
+      justification = "日志变量为库中 name（建 Key 时已经 validateName 拒绝空白字符）与内部生成的 prefix，均不可能携带 CRLF；误报。")
+  @Transactional(rollbackFor = Exception.class)
+  public boolean revoke(String name) {
+    ApiKey key =
+        repository
+            .findByName(name)
+            .orElseThrow(() -> new IllegalArgumentException("api key '" + name + "' not found"));
+    if (!key.isActive()) {
+      return false;
+    }
+    key.setRevokedAt(Instant.now());
+    repository.save(key);
+    LOG.info("api key revoked: name={}, prefix={}", key.getName(), key.getKeyPrefix());
+    return true;
+  }
+
+  /** 列全部 Key（按 name 排序，含已吊销）；仅返回实体（无明文可泄）。 */
+  public List<ApiKey> list() {
+    return repository.findAll().stream().sorted(Comparator.comparing(ApiKey::getName)).toList();
+  }
+
+  /** 启动校验用：是否存在有效（未吊销）Key（FR-012）。 */
+  public boolean hasActiveKey() {
+    return repository.findAll().stream().anyMatch(ApiKey::isActive);
+  }
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "CRLF_INJECTION_LOGS",
+      justification = "日志变量为内部生成的 oryx_+base62 前缀，不可能携带 CRLF；误报。")
+  private void touchLastUsed(ApiKey key) {
+    Instant now = Instant.now();
+    Long id = key.getId();
+    Instant last = id == null ? null : lastPersistedUse.get(id);
+    if (last != null && last.plusSeconds(LAST_USED_THROTTLE_SECONDS).isAfter(now)) {
+      return;
+    }
+    try {
+      key.setLastUsedAt(now);
+      repository.save(key);
+      if (id != null) {
+        lastPersistedUse.put(id, now);
+      }
+    } catch (RuntimeException e) {
+      // FR-009：治理信号更新失败不阻断业务请求；只记前缀不记明文
+      LOG.warn("failed to update last_used_at for api key prefix={}", key.getKeyPrefix(), e);
+    }
+  }
+
+  private String randomBase62() {
+    StringBuilder sb = new StringBuilder(RANDOM_LENGTH);
+    for (int i = 0; i < RANDOM_LENGTH; i++) {
+      sb.append(BASE62.charAt(secureRandom.nextInt(BASE62.length())));
+    }
+    return sb.toString();
+  }
+
+  private static String sha256Hex(String plaintext) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest(plaintext.getBytes(StandardCharsets.UTF_8)));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 unavailable", e);
+    }
+  }
+
+  private static void validateName(String name) {
+    if (name == null || name.isBlank()) {
+      throw new IllegalArgumentException("api key name must not be empty");
+    }
+    String trimmed = name.strip();
+    if (trimmed.length() > MAX_NAME_LENGTH) {
+      throw new IllegalArgumentException(
+          "api key name must be at most " + MAX_NAME_LENGTH + " characters");
+    }
+    if (trimmed.chars().anyMatch(Character::isWhitespace)) {
+      throw new IllegalArgumentException("api key name must not contain whitespace");
+    }
+  }
+}

--- a/oryxos-storage/src/main/resources/schema.sql
+++ b/oryxos-storage/src/main/resources/schema.sql
@@ -241,3 +241,17 @@ CREATE TABLE IF NOT EXISTS knowledge_chunks (
 );
 CREATE INDEX IF NOT EXISTS idx_kchunk_kb ON knowledge_chunks (kb_name, generation);
 CREATE INDEX IF NOT EXISTS idx_kchunk_doc ON knowledge_chunks (document_id);
+
+-- api_keys：REST API 机器调用凭证（018-rest-api-key）
+-- 只存 SHA-256 哈希绝不存明文（宪法 VI）；key_prefix = 明文头部片段（oryx_ + 前 8 位随机），供盘点/日志对账
+-- revoked_at 非空即失效（吊销即时生效，无缓存窗口）；key_hash UNIQUE 自带隐式索引，校验按此列查找
+-- 新表，CREATE TABLE IF NOT EXISTS，非 ALTER，存量库无迁移风险
+CREATE TABLE IF NOT EXISTS api_keys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name VARCHAR(64) NOT NULL UNIQUE,
+    key_prefix VARCHAR(16) NOT NULL,
+    key_hash VARCHAR(64) NOT NULL UNIQUE,
+    created_at TIMESTAMP NOT NULL,
+    last_used_at TIMESTAMP,
+    revoked_at TIMESTAMP
+);

--- a/oryxos-storage/src/test/java/io/oryxos/storage/ApiKeyServiceTest.java
+++ b/oryxos-storage/src/test/java/io/oryxos/storage/ApiKeyServiceTest.java
@@ -1,0 +1,201 @@
+package io.oryxos.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * 018 验收 harness：ApiKeyServiceTest——凭证生成/校验/吊销口径钉死。守：明文格式（oryx_ 前缀 + 42 位 base62）、 库中只有 64 位 hex
+ * 哈希无明文、verify 对/错/不存在/已吊销四路、revoke 幂等、重名拒绝、last_used 60s 节流。
+ */
+class ApiKeyServiceTest {
+
+  private ApiKeyRepository repository;
+  private ApiKeyService service;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(ApiKeyRepository.class);
+    when(repository.save(any(ApiKey.class))).thenAnswer(inv -> inv.getArgument(0));
+    service = new ApiKeyService(repository);
+  }
+
+  @Test
+  @DisplayName("create_明文为oryx_前缀+42位base62_共47字符")
+  void create_plaintextFormat() {
+    when(repository.existsByName("ci-bot")).thenReturn(false);
+
+    ApiKeyService.CreatedKey created = service.create("ci-bot");
+
+    assertThat(created.plaintext()).startsWith("oryx_").hasSize("oryx_".length() + 42);
+    assertThat(created.plaintext().substring(5)).matches("[A-Za-z0-9]{42}");
+  }
+
+  @Test
+  @DisplayName("create_落库只有64位hex哈希与前缀_无明文")
+  void create_storesHashNotPlaintext() {
+    when(repository.existsByName("ci-bot")).thenReturn(false);
+
+    ApiKeyService.CreatedKey created = service.create("ci-bot");
+    ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+    verify(repository).save(captor.capture());
+    ApiKey saved = captor.getValue();
+
+    assertThat(saved.getKeyHash()).matches("[0-9a-f]{64}").isNotEqualTo(created.plaintext());
+    assertThat(saved.getKeyPrefix())
+        .isEqualTo(created.plaintext().substring(0, "oryx_".length() + 8));
+    assertThat(saved.getName()).isEqualTo("ci-bot");
+    assertThat(saved.isActive()).isTrue();
+  }
+
+  @Test
+  @DisplayName("create_重名拒绝_不覆盖")
+  void create_duplicateNameRejected() {
+    when(repository.existsByName("ci-bot")).thenReturn(true);
+
+    assertThatThrownBy(() -> service.create("ci-bot"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("already exists");
+    verify(repository, times(0)).save(any());
+  }
+
+  @Test
+  @DisplayName("create_名称为空/超长/含空白_拒绝")
+  void create_invalidNameRejected() {
+    assertThatThrownBy(() -> service.create("  ")).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> service.create("a".repeat(65)))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> service.create("ci bot")).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("verify_正确明文_true且更新last_used")
+  void verify_correctKey() {
+    when(repository.existsByName("ci-bot")).thenReturn(false);
+    ApiKeyService.CreatedKey created = service.create("ci-bot");
+    stubFindByHash(created.key());
+
+    assertThat(service.verify(created.plaintext())).isTrue();
+    assertThat(created.key().getLastUsedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("verify_错误/不存在/格式错/null_均false")
+  void verify_wrongKeyVariants() {
+    when(repository.findByKeyHash(anyString())).thenReturn(Optional.empty());
+
+    assertThat(service.verify("oryx_" + "A".repeat(42))).isFalse();
+    assertThat(service.verify("not-a-key")).isFalse();
+    assertThat(service.verify("")).isFalse();
+    assertThat(service.verify(null)).isFalse();
+  }
+
+  @Test
+  @DisplayName("verify_已吊销Key_false_与不存在同结果")
+  void verify_revokedKey_false() {
+    when(repository.existsByName("ci-bot")).thenReturn(false);
+    ApiKeyService.CreatedKey created = service.create("ci-bot");
+    created.key().setRevokedAt(Instant.now());
+    stubFindByHash(created.key());
+
+    assertThat(service.verify(created.plaintext())).isFalse();
+  }
+
+  @Test
+  @DisplayName("revoke_有效Key_true并写revoked_at_再吊销幂等false")
+  void revoke_thenIdempotent() {
+    ApiKey key = namedKey("ci-bot");
+    when(repository.findByName("ci-bot")).thenReturn(Optional.of(key));
+
+    assertThat(service.revoke("ci-bot")).isTrue();
+    assertThat(key.getRevokedAt()).isNotNull();
+    assertThat(service.revoke("ci-bot")).isFalse();
+  }
+
+  @Test
+  @DisplayName("revoke_不存在名称_抛清晰异常")
+  void revoke_unknownName() {
+    when(repository.findByName("ghost")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.revoke("ghost"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not found");
+  }
+
+  @Test
+  @DisplayName("last_used_60秒内重复verify只落库一次（节流）")
+  void verify_lastUsedThrottled() {
+    when(repository.existsByName("ci-bot")).thenReturn(false);
+    ApiKeyService.CreatedKey created = service.create("ci-bot");
+    ReflectionTestUtils.setField(created.key(), "id", 7L);
+    stubFindByHash(created.key());
+
+    assertThat(service.verify(created.plaintext())).isTrue();
+    assertThat(service.verify(created.plaintext())).isTrue();
+    assertThat(service.verify(created.plaintext())).isTrue();
+
+    // save 共 2 次：create 一次 + 首次 verify 落 last_used 一次；后两次 verify 被节流
+    verify(repository, times(2)).save(any(ApiKey.class));
+  }
+
+  @Test
+  @DisplayName("last_used_落库失败_verify仍返回true（不阻断）")
+  void verify_lastUsedFailureDoesNotBlock() {
+    when(repository.existsByName("ci-bot")).thenReturn(false);
+    ApiKeyService.CreatedKey created = service.create("ci-bot");
+    stubFindByHash(created.key());
+    when(repository.save(any(ApiKey.class))).thenThrow(new RuntimeException("db busy"));
+
+    assertThat(service.verify(created.plaintext())).isTrue();
+  }
+
+  @Test
+  @DisplayName("hasActiveKey_全吊销false_有未吊销true")
+  void hasActiveKey() {
+    ApiKey revoked = namedKey("a");
+    revoked.setRevokedAt(Instant.now());
+    when(repository.findAll()).thenReturn(java.util.List.of(revoked));
+    assertThat(service.hasActiveKey()).isFalse();
+
+    when(repository.findAll()).thenReturn(java.util.List.of(revoked, namedKey("b")));
+    assertThat(service.hasActiveKey()).isTrue();
+  }
+
+  @Test
+  @DisplayName("list_按名称排序_返回实体不含任何明文")
+  void list_sortedNoPlaintext() {
+    when(repository.findAll()).thenReturn(java.util.List.of(namedKey("zeta"), namedKey("alpha")));
+
+    var keys = service.list();
+
+    assertThat(keys).extracting(ApiKey::getName).containsExactly("alpha", "zeta");
+    verify(repository, atLeastOnce()).findAll();
+  }
+
+  /** 只 stub 正向命中；其它哈希走 Mockito 默认的 Optional.empty()。 */
+  private void stubFindByHash(ApiKey key) {
+    when(repository.findByKeyHash(key.getKeyHash())).thenReturn(Optional.of(key));
+  }
+
+  private static ApiKey namedKey(String name) {
+    ApiKey key = new ApiKey();
+    key.setName(name);
+    key.setKeyPrefix("oryx_test1234");
+    key.setKeyHash("0".repeat(64));
+    return key;
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/config/ApiKeyFilterConfig.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/config/ApiKeyFilterConfig.java
@@ -1,0 +1,35 @@
+package io.oryxos.web.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.storage.ApiKeyService;
+import io.oryxos.storage.WebSessionService;
+import io.oryxos.web.security.ApiKeyAuthFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+/**
+ * ApiKeyAuthFilter 注册（018-rest-api-key）。
+ *
+ * <p>{@code addUrlPatterns("/api/v1/*")} 精确限定只拦 REST API；与 012 {@code AuthFilterConfig} 的 {@code
+ * /admin/*} 模式互不重叠，{@code /admin/**} 与静态资源天然不受影响（FR-002）。豁免路径（health/auth 子树/OPTIONS） 在 filter
+ * 内部判定（{@link ApiKeyAuthFilter}）。
+ */
+@Configuration
+public class ApiKeyFilterConfig {
+
+  @Bean
+  FilterRegistrationBean<ApiKeyAuthFilter> apiKeyAuthFilter(
+      ApiKeyService apiKeyService,
+      WebSessionService sessionService,
+      WebApiKeyProperties properties,
+      ObjectMapper objectMapper) {
+    FilterRegistrationBean<ApiKeyAuthFilter> registration = new FilterRegistrationBean<>();
+    registration.setFilter(
+        new ApiKeyAuthFilter(apiKeyService, sessionService, properties, objectMapper));
+    registration.addUrlPatterns("/api/v1/*");
+    registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 11);
+    return registration;
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/config/WebApiKeyProperties.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/config/WebApiKeyProperties.java
@@ -1,0 +1,25 @@
+package io.oryxos.web.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * REST API Key 认证配置（018-rest-api-key）。
+ *
+ * <p>{@code oryxos.web.apikey.enabled} 默认 {@code false}——假设内网现状不变（回归零破坏，FR-001）；置 {@code true} 后
+ * {@code /api/v1/**} 启用 API Key 门禁（豁免 {@code /api/v1/health}、{@code /api/v1/auth/*}、OPTIONS 预检），
+ * {@code /admin/**} 完全不受影响。与 012 的 {@code oryxos.web.auth.enabled} 相互独立。
+ */
+@ConfigurationProperties(prefix = "oryxos.web.apikey")
+public class WebApiKeyProperties {
+
+  /** 是否启用 REST API Key 认证。默认关：保持「假设内网」现状。 */
+  private boolean enabled = false;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/config/WebAuthConfig.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/config/WebAuthConfig.java
@@ -11,5 +11,5 @@ import org.springframework.context.annotation.Configuration;
  * scanBasePackages="io.oryxos"} 运行时发现本类即可。
  */
 @Configuration
-@EnableConfigurationProperties(WebAuthProperties.class)
+@EnableConfigurationProperties({WebAuthProperties.class, WebApiKeyProperties.class})
 public class WebAuthConfig {}

--- a/oryxos-web/src/main/java/io/oryxos/web/security/ApiKeyAuthFilter.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/ApiKeyAuthFilter.java
@@ -1,0 +1,169 @@
+package io.oryxos.web.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.storage.ApiKeyService;
+import io.oryxos.storage.WebSessionService;
+import io.oryxos.web.common.ApiResponse;
+import io.oryxos.web.config.WebApiKeyProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * REST API Key 认证过滤器（018-rest-api-key）。
+ *
+ * <p>仅拦 {@code /api/v1/**}（由 {@code ApiKeyFilterConfig} 的 {@code FilterRegistrationBean} 限定 URL
+ * 模式）；与 012 的 {@code BasicAuthFilter}（只拦 {@code /admin/*}）URL 模式互不重叠，两扇门各管各的（FR-002）。
+ *
+ * <p>豁免（filter 内判定，契约见 specs/018 contracts/auth-contract.md §1）：
+ *
+ * <ol>
+ *   <li>HTTP {@code OPTIONS}——CORS 预检不携带自定义头（FR-014）；
+ *   <li>{@code /api/v1/health}——K8s/LB 探活（FR-002）;
+ *   <li>{@code /api/v1/auth/**}——012 管理台登录子树，端点自身校验（FR-002）。
+ * </ol>
+ *
+ * <p>凭据两条路径（任一有效即放行）：
+ *
+ * <ol>
+ *   <li>API Key——{@code Authorization: Bearer <key>} 或 {@code X-API-Key: <key>} 二选一等效（FR-003）→
+ *       {@link ApiKeyService#verify}；
+ *   <li>管理台 session——{@code oryxos_session} cookie → {@link WebSessionService#findValid}（FR-011，
+ *       管理台 SPA 与 REST 同源，锁门不锁自己人；Clarifications Q1「session 即凭据」）。
+ * </ol>
+ *
+ * <p>都无/都失败：统一 401 JSON（{@link ApiResponse} 信封）+ {@code WWW-Authenticate: Bearer}。无 Key/格式错/
+ * 不存在/已吊销返回完全相同的响应（防探测，FR-004）；具体原因只进 DEBUG 日志且只记前缀，NEVER 记明文（宪法 VI）。
+ *
+ * <p>{@code apikey.enabled=false} 直接放行（默认关，SC-001 回归零破坏）。不抛异常——filter 在 DispatcherServlet
+ * 之前，{@code @RestControllerAdvice} 捕不到，直接写响应（镜像 BasicAuthFilter）。
+ */
+public class ApiKeyAuthFilter extends OncePerRequestFilter {
+
+  /** Bearer scheme 前缀（RFC 6750），含尾随空格。 */
+  private static final String BEARER_PREFIX = "Bearer ";
+
+  /** 备选请求头（与项目出站 HTTP 工具的 X-API-Key 约定同名）。 */
+  private static final String API_KEY_HEADER = "X-API-Key";
+
+  /** 401 挑战头 realm（R9，与 012 默认 realm 一致）。 */
+  private static final String CHALLENGE = "Bearer realm=\"OryxOS\"";
+
+  private static final int UNAUTHORIZED_CODE = HttpStatus.UNAUTHORIZED.value();
+  private static final String UNAUTHORIZED_MESSAGE = "Unauthorized";
+
+  /** 探活豁免路径（FR-002）。 */
+  private static final String HEALTH_PATH = "/api/v1/health";
+
+  /** 012 管理台登录子树（端点自身校验，FR-002）。 */
+  private static final String AUTH_SUBTREE_PREFIX = "/api/v1/auth/";
+
+  private static final String AUTH_SUBTREE_ROOT = "/api/v1/auth";
+
+  private final ApiKeyService apiKeyService;
+  private final WebSessionService sessionService;
+  private final WebApiKeyProperties properties;
+  private final ObjectMapper objectMapper;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "apiKeyService/sessionService/properties/objectMapper 均为 Spring 注入的共享单例，构造注入存同一引用正是意图"
+              + "（镜像 BasicAuthFilter 的 SuppressFBWarnings 模式）。")
+  public ApiKeyAuthFilter(
+      ApiKeyService apiKeyService,
+      WebSessionService sessionService,
+      WebApiKeyProperties properties,
+      ObjectMapper objectMapper) {
+    this.apiKeyService = apiKeyService;
+    this.sessionService = sessionService;
+    this.properties = properties;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    if (!properties.isEnabled()) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+    if (isExempt(request)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+    // (1) API Key 路径（Bearer / X-API-Key 等效）
+    String presented = extractKey(request);
+    if (presented != null && apiKeyService.verify(presented)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+    // (2) 管理台 session 互认（FR-011：session 即凭据）
+    if (authenticatedBySession(request)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+    reject(response);
+  }
+
+  private static boolean isExempt(HttpServletRequest request) {
+    if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+      return true;
+    }
+    String uri = request.getRequestURI();
+    return HEALTH_PATH.equals(uri)
+        || AUTH_SUBTREE_ROOT.equals(uri)
+        || (uri != null && uri.startsWith(AUTH_SUBTREE_PREFIX));
+  }
+
+  /** 提取明文 Key：Authorization Bearer 优先，X-API-Key 兜底；都无返 null。 */
+  private static String extractKey(HttpServletRequest request) {
+    String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (authorization != null && authorization.startsWith(BEARER_PREFIX)) {
+      String key = authorization.substring(BEARER_PREFIX.length()).strip();
+      if (!key.isEmpty()) {
+        return key;
+      }
+    }
+    String header = request.getHeader(API_KEY_HEADER);
+    return header == null || header.isBlank() ? null : header.strip();
+  }
+
+  private boolean authenticatedBySession(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) {
+      return false;
+    }
+    return Arrays.stream(cookies)
+        .filter(c -> BasicAuthFilter.SESSION_COOKIE.equals(c.getName()))
+        .map(Cookie::getValue)
+        .filter(v -> v != null && !v.isBlank())
+        .findFirst()
+        .flatMap(sessionService::findValid)
+        .isPresent();
+  }
+
+  /** 统一 401：所有失败原因同一响应（防探测，FR-004）。 */
+  private void reject(HttpServletResponse response) throws IOException {
+    response.setStatus(UNAUTHORIZED_CODE);
+    response.setHeader(HttpHeaders.WWW_AUTHENTICATE, CHALLENGE);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    response
+        .getWriter()
+        .write(
+            objectMapper.writeValueAsString(
+                ApiResponse.error(UNAUTHORIZED_CODE, UNAUTHORIZED_MESSAGE)));
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/security/ApiKeyStartupCheck.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/ApiKeyStartupCheck.java
@@ -1,0 +1,72 @@
+package io.oryxos.web.security;
+
+import io.oryxos.storage.ApiKeyService;
+import io.oryxos.web.config.WebApiKeyProperties;
+import io.oryxos.web.config.WebAuthProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.stereotype.Component;
+
+/**
+ * 启动校验（018-rest-api-key，FR-012）：两种异常 flag 组合只 WARN 不阻断。
+ *
+ * <ol>
+ *   <li>{@code apikey.enabled=true} 但库中无有效 Key——非豁免请求将全部 401，提示先跑 {@code oryxos apikey add}；
+ *   <li>{@code apikey.enabled=true} 但 {@code auth.enabled=false}——浏览器既无 session 也无 Key，管理台数据页
+ *       将不可用，建议同时开启管理台认证（Clarifications Q2）。
+ * </ol>
+ *
+ * <p>与 012 {@code AuthStartupCheck} 的 fail-fast 差异是有意的（research R7）：012 无账号开 auth 等于永久锁死 管理台（serve
+ * 起不来就建不了账号的死锁不存在，但登录永远不可能成功）；018 无 Key 开门禁是「全拒」的安全状态而非 坏状态，且 {@code oryxos apikey add} 用 {@code
+ * WebApplicationType.NONE} 起 Spring、不依赖 serve 存活， 告警即可。纯机器调用部署（不用管理台）是合法场景，故组合 ② 也不阻断。
+ *
+ * <p>{@link ConditionalOnWebApplication} 限定只 SERVLET 模式（serve/gateway）装配，CLI 管理命令不受影响 （镜像
+ * AuthStartupCheck）。
+ */
+@Component
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+public class ApiKeyStartupCheck implements ApplicationRunner {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ApiKeyStartupCheck.class);
+
+  private final WebApiKeyProperties apiKeyProperties;
+  private final WebAuthProperties authProperties;
+  private final ApiKeyService apiKeyService;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "apiKeyProperties/authProperties/apiKeyService 均为 Spring 注入的共享单例，构造注入存同一引用正是意图"
+              + "（镜像 AuthStartupCheck 的 SuppressFBWarnings 模式）。")
+  public ApiKeyStartupCheck(
+      WebApiKeyProperties apiKeyProperties,
+      WebAuthProperties authProperties,
+      ApiKeyService apiKeyService) {
+    this.apiKeyProperties = apiKeyProperties;
+    this.authProperties = authProperties;
+    this.apiKeyService = apiKeyService;
+  }
+
+  @Override
+  public void run(ApplicationArguments args) {
+    if (!apiKeyProperties.isEnabled()) {
+      LOG.debug("Api key auth disabled (oryxos.web.apikey.enabled=false), startup check skipped");
+      return;
+    }
+    if (!apiKeyService.hasActiveKey()) {
+      LOG.warn(
+          "Api key auth enabled (oryxos.web.apikey.enabled=true) but no active key found. "
+              + "All non-exempt /api/v1/** requests will be rejected (401). "
+              + "Run 'oryxos apikey add <name>' to create one.");
+    }
+    if (!authProperties.isEnabled()) {
+      LOG.warn(
+          "Api key auth enabled but web auth disabled (oryxos.web.auth.enabled=false). "
+              + "Admin console data pages will be unusable (browser has neither session nor key). "
+              + "Enable oryxos.web.auth.enabled or use REST API only.");
+    }
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/security/BasicAuthFilter.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/BasicAuthFilter.java
@@ -70,6 +70,13 @@ public class BasicAuthFilter extends OncePerRequestFilter {
   /** 登录页路径前缀（放行）。 */
   private static final String LOGIN_PATH = "/admin/login";
 
+  /**
+   * SPA 静态资源前缀（放行）：登录页与 SPA 共用一个 shell（{@code index.html} + content-hash 命名的 JS/CSS bundle），
+   * 未登录渲染登录表单同样要加载 {@code /admin/assets/**}——拦下它登录页白屏，任何人都登不进去（018 SC-006 浏览器走查发现的缺陷）。bundle
+   * 是公开前端代码不含数据，数据面由 {@code /api/v1/**} 各自的认证把守。
+   */
+  private static final String ASSETS_PATH = "/admin/assets/";
+
   /** Basic Auth 校验结果（无头/解码失败不计失败次数）。 */
   private enum BasicOutcome {
     NONE,
@@ -111,8 +118,8 @@ public class BasicAuthFilter extends OncePerRequestFilter {
       filterChain.doFilter(request, response);
       return;
     }
-    // 登录页路径放行（FR-017）
-    if (isLoginPath(request.getRequestURI())) {
+    // 登录页路径与 SPA 静态资源放行（FR-017：未登录也要能渲染登录页）
+    if (isLoginPath(request.getRequestURI()) || isAssetPath(request.getRequestURI())) {
       filterChain.doFilter(request, response);
       return;
     }
@@ -137,6 +144,10 @@ public class BasicAuthFilter extends OncePerRequestFilter {
 
   private boolean isLoginPath(String uri) {
     return uri != null && uri.startsWith(LOGIN_PATH);
+  }
+
+  private static boolean isAssetPath(String uri) {
+    return uri != null && uri.startsWith(ASSETS_PATH);
   }
 
   private boolean authenticatedBySession(HttpServletRequest request) {

--- a/oryxos-web/src/test/java/io/oryxos/web/security/ApiKeyAuthFilterTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/security/ApiKeyAuthFilterTest.java
@@ -1,0 +1,229 @@
+package io.oryxos.web.security;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.storage.ApiKeyService;
+import io.oryxos.storage.WebSession;
+import io.oryxos.storage.WebSessionService;
+import io.oryxos.web.config.WebApiKeyProperties;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * 018 验收 harness：ApiKeyAuthFilterTest——路径裁决表钉死（contracts/auth-contract.md §1）。用 standalone MockMvc
+ * + stub controller 映射 /api/v1/**（filter 放行后要有 handler），按注册模式 addFilter(filter, "/api/v1/*")。mock
+ * ApiKeyService/WebSessionService。守：flag 关放行、双请求头等效、401 统一响应不可区分、 豁免（OPTIONS/health/auth
+ * 子树）、session 互认、多 Key 吊销互不影响。
+ */
+class ApiKeyAuthFilterTest {
+
+  private static final String GOOD_KEY = "oryx_" + "A".repeat(42);
+  private static final String BAD_KEY = "oryx_" + "B".repeat(42);
+
+  private ApiKeyService apiKeyService;
+  private WebSessionService sessionService;
+  private WebApiKeyProperties properties;
+  private MockMvc mvc;
+
+  @Controller
+  static class StubController {
+    @GetMapping("/api/v1/profiles")
+    @ResponseBody
+    public String profiles() {
+      return "ok";
+    }
+
+    @GetMapping("/api/v1/health")
+    @ResponseBody
+    public String health() {
+      return "up";
+    }
+
+    @PostMapping("/api/v1/auth/login")
+    @ResponseBody
+    public String login() {
+      return "login";
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    apiKeyService = mock(ApiKeyService.class);
+    sessionService = mock(WebSessionService.class);
+    properties = new WebApiKeyProperties();
+    ApiKeyAuthFilter filter =
+        new ApiKeyAuthFilter(apiKeyService, sessionService, properties, new ObjectMapper());
+    mvc =
+        MockMvcBuilders.standaloneSetup(new StubController())
+            .addFilter(filter, "/api/v1/*")
+            .build();
+  }
+
+  @Test
+  @DisplayName("enabled=false_无凭据放行_200（SC-001回归零破坏）")
+  void disabled_passesThrough() throws Exception {
+    properties.setEnabled(false);
+    mvc.perform(get("/api/v1/profiles")).andExpect(status().isOk());
+    verify(apiKeyService, never()).verify(anyString());
+  }
+
+  @Test
+  @DisplayName("enabled=true_无凭据_401+Bearer挑战头+统一信封")
+  void enabledNoCredentials_401() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(get("/api/v1/profiles"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(header().string("WWW-Authenticate", "Bearer realm=\"OryxOS\""))
+        .andExpect(jsonPath("$.code").value(401))
+        .andExpect(jsonPath("$.message").value("Unauthorized"));
+  }
+
+  @Test
+  @DisplayName("enabled=true_Bearer正确Key_200")
+  void enabledBearerCorrectKey_200() throws Exception {
+    properties.setEnabled(true);
+    when(apiKeyService.verify(GOOD_KEY)).thenReturn(true);
+
+    mvc.perform(get("/api/v1/profiles").header("Authorization", "Bearer " + GOOD_KEY))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("enabled=true_X-API-Key正确Key_200（双写法等效）")
+  void enabledHeaderCorrectKey_200() throws Exception {
+    properties.setEnabled(true);
+    when(apiKeyService.verify(GOOD_KEY)).thenReturn(true);
+
+    mvc.perform(get("/api/v1/profiles").header("X-API-Key", GOOD_KEY)).andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("enabled=true_错误Key与无Key_响应体完全一致（防探测）")
+  void enabledWrongKey_indistinguishableFromNoKey() throws Exception {
+    properties.setEnabled(true);
+    when(apiKeyService.verify(anyString())).thenReturn(false);
+
+    String noKeyBody =
+        mvc.perform(get("/api/v1/profiles"))
+            .andExpect(status().isUnauthorized())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    String wrongKeyBody =
+        mvc.perform(get("/api/v1/profiles").header("X-API-Key", BAD_KEY))
+            .andExpect(status().isUnauthorized())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    String revokedKeyBody =
+        mvc.perform(get("/api/v1/profiles").header("Authorization", "Bearer " + BAD_KEY))
+            .andExpect(status().isUnauthorized())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    // 剥离 timestamp 后逐字节一致：无 Key / 错 Key / 已吊销（verify 均 false）不可区分
+    org.assertj.core.api.Assertions.assertThat(stripTimestamp(wrongKeyBody))
+        .isEqualTo(stripTimestamp(noKeyBody));
+    org.assertj.core.api.Assertions.assertThat(stripTimestamp(revokedKeyBody))
+        .isEqualTo(stripTimestamp(noKeyBody));
+  }
+
+  @Test
+  @DisplayName("enabled=true_多Key并存_吊销A后A被拒B仍通过（SC-004）")
+  void multiKey_revokeOneOtherUnaffected() throws Exception {
+    properties.setEnabled(true);
+    // 吊销后 service.verify(A)=false、verify(B)=true——filter 面只信 verify 裁决
+    when(apiKeyService.verify(GOOD_KEY)).thenReturn(true);
+    when(apiKeyService.verify(BAD_KEY)).thenReturn(false);
+
+    mvc.perform(get("/api/v1/profiles").header("X-API-Key", GOOD_KEY)).andExpect(status().isOk());
+    mvc.perform(get("/api/v1/profiles").header("X-API-Key", BAD_KEY))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("OPTIONS预检_无凭据放行（FR-014）")
+  void optionsPreflight_exempt() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(options("/api/v1/profiles")).andExpect(status().isOk());
+    verify(apiKeyService, never()).verify(anyString());
+  }
+
+  @Test
+  @DisplayName("/api/v1/health_无凭据放行（探活豁免）")
+  void health_exempt() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(get("/api/v1/health")).andExpect(status().isOk()).andExpect(content().string("up"));
+  }
+
+  @Test
+  @DisplayName("/api/v1/auth/*子树_无凭据放行（012现状）")
+  void authSubtree_exempt() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(post("/api/v1/auth/login")).andExpect(status().isOk());
+    verify(apiKeyService, never()).verify(anyString());
+  }
+
+  @Test
+  @DisplayName("enabled=true_有效管理台session无Key_放行（FR-011互认）")
+  void validSessionNoKey_passes() throws Exception {
+    properties.setEnabled(true);
+    WebSession session = new WebSession();
+    session.setSessionId("sid-1");
+    session.setUsername("admin");
+    session.setExpiresAt(Instant.now().plusSeconds(3600));
+    when(sessionService.findValid("sid-1")).thenReturn(Optional.of(session));
+
+    mvc.perform(
+            get("/api/v1/profiles")
+                .cookie(new jakarta.servlet.http.Cookie("oryxos_session", "sid-1")))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("enabled=true_无效session无Key_401")
+  void invalidSessionNoKey_401() throws Exception {
+    properties.setEnabled(true);
+    when(sessionService.findValid("sid-x")).thenReturn(Optional.empty());
+
+    mvc.perform(
+            get("/api/v1/profiles")
+                .cookie(new jakarta.servlet.http.Cookie("oryxos_session", "sid-x")))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("enabled=true_Basic头（非Bearer）无Key_401")
+  void basicHeaderNotAccepted_401() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(get("/api/v1/profiles").header("Authorization", "Basic dXNlcjpwdw=="))
+        .andExpect(status().isUnauthorized());
+    verify(apiKeyService, never()).verify(anyString());
+  }
+
+  private static String stripTimestamp(String body) {
+    return body.replaceAll("\"timestamp\":\\d+", "\"timestamp\":0");
+  }
+}

--- a/oryxos-web/src/test/java/io/oryxos/web/security/ApiKeyStartupCheckTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/security/ApiKeyStartupCheckTest.java
@@ -1,0 +1,103 @@
+package io.oryxos.web.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.oryxos.storage.ApiKeyService;
+import io.oryxos.web.config.WebApiKeyProperties;
+import io.oryxos.web.config.WebAuthProperties;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 018 验收 harness：ApiKeyStartupCheckTest——两条启动 WARN 钉死且均不抛异常（FR-012，与 012 fail-fast 有意不同）。 用 Logback
+ * ListAppender 捕获 WARN。
+ */
+class ApiKeyStartupCheckTest {
+
+  private WebApiKeyProperties apiKeyProperties;
+  private WebAuthProperties authProperties;
+  private ApiKeyService apiKeyService;
+  private ApiKeyStartupCheck check;
+  private ListAppender<ILoggingEvent> appender;
+  private Logger logger;
+
+  @BeforeEach
+  void setUp() {
+    apiKeyProperties = new WebApiKeyProperties();
+    authProperties = new WebAuthProperties();
+    apiKeyService = mock(ApiKeyService.class);
+    check = new ApiKeyStartupCheck(apiKeyProperties, authProperties, apiKeyService);
+    logger = (Logger) LoggerFactory.getLogger(ApiKeyStartupCheck.class);
+    appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+  }
+
+  @AfterEach
+  void tearDown() {
+    logger.detachAppender(appender);
+  }
+
+  @Test
+  @DisplayName("enabled=true且无有效Key_WARN提示apikey_add_不抛异常")
+  void enabledNoKey_warnsWithoutThrowing() {
+    apiKeyProperties.setEnabled(true);
+    authProperties.setEnabled(true);
+    when(apiKeyService.hasActiveKey()).thenReturn(false);
+
+    assertThatCode(() -> check.run(null)).doesNotThrowAnyException();
+    assertThat(warnMessages()).anyMatch(m -> m.contains("oryxos apikey add"));
+  }
+
+  @Test
+  @DisplayName("enabled=true且auth关闭_WARN管理台不可用_不抛异常")
+  void enabledAuthOff_warnsWithoutThrowing() {
+    apiKeyProperties.setEnabled(true);
+    authProperties.setEnabled(false);
+    when(apiKeyService.hasActiveKey()).thenReturn(true);
+
+    assertThatCode(() -> check.run(null)).doesNotThrowAnyException();
+    assertThat(warnMessages()).anyMatch(m -> m.contains("Admin console"));
+  }
+
+  @Test
+  @DisplayName("正常配置（双开且有Key）_无WARN")
+  void healthyConfig_noWarn() {
+    apiKeyProperties.setEnabled(true);
+    authProperties.setEnabled(true);
+    when(apiKeyService.hasActiveKey()).thenReturn(true);
+
+    check.run(null);
+
+    assertThat(warnMessages()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("enabled=false_跳过校验_无WARN")
+  void disabled_skipsCheck() {
+    apiKeyProperties.setEnabled(false);
+    authProperties.setEnabled(false);
+
+    check.run(null);
+
+    assertThat(warnMessages()).isEmpty();
+  }
+
+  private List<String> warnMessages() {
+    return appender.list.stream()
+        .filter(e -> e.getLevel() == Level.WARN)
+        .map(ILoggingEvent::getFormattedMessage)
+        .toList();
+  }
+}

--- a/oryxos-web/src/test/java/io/oryxos/web/security/BasicAuthFilterTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/security/BasicAuthFilterTest.java
@@ -49,6 +49,9 @@ class BasicAuthFilterTest {
 
     @GetMapping("/admin/login")
     public void adminLogin() {}
+
+    @GetMapping("/admin/assets/index-test.js")
+    public void adminAsset() {}
   }
 
   @BeforeEach
@@ -236,6 +239,14 @@ class BasicAuthFilterTest {
   void loginPath_passesThrough() throws Exception {
     properties.setEnabled(true);
     mvc.perform(get("/admin/login")).andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("/admin/assets/**_未登录放行（登录页渲染依赖SPA静态资源，018走查修复）")
+  void assetPath_passesThrough() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(get("/admin/assets/index-test.js")).andExpect(status().isOk());
+    verify(userService, never()).verify(anyString(), anyString());
   }
 
   @Test

--- a/specs/018-rest-api-key/acceptance-report.md
+++ b/specs/018-rest-api-key/acceptance-report.md
@@ -1,0 +1,47 @@
+# 验收报告: REST API Key 认证（018）
+
+**Date**: 2026-08-26 | **验收方式**: 自动化测试（33 用例）+ fat JAR 真机走查（quickstart V1~V6）
+
+## 自动化测试
+
+| 套件 | 用例 | 结果 |
+|------|------|------|
+| `ApiKeyServiceTest`（storage） | 13 | ✅ 全过 |
+| `ApiKeyAuthFilterTest`（web） | 12 | ✅ 全过 |
+| `ApiKeyStartupCheckTest`（web） | 4 | ✅ 全过 |
+| `ApiKeyAuthE2ETest`（boot，真实 HTTP+SQLite） | 4 | ✅ 全过 |
+
+## 真机走查（quickstart V1~V6）
+
+环境：WSL2，fat JAR `oryxos-boot-0.1.3-RELEASE.jar`，独立 scratch 工作区。
+
+| 走查 | 步骤 | 观测 | 结论 |
+|------|------|------|------|
+| V1 回归零破坏 | 默认配置起 serve，无凭据 GET `/api/v1/profiles` | `200` | ✅ |
+| V2 生成 Key | `apikey add ci-bot` / 重名再 add / python 查库 | 明文 `oryx_`+42 位仅显示一次并附警告；重名抛 `already exists`；库中 `key_hash` 为 64 位 hex（非明文），`key_prefix`=`oryx_fudnBc3y` | ✅ |
+| V3 锁门生效 | `apikey.enabled=true` 起 serve 后四组 curl | 无凭据 `401`+`WWW-Authenticate: Bearer realm="OryxOS"`；错 Key `401`；`Bearer` 与 `X-API-Key` 双写法均 `200`；无 Key/错 Key 401 响应体逐字段一致（仅 timestamp 异） | ✅ |
+| V4 生命周期 | 第二把 Key `report`；`revoke ci-bot`；`revoke ghost`；`list` | 吊销后被吊 Key 下一请求即 `401`、`report` 仍 `200`（serve 不重启）；ghost 报 `not found`；list 输出 NAME/PREFIX/STATUS/CREATED_AT/LAST_USED_AT 无明文 | ✅ |
+| V5 共存豁免 | health / OPTIONS / 401 防探测 | `/api/v1/health` 无凭据 `200`；`OPTIONS` 预检 `200`；`/api/v1/auth/*` 豁免与 session 互认由 `ApiKeyAuthFilterTest`（authSubtree_exempt / validSessionNoKey_passes）钉死 | ✅ |
+| V6 启动告警 | ① 空库开 apikey；② apikey 开 + auth 关 | ① 启动成功，WARN `no active key found… Run 'oryxos apikey add'`，请求全 `401`；② 启动成功，WARN `Admin console data pages will be unusable…`——均见真实 serve 日志 | ✅ |
+
+## SC 达成情况
+
+| SC | 口径 | 结论 |
+|----|------|------|
+| SC-001 回归零破坏 | V1 真机 `200` + 全量既有测试随 `mvn verify` 通过 | ✅ |
+| SC-002 拒绝与放行 100% | V3 真机四组 + filter 测试 12 用例路径裁决表全覆盖 | ✅ |
+| SC-003 认证开销无感 | SHA-256 一次 + UNIQUE 索引查一次（微秒级，弃 BCrypt 的设计裁决见 research R1）；真机 curl 无可感知差异。未做量化压测（analyze G2 裁决：LOW，可接受） | ✅ |
+| SC-004 吊销即时 | V4：serve 不重启，吊销后下一请求即 `401`，另一把 Key 不受影响 | ✅ |
+| SC-005 明文零泄漏 | 明文仅 `apikey add` stdout 一次；库中 64 位 hex；list/日志（含 revoke INFO 日志）只含前缀 | ✅ |
+| SC-006 双开共存 | session 互认与 auth 子树豁免由单测钉死；health 真机 `200`。浏览器端双开人工走查未执行（无浏览器环境），部署时按 quickstart V5 复核 | ✅（自动化口径） |
+| SC-007 5 分钟接入 | 真机全流程（add → 开 flag → 重启 → curl 接入）约 3 分钟 | ✅ |
+
+## 实现与设计偏差
+
+- **012 零改动比计划更彻底**：`ApiKeyAuthFilter` 与 `BasicAuthFilter` 同包，package-private 的 `SESSION_COOKIE` 直接可见，原计划的常量可见性调整都不需要（contracts §4 已同步更正）。
+- **T013 CLI 独立测试并入**：CLI 子命令自起完整 Spring 上下文（镜像 `UserCommand`，其同样无独立单测），list 无明文/revoke 错误路径断言并入 `ApiKeyServiceTest`，CLI 面行为由真机走查 V2/V4 覆盖。
+- **E2E 中管理台认证保持关闭**：012 `AuthStartupCheck` 无账号 fail-fast 与测试启动时序冲突，session 互认改由 filter 单测覆盖，语义等价。
+
+## 质量门禁
+
+`mvn verify`（Spotless + P3C + Checkstyle + SpotBugs/FindSecBugs + OWASP Dependency-Check）：**BUILD SUCCESS**，全仓 1760 个测试 0 失败 0 错误。过程记录：首轮 Spotless 格式违规经 `spotless:apply` 修复；FindSecBugs 对 `ApiKeyService` 报 3 个 CRLF_INJECTION_LOGS（误报——name 经 validateName 拒绝一切空白字符、prefix 为内部生成 base62）与 2 个 EI_EXPOSE_REP（CreatedKey record 携带实体引用系有意设计），均按项目既有模式以带理由的 `SuppressFBWarnings` 落案。

--- a/specs/018-rest-api-key/acceptance-report.md
+++ b/specs/018-rest-api-key/acceptance-report.md
@@ -1,6 +1,6 @@
 # 验收报告: REST API Key 认证（018）
 
-**Date**: 2026-08-26 | **验收方式**: 自动化测试（33 用例）+ fat JAR 真机走查（quickstart V1~V6）
+**Date**: 2026-08-26（初验）/ 2026-08-27（SC-006 浏览器走查补全） | **验收方式**: 自动化测试（35 用例）+ fat JAR 真机走查（quickstart V1~V6）+ Chromium 无头浏览器双开走查
 
 ## 自动化测试
 
@@ -9,7 +9,8 @@
 | `ApiKeyServiceTest`（storage） | 13 | ✅ 全过 |
 | `ApiKeyAuthFilterTest`（web） | 12 | ✅ 全过 |
 | `ApiKeyStartupCheckTest`（web） | 4 | ✅ 全过 |
-| `ApiKeyAuthE2ETest`（boot，真实 HTTP+SQLite） | 4 | ✅ 全过 |
+| `ApiKeyAuthE2ETest`（boot，真实 HTTP+SQLite） | 5 | ✅ 全过（含双认证共存：真实 HTTP 登录拿 session → 无 Key 调 REST 通过、伪造 session 401） |
+| `BasicAuthFilterTest` 新增资源放行用例（web） | 1 | ✅（走查发现的存量缺陷回归钉死） |
 
 ## 真机走查（quickstart V1~V6）
 
@@ -22,6 +23,7 @@
 | V3 锁门生效 | `apikey.enabled=true` 起 serve 后四组 curl | 无凭据 `401`+`WWW-Authenticate: Bearer realm="OryxOS"`；错 Key `401`；`Bearer` 与 `X-API-Key` 双写法均 `200`；无 Key/错 Key 401 响应体逐字段一致（仅 timestamp 异） | ✅ |
 | V4 生命周期 | 第二把 Key `report`；`revoke ci-bot`；`revoke ghost`；`list` | 吊销后被吊 Key 下一请求即 `401`、`report` 仍 `200`（serve 不重启）；ghost 报 `not found`；list 输出 NAME/PREFIX/STATUS/CREATED_AT/LAST_USED_AT 无明文 | ✅ |
 | V5 共存豁免 | health / OPTIONS / 401 防探测 | `/api/v1/health` 无凭据 `200`；`OPTIONS` 预检 `200`；`/api/v1/auth/*` 豁免与 session 互认由 `ApiKeyAuthFilterTest`（authSubtree_exempt / validSessionNoKey_passes）钉死 | ✅ |
+| V5+ 浏览器双开走查 | 双 flag 全开，Chromium 无头（playwright-core）完整用户路径 | 未登录访问 `/admin/` 正确跳登录页 → 表单登录 `200` 拿 `oryxos_session` → 进入 SPA 概览页（截图留证：admin 已登录、25 内置 Tool / 2 Provider 等实时数据渲染）→ 带 session 的 `/api/v1/info`/`profiles`/`tools`/`providers`/`sessions/stats` 全 `200`；登录前无 cookie 的同批请求全 `401`（门禁生效的反向证据） | ✅ |
 | V6 启动告警 | ① 空库开 apikey；② apikey 开 + auth 关 | ① 启动成功，WARN `no active key found… Run 'oryxos apikey add'`，请求全 `401`；② 启动成功，WARN `Admin console data pages will be unusable…`——均见真实 serve 日志 | ✅ |
 
 ## SC 达成情况
@@ -33,14 +35,18 @@
 | SC-003 认证开销无感 | SHA-256 一次 + UNIQUE 索引查一次（微秒级，弃 BCrypt 的设计裁决见 research R1）；真机 curl 无可感知差异。未做量化压测（analyze G2 裁决：LOW，可接受） | ✅ |
 | SC-004 吊销即时 | V4：serve 不重启，吊销后下一请求即 `401`，另一把 Key 不受影响 | ✅ |
 | SC-005 明文零泄漏 | 明文仅 `apikey add` stdout 一次；库中 64 位 hex；list/日志（含 revoke INFO 日志）只含前缀 | ✅ |
-| SC-006 双开共存 | session 互认与 auth 子树豁免由单测钉死；health 真机 `200`。浏览器端双开人工走查未执行（无浏览器环境），部署时按 quickstart V5 复核 | ✅（自动化口径） |
+| SC-006 双开共存 | 三层证据齐备：filter 单测（session 互认/豁免）+ E2E 真实 HTTP（登录→session 调 REST 200、伪造 session 401）+ Chromium 浏览器完整用户路径（登录→SPA 数据页全 200，截图留证） | ✅（全量） |
 | SC-007 5 分钟接入 | 真机全流程（add → 开 flag → 重启 → curl 接入）约 3 分钟 | ✅ |
 
 ## 实现与设计偏差
 
-- **012 零改动比计划更彻底**：`ApiKeyAuthFilter` 与 `BasicAuthFilter` 同包，package-private 的 `SESSION_COOKIE` 直接可见，原计划的常量可见性调整都不需要（contracts §4 已同步更正）。
 - **T013 CLI 独立测试并入**：CLI 子命令自起完整 Spring 上下文（镜像 `UserCommand`，其同样无独立单测），list 无明文/revoke 错误路径断言并入 `ApiKeyServiceTest`，CLI 面行为由真机走查 V2/V4 覆盖。
-- **E2E 中管理台认证保持关闭**：012 `AuthStartupCheck` 无账号 fail-fast 与测试启动时序冲突，session 互认改由 filter 单测覆盖，语义等价。
+- **E2E 双认证时序解法**：012 `AuthStartupCheck` 无账号 fail-fast 与测试启动时序冲突，E2E 改为「先建账号、再运行时开启 `WebAuthProperties.enabled`」——filter 每请求读该单例的开关，与生产开启态行为一致，从而在真实 HTTP 链路覆盖双认证共存（初版曾因此仅靠单测覆盖，已补全）。
+- **计划中的 `SESSION_COOKIE` 可见性调整无需执行**：`ApiKeyAuthFilter` 与 `BasicAuthFilter` 同包，package-private 常量直接可见。
+
+## 走查发现并修复的存量缺陷（012/013 交互）
+
+浏览器走查发现：`oryxos.web.auth.enabled=true` 时登录页白屏——`BasicAuthFilter` 仅放行 `/admin/login` 前缀，而登录页与 SPA 共用的 JS/CSS bundle 位于 `/admin/assets/`，未登录请求被 401 拦下（curl 可复现），导致**开启管理台认证后任何人都无法登录**。该缺陷在 main 上即存在（012 验收后 013 管理台重建改变了资源路径），与 018 无关，但被本次真实浏览器走查首次暴露。修复：`BasicAuthFilter` 放行 `/admin/assets/**` 静态资源（content-hash 公开前端代码不含数据，数据面由 `/api/v1/**` 认证把守），`BasicAuthFilterTest` 补回归用例。
 
 ## 质量门禁
 

--- a/specs/018-rest-api-key/checklists/requirements.md
+++ b/specs/018-rest-api-key/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: REST API Key 认证
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- FR 中出现的配置键名（`oryxos.web.apikey.enabled`）、CLI 子命令（`oryxos apikey add/list/revoke`）与请求头名是对外接口契约而非实现细节，沿用 012-web-auth spec 的同一口径。
+- 三个潜在分歧点（管理台 SPA 兼容方式、flag 组合的启停策略、Key 过期）均已按合理默认拍板并写入 Assumptions，未留 [NEEDS CLARIFICATION]。
+- 所有项通过，可进入 `/speckit-clarify` 或直接 `/speckit-plan`。

--- a/specs/018-rest-api-key/contracts/auth-contract.md
+++ b/specs/018-rest-api-key/contracts/auth-contract.md
@@ -1,0 +1,93 @@
+# Contract: REST API Key 认证行为
+
+**Feature**: 018-rest-api-key | **Date**: 2026-08-26
+
+## 1. 请求认证契约（`oryxos.web.apikey.enabled=true` 时）
+
+### 凭据携带方式（FR-003，二选一等效）
+
+```
+Authorization: Bearer oryx_<42位base62>
+X-API-Key: oryx_<42位base62>
+```
+
+同时携带时任一有效即通过。查询参数携带不支持（不安全，进访问日志）。
+
+### 路径裁决表（FR-002）
+
+| 路径 / 条件 | 裁决 |
+|------------|------|
+| `OPTIONS` 任意路径 | 放行（CORS 预检，FR-014） |
+| `/api/v1/health` | 放行（探活豁免） |
+| `/api/v1/auth/**` | 放行（012 现状，端点自身校验 session/账密） |
+| 其余 `/api/v1/**` + 有效 API Key | 放行 |
+| 其余 `/api/v1/**` + 有效管理台 session（`oryxos_session` cookie） | 放行（FR-011） |
+| 其余 `/api/v1/**` + 无凭据 / 无效 / 已吊销 Key | **401**（统一响应，见下） |
+| `/admin/**`、静态资源、非 `/api/v1` 路径 | 不在本 filter 模式内，完全不受影响 |
+
+`enabled=false`（默认）：filter 直接放行一切，行为与现状 100% 一致（FR-001）。
+
+### 401 响应（FR-004）
+
+```
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer realm="OryxOS"
+Content-Type: application/json
+
+{"code": 401, "message": "Unauthorized", "data": null, "timestamp": ...}
+```
+
+所有失败原因（无 Key / 格式错 / 不存在 / 已吊销）返回**同一**响应体，不可区分（防探测）。服务端日志只记 Key 前缀，永不记明文。
+
+## 2. CLI 契约（FR-005）
+
+### `oryxos apikey add <name>`
+
+- `<name>`：≤64 字符、无空格、全局唯一；重名 → 报错退出（非零退出码），不覆盖。
+- 成功输出（明文仅此一次，FR-006）：
+
+```
+Created API key 'ci-bot':
+
+  oryx_Xy7...42位base62...Qk
+
+This is the ONLY time the key is displayed. Store it securely.
+```
+
+### `oryxos apikey list`
+
+```
+NAME       PREFIX          STATUS    CREATED_AT             LAST_USED_AT
+ci-bot     oryx_Xy7aB2cD   active    2026-08-26T10:00:00Z   2026-08-26T12:34:56Z
+report     oryx_Zw9eF4gH   revoked   2026-08-20T09:00:00Z   -
+```
+
+- 无明文；无 Key 时提示 `Run 'oryxos apikey add <name>' to create one.`
+
+### `oryxos apikey revoke <name>`
+
+- 成功：`Revoked API key '<name>'`，立即生效（下一次请求即 401，FR-008）。
+- 名称不存在：清晰报错，非零退出码。
+- 已吊销的再吊销：幂等提示（不报错不改状态）。
+
+## 3. 配置契约（FR-001/FR-012）
+
+```yaml
+oryxos:
+  web:
+    apikey:
+      enabled: false   # 默认关；true 时启用 /api/v1/** Key 门禁
+```
+
+启动告警（均不阻断）：
+
+| 条件 | 行为 |
+|------|------|
+| `apikey.enabled=true` 且库中无有效 Key | WARN：提示 `oryxos apikey add`，此时非豁免请求全 401 |
+| `apikey.enabled=true` 且 `auth.enabled=false` | WARN：管理台数据页面将不可用，建议同时开启管理台认证 |
+
+## 4. 兼容性承诺
+
+- `/api/v1` 全部 17 个既有子树的响应格式、语义零变更；本 feature 只加认证门，不改端点。
+- 012-web-auth 的 `/admin/**` filter、`/api/v1/auth/*` 端点、`web_users`/`web_sessions` 表零改动（实现落定：`ApiKeyAuthFilter` 与 `BasicAuthFilter` 同包，package-private 的 `SESSION_COOKIE` 常量直接可见，连可见性调整都无需做）。
+- OpenAPI 文档（springdoc）路径不在 `/api/v1` 下，不受影响。

--- a/specs/018-rest-api-key/contracts/auth-contract.md
+++ b/specs/018-rest-api-key/contracts/auth-contract.md
@@ -89,5 +89,5 @@ oryxos:
 ## 4. 兼容性承诺
 
 - `/api/v1` 全部 17 个既有子树的响应格式、语义零变更；本 feature 只加认证门，不改端点。
-- 012-web-auth 的 `/admin/**` filter、`/api/v1/auth/*` 端点、`web_users`/`web_sessions` 表零改动（实现落定：`ApiKeyAuthFilter` 与 `BasicAuthFilter` 同包，package-private 的 `SESSION_COOKIE` 常量直接可见，连可见性调整都无需做）。
+- 012-web-auth 的 `/admin/**` filter、`/api/v1/auth/*` 端点、`web_users`/`web_sessions` 表零改动（实现落定：`ApiKeyAuthFilter` 与 `BasicAuthFilter` 同包，package-private 的 `SESSION_COOKIE` 常量直接可见，连可见性调整都无需做）。例外说明：018 的 SC-006 浏览器走查暴露了一个与 018 无关的存量缺陷（`auth.enabled=true` 时登录页静态资源 `/admin/assets/**` 被 401、登录页白屏），已作为独立 bug fix 修复 `BasicAuthFilter`（放行静态资源前缀），详见 acceptance-report.md。
 - OpenAPI 文档（springdoc）路径不在 `/api/v1` 下，不受影响。

--- a/specs/018-rest-api-key/data-model.md
+++ b/specs/018-rest-api-key/data-model.md
@@ -1,0 +1,57 @@
+# Data Model: REST API Key 认证
+
+**Feature**: 018-rest-api-key | **Date**: 2026-08-26
+
+## api_keys（新表）
+
+机器调用凭证。与 `web_users`（人的账密）相互独立，互不引用。
+
+```sql
+-- api_keys：REST API 机器调用凭证（018-rest-api-key）
+-- 新表，CREATE TABLE IF NOT EXISTS，非 ALTER，存量库无迁移风险（FR-013）。
+CREATE TABLE IF NOT EXISTS api_keys (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    name         VARCHAR(64)  NOT NULL UNIQUE,   -- 管理员命名，标识调用方（FR-007）
+    key_prefix   VARCHAR(16)  NOT NULL,          -- 明文头部片段 oryx_XXXXXXXX，供盘点/日志对账
+    key_hash     VARCHAR(64)  NOT NULL UNIQUE,   -- SHA-256 hex，无明文（FR-007）
+    created_at   TIMESTAMP    NOT NULL,
+    last_used_at TIMESTAMP,                      -- 可空；校验通过后节流更新（FR-009）
+    revoked_at   TIMESTAMP                       -- 可空；非空即失效（FR-008）
+);
+-- 无需显式索引：key_hash 的 UNIQUE 约束在 SQLite 下自带隐式索引，校验查找即走该索引
+```
+
+### 字段约束
+
+| 字段 | 约束 | 来源 |
+|------|------|------|
+| `name` | 非空、全局唯一、≤64 字符；重名创建拒绝 | FR-007、US2 场景 5 |
+| `key_prefix` | `oryx_` + 明文随机部分前 8 位；list/日志中唯一允许出现的 Key 片段 | FR-006、R1 |
+| `key_hash` | SHA-256(完整明文) 的 hex；唯一索引，校验按此列查找 | R1、R2 |
+| `last_used_at` | 分钟级精度即可（60s 内存节流）；更新失败不阻断请求 | FR-009、R6 |
+| `revoked_at` | 吊销即写入；校验时非空一律拒绝，无缓存窗口 | FR-008 |
+
+### 生命周期（状态转移）
+
+```
+（不存在） --apikey add--> 有效（revoked_at IS NULL）
+有效 --请求校验通过--> 有效（last_used_at 刷新，节流）
+有效 --apikey revoke--> 已吊销（revoked_at = now，终态，不可恢复）
+```
+
+- 无自动过期（Clarifications Q3）；无删除操作（保留吊销记录供盘点，list 显示状态）。
+- 认证开关关闭时，表中数据静默不生效（Edge Case：开关是唯一裁决）。
+
+## Java 侧映射（oryxos-storage，镜像 WebUser 三件套）
+
+| 类 | 职责 |
+|----|------|
+| `ApiKey`（`@Entity`） | 表映射，字段同上 |
+| `ApiKeyRepository`（Spring Data JPA） | `findByKeyHash`、`findByName`、`findAll`、`existsByName` |
+| `ApiKeyService` | `create(name)` → 生成明文+落哈希、返明文（仅此一次）；`verify(plaintext)` → 哈希查找 + 恒时复核 + 吊销判定 + last_used 节流更新；`revoke(name)`；`list()`；`hasActiveKey()`（启动校验用） |
+
+## 不新增的
+
+- 不加 `expires_at`（Clarifications Q3：不做过期，需求出现再加列——新列可走既有 SchemaUpgrade 模式）。
+- 不加认证事件审计表（spec Assumptions：沿用两张审计表口径，Key 治理信号 = `last_used_at`）。
+- `web_users` / `web_sessions` 零改动。

--- a/specs/018-rest-api-key/plan.md
+++ b/specs/018-rest-api-key/plan.md
@@ -1,0 +1,111 @@
+# Implementation Plan: REST API Key 认证
+
+**Branch**: `018-rest-api-key` | **Date**: 2026-08-26 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/018-rest-api-key/spec.md`
+
+## Summary
+
+为 `/api/v1/**` 加 API Key 机器调用认证，补齐 v0.2「把门锁上」缺角。技术路线：完整镜像 012-web-auth 的既有模式——`FilterRegistrationBean` 挂 `ApiKeyAuthFilter`（只拦 `/api/v1/*`，与 012 的 `/admin/*` filter 互不重叠）、`WebApiKeyProperties` feature flag 默认关、`api_keys` 新表进 schema.sql（`CREATE TABLE IF NOT EXISTS`，无迁移风险）、`ApiKeyService` 三件套进 oryxos-storage、`oryxos apikey` 子命令镜像 `UserCommand`。Key 为 `oryx_` 前缀高熵随机串，存 SHA-256 哈希，按哈希查找 + 恒时复核；管理台 session 互认复用 `WebSessionService`。零新依赖、零新模块。
+
+## Technical Context
+
+**Language/Version**: Java 21（virtual thread）
+
+**Primary Dependencies**: Spring Boot 3.x（Spring MVC servlet filter）、Spring Data JPA、Picocli；零新增依赖（哈希用 JDK `MessageDigest`，随机用 `SecureRandom`）
+
+**Storage**: SQLite 新表 `api_keys`（schema.sql 手工建表，新表非 ALTER）
+
+**Testing**: JUnit 5 + MockMvc（filter 行为）+ 既有 E2E 模式（oryxos-boot）；`mvn verify` 全量质量门禁
+
+**Target Platform**: Linux server（单 fat JAR，同现状）
+
+**Project Type**: Maven 多模块单体——涉及 oryxos-storage（实体/服务）、oryxos-web（filter/配置/启动校验）、oryxos-cli（apikey 子命令）三个既有模块
+
+**Performance Goals**: 认证开销对调用方无感（SC-003）：SHA-256 一次 + 索引查一次，微秒级；不用 BCrypt（见 research R1）
+
+**Constraints**: flag 默认关回归零破坏（SC-001）；明文 Key 全链路只出现一次（SC-005）；恒定时间比较（FR-010）；同步阻塞模型（宪法 VII）
+
+**Scale/Scope**: Key 数量个位数到几十把（每调用方一把）；三模块合计约 10 个新文件 + 2 个既有文件小改（schema.sql、CLI 主入口注册子命令）
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| 原则 | 评估 | 结论 |
+|------|------|------|
+| I 自实现 ReAct | 不涉及（纯 web 认证层） | ✅ |
+| II Spring AI 边界 | 不涉及 | ✅ |
+| III Provider 显式映射 | 不涉及 | ✅ |
+| IV 目录=Agent / Skill 软连接 | 不涉及 | ✅ |
+| V 审计 Day One 落库 | 两张审计表口径不变；Key 治理信号走 `last_used_at`（spec Assumptions 明确不为认证单独落审计表） | ✅ |
+| VI 安全是地基 | Key 只存 SHA-256 哈希、明文仅生成时 stdout 一次、日志只记前缀、恒时比较防侧信道、失败响应防探测；不用 SecurityManager | ✅ |
+| VII 同步 + 虚拟线程 | `OncePerRequestFilter` 同步阻塞；无 Reactor/CompletableFuture | ✅ |
+| VIII 目录配置 / 状态外置 / 手工 schema | Key 持久化 SQLite；新表走 schema.sql `CREATE TABLE IF NOT EXISTS`（非 Hibernate 自动迁移）；last_used 节流表是内存缓存非状态，重启丢失无害 | ✅ |
+| 模块约束 | 不新建模块，不改 oryxos-core；storage/web/cli 各归其位，无循环依赖 | ✅ |
+
+**Phase 1 设计后复评**: 设计未引入新违背项，全部通过。无需 Complexity Tracking。
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/018-rest-api-key/
+├── plan.md              # 本文件
+├── research.md          # Phase 0：9 项技术裁决（R1~R9）
+├── data-model.md        # Phase 1：api_keys 表 + 生命周期
+├── quickstart.md        # Phase 1：V1~V6 验收走查
+├── contracts/
+│   └── auth-contract.md # Phase 1：请求认证/CLI/配置契约
+└── tasks.md             # Phase 2（/speckit-tasks 生成）
+```
+
+### Source Code (repository root)
+
+```text
+oryxos-storage/
+├── src/main/java/io/oryxos/storage/
+│   ├── ApiKey.java                      # 新增：JPA 实体
+│   ├── ApiKeyRepository.java            # 新增：findByKeyHash/findByName/existsByName
+│   └── ApiKeyService.java               # 新增：create/verify/revoke/list/hasActiveKey
+├── src/main/resources/schema.sql        # 修改：追加 api_keys 表
+└── src/test/java/io/oryxos/storage/
+    └── ApiKeyServiceTest.java           # 新增：生成/校验/吊销/重名/哈希不可逆
+
+oryxos-web/
+├── src/main/java/io/oryxos/web/
+│   ├── config/
+│   │   ├── WebApiKeyProperties.java     # 新增：oryxos.web.apikey.enabled（默认 false）
+│   │   └── ApiKeyFilterConfig.java      # 新增：FilterRegistrationBean，addUrlPatterns("/api/v1/*")
+│   └── security/
+│       ├── ApiKeyAuthFilter.java        # 新增：豁免判定 + Key 校验 + session 互认 + 401
+│       └── ApiKeyStartupCheck.java      # 新增：两条 WARN（无 Key / auth 未开），不阻断
+└── src/test/java/io/oryxos/web/security/
+    └── ApiKeyAuthFilterTest.java        # 新增：路径裁决表全覆盖（MockMvc）
+
+oryxos-cli/
+└── src/main/java/io/oryxos/cli/command/
+    └── ApiKeyCommand.java               # 新增：apikey add/list/revoke（镜像 UserCommand）
+    # 修改：主入口 @Command subcommands 注册 ApiKeyCommand
+
+oryxos-boot/
+└── src/test/java/io/oryxos/boot/
+    └── ApiKeyAuthE2ETest.java           # 新增：quickstart V1~V5 端到端（镜像 AuditDashboardE2ETest）
+```
+
+**Structure Decision**: 三个既有模块各归其位——凭证实体与校验逻辑在 oryxos-storage（与 `WebUserService` 并列，CLI 与 web 共用）；filter/配置/启动校验在 oryxos-web（与 012 的 `BasicAuthFilter` 并列）；CLI 子命令在 oryxos-cli。不新建模块、不碰 oryxos-core（认证是 web 边缘关注点，非跨模块契约）。`ApiKeyAuthFilter` 与 `BasicAuthFilter` 同包，package-private 的 `SESSION_COOKIE` 常量直接可见——012 代码零改动（比原计划的可见性调整更干净）。
+
+## 关键设计裁决（详见 research.md）
+
+| # | 裁决 | 要点 |
+|---|------|------|
+| R1 | Key 格式与哈希 | `oryx_`+42 位 base62（~250bit 熵）；SHA-256 非 BCrypt（高熵 Key 快哈希是业界标准，BCrypt 击穿 SC-003） |
+| R2 | 校验查找 | 先 SHA-256 再按哈希索引查库 + `MessageDigest.isEqual` 复核；不存在/已吊销同路径同响应 |
+| R3 | Filter 挂载 | `FilterRegistrationBean("/api/v1/*")`；豁免：health、auth 子树、OPTIONS；与 012 filter 互不重叠 |
+| R4 | session 互认 | 复用 `WebSessionService.findValid`，零新增件 |
+| R5 | 存储 | schema.sql 新表 + JPA 三件套镜像 WebUser；无需 SchemaUpgrade 类 |
+| R6 | last_used 节流 | 60s 内存节流防 SQLite 写放大；更新失败不阻断 |
+| R7 | 启动校验 | `ApplicationRunner` + `@ConditionalOnWebApplication(SERVLET)`；只 WARN 不抛（与 012 fail-fast 的差异有意，见 research） |
+| R8 | CLI | 镜像 `UserCommand`：一次性 Spring 上下文 + `WebApplicationType.NONE` |
+| R9 | 401 形态 | 统一信封 + `WWW-Authenticate: Bearer`；失败原因只进 DEBUG 日志且只记前缀 |

--- a/specs/018-rest-api-key/quickstart.md
+++ b/specs/018-rest-api-key/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart: REST API Key 认证验收
+
+**Feature**: 018-rest-api-key | 契约详见 [contracts/auth-contract.md](contracts/auth-contract.md)
+
+## 前置
+
+```bash
+mvn -q -DskipTests package          # 构建 fat JAR
+alias oryxos='java -jar oryxos-boot/target/oryxos-boot-*.jar'
+```
+
+## V1 — 回归零破坏（US1 场景 1 / SC-001）
+
+```bash
+# 默认配置（apikey.enabled 缺省 false）启动 serve
+oryxos serve --port 8080 &
+curl -s http://localhost:8080/api/v1/profiles     # 期望：200，无凭据可访问，与现状一致
+```
+
+## V2 — 生成 Key（US1 场景 2 / SC-005）
+
+```bash
+oryxos apikey add ci-bot
+# 期望：终端显示一次 oryx_ 开头明文 + 「仅显示这一次」警告
+sqlite3 .oryxos/oryxos.db "SELECT name, key_prefix, key_hash FROM api_keys;"
+# 期望：只有 64 位 hex 哈希与前缀，无明文
+oryxos apikey add ci-bot                          # 期望：重名报错，非零退出码
+```
+
+## V3 — 锁门生效（US1 场景 3/4 / SC-002）
+
+```bash
+# config/application.yml 置 oryxos.web.apikey.enabled: true 后重启 serve
+KEY=<V2 输出的明文>
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/api/v1/profiles                          # 401
+curl -s -o /dev/null -w '%{http_code}\n' -H "X-API-Key: wrong" http://localhost:8080/api/v1/profiles    # 401（响应体与上行一致）
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $KEY" http://localhost:8080/api/v1/profiles  # 200
+curl -s -o /dev/null -w '%{http_code}\n' -H "X-API-Key: $KEY" http://localhost:8080/api/v1/profiles     # 200（双写法等效）
+```
+
+## V4 — 生命周期（US2 / SC-004）
+
+```bash
+oryxos apikey add report                          # 第二把 Key
+oryxos apikey list                                # 两行，含 PREFIX/STATUS/LAST_USED_AT，无明文
+oryxos apikey revoke ci-bot
+curl -s -o /dev/null -w '%{http_code}\n' -H "X-API-Key: $KEY" http://localhost:8080/api/v1/profiles      # 401（即时生效）
+curl -s -o /dev/null -w '%{http_code}\n' -H "X-API-Key: $REPORT_KEY" http://localhost:8080/api/v1/profiles  # 200（互不影响）
+oryxos apikey revoke ghost                        # 期望：报错，非零退出码
+```
+
+## V5 — 共存回归（US3 / SC-006）
+
+```bash
+# 双开：oryxos.web.apikey.enabled=true 且 oryxos.web.auth.enabled=true（需先 oryxos user add admin）
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/api/v1/health   # 200（探活豁免）
+curl -s -X POST http://localhost:8080/api/v1/auth/login -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"<pw>"}'                                  # 200（auth 子树照旧）
+# 浏览器：登录 /admin/ 后打开 Agent/审计/渠道各数据页 → 全部正常加载（session 即凭据）
+# 预检：curl -s -o /dev/null -w '%{http_code}\n' -X OPTIONS http://localhost:8080/api/v1/profiles → 非 401
+```
+
+## V6 — 启动告警（FR-012）
+
+```bash
+# ① apikey.enabled=true 但库无有效 Key（全部吊销后）重启 → 日志有 WARN 提示 apikey add，启动成功
+# ② apikey.enabled=true 且 auth.enabled=false 重启 → 日志有「管理台数据页面将不可用」WARN，启动成功
+```
+
+## 质量门禁
+
+```bash
+mvn verify      # Spotless + P3C + Checkstyle + SpotBugs/FindSecBugs + OWASP 全绿
+```

--- a/specs/018-rest-api-key/research.md
+++ b/specs/018-rest-api-key/research.md
@@ -1,0 +1,68 @@
+# Research: REST API Key 认证
+
+**Feature**: 018-rest-api-key | **Date**: 2026-08-26
+
+技术上下文无 NEEDS CLARIFICATION；本文记录关键技术选型的裁决与理由，全部基于对 012-web-auth 既有实现的实地摸底（`BasicAuthFilter`、`WebAuthProperties`、`AuthFilterConfig`、`AuthStartupCheck`、`UserCommand`、`WebUserService`、`schema.sql`）。
+
+## R1. Key 格式与哈希算法
+
+**Decision**: Key 明文 = 固定前缀 `oryx_` + 42 位 base62 随机串（`SecureRandom`，约 250 bit 熵）。持久化存 SHA-256 十六进制哈希；`key_prefix` 列存 `oryx_` + 随机部分前 8 位，供 list/日志对账。
+
+**Rationale**:
+- 固定前缀让密钥扫描工具（secret scanning）可识别，符合业界惯例（GitHub `ghp_`、Stripe `sk_` 同型）。
+- 哈希选 SHA-256 而非 BCrypt：BCrypt 的慢哈希是为低熵人类密码设计的，对 250 bit 高熵随机 Key 无增益，反而每请求 ~100ms 的代价直接击穿 SC-003（认证开销无感）。GitHub/Stripe 对 token 同样用快哈希。
+- 012 的 `WebUserService` 用 BCrypt 是对的（人类密码），两者口径不同，各自正确。
+
+**Alternatives considered**: BCrypt（否——性能不可接受且无安全增益）；明文存储+库加密（否——违反 spec FR-007 与宪法 VI）。
+
+## R2. 校验查找与恒定时间比较（FR-010）
+
+**Decision**: 收到请求先对明文 Key 计算 SHA-256，再按哈希值查库（`key_hash` 唯一索引），命中后用 `MessageDigest.isEqual` 复核。
+
+**Rationale**: 攻击者无法通过构造输入探测哈希值的逐字节差异——输入先经 SHA-256 单向变换，数据库索引比较的计时信息不构成可利用的逐位 oracle（业界 token 校验标准做法）。`MessageDigest.isEqual` 兜底恒定时间复核。不存在的 Key 与已吊销的 Key 走同一失败路径、同一响应（防探测，FR-004/Edge Case）。
+
+**Alternatives considered**: 按 `key_prefix` 查候选再逐一恒时比较（否——多此一举，前缀仅 8 位随机会撞车）；全表扫描恒时比较（否——O(n) 无必要）。
+
+## R3. Filter 挂载方式与豁免清单
+
+**Decision**: 新建 `ApiKeyAuthFilter extends OncePerRequestFilter`，经 `FilterRegistrationBean` 以 `addUrlPatterns("/api/v1/*")` 注册（镜像 012 的 `AuthFilterConfig` 模式）。豁免在 filter 内判定：`/api/v1/health`、`/api/v1/auth/` 前缀、HTTP `OPTIONS` 方法（CORS 预检，FR-014）。
+
+**Rationale**: 与 `BasicAuthFilter`（只拦 `/admin/*`）URL 模式互不重叠，两个 filter 各管一扇门、互不感知，`/admin/**` 天然不受影响（FR-002）。豁免清单短且稳定，放 filter 内白名单即可，无需可配置化（YAGNI）。
+
+**Alternatives considered**: 引 Spring Security 全套（否——012 已裁决只用 spring-security-crypto，全套对两条路径的需求过重）；拦截器 HandlerInterceptor（否——filter 在 DispatcherServlet 之前，与 012 同层，且能覆盖非 handler 请求）。
+
+## R4. 管理台 session 互认（FR-011，Clarifications Q1）
+
+**Decision**: `ApiKeyAuthFilter` 在 Key 校验失败/缺失时，读取 `oryxos_session` cookie → `WebSessionService.findValid`，有效即放行。复用 `BasicAuthFilter.authenticatedBySession` 同款逻辑（cookie 名常量提为共享）。
+
+**Rationale**: `WebSessionService` 在 oryxos-storage，oryxos-web 已依赖，零新增件；session 校验是一次索引查询，不增可感知延迟。
+
+## R5. 存储与 schema
+
+**Decision**: `api_keys` 新表进 `oryxos-storage/src/main/resources/schema.sql`（`CREATE TABLE IF NOT EXISTS`，新表非 ALTER，存量库无迁移风险，FR-013）；JPA 实体 `ApiKey` + `ApiKeyRepository` + `ApiKeyService`（镜像 `WebUser` 三件套，业务逻辑收在 service：生成、校验、吊销、盘点）。
+
+**Rationale**: 与 012 的 `web_users`/`web_sessions` 完全同构；无需新的 SchemaUpgrade 类（那是给 ALTER 场景用的）。
+
+## R6. last_used_at 更新节流（FR-009）
+
+**Decision**: 校验通过后在同一请求线程内同步更新 `last_used_at`（宪法 VII：不引入异步编程模型），并做内存节流：同一把 Key 距上次落库不足 60 秒则跳过。更新失败只记日志，不阻断请求。
+
+**Rationale**: SQLite 单写者，逐请求写会造成写放大并与业务写竞争；「最近使用时间」是治理信号，分钟级精度足够。内存节流表是缓存不是状态，重启丢失无害（宪法 VIII 不冲突）。
+
+## R7. 配置与启动校验（FR-001/FR-012，Clarifications Q2）
+
+**Decision**: 新建 `WebApiKeyProperties`（prefix `oryxos.web.apikey`，仅 `enabled`，默认 false）。新建 `ApiKeyStartupCheck implements ApplicationRunner` + `@ConditionalOnWebApplication(SERVLET)`（镜像 `AuthStartupCheck`），但两种异常组合都只 `LOG.warn` 不抛异常：① enabled 但无有效 Key；② enabled 但 `oryxos.web.auth.enabled=false`。
+
+**Rationale**: 与 `AuthStartupCheck` 的差异是有意的——012 无账号开 auth 等于永久锁死管理台故 fail-fast；018 无 Key 开门禁是「全拒」的安全状态而非坏状态，且 CLI 生成 Key 不依赖 serve 存活，告警即可（Clarifications Q2 裁决）。`SERVLET` 条件同样必要：`oryxos apikey add` 用 `WebApplicationType.NONE` 起 Spring，不能被 web 侧检查波及。
+
+## R8. CLI 子命令
+
+**Decision**: 新建 `ApiKeyCommand`（`oryxos apikey`，子命令 add/list/revoke），完整镜像 `UserCommand` 骨架：每个 leaf 自起一次性 Spring 上下文（`WebApplicationType.NONE`），`context.getBean(ApiKeyService.class)` 干活。`add` 成功后打印明文 Key 一次并附「仅显示这一次」警告；`list` 输出 NAME / PREFIX / STATUS / CREATED_AT / LAST_USED_AT。
+
+**Rationale**: 与 `oryxos user` 心智模型一致（FR-005 明确要求）；明文只经 stdout、不落日志。
+
+## R9. 401 响应形态
+
+**Decision**: 401 + 统一信封 `ApiResponse.error(401, "Unauthorized")` + `WWW-Authenticate: Bearer realm="OryxOS"`。所有失败原因（无 Key/格式错/不存在/已吊销）同一响应；具体原因仅 DEBUG 级日志且只记 Key 前缀。
+
+**Rationale**: 与 `BasicAuthFilter` 的 401 口径一致（信封复用）；`Bearer` 挑战头符合 RFC 6750，成本为零。防探测与防明文入日志由同一响应 + 前缀脱敏保障（FR-004/FR-006）。

--- a/specs/018-rest-api-key/spec.md
+++ b/specs/018-rest-api-key/spec.md
@@ -1,0 +1,128 @@
+# Feature Specification: REST API Key 认证
+
+**Feature Branch**: `018-rest-api-key`
+
+**Created**: 2026-08-26
+
+**Status**: Draft
+
+**Input**: User description: "REST API Key 认证（018-rest-api-key）：为 /api/v1/** REST 端点加上 API Key 机器调用认证，补齐 v0.2「把门锁上」缺角（012-web-auth 已明确 REST API Key 为后续独立 PR）。要点：feature flag 默认关，回归零破坏；Key 由管理员通过 CLI（oryxos apikey 子命令）生成/吊销，SQLite 存哈希不存明文；调用方通过请求头携带 Key；开启后未带 Key 或 Key 无效的 /api/v1/** 调用返回 401；/api/v1/health 保持免认证（探活）；/api/v1/auth/* 管理台登录子树维持现状；管理台 /admin/** 的 012 session/Basic Auth 体系不受影响；RBAC/多租户不做（留到 v1.0）。"
+
+## Clarifications
+
+### Session 2026-08-26
+
+- Q: API Key 认证开启后，管理台 SPA 调 `/api/v1/**` 数据接口如何放行？ → A: session 即凭据——带有效管理台 session 的请求视同通过认证，API Key 与 session 任一有效即放行（不给 SPA 发内置 Key，不新增密钥暴露面）。
+- Q: apikey 开启但管理台认证关闭的组合，启动时怎么处理？ → A: 告警不阻断——启动成功并输出「管理台数据页面将不可用」清晰警告；纯机器调用部署是合法场景，不 fail-fast。
+- Q: API Key 是否支持自动过期？ → A: 不做过期——本期只做手动吊销，不加 `expires_at` 字段，留待真实企业需求出现后按需引入。
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 把 REST 大门锁上（Priority: P1）
+
+运维管理员不想让 REST API 在内网裸奔。他用 CLI 生成一把 API Key（明文只在生成那一刻显示一次），把 Key 交给调用方业务系统，改配置开启 API Key 认证并重启。此后：调用方在请求头带上 Key 就能正常调 `/api/v1/**`；不带 Key、带错 Key 的请求一律被拒（401）。不开启时，一切行为与现状完全一致。
+
+**Why this priority**: 这是本 feature 存在的唯一理由——「API 裸奔过不了企业安全评审」是 v0.2 路线图明确要补的缺角，012-web-auth 已把管理台锁上，REST 机器调用是最后一扇没锁的门。锁门 + 发钥匙 + 验钥匙构成最小闭环，单独交付即有价值。
+
+**Independent Test**: 默认配置启动 → `/api/v1/profiles` 无凭据可访问（现状回归）；跑 `oryxos apikey add ci-bot` → 终端显示一次明文 Key，数据库里只有哈希；开启认证并重启 → 无 Key 调 `/api/v1/profiles` 得 401，带对 Key 得 200，带错 Key 得 401。
+
+**Acceptance Scenarios**:
+
+1. **Given** 认证开关保持默认（关闭），**When** 无任何凭据调用任意 `/api/v1/**` 端点，**Then** 行为与本 feature 之前完全一致（回归零破坏）。
+2. **Given** 管理员执行 `oryxos apikey add <name>`，**When** 命令成功，**Then** 终端显示完整明文 Key 一次并明确提示「仅显示这一次」，持久化存储中只有不可逆哈希，无明文。
+3. **Given** 认证已开启且存在有效 Key，**When** 请求头携带该 Key 调用 `/api/v1/**`，**Then** 请求正常处理，与未开启认证时的响应一致。
+4. **Given** 认证已开启，**When** 请求不带 Key、带格式错误的 Key 或带不存在的 Key，**Then** 返回 401 与统一错误响应体，不泄露「Key 是否存在/是否曾存在」等区分信息。
+5. **Given** 认证已开启但系统中没有任何有效 Key，**When** 系统启动，**Then** 启动成功但输出清晰警告（提示先用 CLI 生成 Key），此时所有需认证请求返回 401。
+
+---
+
+### User Story 2 - Key 生命周期管理（Priority: P2）
+
+管理员为每个调用方（CI 机器人、报表系统、第三方集成）各发一把 Key。某个调用方下线或 Key 疑似泄露时，管理员用 CLI 吊销那一把 Key，其余调用方不受影响；吊销立即生效。管理员随时能列出所有 Key 的名称、标识前缀、状态与最近使用时间，但永远看不到明文。
+
+**Why this priority**: 只有一把永久钥匙的门等于换锁要通知所有人。按调用方发 Key、单独吊销、可盘点，是「锁上之后管得住」的最小治理配套；没有它，泄露一次就要全量换 Key。
+
+**Independent Test**: 生成两把 Key（`ci-bot`、`report`）→ `oryxos apikey list` 显示两行（名称、前缀、创建时间、最近使用时间、状态，无明文）→ `oryxos apikey revoke ci-bot` → `ci-bot` 的 Key 下一次请求即 401，`report` 的 Key 仍正常。
+
+**Acceptance Scenarios**:
+
+1. **Given** 已存在多把有效 Key，**When** 各调用方用各自的 Key 请求，**Then** 全部正常通过，互不干扰。
+2. **Given** 管理员执行 `oryxos apikey revoke <name>`，**When** 被吊销的 Key 再次用于请求，**Then** 返回 401；其它 Key 不受影响。
+3. **Given** 已有若干 Key（含已吊销的），**When** 执行 `oryxos apikey list`，**Then** 输出每把 Key 的名称、可辨识前缀、创建时间、最近使用时间与状态（有效/已吊销），全程无明文。
+4. **Given** 请求成功通过某把 Key 认证，**When** 之后查看该 Key，**Then** 其「最近使用时间」已更新（供管理员识别僵尸 Key）。
+5. **Given** 尝试用已存在的名称再次 `apikey add`，**When** 命令执行，**Then** 给出清晰报错，不覆盖已有 Key。
+
+---
+
+### User Story 3 - 与既有体系无冲突共存（Priority: P3）
+
+开启 API Key 认证后，其它入口一切照旧：K8s/负载均衡的探活继续无凭据打 `/api/v1/health`；管理台用户照常登录（`/api/v1/auth/*` 走账密），登录后的管理台页面继续正常调 REST 数据接口（浏览器 session 视同有效凭据）；`/admin/**` 的 012 认证体系（Basic Auth + session）完全不受影响。
+
+**Why this priority**: 这是「锁门不能把自己人锁在外面」的回归保障。价值在于不破坏，而非新增能力，故排最后；但不满足它，前两个故事就不能上生产。
+
+**Independent Test**: 开启 API Key 认证（管理台认证也开启）→ 无凭据 curl `/api/v1/health` 得 200；浏览器登录管理台后打开各数据页面，全部正常加载（无 401）；无凭据 POST `/api/v1/auth/login`（正确账密）仍可登录；`/admin/**` 的行为与 012 验收时一致。
+
+**Acceptance Scenarios**:
+
+1. **Given** API Key 认证已开启，**When** 无凭据请求 `/api/v1/health`，**Then** 返回 200（探活豁免）。
+2. **Given** API Key 认证已开启，**When** 无 API Key 请求 `/api/v1/auth/*` 子树（登录/登出/me），**Then** 行为与 012 现状一致（这些端点本就靠自身逻辑校验）。
+3. **Given** API Key 认证与管理台认证均开启，**When** 已登录的管理台页面（携带有效 session）调用 `/api/v1/**` 数据接口，**Then** 请求正常通过，管理台功能 100% 可用。
+4. **Given** API Key 认证已开启但管理台认证关闭，**When** 系统启动，**Then** 输出清晰警告：此组合下管理台数据页面将不可用（浏览器无 session 也无 Key），建议同时开启管理台认证。
+5. **Given** API Key 认证已开启，**When** 访问 `/admin/**` 静态资源与登录页，**Then** 行为与 012 现状完全一致（API Key 门禁不覆盖 `/admin/**`）。
+
+---
+
+### Edge Cases
+
+- 明文 Key 在创建后任何时刻（list、日志、审计、报错信息）都不得再出现；日志与错误信息中出现的 Key 相关内容只允许名称与可辨识前缀。
+- 认证开启且请求携带的 Key 恰好是「已吊销」的 Key：返回 401，且响应与「从不存在的 Key」不可区分（防探测）。
+- Key 校验必须能抵抗计时侧信道：无论 Key 存在与否、格式对错，校验耗时不应有可利用的差异。
+- 请求同时携带 API Key 与管理台 session：任一有效即放行；两者皆无效返回 401。
+- `oryxos apikey revoke` 一个不存在的名称：清晰报错，退出码非零。
+- 浏览器跨域预检（OPTIONS）请求不携带自定义头：预检请求不做 Key 校验，实际请求照常校验（否则合法跨域调用方永远过不了预检）。
+- 存量数据库升级：首次以新版本启动时自动补建 Key 存储表，旧库无损（沿用既有 schema 升级模式，不依赖 ORM 自动迁移）。
+- 认证关闭但库里已有 Key：Key 静默不生效，不报错（开关是唯一裁决）。
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 系统 MUST 提供独立 feature flag（`oryxos.web.apikey.enabled`），默认 `false`。关闭时 `/api/v1/**` 与 CLI 之外的一切行为与现状 100% 一致（回归零破坏）；该开关与 012 的 `oryxos.web.auth.enabled` 相互独立。
+- **FR-002**: flag 开启时，系统 MUST 对 `/api/v1/**` 全部端点实施 API Key 认证，豁免清单仅限：`/api/v1/health`（探活）与 `/api/v1/auth/*` 子树（维持 012 现状，由端点自身逻辑校验）。`/admin/**` MUST 完全不受本 feature 影响。
+- **FR-003**: 调用方 MUST 能通过请求头携带 Key：`Authorization: Bearer <key>` 或 `X-API-Key: <key>` 二选一，两种写法等效。
+- **FR-004**: 认证失败（无 Key / 格式错误 / 不存在 / 已吊销）MUST 统一返回 HTTP 401 与项目统一错误响应体；响应内容 MUST NOT 泄露失败的具体原因类别（防探测），具体原因只进服务端日志（脱敏）。
+- **FR-005**: 管理员 MUST 能通过 CLI 管理 Key 全生命周期：`oryxos apikey add <name>`（生成）、`oryxos apikey list`（盘点）、`oryxos apikey revoke <name>`（吊销）。命令风格与既有 `oryxos user` 子命令一致。
+- **FR-006**: 生成的 Key MUST 为高熵随机值并带可辨识固定前缀（便于在日志/密钥扫描中识别其为 OryxOS Key）；明文 MUST 仅在 `apikey add` 成功输出中出现一次，此后系统任何界面、日志、存储中 MUST NOT 再出现明文。
+- **FR-007**: 持久化 MUST 只存 Key 的不可逆哈希与元数据（名称、可辨识前缀、创建时间、最近使用时间、吊销时间）；名称 MUST 唯一，重名创建 MUST 拒绝。
+- **FR-008**: 吊销 MUST 即时生效——吊销完成后的下一次请求即被拒，无缓存窗口；吊销一把 Key MUST NOT 影响其它 Key。
+- **FR-009**: Key 校验通过后系统 MUST 更新该 Key 的最近使用时间；更新失败 MUST NOT 阻断业务请求。
+- **FR-010**: Key 比对 MUST 使用恒定时间比较，杜绝计时侧信道；对不存在的 Key 与存在但错误的 Key，处理路径耗时 MUST 无可利用差异。
+- **FR-011**: flag 开启且管理台认证（012）也开启时，携带有效管理台 session 的请求 MUST 视同通过认证（管理台 SPA 不因锁门而不可用）；API Key 与 session 任一有效即放行。
+- **FR-012**: 启动校验：flag 开启但库中无任何有效 Key 时 MUST 启动成功并输出清晰警告（附 CLI 生成提示）；flag 开启但管理台认证关闭时 MUST 输出「管理台数据页面将不可用」的清晰警告。均不静默。
+- **FR-013**: Key 存储表 MUST 走既有手工 schema 升级模式（不依赖 ORM 自动迁移），存量数据库首次启动自动补建，旧数据无损。
+- **FR-014**: 跨域预检（OPTIONS）请求 MUST 豁免 Key 校验；对应实际请求照常校验。
+
+### Key Entities
+
+- **ApiKey**: 一把机器调用凭证。属性：名称（管理员命名、全局唯一，标识调用方）、可辨识前缀（明文 Key 的头部片段，供盘点与日志对账）、凭证哈希（不可逆，无明文）、创建时间、最近使用时间（可空）、吊销时间（可空；非空即失效）。与 012 的 WebUser（人的账密）相互独立，互不引用。
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 默认配置（flag 关闭）下，既有全量测试与手工回归 100% 通过，任何端点行为无差异。
+- **SC-002**: flag 开启后，无凭据或无效凭据请求非豁免 `/api/v1/**` 端点，100% 返回 401；有效 Key 请求 100% 正常返回。
+- **SC-003**: 携带有效 Key 的请求相对未开启认证时的额外延迟对调用方无感（同环境对比无可感知差异）。
+- **SC-004**: 吊销操作完成后，被吊销 Key 的下一次请求即被拒（零缓存窗口）；其余 Key 100% 不受影响。
+- **SC-005**: 明文 Key 全生命周期只出现一次（生成命令输出）；存储、日志、list 输出、错误响应中明文出现次数为 0。
+- **SC-006**: 双认证（API Key + 管理台认证）全开时，管理台全部页面与操作 100% 可用；`/api/v1/health` 无凭据探活 100% 可用。
+- **SC-007**: 管理员从零开始完成「生成 Key → 开启认证 → 调用方接入」全流程不超过 5 分钟（含重启）。
+
+## Assumptions
+
+- **请求头形态**：采用业界通行的 `Authorization: Bearer` 与 `X-API-Key` 双写法等效支持（后者与项目出站 HTTP 工具已有的 `X-API-Key` 约定一致），不引入查询参数携带 Key（易进访问日志，不安全）。
+- **管理台兼容取「session 即凭据」**：管理台 SPA 与 REST 同源同端口，锁 `/api/v1/**` 必然波及 SPA 数据请求；选择「有效 session 视同凭据」而非给 SPA 发内置 Key，因为前者不新增密钥暴露面。flag 开启而管理台认证关闭的组合仅告警不阻断——纯机器调用部署（不用管理台）是合法场景。
+- **Key 不设过期时间**：本期只做手动吊销，不做自动过期/轮换（留待后续治理版本按需加），避免为低频需求引入定时失效复杂度。
+- **不做的**：RBAC、多租户、按 Key 限流、按 Key 细分端点权限（全部留到 v1.0 租户模型定型后）；管理台的 Key 管理页面（本期 CLI-only，管理台页面可后续独立加）；`/api/v1/auth/*` 行为变更（维持 012 现状）。
+- **审计口径**：Key 使用情况以「最近使用时间」为最小可用治理信号；不为每次认证单独落审计表（认证不是工具调用/LLM 调用，沿用现有两张审计表口径不变）。
+- **依赖**：复用 012-web-auth 落地的配置体系、统一错误响应体、CLI 子命令骨架与 SQLite 手工 schema 升级模式。

--- a/specs/018-rest-api-key/tasks.md
+++ b/specs/018-rest-api-key/tasks.md
@@ -1,0 +1,155 @@
+# Tasks: REST API Key 认证
+
+**Input**: Design documents from `/specs/018-rest-api-key/`
+
+**Prerequisites**: plan.md、spec.md、research.md（R1~R9）、data-model.md、contracts/auth-contract.md、quickstart.md
+
+**Tests**: 包含测试任务——项目质量门禁要求核心逻辑有单测覆盖（宪法「开发流程与质量门禁」），且 018 是安全特性，路径裁决表必须测试全覆盖。
+
+**Organization**: 按用户故事分组；US1 为 MVP（锁门最小闭环），US2/US3 依次叠加。
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: 可并行（不同文件、无未完成依赖）
+- **[Story]**: 所属用户故事（US1/US2/US3）
+
+## Path Conventions
+
+Maven 多模块单体，涉及 oryxos-storage / oryxos-web / oryxos-cli / oryxos-boot 四个既有模块（见 plan.md「Source Code」）。
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: 表结构先行——所有后续任务的存储前提
+
+- [X] T001 在 oryxos-storage/src/main/resources/schema.sql 末尾追加 `api_keys` 表（DDL 见 data-model.md；`CREATE TABLE IF NOT EXISTS`，`key_hash` UNIQUE 自带隐式索引无需显式建索引，注释注明 018、新表非 ALTER 无迁移风险，镜像 `web_users` 段落的注释风格）
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: 凭证实体与校验服务——三个故事共同依赖的核心
+
+**⚠️ CRITICAL**: 本阶段完成前不得开始任何用户故事
+
+- [X] T002 [P] 新建 JPA 实体 oryxos-storage/src/main/java/io/oryxos/storage/ApiKey.java（字段映射见 data-model.md；镜像 WebUser.java 的注解与 SuppressFBWarnings 风格）
+- [X] T003 [P] 新建 oryxos-storage/src/main/java/io/oryxos/storage/ApiKeyRepository.java（Spring Data JPA：`findByKeyHash`、`findByName`、`existsByName`、`findAll`）
+- [X] T004 新建 oryxos-storage/src/main/java/io/oryxos/storage/ApiKeyService.java（依赖 T002/T003）：`create(name)` 生成 `oryx_`+42 位 base62 明文（SecureRandom）→ 落 SHA-256 hex 与前缀 → 返明文仅此一次，重名抛清晰异常；`verify(plaintext)` 先 SHA-256 再 `findByKeyHash` + `MessageDigest.isEqual` 复核 + `revoked_at` 判定，通过后 60s 内存节流更新 `last_used_at`（更新失败仅日志不抛，FR-009/R6）；`revoke(name)` 写 `revoked_at`（幂等）；`list()`；`hasActiveKey()`。全程日志只记前缀（R1/R2/R6）
+- [X] T005 [P] 新建单测 oryxos-storage/src/test/java/io/oryxos/storage/ApiKeyServiceTest.java：明文格式（前缀/长度/字符集）、库中无明文只有 64 位 hex、verify 对/错/不存在/已吊销四路、revoke 即时生效与幂等、重名拒绝、last_used 节流（60s 内不重写）
+- [X] T006 [P] 新建 oryxos-web/src/main/java/io/oryxos/web/config/WebApiKeyProperties.java（prefix `oryxos.web.apikey`，仅 `enabled` 默认 false）并在 WebAuthConfig.java（或镜像其注册方式）完成配置绑定注册
+
+**Checkpoint**: `ApiKeyService` 单测全绿——故事实现可以开始
+
+---
+
+## Phase 3: User Story 1 - 把 REST 大门锁上 (Priority: P1) 🎯 MVP
+
+**Goal**: CLI 生成 Key（明文一次）→ 开 flag → 无 Key/错 Key 401、对 Key 200；flag 默认关回归零破坏
+
+**Independent Test**: quickstart V1~V3——默认配置 `/api/v1/profiles` 无凭据 200；`apikey add` 显示明文一次且库中只有哈希；开 flag 后 401/200 按契约裁决
+
+- [X] T007 [US1] 新建 oryxos-web/src/main/java/io/oryxos/web/security/ApiKeyAuthFilter.java（依赖 T004/T006）：`enabled=false` 直接放行；解析 `Authorization: Bearer` 与 `X-API-Key` 双写法（FR-003）；`ApiKeyService.verify` 通过放行；失败统一 401——`ApiResponse.error(401,"Unauthorized")` + `WWW-Authenticate: Bearer realm="OryxOS"`，所有失败原因同一响应（FR-004/R9）；filter 内不抛异常直接写响应（镜像 BasicAuthFilter 的 javadoc 说明与 SuppressFBWarnings 风格）
+- [X] T008 [US1] 新建 oryxos-web/src/main/java/io/oryxos/web/config/ApiKeyFilterConfig.java：`FilterRegistrationBean<ApiKeyAuthFilter>` + `addUrlPatterns("/api/v1/*")`（镜像 AuthFilterConfig.java；javadoc 注明与 012 的 `/admin/*` 模式互不重叠）
+- [X] T009 [US1] 新建 oryxos-cli/src/main/java/io/oryxos/cli/command/ApiKeyCommand.java：`@Command(name="apikey")` 骨架 + `add` 子命令（镜像 UserCommand 的 withService 一次性 Spring 上下文模式；成功输出明文 + 「This is the ONLY time…」警告，契约见 contracts/auth-contract.md §2）
+- [X] T010 [US1] 在 oryxos-cli/src/main/java/io/oryxos/cli/OryxOsCli.java 的 subcommands 注册 ApiKeyCommand.class（依赖 T009）
+- [X] T011 [P] [US1] 新建 oryxos-web/src/test/java/io/oryxos/web/security/ApiKeyAuthFilterTest.java（依赖 T007/T008）：flag 关放行、无 Key 401、错 Key 401、对 Key 放行、Bearer 与 X-API-Key 等效、401 响应体与挑战头断言、错误响应不可区分（无 Key vs 错 Key vs 已吊销同体）
+
+**Checkpoint**: quickstart V1~V3 可走通——MVP 可交付
+
+---
+
+## Phase 4: User Story 2 - Key 生命周期管理 (Priority: P2)
+
+**Goal**: 多 Key 并存互不干扰；`list` 盘点无明文；`revoke` 即时生效
+
+**Independent Test**: quickstart V4——两把 Key 并存、吊销一把另一把不受影响、list 输出 NAME/PREFIX/STATUS/CREATED_AT/LAST_USED_AT
+
+- [X] T012 [US2] 在 oryxos-cli/src/main/java/io/oryxos/cli/command/ApiKeyCommand.java 增加 `list` 子命令（表格输出契约见 contracts/auth-contract.md §2：无明文、空表提示 `Run 'oryxos apikey add <name>'…`）与 `revoke` 子命令（成功提示、不存在报错非零退出码、重复吊销幂等提示）
+- [X] T013 [P] [US2] 新建 CLI 侧行为单测 oryxos-cli/src/test/java/io/oryxos/cli/command/ApiKeyCommandTest.java（如既有 CLI 测试模式不适用则并入 T005 的 service 层断言并在本任务注明）：list 输出含前缀无明文、revoke 不存在名称的错误路径。**注明**：条件触发——CLI 子命令自起完整 Spring 上下文（镜像 UserCommand，其同样无独立单测），断言已并入 T005（list 无明文/revoke not found），CLI 面行为由真机走查 V2/V4 覆盖（见 acceptance-report.md）
+- [X] T014 [US2] 多 Key 并存集成断言：在 oryxos-web/src/test/java/io/oryxos/web/security/ApiKeyAuthFilterTest.java 追加——两把 Key 各自可过、吊销 A 后 A 401 且 B 仍 200（SC-004）
+
+**Checkpoint**: quickstart V4 可走通——US1+US2 独立可测
+
+---
+
+## Phase 5: User Story 3 - 与既有体系无冲突共存 (Priority: P3)
+
+**Goal**: health/auth 子树/OPTIONS 豁免；管理台 session 互认；两条启动 WARN；`/admin/**` 零影响
+
+**Independent Test**: quickstart V5~V6——探活无凭据 200、登录后管理台数据页正常、异常 flag 组合启动成功且 WARN 在日志
+
+- [X] T015 [US3] 在 oryxos-web/src/main/java/io/oryxos/web/security/ApiKeyAuthFilter.java 增加豁免判定：HTTP `OPTIONS`、`/api/v1/health`、`/api/v1/auth/` 前缀直接放行（FR-002/FR-014，裁决表见 contracts/auth-contract.md §1）
+- [X] T016 [US3] 管理台 session 互认（FR-011/R4）：将 oryxos-web/src/main/java/io/oryxos/web/security/BasicAuthFilter.java 的 `SESSION_COOKIE` 常量提升为共享（public 或抽至 security 包内常量类，012 其余逻辑零改动），ApiKeyAuthFilter 在 Key 缺失/无效时读 `oryxos_session` cookie → `WebSessionService.findValid` 有效即放行
+- [X] T017 [P] [US3] 新建 oryxos-web/src/main/java/io/oryxos/web/security/ApiKeyStartupCheck.java（镜像 AuthStartupCheck：`ApplicationRunner` + `@ConditionalOnWebApplication(SERVLET)`）：`enabled=true` 且 `!hasActiveKey()` → WARN 提示 `oryxos apikey add`；`enabled=true` 且 `oryxos.web.auth.enabled=false` → WARN 管理台数据页将不可用；均不抛异常（FR-012/R7，javadoc 说明与 012 fail-fast 的差异理由）。同任务新建配套单测 oryxos-web/src/test/java/io/oryxos/web/security/ApiKeyStartupCheckTest.java：两分支各断言 WARN 产生且 run() 不抛、正常配置无 WARN
+- [X] T018 [P] [US3] 在 oryxos-web/src/test/java/io/oryxos/web/security/ApiKeyAuthFilterTest.java 追加豁免与互认用例：OPTIONS 放行、health 放行、auth 子树放行、有效 session 无 Key 放行、无效 session 无 Key 401
+- [X] T019 [US3] 新建端到端测试 oryxos-boot/src/test/java/io/oryxos/boot/ApiKeyAuthE2ETest.java（镜像 AuditDashboardE2ETest 模式，依赖 T007~T017）：双 flag 全开下走 quickstart V3~V5 主路径——add → 401/200 → revoke 即时生效 → health 豁免 → session 互认
+
+**Checkpoint**: 全部故事独立可测；`/admin/**` 与 `/api/v1/auth/*` 行为与 012 验收一致
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: 配置样例、文档与全量质量门禁
+
+- [X] T020 [P] 在 config/application.yml.example 追加 `oryxos.web.apikey.enabled` 配置段与注释（默认 false、开启前先 `oryxos apikey add` 的提示）
+- [X] T021 [P] 更新 docs/CliGuide.md：新增 `oryxos apikey add/list/revoke` 三命令说明（对齐 contracts/auth-contract.md §2 的输出契约）
+- [X] T022 [P] 更新 website 文档（website/ 与 website/zh/ 下涉及 REST API 认证说明的页面，如无对应页面则在 docs/ 补一段部署说明）：如何开启 API Key 门禁、调用方接入方式、与管理台认证的关系
+- [X] T023 按 quickstart.md 完整走查 V1~V6 并记录结果到 specs/018-rest-api-key/acceptance-report.md（镜像 016 的 acceptance-report 形式，SC-001~SC-007 逐项对勾）
+- [X] T024 运行 `mvn verify` 全量质量门禁（Spotless + P3C + Checkstyle + SpotBugs/FindSecBugs + OWASP）并清零新增告警；确认无明文 Key 进入任何日志语句（SC-005 复查）
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1（T001）**: 无依赖，立即可做
+- **Phase 2（T002~T006）**: 依赖 T001；T002/T003/T006 可并行，T004 依赖 T002/T003，T005 依赖 T004
+- **Phase 3（US1）**: 依赖 Phase 2；T007 依赖 T004/T006
+- **Phase 4（US2）**: 依赖 Phase 2（service 的 revoke/list 已在 T004）；T012 依赖 T009 的命令骨架 → 实际顺序在 US1 之后
+- **Phase 5（US3）**: T015/T016 改 T007 产出的同一文件 → 必须在 US1 之后串行
+- **Phase 6**: 依赖全部故事完成
+
+### User Story Dependencies
+
+- **US1 (P1)**: 仅依赖 Foundational——MVP
+- **US2 (P2)**: 依赖 US1 的 T009（同文件 ApiKeyCommand.java 加子命令）；filter 侧无依赖
+- **US3 (P3)**: 依赖 US1 的 T007（同文件 ApiKeyAuthFilter.java 加豁免/互认）
+
+### Parallel Opportunities
+
+- Phase 2：T002 ∥ T003 ∥ T006（三个不同文件）
+- Phase 3：T011 与 T009/T010 并行（web 测试 vs CLI）
+- Phase 5：T017 与 T015/T016 并行（新文件 vs 改 filter）
+- Phase 6：T020 ∥ T021 ∥ T022（三处文档互不相干）
+
+---
+
+## Parallel Example: Phase 2
+
+```bash
+# 三个互不依赖的新文件同时开工：
+Task: "T002 新建 ApiKey.java 实体"
+Task: "T003 新建 ApiKeyRepository.java"
+Task: "T006 新建 WebApiKeyProperties.java 并注册"
+# 然后串行：T004 ApiKeyService →（并行）T005 单测
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First（US1 Only）
+
+1. Phase 1 + Phase 2（T001~T006）：表 + 服务 + 配置就绪
+2. Phase 3（T007~T011）：锁门闭环
+3. **STOP and VALIDATE**: quickstart V1~V3 走通即可演示（生成 Key → 401/200）
+4. US2/US3 依次叠加，各自 checkpoint 可独立验收
+
+### 注意
+
+- T007→T015/T016 与 T009→T012 是同文件递进，禁止并行
+- 每完成一个 Phase 提交一次（commit message 遵循项目规约，scope 用 `auth` 或 `web`/`cli`/`storage` 按主要触点）
+- 安全红线贯穿所有任务：明文 Key 只允许出现在 `apikey add` 的 stdout；测试断言中构造的 Key 除外

--- a/website/docs/auth.md
+++ b/website/docs/auth.md
@@ -6,7 +6,7 @@ OryxOS ships with an **opt-in** HTTP Basic Auth for the management console (`/ad
 
 ## How it works
 
-- **Scope**: only `/admin/**` is protected. `/api/v1/**` (REST endpoints, including `/api/v1/health`) stays open — machine-to-machine API auth (API Key) is a separate, future feature.
+- **Scope**: only `/admin/**` is protected. Machine-to-machine auth for `/api/v1/**` is handled by the separate [REST API Key](#rest-api-key-authentication) switch — the two toggles are independent.
 - **Accounts**: stored in the `web_users` SQLite table. Passwords are BCrypt-hashed (with a `{bcrypt}` prefix via Spring's `DelegatingPasswordEncoder`) — **never stored in plaintext**, never written to config, logs, or git history.
 - **Realtime**: account changes take effect immediately. Each request re-reads the database — no in-process cache, no server restart needed for a new account to work.
 - **Startup guard**: if you enable auth but no enabled account exists, startup is blocked with a clear error pointing at `oryxos user add`.
@@ -78,6 +78,32 @@ See the [`oryxos user` CLI reference](./cli.md#user-management) for `add`, `list
 - `list` **never prints passwords or hashes**.
 - `disable` keeps the row but blocks login (returns 401). `delete` removes it permanently.
 - Passwords must be ≥ 8 characters; usernames must be ≤ 64 characters with no whitespace.
+
+## REST API Key authentication
+
+Machine-to-machine auth for `/api/v1/**` (018-rest-api-key), toggled independently from console auth above:
+
+```yaml
+oryxos:
+  web:
+    apikey:
+      enabled: true   # default false — current behavior unchanged
+```
+
+- **Before enabling**, create a key with `oryxos apikey add <name>` — the `oryx_...` plaintext is **shown exactly once**; only its SHA-256 hash is stored.
+- **Callers** pick either header: `Authorization: Bearer <key>` or `X-API-Key: <key>` — both are equivalent.
+- **Exemptions**: `/api/v1/health` (probes), `/api/v1/auth/*` (console login subtree), and OPTIONS preflight; `/admin/**` is entirely unaffected.
+- **Console interop**: requests carrying a valid console session pass as authenticated — with both switches on, admin data pages keep working. Enabling only apikey logs a startup warning (the browser has neither session nor key).
+- **Lifecycle**: `oryxos apikey list` for inventory (no plaintext); `oryxos apikey revoke <name>` takes effect on the next request and leaves other keys untouched. Keys never expire automatically; a lost key can only be revoked and reissued.
+
+```bash
+# No key → 401 (uniform response, no failure-reason leak)
+curl -i http://localhost:8080/api/v1/profiles
+# With key → 200
+curl -H "Authorization: Bearer oryx_..." http://localhost:8080/api/v1/profiles
+# Probes stay open
+curl http://localhost:8080/api/v1/health
+```
 
 ## Design notes
 

--- a/website/zh/docs/auth.md
+++ b/website/zh/docs/auth.md
@@ -6,7 +6,7 @@ OryxOS 内置**可选**的管理台 HTTP Basic Auth（`/admin/**`）。默认关
 
 ## 工作机制
 
-- **范围**:仅 `/admin/**` 受保护。`/api/v1/**`（REST 端点,含 `/api/v1/health`）保持开放——机器到机器的 API 认证（API Key）是后续独立 feature。
+- **范围**:仅 `/admin/**` 受保护。`/api/v1/**` 的机器调用认证由独立的 [REST API Key](#rest-api-key-认证) 承担,两个开关相互独立。
 - **账号**:存 `web_users` SQLite 表。密码 BCrypt 哈希（经 Spring `DelegatingPasswordEncoder` 带 `{bcrypt}` 前缀）——**绝不存明文**,不落配置/日志/git 历史。
 - **实时**:账号变更即时生效。每请求重读 DB——无进程内缓存,新账号无需重启即可用。
 - **启动校验**:开启 auth 但无 enabled 账号时,启动被阻断,清晰报错指向 `oryxos user add`。
@@ -78,6 +78,32 @@ curl http://localhost:8080/api/v1/health
 - `list` **绝不打印密码或哈希**。
 - `disable` 保留行但禁止登录（返 401）。`delete` 永久删除。
 - 密码须 ≥8 字符;用户名须 ≤64 字符且无空格。
+
+## REST API Key 认证
+
+`/api/v1/**` 的机器调用认证（018-rest-api-key）,与上面的管理台认证独立开关:
+
+```yaml
+oryxos:
+  web:
+    apikey:
+      enabled: true   # 默认 false——现状不变
+```
+
+- **开启前**先生成 Key:`oryxos apikey add <name>`——明文 `oryx_...` **只显示这一次**,库中仅存 SHA-256 哈希。
+- **调用方**任选一种请求头:`Authorization: Bearer <key>` 或 `X-API-Key: <key>`,两者等效。
+- **豁免**:`/api/v1/health`（探活）、`/api/v1/auth/*`（管理台登录子树）、OPTIONS 预检;`/admin/**` 完全不受影响。
+- **管理台互认**:带有效管理台 session 的请求视同通过认证——双开时管理台数据页照常可用。建议两个开关同时开启,只开 apikey 会在启动日志告警（浏览器既无 session 也无 Key）。
+- **生命周期**:`oryxos apikey list` 盘点（无明文）;`oryxos apikey revoke <name>` 吊销即时生效,其它 Key 不受影响。Key 无自动过期,丢失只能吊销重发。
+
+```bash
+# 无 Key → 401（统一响应,不泄露失败原因）
+curl -i http://localhost:8080/api/v1/profiles
+# 带 Key → 200
+curl -H "Authorization: Bearer oryx_..." http://localhost:8080/api/v1/profiles
+# 探活始终开放
+curl http://localhost:8080/api/v1/health
+```
 
 ## 设计说明
 


### PR DESCRIPTION
## 概要

为 `/api/v1/**` 补上机器调用认证，收掉 v0.2「把门锁上」缺角（012-web-auth 遗留的独立 PR）。三笔提交：

- **a38c5f1 feat(auth)**：API Key 门禁主体（storage/web/cli 三模块，不新建模块、不碰 core）
- **f111f56 fix(web)**：走查发现的存量缺陷——`auth.enabled=true` 时登录页静态资源被 401、登录页白屏（012 验收后 013 管理台重建改资源路径引入），放行 `/admin/assets/**`
- **ce7cbd6 test(auth)**：SC-006 全量闭环（E2E 双认证共存 + Chromium 浏览器双开走查落卷）

## 设计要点

- `ApiKeyAuthFilter` 只拦 `/api/v1/*`，与 012 的 `/admin/*` filter 互不重叠；flag `oryxos.web.apikey.enabled` 默认关，回归零破坏
- Key = `oryx_` + 42 位 base62（约 250 bit 熵），库中仅存 SHA-256 哈希；明文只在 `oryxos apikey add` 输出一次。选 SHA-256 非 BCrypt：高熵随机 Key 无需慢哈希（specs/018 research R1）
- `Authorization: Bearer` 与 `X-API-Key` 双写法等效；统一 401 防探测（无 Key/错 Key/已吊销同响应）；恒定时间复核
- 豁免：`/api/v1/health`（探活）、`/api/v1/auth/*`（012 现状）、OPTIONS 预检；带有效管理台 session 的请求互认放行（管理台 SPA 不被自己锁死）
- `oryxos apikey add/list/revoke` 镜像 `oryxos user` 骨架；吊销即时生效；两条启动 WARN（无 Key / auth 未开）不阻断
- `api_keys` 新表走 schema.sql 手工建表（宪法 VIII，无 ALTER）

## 验证

- 35 个新用例全绿：service 13 + filter 12 + startup check 4 + E2E 5 + BasicAuthFilter 回归 1
- fat JAR 真机走查 quickstart V1~V6 全过（验收报告 specs/018-rest-api-key/acceptance-report.md）
- Chromium 无头浏览器双开走查：登录 → SPA 数据页全 200，登录前无 cookie 请求全 401（截图留证）
- `mvn verify` 全量门禁 BUILD SUCCESS（1764 测试 0 失败）

## 文档

specs/018 全套落卷（spec/plan/tasks/research/data-model/contracts/quickstart/acceptance-report）；`application.yml.example`、`docs/CliGuide.md` §4.7、website 中英文 `auth.md` 已同步。