### PR TITLE
fix(profile): require cron for schedule entries (#266)

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -217,11 +217,15 @@ public class ProfileLoader {
       if (!keys.add(key)) {
         throw new ProfileValidationException("Profile 定时配置 key 重复: " + key + " (" + source + ")");
       }
+      String cron = asString(entry.get("cron"));
+      if (cron == null || cron.isBlank()) {
+        throw new ProfileValidationException("Profile 定时配置 " + key + " 缺少 cron: " + source);
+      }
       schedules.add(
           new Profile.ScheduleConfig(
               key,
               name,
-              asString(entry.get("cron")),
+              cron.strip(),
               asString(entry.get("zone")),
               asString(entry.get("message"))));
     }

--- a/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
@@ -465,4 +465,53 @@ class ProfileLoaderTest {
     Profile profile = loader().parse(profilesDir.resolve("quoted-yes-key.yaml"));
     assertEquals("yes", profile.schedules().get(0).key());
   }
+
+  @Test
+  void 定时配置缺少cron时报错点名() throws IOException {
+    write(
+        "missing-cron.yaml",
+        """
+        name: missing-cron
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - key: morning
+            name: Morning digest
+            message: run now
+        """);
+
+    ProfileValidationException ex =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("missing-cron.yaml")));
+
+    assertTrue(ex.getMessage().contains("morning"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("cron"), ex.getMessage());
+  }
+
+  @Test
+  void 定时配置cron为空字符串时报错点名() throws IOException {
+    write(
+        "blank-cron.yaml",
+        """
+        name: blank-cron
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - key: evening
+            name: Evening digest
+            cron: ""
+            message: run now
+        """);
+
+    ProfileValidationException ex =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("blank-cron.yaml")));
+
+    assertTrue(ex.getMessage().contains("evening"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("cron"), ex.getMessage());
+  }
 }


### PR DESCRIPTION
Reject missing or blank schedule cron at Profile load time instead of letting AgentScheduler WARN-skip silently at register.

Fixes #266

## Summary
- Reject missing or blank `cron` in `ProfileLoader.toSchedules`.
- Fail at load time instead of `AgentScheduler` WARN-skipping at register.
- Distinct from #264 (list shape) and #254 (quoted numerics).

## Test plan
- [x] `ProfileLoaderTest` — missing `cron` fails with schedule key
- [x] `ProfileLoaderTest` — blank `cron: ""` fails with schedule key
- [x] `mvn -pl oryxos-core pmd:check`