### PR TITLE
fix(profile): reject non-list YAML for list fields (#264)

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -116,12 +116,12 @@ public class ProfileLoader {
         asString(map.get("description")),
         toIdentity(asMap(map.get("identity"))),
         provider,
-        asStringList(map.get("tools")),
-        asStringList(map.get("mcp_servers")),
-        asStringList(map.get("channels")),
-        toNotifyChannels(asList(map.get("notify_channels"))),
-        toSchedules(asList(map.get("schedules")), source),
-        asStringList(map.get("bootstrap")),
+        asStringList(map.get("tools"), "tools", name),
+        asStringList(map.get("mcp_servers"), "mcp_servers", name),
+        asStringList(map.get("channels"), "channels", name),
+        toNotifyChannels(requireListOrNull(map.get("notify_channels"), "notify_channels", name)),
+        toSchedules(requireListOrNull(map.get("schedules"), "schedules", name), source),
+        asStringList(map.get("bootstrap"), "bootstrap", name),
         toSettings(asMap(map.get("settings")), name));
   }
 
@@ -354,13 +354,21 @@ public class ProfileLoader {
     return value instanceof Map ? (Map<String, Object>) value : null;
   }
 
+  /** 列表字段：缺省（null）→ 空列表语义由调用方处理；显式写成标量/映射则报错，避免「写了却静默变空」。 */
   @SuppressWarnings("unchecked")
-  private static List<Object> asList(Object value) {
-    return value instanceof List ? (List<Object>) value : null;
+  private static List<Object> requireListOrNull(Object value, String field, String profileName) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof List<?> list) {
+      return (List<Object>) list;
+    }
+    throw new ProfileValidationException(
+        "Profile " + profileName + " 的 " + field + " 必须是列表: " + value);
   }
 
-  private static List<String> asStringList(Object value) {
-    List<Object> list = asList(value);
+  private static List<String> asStringList(Object value, String field, String profileName) {
+    List<Object> list = requireListOrNull(value, field, profileName);
     if (list == null) {
       return List.of();
     }

--- a/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
@@ -172,6 +172,51 @@ class ProfileLoaderTest {
   }
 
   @Test
+  void 列表字段写成标量时报错点名() throws IOException {
+    write(
+        "scalar-tools.yaml",
+        """
+        name: scalar-tools
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        tools: http_get
+        """);
+
+    ProfileValidationException ex =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("scalar-tools.yaml")));
+
+    assertTrue(ex.getMessage().contains("tools"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("必须是列表"), ex.getMessage());
+  }
+
+  @Test
+  void 列表字段写成映射时报错点名() throws IOException {
+    write(
+        "map-schedules.yaml",
+        """
+        name: map-schedules
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          morning:
+            cron: "0 0 8 * * *"
+            message: hi
+        """);
+
+    ProfileValidationException ex =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("map-schedules.yaml")));
+
+    assertTrue(ex.getMessage().contains("schedules"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("必须是列表"), ex.getMessage());
+  }
+
+  @Test
   void 引用不存在的provider_报错信息包含该名字() throws IOException {
     write(
         "bad-provider.yaml",


### PR DESCRIPTION
ProfileLoader now throws when tools/schedules/etc. are scalars or mappings instead of silently becoming empty lists.

Fixes #264

## Summary
- Reject scalar/mapping YAML for Profile list fields (`tools`, `mcp_servers`, `channels`, `bootstrap`, `notify_channels`, `schedules`).
- Omitted fields still mean empty list.
- Distinct from #254 (quoted numerics).

## Test plan
- [x] `ProfileLoaderTest` — scalar `tools: http_get` fails with field name
- [x] `ProfileLoaderTest` — mapping `schedules:` fails with field name
- [x] `mvn -pl oryxos-core pmd:check`