### PR TITLE
fix(ssrf): unwrap IPv6 6to4 and IPv4-compatible embeddings

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -53,6 +53,17 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   /** {@code ::ffff:0:0/96} 前缀中必须为 0 的前缀字节数（随后两字节为 0xff）。 */
   private static final int IPV4_MAPPED_ZERO_PREFIX_LENGTH = 10;
 
+  /** IPv4-mapped / NAT64 / IPv4-compatible：嵌入 IPv4 起始下标（末 4 字节）。 */
+  private static final int EMBEDDED_IPV4_TAIL_OFFSET = 12;
+
+  /** 6to4：嵌入 IPv4 起始下标（字节 2–5）。 */
+  private static final int SIXTOFOUR_IPV4_OFFSET = 2;
+
+  private static final int IPV4_OCTET_COUNT = 4;
+
+  /** 原生 IPv6 {@code ::1} 的末字节。 */
+  private static final byte IPV6_LOOPBACK_SUFFIX = 1;
+
   // 具体类型 CopyOnWriteArrayList（而非 List 接口）：需要 addIfAbsent 的原子"不存在才加"语义
   private final CopyOnWriteArrayList<Path> allowedRoots = new CopyOnWriteArrayList<>();
   private final Set<String> allowedCommands = ConcurrentHashMap.newKeySet();
@@ -296,10 +307,22 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
     }
     byte[] ipv4;
     if (isIpv4MappedPrefix(b) || isNat64WellKnownPrefix(b) || isIpv4CompatiblePrefix(b)) {
-      ipv4 = new byte[] {b[12], b[13], b[14], b[15]};
+      ipv4 =
+          new byte[] {
+            b[EMBEDDED_IPV4_TAIL_OFFSET],
+            b[EMBEDDED_IPV4_TAIL_OFFSET + 1],
+            b[EMBEDDED_IPV4_TAIL_OFFSET + 2],
+            b[EMBEDDED_IPV4_TAIL_OFFSET + 3]
+          };
     } else if (isSixToFourPrefix(b)) {
       // RFC 3056：2002:V4ADDR::/48 —— IPv4 在字节 2–5
-      ipv4 = new byte[] {b[2], b[3], b[4], b[5]};
+      ipv4 =
+          new byte[] {
+            b[SIXTOFOUR_IPV4_OFFSET],
+            b[SIXTOFOUR_IPV4_OFFSET + 1],
+            b[SIXTOFOUR_IPV4_OFFSET + 2],
+            b[SIXTOFOUR_IPV4_OFFSET + 3]
+          };
     } else {
       return addr;
     }
@@ -351,14 +374,22 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
         return false;
       }
     }
-    if (b[10] != 0 || b[11] != 0) {
+    if (b[IPV4_MAPPED_ZERO_PREFIX_LENGTH] != 0 || b[IPV4_MAPPED_ZERO_PREFIX_LENGTH + 1] != 0) {
       return false;
     }
-    // :: 与 ::1
-    if (b[12] == 0 && b[13] == 0 && b[14] == 0 && (b[15] == 0 || b[15] == 1)) {
-      return false;
+    return !isNativeIpv6UnspecifiedOrLoopbackTail(b);
+  }
+
+  /** 末 4 字节为 {@code 0.0.0.0}（{@code ::}）或 {@code 0.0.0.1}（{@code ::1}）。 */
+  private static boolean isNativeIpv6UnspecifiedOrLoopbackTail(byte[] b) {
+    int lastIndex = EMBEDDED_IPV4_TAIL_OFFSET + IPV4_OCTET_COUNT - 1;
+    for (int i = EMBEDDED_IPV4_TAIL_OFFSET; i < lastIndex; i++) {
+      if (b[i] != 0) {
+        return false;
+      }
     }
-    return true;
+    byte last = b[lastIndex];
+    return last == 0 || last == IPV6_LOOPBACK_SUFFIX;
   }
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -267,12 +267,16 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   }
 
   /**
-   * 对解析结果做 SSRF 分类。IPv4-mapped（{@code ::ffff:0:0/96}）与 NAT64 知名前缀（{@code 64:ff9b::/96}）先展开末 32 位
-   * IPv4，再套用回环/链路本地/站点内网/CGNAT 等判定——否则 {@code [64:ff9b::169.254.169.254]} 会以「公网 IPv6」放行。
+   * 对解析结果做 SSRF 分类。IPv4-mapped（{@code ::ffff:0:0/96}）、NAT64 知名前缀（{@code 64:ff9b::/96}）、6to4（{@code
+   * 2002::/16}）与已弃用的 IPv4-compatible（{@code ::/96}）先展开嵌入 IPv4，再套用回环/链路本地/站点内网/CGNAT 等判定——否则 {@code
+   * [2002:a9fe:a9fe::1]}（≡169.254.169.254）会以「公网 IPv6」放行。
    */
   private static boolean isBlockedSsrfAddress(InetAddress addr) {
     InetAddress effective = unwrapEmbeddedIpv4(addr);
-    return effective.isLoopbackAddress()
+    // addr 侧保留原生 IPv6 回环/未指定（避免 ::1 被误展开成 0.0.0.1 后漏拦）
+    return addr.isLoopbackAddress()
+        || addr.isAnyLocalAddress()
+        || effective.isLoopbackAddress()
         || effective.isAnyLocalAddress()
         || effective.isLinkLocalAddress()
         || effective.isSiteLocalAddress()
@@ -282,24 +286,28 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   }
 
   /**
-   * 若为 IPv4-mapped 或 NAT64 well-known prefix，返回嵌入的 IPv4；否则原样返回。JDK 常把 mapped 字面量直接解成 {@link
-   * java.net.Inet4Address}，此展开主要兜住仍以 16 字节返回的形态与 NAT64。
+   * 若为 IPv4-mapped / NAT64 / 6to4 / IPv4-compatible，返回嵌入的 IPv4；否则原样返回。JDK 常把 mapped 字面量直接解成 {@link
+   * java.net.Inet4Address}，此展开主要兜住仍以 16 字节返回的形态与隧道前缀。
    */
   private static InetAddress unwrapEmbeddedIpv4(InetAddress addr) {
     byte[] b = addr.getAddress();
-    if (!isEmbeddedIpv4Candidate(b)) {
+    if (b.length != IPV6_ADDRESS_LENGTH) {
+      return addr;
+    }
+    byte[] ipv4;
+    if (isIpv4MappedPrefix(b) || isNat64WellKnownPrefix(b) || isIpv4CompatiblePrefix(b)) {
+      ipv4 = new byte[] {b[12], b[13], b[14], b[15]};
+    } else if (isSixToFourPrefix(b)) {
+      // RFC 3056：2002:V4ADDR::/48 —— IPv4 在字节 2–5
+      ipv4 = new byte[] {b[2], b[3], b[4], b[5]};
+    } else {
       return addr;
     }
     try {
-      return InetAddress.getByAddress(new byte[] {b[12], b[13], b[14], b[15]});
+      return InetAddress.getByAddress(ipv4);
     } catch (UnknownHostException e) {
       return addr; // 4 字节形式不会失败；保底不改变判定输入
     }
-  }
-
-  /** 16 字节且带 IPv4-mapped 或 NAT64 知名前缀时，才做末 32 位展开。 */
-  private static boolean isEmbeddedIpv4Candidate(byte[] b) {
-    return b.length == IPV6_ADDRESS_LENGTH && (isIpv4MappedPrefix(b) || isNat64WellKnownPrefix(b));
   }
 
   /** {@code ::ffff:0:0/96}——前 10 字节为 0，第 11–12 字节为 {@code 0xff}。 */
@@ -326,6 +334,31 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
         && b[9] == 0
         && b[10] == 0
         && b[11] == 0;
+  }
+
+  /** 6to4 {@code 2002::/16}（RFC 3056）。 */
+  private static boolean isSixToFourPrefix(byte[] b) {
+    return (b[0] & 0xFF) == 0x20 && (b[1] & 0xFF) == 0x02;
+  }
+
+  /**
+   * 已弃用的 IPv4-compatible {@code ::/96}（RFC 4291），排除 {@code ::ffff:0:0/96} mapped，以及原生 {@code
+   * ::}/{@code ::1}（否则会展开成 0.0.0.0/0.0.0.1 漏拦）。
+   */
+  private static boolean isIpv4CompatiblePrefix(byte[] b) {
+    for (int i = 0; i < IPV4_MAPPED_ZERO_PREFIX_LENGTH; i++) {
+      if (b[i] != 0) {
+        return false;
+      }
+    }
+    if (b[10] != 0 || b[11] != 0) {
+      return false;
+    }
+    // :: 与 ::1
+    if (b[12] == 0 && b[13] == 0 && b[14] == 0 && (b[15] == 0 || b[15] == 1)) {
+      return false;
+    }
+    return true;
   }
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
@@ -303,19 +303,24 @@ class WhitelistSandboxTest {
             "http://[::ffff:169.254.169.254]/x", // IPv4-mapped 云元数据
             "http://[64:ff9b::a9fe:a9fe]/x", // NAT64 well-known → 169.254.169.254
             "http://[64:ff9b::100.64.1.1]/x", // NAT64 → CGNAT
+            "http://[2002:a9fe:a9fe::1]/x", // 6to4 → 169.254.169.254
+            "http://[::a9fe:a9fe]/x", // IPv4-compatible → 169.254.169.254
             "http://localhost/x"
           }) {
         assertThrows(
             SandboxViolationException.class,
-            () -> sb.enforce(new SandboxAction(ActionType.HTTP_READ, url)));
+            () -> sb.enforce(new SandboxAction(ActionType.HTTP_READ, url)),
+            () -> "should block: " + url);
       }
     }
 
     @Test
-    @DisplayName("NAT64 嵌入公网 IPv4 仍放行")
-    void nat64PublicIpv4Allowed() {
+    @DisplayName("NAT64 / 6to4 嵌入公网 IPv4 仍放行")
+    void embeddedPublicIpv4Allowed() {
       assertDoesNotThrow(
           () -> sb.enforce(new SandboxAction(ActionType.HTTP_READ, "http://[64:ff9b::8.8.8.8]/x")));
+      assertDoesNotThrow(
+          () -> sb.enforce(new SandboxAction(ActionType.HTTP_READ, "http://[2002:808:808::1]/x")));
     }
   }
 

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
@@ -227,12 +227,14 @@ public class SkillApiController {
   }
 
   /**
-   * IPv4-mapped（{@code ::ffff:0:0/96}）与 NAT64 知名前缀（{@code 64:ff9b::/96}）先展开末 32 位 IPv4，再套用内网/元数据判定；
-   * 与 {@code WhitelistSandbox} 读路径 SSRF 兜底对齐。
+   * IPv4-mapped / NAT64 / 6to4 / IPv4-compatible 先展开嵌入 IPv4，再套用内网/元数据判定；与 {@code WhitelistSandbox}
+   * 读路径 SSRF 兜底对齐。
    */
   private static boolean isBlockedSsrfAddress(InetAddress addr) {
     InetAddress effective = unwrapEmbeddedIpv4(addr);
-    return effective.isLoopbackAddress()
+    return addr.isLoopbackAddress()
+        || addr.isAnyLocalAddress()
+        || effective.isLoopbackAddress()
         || effective.isAnyLocalAddress()
         || effective.isLinkLocalAddress()
         || effective.isSiteLocalAddress()
@@ -243,19 +245,22 @@ public class SkillApiController {
 
   private static InetAddress unwrapEmbeddedIpv4(InetAddress addr) {
     byte[] b = addr.getAddress();
-    if (!isEmbeddedIpv4Candidate(b)) {
+    if (b.length != IPV6_ADDRESS_LENGTH) {
+      return addr;
+    }
+    byte[] ipv4;
+    if (isIpv4MappedPrefix(b) || isNat64WellKnownPrefix(b) || isIpv4CompatiblePrefix(b)) {
+      ipv4 = new byte[] {b[12], b[13], b[14], b[15]};
+    } else if (isSixToFourPrefix(b)) {
+      ipv4 = new byte[] {b[2], b[3], b[4], b[5]};
+    } else {
       return addr;
     }
     try {
-      return InetAddress.getByAddress(new byte[] {b[12], b[13], b[14], b[15]});
+      return InetAddress.getByAddress(ipv4);
     } catch (UnknownHostException e) {
       return addr;
     }
-  }
-
-  /** 16 字节且带 IPv4-mapped 或 NAT64 知名前缀时，才做末 32 位展开。 */
-  private static boolean isEmbeddedIpv4Candidate(byte[] b) {
-    return b.length == IPV6_ADDRESS_LENGTH && (isIpv4MappedPrefix(b) || isNat64WellKnownPrefix(b));
   }
 
   private static boolean isIpv4MappedPrefix(byte[] b) {
@@ -280,6 +285,25 @@ public class SkillApiController {
         && b[9] == 0
         && b[10] == 0
         && b[11] == 0;
+  }
+
+  private static boolean isSixToFourPrefix(byte[] b) {
+    return (b[0] & 0xFF) == 0x20 && (b[1] & 0xFF) == 0x02;
+  }
+
+  private static boolean isIpv4CompatiblePrefix(byte[] b) {
+    for (int i = 0; i < IPV4_MAPPED_ZERO_PREFIX_LENGTH; i++) {
+      if (b[i] != 0) {
+        return false;
+      }
+    }
+    if (b[10] != 0 || b[11] != 0) {
+      return false;
+    }
+    if (b[12] == 0 && b[13] == 0 && b[14] == 0 && (b[15] == 0 || b[15] == 1)) {
+      return false;
+    }
+    return true;
   }
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
@@ -71,6 +71,11 @@ public class SkillApiController {
   /** {@code ::ffff:0:0/96} 前缀中必须为 0 的前缀字节数（随后两字节为 0xff）。 */
   private static final int IPV4_MAPPED_ZERO_PREFIX_LENGTH = 10;
 
+  private static final int EMBEDDED_IPV4_TAIL_OFFSET = 12;
+  private static final int SIXTOFOUR_IPV4_OFFSET = 2;
+  private static final int IPV4_OCTET_COUNT = 4;
+  private static final byte IPV6_LOOPBACK_SUFFIX = 1;
+
   private final SkillService skills;
   private final SkillCatalog catalog;
   private final AgentSkillBindingService bindings;
@@ -250,9 +255,21 @@ public class SkillApiController {
     }
     byte[] ipv4;
     if (isIpv4MappedPrefix(b) || isNat64WellKnownPrefix(b) || isIpv4CompatiblePrefix(b)) {
-      ipv4 = new byte[] {b[12], b[13], b[14], b[15]};
+      ipv4 =
+          new byte[] {
+            b[EMBEDDED_IPV4_TAIL_OFFSET],
+            b[EMBEDDED_IPV4_TAIL_OFFSET + 1],
+            b[EMBEDDED_IPV4_TAIL_OFFSET + 2],
+            b[EMBEDDED_IPV4_TAIL_OFFSET + 3]
+          };
     } else if (isSixToFourPrefix(b)) {
-      ipv4 = new byte[] {b[2], b[3], b[4], b[5]};
+      ipv4 =
+          new byte[] {
+            b[SIXTOFOUR_IPV4_OFFSET],
+            b[SIXTOFOUR_IPV4_OFFSET + 1],
+            b[SIXTOFOUR_IPV4_OFFSET + 2],
+            b[SIXTOFOUR_IPV4_OFFSET + 3]
+          };
     } else {
       return addr;
     }
@@ -297,13 +314,21 @@ public class SkillApiController {
         return false;
       }
     }
-    if (b[10] != 0 || b[11] != 0) {
+    if (b[IPV4_MAPPED_ZERO_PREFIX_LENGTH] != 0 || b[IPV4_MAPPED_ZERO_PREFIX_LENGTH + 1] != 0) {
       return false;
     }
-    if (b[12] == 0 && b[13] == 0 && b[14] == 0 && (b[15] == 0 || b[15] == 1)) {
-      return false;
+    return !isNativeIpv6UnspecifiedOrLoopbackTail(b);
+  }
+
+  private static boolean isNativeIpv6UnspecifiedOrLoopbackTail(byte[] b) {
+    int lastIndex = EMBEDDED_IPV4_TAIL_OFFSET + IPV4_OCTET_COUNT - 1;
+    for (int i = EMBEDDED_IPV4_TAIL_OFFSET; i < lastIndex; i++) {
+      if (b[i] != 0) {
+        return false;
+      }
     }
-    return true;
+    byte last = b[lastIndex];
+    return last == 0 || last == IPV6_LOOPBACK_SUFFIX;
   }
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/SkillImportSsrfGuardTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/SkillImportSsrfGuardTest.java
@@ -50,13 +50,15 @@ class SkillImportSsrfGuardTest {
   }
 
   @Test
-  @DisplayName("IPv4-mapped / NAT64 嵌入内网或元数据地址被拒绝")
-  void nat64AndMappedPrivateBlocked() {
+  @DisplayName("IPv4-mapped / NAT64 / 6to4 / compatible 嵌入内网或元数据地址被拒绝")
+  void embeddedPrivateBlocked() {
     for (String url :
         new String[] {
           "http://[::ffff:169.254.169.254]/latest/meta-data/",
           "http://[64:ff9b::a9fe:a9fe]/latest/meta-data/",
-          "http://[64:ff9b::100.64.1.1]/x"
+          "http://[64:ff9b::100.64.1.1]/x",
+          "http://[2002:a9fe:a9fe::1]/latest/meta-data/",
+          "http://[::a9fe:a9fe]/x"
         }) {
       assertThrows(
           IllegalArgumentException.class,
@@ -65,9 +67,11 @@ class SkillImportSsrfGuardTest {
   }
 
   @Test
-  @DisplayName("NAT64 嵌入公网 IPv4 仍放行")
-  void nat64PublicIpv4Allowed() {
+  @DisplayName("NAT64 / 6to4 嵌入公网 IPv4 仍放行")
+  void embeddedPublicIpv4Allowed() {
     assertDoesNotThrow(
         () -> SkillApiController.guardPublicHost(URI.create("http://[64:ff9b::8.8.8.8]/x")));
+    assertDoesNotThrow(
+        () -> SkillApiController.guardPublicHost(URI.create("http://[2002:808:808::1]/x")));
   }
 }


### PR DESCRIPTION
## Summary
- Unwrap `2002::/16` (6to4, bytes 2–5) and deprecated IPv4-compatible `::/96` before private/metadata SSRF checks
- Exclude native `::` / `::1` from compatible unwrap; keep original-address loopback checks
- Mirror in `SkillApiController`; unit tests for block + public `8.8.8.8` allow

Fixes #252

## Test plan
- [x] `WhitelistSandboxTest` HTTP read SSRF (6to4 / compatible / NAT64 / `::1`)
- [x] `SkillImportSsrfGuardTest`
- [ ] CI green on this PR