### PR TITLE
fix(profile): parse quoted numeric YAML fields (#254)

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -122,7 +122,7 @@ public class ProfileLoader {
         toNotifyChannels(asList(map.get("notify_channels"))),
         toSchedules(asList(map.get("schedules")), source),
         asStringList(map.get("bootstrap")),
-        toSettings(asMap(map.get("settings"))));
+        toSettings(asMap(map.get("settings")), name));
   }
 
   private Profile.ProviderRef toProviderRef(Map<String, Object> map, String profileName) {
@@ -147,7 +147,8 @@ public class ProfileLoader {
               + knownProviders
               + "）");
     }
-    return new Profile.ProviderRef(providerName, model, asDouble(map.get("temperature")));
+    return new Profile.ProviderRef(
+        providerName, model, asDouble(map.get("temperature"), "provider.temperature", profileName));
   }
 
   private static Profile.Identity toIdentity(Map<String, Object> map) {
@@ -227,14 +228,22 @@ public class ProfileLoader {
     return schedules;
   }
 
-  private static Profile.Settings toSettings(Map<String, Object> map) {
+  private static Profile.Settings toSettings(Map<String, Object> map, String profileName) {
     if (map == null) {
       return Profile.Settings.defaults();
     }
     Profile.Settings defaults = Profile.Settings.defaults();
     return new Profile.Settings(
-        asInt(map.get("max_iterations"), defaults.maxIterations()),
-        asInt(map.get("max_history_turns"), defaults.maxHistoryTurns()));
+        asInt(
+            map.get("max_iterations"),
+            defaults.maxIterations(),
+            "settings.max_iterations",
+            profileName),
+        asInt(
+            map.get("max_history_turns"),
+            defaults.maxHistoryTurns(),
+            "settings.max_history_turns",
+            profileName));
   }
 
   /** 递归解析 ${ENV} 占位；环境变量缺失时保留原样并 WARN（凭证必填校验属全局层职责）。 */
@@ -288,12 +297,48 @@ public class ProfileLoader {
     return value == null ? null : String.valueOf(value);
   }
 
-  private static Double asDouble(Object value) {
-    return value instanceof Number number ? number.doubleValue() : null;
+  private static Double asDouble(Object value, String field, String profileName) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Number number) {
+      return number.doubleValue();
+    }
+    if (value instanceof String text) {
+      if (text.isBlank()) {
+        return null;
+      }
+      try {
+        return Double.parseDouble(text.strip());
+      } catch (NumberFormatException e) {
+        throw new ProfileValidationException(
+            "Profile " + profileName + " 的 " + field + " 必须是数字: " + text);
+      }
+    }
+    throw new ProfileValidationException(
+        "Profile " + profileName + " 的 " + field + " 必须是数字: " + value);
   }
 
-  private static int asInt(Object value, int defaultValue) {
-    return value instanceof Number number ? number.intValue() : defaultValue;
+  private static int asInt(Object value, int defaultValue, String field, String profileName) {
+    if (value == null) {
+      return defaultValue;
+    }
+    if (value instanceof Number number) {
+      return number.intValue();
+    }
+    if (value instanceof String text) {
+      if (text.isBlank()) {
+        return defaultValue;
+      }
+      try {
+        return Integer.parseInt(text.strip());
+      } catch (NumberFormatException e) {
+        throw new ProfileValidationException(
+            "Profile " + profileName + " 的 " + field + " 必须是整数: " + text);
+      }
+    }
+    throw new ProfileValidationException(
+        "Profile " + profileName + " 的 " + field + " 必须是整数: " + value);
   }
 
   @SuppressWarnings("unchecked")

--- a/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
@@ -110,6 +110,68 @@ class ProfileLoaderTest {
   }
 
   @Test
+  void 数字字段支持引号字符串并正确解析() throws IOException {
+    write(
+        "quoted-numbers.yaml",
+        """
+        name: quoted-numbers
+        provider:
+          name: deepseek
+          model: deepseek-chat
+          temperature: "0.7"
+        settings:
+          max_iterations: "10"
+          max_history_turns: "15"
+        """);
+
+    Profile profile = loader().loadAll().get("quoted-numbers").orElseThrow();
+
+    assertEquals(0.7, profile.provider().temperature());
+    assertEquals(10, profile.settings().maxIterations());
+    assertEquals(15, profile.settings().maxHistoryTurns());
+  }
+
+  @Test
+  void 数字字段非法值报错点名() throws IOException {
+    write(
+        "bad-temp.yaml",
+        """
+        name: bad-temp
+        provider:
+          name: deepseek
+          model: deepseek-chat
+          temperature: true
+        """);
+
+    ProfileValidationException ex =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("bad-temp.yaml")));
+
+    assertTrue(ex.getMessage().contains("provider.temperature"));
+    assertTrue(ex.getMessage().contains("bad-temp"));
+
+    write(
+        "bad-iter.yaml",
+        """
+        name: bad-iter
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        settings:
+          max_iterations: not-a-number
+        """);
+
+    ex =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("bad-iter.yaml")));
+
+    assertTrue(ex.getMessage().contains("settings.max_iterations"));
+    assertTrue(ex.getMessage().contains("not-a-number"));
+  }
+
+  @Test
   void 引用不存在的provider_报错信息包含该名字() throws IOException {
     write(
         "bad-provider.yaml",


### PR DESCRIPTION
Fixes #254

## Summary
- `ProfileLoader.asDouble` / `asInt` now parse numeric strings (quoted YAML, `${ENV}` resolution).
- Invalid types raise `ProfileValidationException` with profile name and field path.
- Covers `provider.temperature`, `settings.max_iterations`, `settings.max_history_turns`.

## Test plan
- [x] `ProfileLoaderTest` — quoted numerics parse correctly
- [x] `ProfileLoaderTest` — invalid `temperature: true` / `max_iterations: not-a-number` fail with field names
- [x] `mvn -pl oryxos-core pmd:check`