### PR TITLE
fix(mcp): fail loud on malformed mcp_servers.yaml (#270)

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/mcp/McpConfigLoader.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/mcp/McpConfigLoader.java
@@ -25,6 +25,9 @@ import org.yaml.snakeyaml.Yaml;
  * <p><b>raw 与 resolved 两套读法，不能混用</b>：{@link #load} 解析占位符拿真实凭证，只给要发起真实连接的 {@code McpClientService}
  * 用；{@link #loadRaw} 保留字面量 {@code ${VAR}} 不解析，给管理台 CRUD（列表展示 / 改配置再 {@link
  * #save}）用——否则改一次配置就会把解析出的明文 token 写回磁盘，凭证泄露进文件（宪法：敏感配置走环境变量，不落盘明文）。
+ *
+ * <p>结构非法（YAML 解析失败 / 顶层 servers 非列表 / 条目非对象）抛 {@link IllegalArgumentException} 点名报错， 不静默按零 server
+ * 处理——与 {@code ChannelConfigLoader} 同口径。
  */
 public class McpConfigLoader {
 
@@ -68,26 +71,30 @@ public class McpConfigLoader {
     try (Reader reader = Files.newBufferedReader(configFile)) {
       root = new Yaml().load(reader);
     } catch (IOException | RuntimeException e) {
-      LOG.warn("mcp_servers.yaml 解析失败，按零 server 处理: {}", sanitize(e.getMessage()));
-      return List.of();
+      throw new IllegalArgumentException("mcp_servers.yaml 解析失败: " + sanitize(e.getMessage()), e);
     }
     Object servers = root == null ? null : root.get("servers");
-    if (!(servers instanceof List)) {
+    if (servers == null) {
       return List.of();
+    }
+    if (!(servers instanceof List)) {
+      throw new IllegalArgumentException("mcp_servers.yaml 顶层 servers 必须是列表");
     }
     List<McpServerConfig> configs = new ArrayList<>();
     for (Object item : (List<Object>) servers) {
-      if (item instanceof Map) {
-        Map<String, Object> entry = (Map<String, Object>) item;
-        configs.add(
-            new McpServerConfig(
-                asString(entry.get("name")),
-                asString(entry.get("transport")),
-                asString(entry.get("command")),
-                asStringMap(entry.get("env")),
-                asString(entry.get("url")),
-                asStringMap(entry.get("headers"))));
+      if (!(item instanceof Map)) {
+        throw new IllegalArgumentException(
+            "mcp_servers.yaml 存在非对象条目: " + sanitize(String.valueOf(item)));
       }
+      Map<String, Object> entry = (Map<String, Object>) item;
+      configs.add(
+          new McpServerConfig(
+              asString(entry.get("name")),
+              asString(entry.get("transport")),
+              asString(entry.get("command")),
+              asStringMap(entry.get("env")),
+              asString(entry.get("url")),
+              asStringMap(entry.get("headers"))));
     }
     return configs;
   }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpConfigLoaderTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpConfigLoaderTest.java
@@ -77,7 +77,8 @@ class McpConfigLoaderTest {
             command: echo
         """);
     IllegalArgumentException e =
-        assertThrows(IllegalArgumentException.class, () -> new McpConfigLoader(configFile()).loadRaw());
+        assertThrows(
+            IllegalArgumentException.class, () -> new McpConfigLoader(configFile()).loadRaw());
     assertTrue(e.getMessage().contains("字符串") || e.getMessage().contains("Boolean"));
 
     write(

--- a/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpConfigLoaderTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpConfigLoaderTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -13,14 +14,62 @@ import org.junit.jupiter.api.io.TempDir;
 
 class McpConfigLoaderTest {
 
-  @TempDir Path tempDir;
+  @TempDir Path dir;
+
+  private Path configFile() {
+    return dir.resolve("mcp_servers.yaml");
+  }
+
+  private void write(String yaml) throws IOException {
+    Files.writeString(configFile(), yaml);
+  }
+
+  @Test
+  @DisplayName("文件缺失时 loadRaw 返回空列表")
+  void missingFileReturnsEmpty() {
+    assertEquals(0, new McpConfigLoader(configFile()).loadRaw().size());
+  }
+
+  @Test
+  @DisplayName("YAML 解析失败时 loadRaw 抛 IllegalArgumentException")
+  void malformedYamlFailsLoud() throws IOException {
+    write("servers:\n  - name: [unclosed\n");
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> new McpConfigLoader(configFile()).loadRaw());
+
+    assertTrue(ex.getMessage().contains("mcp_servers.yaml 解析失败"));
+  }
+
+  @Test
+  @DisplayName("顶层 servers 非列表时 loadRaw 抛 IllegalArgumentException")
+  void serversNotListFailsLoud() throws IOException {
+    write("servers: not-a-list\n");
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> new McpConfigLoader(configFile()).loadRaw());
+
+    assertTrue(ex.getMessage().contains("servers 必须是列表"));
+  }
+
+  @Test
+  @DisplayName("servers 条目非对象时 loadRaw 抛 IllegalArgumentException")
+  void serversEntryNotMapFailsLoud() throws IOException {
+    write("servers:\n  - plain-string\n");
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> new McpConfigLoader(configFile()).loadRaw());
+
+    assertTrue(ex.getMessage().contains("非对象条目"));
+  }
 
   @Test
   @DisplayName("YAML 1.1 布尔词 yes 不得被 String.valueOf 改成 name=true")
   void rejectsYamlBooleanWordAsName() throws Exception {
-    Path file = tempDir.resolve("mcp_servers.yaml");
-    Files.writeString(
-        file,
+    write(
         """
         servers:
           - name: yes
@@ -28,18 +77,17 @@ class McpConfigLoaderTest {
             command: echo
         """);
     IllegalArgumentException e =
-        assertThrows(IllegalArgumentException.class, () -> new McpConfigLoader(file).loadRaw());
+        assertThrows(IllegalArgumentException.class, () -> new McpConfigLoader(configFile()).loadRaw());
     assertTrue(e.getMessage().contains("字符串") || e.getMessage().contains("Boolean"));
 
-    Files.writeString(
-        file,
+    write(
         """
         servers:
           - name: "yes"
             transport: stdio
             command: echo
         """);
-    List<io.oryxos.core.mcp.McpServerConfig> ok = new McpConfigLoader(file).loadRaw();
+    List<io.oryxos.core.mcp.McpServerConfig> ok = new McpConfigLoader(configFile()).loadRaw();
     assertEquals(1, ok.size());
     assertEquals("yes", ok.get(0).name());
   }


### PR DESCRIPTION
Parse and structural errors in mcp_servers.yaml now throw IllegalArgumentException instead of logging a warning and returning an empty server list. Aligns with ChannelConfigLoader; missing file or null servers key still means zero servers.

Closes #270

## Summary
- `McpConfigLoader.loadRaw()` throws `IllegalArgumentException` on YAML parse errors, non-list `servers`, or non-object list entries (aligned with `ChannelConfigLoader`).
- Missing file or absent/null `servers` key still returns an empty list.
- Add `McpConfigLoaderTest` for malformed YAML, wrong `servers` type, and non-map entry.

## Test plan
- [x] `McpConfigLoaderTest` — all four cases pass locally