### PR TITLE
fix(notify): clarify channel name vs legacy type wording (#260)

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/NotifyTools.java
@@ -96,7 +96,7 @@ public class NotifyTools implements OryxTool {
           "type": "object",
           "properties": {
             "content": {"type": "string", "description": "要推送的内容"},
-            "channel": {"type": "string", "description": "渠道名（全局 Notify 注册表中的 name）；缺省或 default 用注册表第一个渠道"},
+            "channel": {"type": "string", "description": "渠道名（优先全局 Notify 注册表 name）；未命中时兼容 Profile 内联 notify_channels，仅按 type 匹配（如 webhook/feishu）；缺省或 default 用注册表第一个渠道"},
             "format": {"type": "string", "description": "消息格式：text（默认）；企微 markdown；钉钉 markdown/actionCard；飞书 post/markdown/interactive/card；未知值由对应 Adapter 拒绝"}
           },
           "required": ["content"]
@@ -143,7 +143,12 @@ public class NotifyTools implements OryxTool {
     }
     Profile.NotifyChannel resolved = resolveChannel(channels, channel);
     if (resolved == null) {
-      return ToolResult.error("notify_channels 中不存在类型为 " + channel + " 的渠道（不回退默认，避免消息发错地方）", false);
+      return ToolResult.error(
+          "未找到通知渠道「"
+              + channel
+              + "」：全局注册表无此渠道名；Profile 内联 notify_channels 也无匹配的 type"
+              + "（legacy 仅按 type，如 webhook/feishu；不回退默认，避免消息发错地方）",
+          false);
     }
     NotifyChannelAdapter adapter = adapters.get(resolved.type());
     if (adapter == null) {

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/NotifyToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/NotifyToolsTest.java
@@ -269,8 +269,25 @@ class NotifyToolsTest {
     ToolResult result = notify("hello", "dingtalk");
 
     assertFalse(result.success());
-    assertTrue(result.errorMessage().contains("dingtalk"), "点名未命中的类型");
+    assertTrue(result.errorMessage().contains("dingtalk"), "点名未命中的渠道");
+    assertTrue(
+        result.errorMessage().contains("渠道名") || result.errorMessage().contains("type"),
+        "报错应区分注册表渠道名与 legacy type: " + result.errorMessage());
+    assertFalse(
+        result.errorMessage().contains("不存在类型为"),
+        "不应再暗示 channel 参数本身就是类型: " + result.errorMessage());
     verify(adapter, never()).send(any(), any()); // 不回退默认渠道——回退会把消息发错地方
+  }
+
+  @Test
+  @DisplayName("inputSchema 写明优先渠道名，legacy 仅按 type")
+  void inputSchemaDescribesNameFirstThenLegacyType() {
+    String schema = notifyTools.getInputSchema();
+
+    assertTrue(schema.contains("渠道名"), schema);
+    assertTrue(schema.contains("注册表"), schema);
+    assertTrue(schema.contains("按 type"), "应写明 legacy 按 type: " + schema);
+    assertFalse(schema.contains("渠道类型"), "channel 字段不应再被描述成渠道类型: " + schema);
   }
 
   @Test


### PR DESCRIPTION
Schema and miss errors now state registry name first and that Profile inline notify_channels match by type only; resolve order unchanged.

Fixes #260

## Summary
- Clarify `notify` schema: registry **name** first; Profile inline fallback matches by **type** only.
- Rewrite miss error so it no longer frames `channel` as a type.
- Resolve order unchanged.

## Test plan
- [x] `NotifyToolsTest` — unknown channel error text
- [x] `NotifyToolsTest` — inputSchema name-first / legacy type wording
- [x] `mvn -pl oryxos-tool pmd:check`