### PR TITLE
fix(http): strip Private-Token on cross-origin redirects (#258)

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -217,7 +217,8 @@ public class HttpTools {
 
   /**
    * 去掉跨源重定向不应转发的头（Authorization / Proxy-Authorization / Cookie / Cookie2 / X-API-Key /
-   * Api-Key）。同浏览器对跨站重定向的凭证剥离习惯。
+   * Private-Token / JOB-TOKEN / X-Auth-Token / Api-Key）。同浏览器对跨站重定向的凭证剥离习惯；名单控在常见 API 凭证头，避免误伤泛化的 {@code
+   * *Token*}。
    */
   static String stripSensitiveHeaders(String headers) {
     if (headers == null || headers.isBlank()) {
@@ -244,7 +245,7 @@ public class HttpTools {
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",
       justification =
-          "HTTP header names are ASCII tokens; Locale.ROOT lowercasing is the correct case-fold for Authorization/Cookie/X-API-Key/Api-Key matching.")
+          "HTTP header names are ASCII tokens; Locale.ROOT lowercasing is the correct case-fold for Authorization/Cookie/X-API-Key/Private-Token matching.")
   private static boolean isSensitiveHeaderName(String name) {
     String n = name.toLowerCase(Locale.ROOT);
     return "authorization".equals(n)
@@ -252,7 +253,10 @@ public class HttpTools {
         || "cookie".equals(n)
         || "cookie2".equals(n)
         || "x-api-key".equals(n)
-        || "api-key".equals(n);
+        || "api-key".equals(n)
+        || "private-token".equals(n)
+        || "job-token".equals(n)
+        || "x-auth-token".equals(n);
   }
 
   @Tool(name = "http_get", description = "发起一个 HTTP GET 请求，返回响应体")

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -217,8 +217,8 @@ public class HttpTools {
 
   /**
    * 去掉跨源重定向不应转发的头（Authorization / Proxy-Authorization / Cookie / Cookie2 / X-API-Key /
-   * Private-Token / JOB-TOKEN / X-Auth-Token / Api-Key）。同浏览器对跨站重定向的凭证剥离习惯；名单控在常见 API 凭证头，避免误伤泛化的 {@code
-   * *Token*}。
+   * Private-Token / JOB-TOKEN / X-Auth-Token / Api-Key）。同浏览器对跨站重定向的凭证剥离习惯；名单控在常见 API 凭证头，避免误伤泛化的
+   * {@code *Token*}。
    */
   static String stripSensitiveHeaders(String headers) {
     if (headers == null || headers.isBlank()) {

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
@@ -1,6 +1,7 @@
 package io.oryxos.tool.builtin;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -270,6 +271,85 @@ class HttpToolsTest {
       assertEquals("ok", body);
       assertEquals(1, sinkHits.get());
       assertTrue(sinkAuth.isEmpty(), "跨源重定向不得转发 Authorization");
+      assertEquals(List.of("keep-me"), sinkTrace, "非敏感自定义头仍可转发");
+    } finally {
+      entry.stop(0);
+      sink.stop(0);
+    }
+  }
+
+  @Test
+  @DisplayName("stripSensitiveHeaders 剥离 Private-Token / JOB-TOKEN / X-Auth-Token，保留非凭证头")
+  void stripSensitiveHeadersDropsVendorApiTokens() {
+    String kept =
+        HttpTools.stripSensitiveHeaders(
+            """
+            Private-Token: glpat-secret
+            JOB-TOKEN: ci-job-secret
+            X-Auth-Token: session-secret
+            X-Trace-Id: keep-me
+            Accept: application/json
+            """);
+
+    assertTrue(kept.contains("X-Trace-Id:keep-me"), kept);
+    assertTrue(kept.contains("Accept:application/json"), kept);
+    assertFalse(kept.toLowerCase().contains("private-token"), kept);
+    assertFalse(kept.toLowerCase().contains("job-token"), kept);
+    assertFalse(kept.toLowerCase().contains("x-auth-token"), kept);
+  }
+
+  @Test
+  @DisplayName("http_request 跨源 302 不得把 Private-Token 带到下一跳（白名单内主机亦然）")
+  void httpRequestCrossOriginRedirectStripsPrivateToken() throws IOException {
+    HttpServer entry = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    HttpServer sink = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    AtomicInteger sinkHits = new AtomicInteger();
+    List<String> sinkTokens = new ArrayList<>();
+    List<String> sinkTrace = new ArrayList<>();
+    try {
+      sink.createContext(
+          "/",
+          exchange -> {
+            sinkHits.incrementAndGet();
+            String token = exchange.getRequestHeaders().getFirst("Private-Token");
+            if (token != null) {
+              sinkTokens.add(token);
+            }
+            String trace = exchange.getRequestHeaders().getFirst("X-Trace-Id");
+            if (trace != null) {
+              sinkTrace.add(trace);
+            }
+            byte[] response = "ok".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+          });
+      String sinkUrl = "http://127.0.0.1:" + sink.getAddress().getPort() + "/sink";
+      entry.createContext(
+          "/",
+          exchange -> {
+            exchange.getResponseHeaders().add("Location", sinkUrl);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+          });
+      entry.start();
+      sink.start();
+
+      Sandbox whitelist =
+          new WhitelistSandbox(
+              new FileSandboxProperties(List.of()),
+              new ShellSandboxProperties(List.of()),
+              new HttpSandboxProperties(List.of("localhost", "127.0.0.1")));
+      HttpTools guarded = new HttpTools(whitelist, RestClient.create());
+      String start = "http://localhost:" + entry.getAddress().getPort() + "/";
+
+      String body =
+          guarded.httpRequest(
+              "POST", start, "Private-Token: glpat-secret\nX-Trace-Id: keep-me", "{\"x\":1}");
+
+      assertEquals("ok", body);
+      assertEquals(1, sinkHits.get());
+      assertTrue(sinkTokens.isEmpty(), "跨源重定向不得转发 Private-Token");
       assertEquals(List.of("keep-me"), sinkTrace, "非敏感自定义头仍可转发");
     } finally {
       entry.stop(0);


### PR DESCRIPTION
Fixes #258

## Summary
- Strip `Private-Token`, `JOB-TOKEN`, and `X-Auth-Token` on cross-origin HTTP redirects.
- Exact header names only (does not strip every `*Token*`).
- Distinct from #240/#241 (bare `Api-Key`).

## Test plan
- [x] `HttpToolsTest` — stripSensitiveHeaders drops vendor tokens, keeps X-Trace-Id/Accept
- [x] `HttpToolsTest` — cross-origin 302 does not forward Private-Token
- [x] `mvn -pl oryxos-tool pmd:check`