### PR TITLE
fix(http): strip body headers on redirect-to-GET (#274)

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -155,6 +155,7 @@ public class HttpTools {
           hopMethod = HttpMethod.GET;
           hopBody = null;
           hopJsonBody = false;
+          hopHeaders = stripBodyHeaders(hopHeaders);
         }
         current = next;
         continue;
@@ -239,6 +240,38 @@ public class HttpTools {
       kept.append(name).append(':').append(line.substring(colon + 1).strip());
     }
     return kept.toString();
+  }
+
+  /** 301/302/303 改 GET 时去掉与请求体相关的头，避免无 body 仍带 Content-Type/Content-Length。 */
+  static String stripBodyHeaders(String headers) {
+    if (headers == null || headers.isBlank()) {
+      return headers;
+    }
+    StringBuilder kept = new StringBuilder();
+    for (String line : HEADER_LINE_SEP.split(headers)) {
+      int colon = line.indexOf(':');
+      if (colon <= 0) {
+        continue;
+      }
+      String name = line.substring(0, colon).strip();
+      if (isBodyHeaderName(name)) {
+        continue;
+      }
+      if (kept.length() > 0) {
+        kept.append('\n');
+      }
+      kept.append(name).append(':').append(line.substring(colon + 1).strip());
+    }
+    return kept.toString();
+  }
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "HTTP header names are ASCII tokens; Locale.ROOT lowercasing is the correct case-fold for body-related header matching.")
+  private static boolean isBodyHeaderName(String name) {
+    String n = name.toLowerCase(Locale.ROOT);
+    return "content-type".equals(n) || "content-length".equals(n) || "transfer-encoding".equals(n);
   }
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
@@ -392,6 +392,7 @@ class HttpToolsTest {
     HttpServer sink = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
     List<String> sinkMethods = new ArrayList<>();
     List<String> sinkBodies = new ArrayList<>();
+    List<String> sinkContentTypes = new ArrayList<>();
     try {
       sink.createContext(
           "/",
@@ -399,6 +400,7 @@ class HttpToolsTest {
             sinkMethods.add(exchange.getRequestMethod());
             sinkBodies.add(
                 new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            sinkContentTypes.add(exchange.getRequestHeaders().getFirst("Content-Type"));
             byte[] response = "ok".getBytes(StandardCharsets.UTF_8);
             exchange.sendResponseHeaders(200, response.length);
             exchange.getResponseBody().write(response);
@@ -424,11 +426,14 @@ class HttpToolsTest {
       HttpTools guarded = new HttpTools(whitelist, RestClient.create());
       String start = "http://localhost:" + entry.getAddress().getPort() + "/";
 
-      String body = guarded.httpRequest("POST", start, null, "{\"secret\":\"token\"}");
+      String body =
+          guarded.httpRequest(
+              "POST", start, "Content-Type: application/json", "{\"secret\":\"token\"}");
 
       assertEquals("ok", body);
       assertEquals(List.of("GET"), sinkMethods, "302 下一跳应改为 GET");
       assertEquals(List.of(""), sinkBodies, "302 不得把 POST body 转到下一跳");
+      assertTrue(sinkContentTypes.stream().allMatch(v -> v == null), "302 改 GET 不得转发 Content-Type");
     } finally {
       entry.stop(0);
       sink.stop(0);


### PR DESCRIPTION
When 301/302/303 switches the next hop to GET, clear Content-Type, Content-Length, and Transfer-Encoding from hop headers—not only the body.

Closes #274

## Summary
- On 301/302/303 redirect-to-GET, strip `Content-Type`, `Content-Length`, and `Transfer-Encoding` from hop headers (body was already cleared).
- Extend `HttpToolsTest.httpRequest302DoesNotReplayPostBody` to assert sink receives no `Content-Type`.

## Test plan
- [x] `HttpToolsTest#httpRequest302DoesNotReplayPostBody` passes locally