### PR TITLE
fix(memory): reject MEMORY.md mutation via symlink aliases

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/memory/MemoryMdGuard.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/memory/MemoryMdGuard.java
@@ -1,11 +1,17 @@
 package io.oryxos.core.memory;
 
+import io.oryxos.core.fs.RealPathBoundary;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
 
 /**
  * 长期记忆文件只能经 {@code save_memory} 写入——{@code MarkdownMemoryStore#sanitizeEntryContent}
  * 只覆盖那条路径；其它入口直写会绕过分区头消毒（#163），污染核心/归档召回。
+ *
+ * <p>除词法路径段检查外，还会经 {@link RealPathBoundary} 解析已存在祖先的真实路径，避免 {@code notes.md → MEMORY.md} 这类软链绕过。
  */
 public final class MemoryMdGuard {
 
@@ -14,11 +20,28 @@ public final class MemoryMdGuard {
 
   private MemoryMdGuard() {}
 
+  public static void rejectMutation(String path) {
+    if (path == null || path.isBlank()) {
+      return;
+    }
+    rejectLexical(path);
+    rejectResolved(Path.of(path));
+  }
+
+  /** 对已解析（常为绝对）路径做词法 + 真实路径双重检查；Workspace 等入口应在边界投影后再调。 */
+  public static void rejectMutation(Path path) {
+    if (path == null) {
+      return;
+    }
+    rejectLexical(path.toString());
+    rejectResolved(path);
+  }
+
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",
       justification =
           "文件名是 ASCII「MEMORY.md」；Locale.ROOT 大小写折叠仅用于 Windows 大小写不敏感路径，非安全边界上的任意 Unicode 文本")
-  public static void rejectMutation(String path) {
+  private static void rejectLexical(String path) {
     if (path == null || path.isBlank()) {
       return;
     }
@@ -27,6 +50,36 @@ public final class MemoryMdGuard {
       if (MEMORY_FILE_LOWER.equals(segment.toString().toLowerCase(Locale.ROOT))) {
         throw new IllegalArgumentException("拒绝直接改写 MEMORY.md，请使用 save_memory: " + path);
       }
+    }
+  }
+
+  private static void rejectResolved(Path path) {
+    // 悬空软链：project 可能失败，先按叶子链接目标做词法检查
+    rejectSymlinkLeafTarget(path);
+    Path projected;
+    try {
+      projected = RealPathBoundary.project(path).projectedReal();
+    } catch (UncheckedIOException | IllegalArgumentException e) {
+      return;
+    }
+    rejectLexical(projected.toString());
+  }
+
+  /** 叶子是软链时，目标字符串及其相对父目录解析结果也做词法检查（覆盖悬空链）。 */
+  private static void rejectSymlinkLeafTarget(Path path) {
+    Path absolute = path.toAbsolutePath().normalize();
+    if (!Files.isSymbolicLink(absolute)) {
+      return;
+    }
+    try {
+      Path linkTarget = Files.readSymbolicLink(absolute);
+      rejectLexical(linkTarget.toString());
+      Path parent = absolute.getParent();
+      if (parent != null) {
+        rejectLexical(parent.resolve(linkTarget).normalize().toString());
+      }
+    } catch (IOException ignored) {
+      // 读链失败则保守放行词法已通过的路径；真实写入仍受沙箱约束
     }
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/memory/MemoryMdGuardTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/memory/MemoryMdGuardTest.java
@@ -2,11 +2,18 @@ package io.oryxos.core.memory;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class MemoryMdGuardTest {
+
+  @TempDir Path temp;
 
   @Test
   @DisplayName("叶子名为 MEMORY.md 时拒绝")
@@ -35,7 +42,43 @@ class MemoryMdGuardTest {
   void allowsOrdinaryPaths() {
     assertDoesNotThrow(() -> MemoryMdGuard.rejectMutation("agents/demo/notes.md"));
     assertDoesNotThrow(() -> MemoryMdGuard.rejectMutation("memory/backup.txt"));
-    assertDoesNotThrow(() -> MemoryMdGuard.rejectMutation(null));
+    assertDoesNotThrow(() -> MemoryMdGuard.rejectMutation((String) null));
     assertDoesNotThrow(() -> MemoryMdGuard.rejectMutation("  "));
+    assertDoesNotThrow(() -> MemoryMdGuard.rejectMutation((Path) null));
+  }
+
+  @Test
+  @DisplayName("软链叶子指向 MEMORY.md 时拒绝（真实路径复检）")
+  void rejectsSymlinkLeafToMemoryMd() throws IOException {
+    Path memory = temp.resolve("MEMORY.md");
+    Files.writeString(memory, "## 核心记忆\n## 归档记忆\n");
+    Path alias = temp.resolve("notes.md");
+    assumeCanSymlink(alias, memory);
+
+    assertThrows(IllegalArgumentException.class, () -> MemoryMdGuard.rejectMutation(alias));
+    assertThrows(
+        IllegalArgumentException.class, () -> MemoryMdGuard.rejectMutation(alias.toString()));
+    assertEqualsUnchanged(memory);
+  }
+
+  @Test
+  @DisplayName("悬空软链目标词法为 MEMORY.md 时也拒绝")
+  void rejectsDanglingSymlinkNamedMemoryMd() throws IOException {
+    Path alias = temp.resolve("alias.md");
+    assumeCanSymlink(alias, Path.of("MEMORY.md"));
+
+    assertThrows(IllegalArgumentException.class, () -> MemoryMdGuard.rejectMutation(alias));
+  }
+
+  private static void assumeCanSymlink(Path link, Path target) {
+    try {
+      Files.createSymbolicLink(link, target);
+    } catch (IOException | UnsupportedOperationException e) {
+      assumeTrue(false, "当前环境无法创建软链: " + e.getMessage());
+    }
+  }
+
+  private static void assertEqualsUnchanged(Path memory) throws IOException {
+    org.junit.jupiter.api.Assertions.assertEquals("## 核心记忆\n## 归档记忆\n", Files.readString(memory));
   }
 }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -205,6 +205,27 @@ class FileToolsTest {
   }
 
   @Test
+  @DisplayName("文件工具拒绝经软链改写 MEMORY.md（notes.md → MEMORY.md）")
+  void fileToolsRejectSymlinkToMemoryMd() throws IOException {
+    Path memory = dir.resolve("agents/demo/MEMORY.md");
+    Files.createDirectories(memory.getParent());
+    Files.writeString(memory, "## 核心记忆\n- keep\n## 归档记忆\n");
+    Path alias = dir.resolve("agents/demo/notes.md");
+    try {
+      Files.createSymbolicLink(alias, memory.getFileName());
+    } catch (IOException | UnsupportedOperationException e) {
+      Assumptions.assumeTrue(false, "当前环境无法创建软链: " + e.getMessage());
+    }
+
+    assertThrows(IllegalArgumentException.class, () -> tools.writeFile(alias.toString(), "hijack"));
+    assertThrows(
+        IllegalArgumentException.class, () -> tools.appendFile(alias.toString(), "hijack\n"));
+    assertThrows(
+        IllegalArgumentException.class, () -> tools.editFile(alias.toString(), "keep", "hijack"));
+    assertEquals("## 核心记忆\n- keep\n## 归档记忆\n", Files.readString(memory), "拒绝后内容不得变");
+  }
+
+  @Test
   @DisplayName("文件工具拒绝经 MEMORY.md 子路径建目录（防 DoS save_memory）")
   void fileToolsRejectMemoryMdAncestorPath() throws IOException {
     Path agentDir = dir.resolve("agents/fresh");

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
@@ -136,8 +136,10 @@ public class WorkspaceApiController {
     if (path == null || path.isBlank()) {
       throw new IllegalArgumentException("path 为空"); // → 400
     }
+    // 先词法拦直写；再投影真实路径后复检——notes.md→MEMORY.md 软链只在投影后能看见
     MemoryMdGuard.rejectMutation(path);
     Path target = resolveWithinRoot(path);
+    MemoryMdGuard.rejectMutation(target);
     if (isAgentSkillsPath(target)) {
       throw new IllegalArgumentException("Agent skills/ 是绑定视图，禁止从工作区入口写入");
     }

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
@@ -139,6 +139,29 @@ class WorkspaceApiControllerTest {
   }
 
   @Test
+  @DisplayName("工作区写入口禁止经软链改写 MEMORY.md（notes.md → MEMORY.md）")
+  void writeViaSymlinkToMemoryMdIsRejected() throws Exception {
+    Path agentDir = Files.createDirectories(oryxosRoot.resolve("agents/demo"));
+    Path memory = agentDir.resolve("MEMORY.md");
+    Files.writeString(memory, "## 核心记忆\n- keep\n## 归档记忆\n");
+    Path alias = agentDir.resolve("notes.md");
+    try {
+      Files.createSymbolicLink(alias, memory.getFileName());
+    } catch (IOException | UnsupportedOperationException e) {
+      org.junit.jupiter.api.Assumptions.assumeTrue(false, "当前环境无法创建软链: " + e.getMessage());
+    }
+
+    mvc.perform(
+            post("/api/v1/workspace/file")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"path\":\"agents/demo/notes.md\",\"content\":\"## 核心记忆\\n## 归档记忆\\n- hijack\"}"))
+        .andExpect(status().isBadRequest());
+    org.junit.jupiter.api.Assertions.assertEquals(
+        "## 核心记忆\n- keep\n## 归档记忆\n", Files.readString(memory));
+  }
+
+  @Test
   @DisplayName("工作区写入口禁止写 Agent skills 绑定视图")
   void writeThroughAgentSkillsIsRejected() throws Exception {
     mvc.perform(


### PR DESCRIPTION
## Summary
- Strengthen `MemoryMdGuard` with `RealPathBoundary` real-path recheck (and dangling symlink leaf targets)
- Workspace write re-checks after `resolveWithinRoot` projection
- Unit tests for guard / FileTools / Workspace symlink cases

Not a duplicate of #229/#230 (segment check); this is symlink real-path bypass.

Fixes #250

## Test plan
- [x] `MemoryMdGuardTest` (symlink + dangling)
- [x] `FileToolsTest#fileToolsRejectSymlinkToMemoryMd`
- [x] `WorkspaceApiControllerTest#writeViaSymlinkToMemoryMdIsRejected`
- [ ] CI green on this PR