### PR TITLE
chore(deps): bump Tomcat to 10.1.58 for OWASP CVE scan (#276)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <!-- Infrastructure libraries -->
         <jackson-bom.version>2.21.5</jackson-bom.version>
         <log4j2.version>2.25.5</log4j2.version>
-        <tomcat.version>10.1.57</tomcat.version>
+        <tomcat.version>10.1.58</tomcat.version>
         <logstash-logback.version>7.4</logstash-logback.version>
         <springdoc.version>2.6.0</springdoc.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <!-- Infrastructure libraries -->
         <jackson-bom.version>2.21.5</jackson-bom.version>
         <log4j2.version>2.25.5</log4j2.version>
-        <tomcat.version>10.1.58</tomcat.version>
+        <tomcat.version>10.1.59</tomcat.version>
         <logstash-logback.version>7.4</logstash-logback.version>
         <springdoc.version>2.6.0</springdoc.version>
 


### PR DESCRIPTION
Raise pinned tomcat.version from 10.1.57 to 10.1.58 to address CVE-2026-65637, CVE-2026-65905 and related Tomcat advisories failing CI OWASP Dependency-Check.

Closes #276

## Summary
- Bump pinned `<tomcat.version>` from `10.1.57` to `10.1.58` to address Tomcat CVEs failing CI `OWASP Dependency-Check` (e.g. CVE-2026-65637, CVE-2026-65905).
- No functional code changes.

## Test plan
- [ ] CI `Build & quality gate` green
- [ ] CI `OWASP Dependency-Check` green (or document any remaining transitive findings for follow-up)

## Notes
If OWASP still reports `commons-lang3`, `pdfbox`, or `springdoc`/DOMPurify after this bump, follow-up version bumps can be done in a separate PR per #276.