### PR TITLE
fix(tool): reject unsupported http_request methods (#256)

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -23,7 +24,7 @@ import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 /**
- * 内置 HTTP 工具：http_get / http_post / http_request（任意方法）/ fetch_webpage（抓网页抽正文）/
+ * 内置 HTTP 工具：http_get / http_post / http_request（GET/POST/PUT/PATCH/DELETE）/ fetch_webpage（抓网页抽正文）/
  * download_file（下载到文件）。读请求走 {@code HTTP_READ}（默认放行 + SSRF）；写请求走 {@code HTTP_REQUEST}（域名白名单）。
  * 读写都禁自动重定向，由本类手动逐跳跟随并每跳重过沙箱校验。
  */
@@ -33,6 +34,10 @@ public class HttpTools {
   private static final int FETCH_TEXT_MAX = 20000;
 
   private static final String DEFAULT_METHOD = "GET";
+
+  /** http_request 允许的方法，与 @ToolParam 描述及文档一致。 */
+  private static final Set<String> ALLOWED_HTTP_REQUEST_METHODS =
+      Set.of("GET", "POST", "PUT", "PATCH", "DELETE");
 
   /** 手动跟随重定向的最大跳数（每跳都重新过沙箱校验，防公网 302→白名单外 / 内网）。 */
   private static final int MAX_REDIRECTS = 5;
@@ -262,7 +267,7 @@ public class HttpTools {
 
   @Tool(
       name = "http_request",
-      description = "发起任意方法的 HTTP 请求（GET/POST/PUT/PATCH/DELETE），可带请求头和请求体，返回响应体")
+      description = "发起 HTTP 请求（GET/POST/PUT/PATCH/DELETE），可带请求头和请求体，返回响应体")
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",
       justification = "HTTP 方法名是 ASCII，Locale.ROOT 大写化是国际化安全的正确写法，仅用于把 method 归一成 GET/POST 等枚举名")
@@ -272,7 +277,12 @@ public class HttpTools {
       @ToolParam(required = false, description = "可选请求头，每行一个「名: 值」") String headers,
       @ToolParam(required = false, description = "可选请求体（如 JSON 文本）") String body) {
     String verb = (method == null || method.isBlank()) ? DEFAULT_METHOD : method.strip();
-    HttpMethod httpMethod = HttpMethod.valueOf(verb.toUpperCase(Locale.ROOT));
+    String normalized = verb.toUpperCase(Locale.ROOT);
+    if (!ALLOWED_HTTP_REQUEST_METHODS.contains(normalized)) {
+      throw new IllegalArgumentException(
+          "不支持的 HTTP 方法: " + method + "（http_request 仅允许 GET/POST/PUT/PATCH/DELETE）");
+    }
+    HttpMethod httpMethod = HttpMethod.valueOf(normalized);
     // 按方法分级：GET 走读路径（放行 + 内网黑名单 + 逐跳重定向重校验），其余写方法走域名白名单 + 逐跳重定向重校验
     if (HttpMethod.GET.equals(httpMethod)) {
       return read(url, headers, String.class);

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
@@ -110,6 +110,39 @@ class HttpToolsTest {
   }
 
   @Test
+  @DisplayName("http_request 拒绝 schema 外方法 TRACE")
+  void httpRequestRejectsTrace() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> tools.httpRequest("TRACE", url(), null, null));
+
+    assertTrue(ex.getMessage().contains("TRACE"));
+    assertTrue(ex.getMessage().contains("GET/POST/PUT/PATCH/DELETE"));
+    assertEquals(0, receivedBodies.size(), "非法方法不得发出请求");
+  }
+
+  @Test
+  @DisplayName("http_request 拒绝 HEAD/OPTIONS 等 Spring 枚举但文档未列出的方法")
+  void httpRequestRejectsHeadAndOptions() {
+    assertThrows(
+        IllegalArgumentException.class, () -> tools.httpRequest("HEAD", url(), null, null));
+    assertThrows(
+        IllegalArgumentException.class, () -> tools.httpRequest("OPTIONS", url(), null, null));
+    assertEquals(0, receivedBodies.size());
+  }
+
+  @Test
+  @DisplayName("http_request 拒绝未知 method")
+  void httpRequestRejectsUnknownMethod() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> tools.httpRequest("FOOBAR", url(), null, null));
+
+    assertTrue(ex.getMessage().contains("FOOBAR"));
+    assertEquals(0, receivedBodies.size());
+  }
+
+  @Test
   @DisplayName("http_get_命中白名单外域名应被拦下")
   void httpGetOutsideWhitelistIsBlocked() {
     Sandbox denying = mock(Sandbox.class);


### PR DESCRIPTION
Fixes #256

## Summary
- `http_request` now allowlists GET/POST/PUT/PATCH/DELETE before `HttpMethod.valueOf`.
- TRACE, HEAD, OPTIONS, and unknown methods raise `IllegalArgumentException` with no network I/O.
- Align `@Tool` / class comment wording with the documented contract.

## Test plan
- [x] `HttpToolsTest` — TRACE rejected
- [x] `HttpToolsTest` — HEAD/OPTIONS rejected
- [x] `HttpToolsTest` — unknown method rejected
- [x] `mvn -pl oryxos-tool pmd:check`