### PR TITLE
fix(tool): bind HTTP reads to validated DNS addresses

### DIFF
--- a/oryxos-tool/pom.xml
+++ b/oryxos-tool/pom.xml
@@ -42,6 +42,11 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
         </dependency>
+        <!-- HTTP_READ 连接层 DNS 绑定：版本由 Boot BOM 管理 -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+        </dependency>
         <!-- 邮件通知渠道（EmailNotifyAdapter）出站 SMTP——版本由 Boot BOM 管理（Angus Mail + jakarta.mail-api） -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -4,6 +4,7 @@ import io.oryxos.core.fs.AdminConfigFileGuard;
 import io.oryxos.core.fs.WorkspaceMutationGuard;
 import io.oryxos.core.memory.MemoryMdGuard;
 import io.oryxos.tool.sandbox.ActionType;
+import io.oryxos.tool.sandbox.PinnedHttpReadClient;
 import io.oryxos.tool.sandbox.Sandbox;
 import io.oryxos.tool.sandbox.SandboxAction;
 import java.io.IOException;
@@ -69,20 +70,20 @@ public class HttpTools {
 
   private final Sandbox sandbox;
 
-  /** 读写共用：**禁自动重定向**，由本类手动逐跳跟随并每跳重过沙箱校验。不使用注入的 RestClient 默认跟随行为（否则写请求会在首跳过白名单后跟到任意 Location）。 */
-  private final RestClient hopClient;
+  /** HTTP_REQUEST 专用：保留域名白名单语义，不额外拒绝运营者显式批准的内网端点。 */
+  private final RestClient writeClient;
 
   public HttpTools(Sandbox sandbox, RestClient restClient) {
-    this.sandbox = sandbox;
+    this.sandbox = Objects.requireNonNull(sandbox, "sandbox 不能为空");
     Objects.requireNonNull(restClient, "restClient 不能为空"); // 保留构造签名，供 Spring 装配
-    JdkClientHttpRequestFactory hopFactory =
+    JdkClientHttpRequestFactory writeFactory =
         new JdkClientHttpRequestFactory(
             HttpClient.newBuilder()
                 .connectTimeout(CONNECT_TIMEOUT)
                 .followRedirects(HttpClient.Redirect.NEVER)
                 .build());
-    hopFactory.setReadTimeout(READ_TIMEOUT);
-    this.hopClient = RestClient.builder().requestFactory(hopFactory).build();
+    writeFactory.setReadTimeout(READ_TIMEOUT);
+    this.writeClient = RestClient.builder().requestFactory(writeFactory).build();
   }
 
   /**
@@ -102,9 +103,13 @@ public class HttpTools {
     String hopHeaders = headers;
     for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
       sandbox.enforce(new SandboxAction(ActionType.HTTP_READ, current)); // 每跳校验
-      RestClient.RequestBodySpec spec = hopClient.method(HttpMethod.GET).uri(current);
-      applyCustomHeaders(spec, hopHeaders);
-      ResponseEntity<T> resp = spec.retrieve().toEntity(type);
+      ResponseEntity<T> resp;
+      try (PinnedHttpReadClient client =
+          PinnedHttpReadClient.open(sandbox, CONNECT_TIMEOUT, READ_TIMEOUT)) {
+        RestClient.RequestBodySpec spec = client.restClient().method(HttpMethod.GET).uri(current);
+        applyCustomHeaders(spec, hopHeaders);
+        resp = spec.retrieve().toEntity(type);
+      }
       if (resp.getStatusCode().is3xxRedirection()) {
         String location = resp.getHeaders().getFirst("Location");
         if (location == null || location.isBlank()) {
@@ -132,7 +137,7 @@ public class HttpTools {
     boolean hopJsonBody = jsonBody;
     for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
       sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, current)); // 每跳校验
-      RestClient.RequestBodySpec spec = hopClient.method(hopMethod).uri(current);
+      RestClient.RequestBodySpec spec = writeClient.method(hopMethod).uri(current);
       applyCustomHeaders(spec, hopHeaders);
       if (hopBody != null && !hopBody.isBlank()) {
         if (hopJsonBody) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/PermissiveSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/PermissiveSandbox.java
@@ -1,12 +1,14 @@
 package io.oryxos.tool.sandbox;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * 24 节 WhitelistSandbox 就位前的临时装配：放行一切，但每次放行都记 WARN 留痕—— 绝不静默裸奔，日志里看得见"这套环境还没开白名单"。生产不可用，Demo 验证专用。
  */
-public class PermissiveSandbox implements Sandbox {
+public class PermissiveSandbox implements Sandbox, ResolvedHttpReadGuard {
 
   private static final Logger LOG = LoggerFactory.getLogger(PermissiveSandbox.class);
 
@@ -21,5 +23,14 @@ public class PermissiveSandbox implements Sandbox {
         "Sandbox 白名单未启用（24 节接入），放行 {} -> {}",
         action.type(),
         target.replace('\r', '_').replace('\n', '_'));
+  }
+
+  @Override
+  public InetAddress[] resolveHttpReadHost(String host) {
+    try {
+      return InetAddress.getAllByName(host);
+    } catch (UnknownHostException e) {
+      throw new SandboxViolationException("无法解析主机: " + host);
+    }
   }
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/PinnedHttpReadClient.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/PinnedHttpReadClient.java
@@ -65,6 +65,10 @@ public final class PinnedHttpReadClient implements AutoCloseable {
     return new PinnedHttpReadClient(connectionManager, httpClient, restClient);
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification =
+          "RestClient is an immutable request facade after build; the wrapper deliberately shares it while retaining and closing the underlying HTTP client lifecycle.")
   public RestClient restClient() {
     return restClient;
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/PinnedHttpReadClient.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/PinnedHttpReadClient.java
@@ -1,0 +1,80 @@
+package io.oryxos.tool.sandbox;
+
+import java.time.Duration;
+import java.util.Objects;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.util.Timeout;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+/**
+ * 一个 HTTP_READ hop 的短生命安全 client：禁自动重定向，socket 只使用 Sandbox 当次校验过的 DNS 地址集。
+ *
+ * <p>调用方必须使用 try-with-resources；每个 hop 独立的连接池不会跨跳复用旧地址集。
+ */
+public final class PinnedHttpReadClient implements AutoCloseable {
+
+  private final PoolingHttpClientConnectionManager connectionManager;
+  private final CloseableHttpClient httpClient;
+  private final RestClient restClient;
+
+  private PinnedHttpReadClient(
+      PoolingHttpClientConnectionManager connectionManager,
+      CloseableHttpClient httpClient,
+      RestClient restClient) {
+    this.connectionManager = connectionManager;
+    this.httpClient = httpClient;
+    this.restClient = restClient;
+  }
+
+  public static PinnedHttpReadClient open(
+      Sandbox sandbox, Duration connectTimeout, Duration readTimeout) {
+    Objects.requireNonNull(sandbox, "sandbox 不能为空");
+    Objects.requireNonNull(connectTimeout, "connectTimeout 不能为空");
+    Objects.requireNonNull(readTimeout, "readTimeout 不能为空");
+    if (!(sandbox instanceof ResolvedHttpReadGuard guard)) {
+      throw new SandboxViolationException("Sandbox 未提供与连接绑定的 HTTP_READ 安全解析能力");
+    }
+
+    ConnectionConfig connectionConfig =
+        ConnectionConfig.custom()
+            .setConnectTimeout(Timeout.of(connectTimeout))
+            .setSocketTimeout(Timeout.of(readTimeout))
+            .build();
+    PoolingHttpClientConnectionManager connectionManager =
+        PoolingHttpClientConnectionManagerBuilder.create()
+            .setDnsResolver(new SandboxDnsResolver(guard))
+            .setDefaultConnectionConfig(connectionConfig)
+            .build();
+    CloseableHttpClient httpClient =
+        HttpClients.custom()
+            .setConnectionManager(connectionManager)
+            .disableRedirectHandling()
+            .disableAutomaticRetries()
+            .build();
+    HttpComponentsClientHttpRequestFactory requestFactory =
+        new HttpComponentsClientHttpRequestFactory(httpClient);
+    requestFactory.setConnectionRequestTimeout(connectTimeout);
+    requestFactory.setReadTimeout(readTimeout);
+    RestClient restClient = RestClient.builder().requestFactory(requestFactory).build();
+    return new PinnedHttpReadClient(connectionManager, httpClient, restClient);
+  }
+
+  public RestClient restClient() {
+    return restClient;
+  }
+
+  boolean isClosed() {
+    return connectionManager.isClosed();
+  }
+
+  @Override
+  public void close() {
+    httpClient.close(CloseMode.GRACEFUL);
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/ResolvedHttpReadGuard.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/ResolvedHttpReadGuard.java
@@ -1,0 +1,15 @@
+package io.oryxos.tool.sandbox;
+
+import java.net.InetAddress;
+
+/**
+ * HTTP 读请求的连接时安全解析能力。
+ *
+ * <p>实现必须在同一次调用中解析主机名、校验全部候选地址，并返回传输层唯一允许使用的地址集。这样校验与建连不会分别观察到不同的 DNS 结果。
+ */
+@FunctionalInterface
+public interface ResolvedHttpReadGuard {
+
+  /** 返回已通过当前 Sandbox 策略校验、可供当次 HTTP_READ 连接使用的地址。 */
+  InetAddress[] resolveHttpReadHost(String host);
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/SandboxDnsResolver.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/SandboxDnsResolver.java
@@ -1,0 +1,34 @@
+package io.oryxos.tool.sandbox;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Objects;
+import org.apache.hc.client5.http.DnsResolver;
+
+/** Apache HttpClient 的 DNS 边界：只把 Sandbox 当次校验返回的地址交给 socket 连接层。 */
+final class SandboxDnsResolver implements DnsResolver {
+
+  private final ResolvedHttpReadGuard guard;
+
+  SandboxDnsResolver(ResolvedHttpReadGuard guard) {
+    this.guard = Objects.requireNonNull(guard, "guard 不能为空");
+  }
+
+  @Override
+  public InetAddress[] resolve(String host) throws UnknownHostException {
+    InetAddress[] addresses = guard.resolveHttpReadHost(host);
+    if (addresses == null || addresses.length == 0) {
+      throw new UnknownHostException("安全解析未返回可连接地址: " + host);
+    }
+    return addresses.clone();
+  }
+
+  @Override
+  public String resolveCanonicalHostname(String host) throws UnknownHostException {
+    if (host == null || host.isBlank()) {
+      throw new UnknownHostException("主机名为空");
+    }
+    // 不在 canonical-name 路径做第二次 DNS 查询；原 hostname 继续用于 Host / TLS SNI / 证书校验。
+    return host;
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -28,11 +28,11 @@ import org.slf4j.LoggerFactory;
  * / {@link ConcurrentHashMap#newKeySet()}）——校验读路径无锁（热路径）， 管理写路径极少发生、拷贝开销可接受；非异步编程模型，符合宪法 VII。每次改动落
  * INFO 日志留痕。
  *
- * <p>四个 {@code check*} 与 {@code matchesDomain} 均 {@code private}——对外只暴露 {@code enforce} 与管理三方法。 若把
- * check* public 暴露到 {@code Sandbox} 接口上，接口就被这一档实现带偏了。
+ * <p>四个 {@code check*} 与 {@code matchesDomain} 均 {@code private}。连接层仅通过 {@link
+ * ResolvedHttpReadGuard} 取得当次已校验的 HTTP_READ 地址集；通用 {@link Sandbox} 接口仍保持 {@code enforce(void)} 契约。
  */
 // final：构造器会因非法配置抛异常（normalizeRoot/requireNonBlank），禁止子类化以杜绝 finalizer attack（CT_CONSTRUCTOR_THROW）
-public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
+public final class WhitelistSandbox implements Sandbox, SandboxWhitelist, ResolvedHttpReadGuard {
 
   private static final Logger LOG = LoggerFactory.getLogger(WhitelistSandbox.class);
 
@@ -215,7 +215,7 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
     if (host == null || host.isBlank()) {
       throw new SandboxViolationException("读请求缺少主机名，拒绝: " + url);
     }
-    assertNotInternalHost(host);
+    resolveHttpReadHost(host);
   }
 
   /**
@@ -288,7 +288,8 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
       value = "IMPROPER_UNICODE",
       justification =
           "IDN.toASCII canonicalizes the complete DNS host before security checks; no substring is transformed independently.")
-  private static void assertNotInternalHost(String host) {
+  @Override
+  public InetAddress[] resolveHttpReadHost(String host) {
     String asciiHost;
     try {
       asciiHost = IDN.toASCII(host);
@@ -315,6 +316,7 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
             "拒绝访问内网 / 保留地址（SSRF 防护）: " + host + " → " + addr.getHostAddress() + "。这是安全策略，请勿重试。");
       }
     }
+    return addresses.clone();
   }
 
   /**

--- a/oryxos-tool/src/main/java/io/oryxos/tool/web/DuckDuckGoSearchProvider.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/web/DuckDuckGoSearchProvider.java
@@ -3,15 +3,14 @@ package io.oryxos.tool.web;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.oryxos.tool.sandbox.ActionType;
+import io.oryxos.tool.sandbox.PinnedHttpReadClient;
 import io.oryxos.tool.sandbox.Sandbox;
 import io.oryxos.tool.sandbox.SandboxAction;
-import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -29,9 +28,6 @@ public class DuckDuckGoSearchProvider implements SearchProvider {
   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
   private static final Duration READ_TIMEOUT = Duration.ofSeconds(20);
 
-  /** 禁自动重定向的专用客户端；不沿用注入 RestClient 的跟随策略。 */
-  private final RestClient hopClient;
-
   private final String endpoint;
   private final Sandbox sandbox;
 
@@ -43,26 +39,23 @@ public class DuckDuckGoSearchProvider implements SearchProvider {
     Objects.requireNonNull(restClient, "restClient 不能为空"); // 保留签名，供 Spring 装配
     this.sandbox = Objects.requireNonNull(sandbox, "sandbox 不能为空");
     this.endpoint = Objects.requireNonNull(endpoint, "endpoint 不能为空");
-    JdkClientHttpRequestFactory hopFactory =
-        new JdkClientHttpRequestFactory(
-            HttpClient.newBuilder()
-                .connectTimeout(CONNECT_TIMEOUT)
-                .followRedirects(HttpClient.Redirect.NEVER)
-                .build());
-    hopFactory.setReadTimeout(READ_TIMEOUT);
-    this.hopClient = RestClient.builder().requestFactory(hopFactory).build();
   }
 
   @Override
   public List<SearchResult> search(String query) {
     // 伪目标 web_search:query 只做工具层标签；真实出网 URL 必须再过 HTTP_READ / SSRF
     sandbox.enforce(new SandboxAction(ActionType.HTTP_READ, endpoint));
-    ResponseEntity<String> resp =
-        hopClient
-            .get()
-            .uri(endpoint + "?q={q}&format=json&no_html=1", query)
-            .retrieve()
-            .toEntity(String.class);
+    ResponseEntity<String> resp;
+    try (PinnedHttpReadClient client =
+        PinnedHttpReadClient.open(sandbox, CONNECT_TIMEOUT, READ_TIMEOUT)) {
+      resp =
+          client
+              .restClient()
+              .get()
+              .uri(endpoint + "?q={q}&format=json&no_html=1", query)
+              .retrieve()
+              .toEntity(String.class);
+    }
     if (resp.getStatusCode().is3xxRedirection()) {
       throw new IllegalStateException("搜索端点返回重定向，拒绝跟随: " + endpoint);
     }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
@@ -4,27 +4,29 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 
 import com.sun.net.httpserver.HttpServer;
 import io.oryxos.tool.sandbox.ActionType;
 import io.oryxos.tool.sandbox.FileSandboxProperties;
 import io.oryxos.tool.sandbox.HttpSandboxProperties;
 import io.oryxos.tool.sandbox.PermissiveSandbox;
+import io.oryxos.tool.sandbox.ResolvedHttpReadGuard;
 import io.oryxos.tool.sandbox.Sandbox;
+import io.oryxos.tool.sandbox.SandboxAction;
 import io.oryxos.tool.sandbox.SandboxViolationException;
 import io.oryxos.tool.sandbox.ShellSandboxProperties;
 import io.oryxos.tool.sandbox.WhitelistSandbox;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,6 +36,29 @@ import org.springframework.web.client.RestClient;
 
 /** 课件《第20节》验收 harness：HttpToolsTest——课件正文两用例即模板。 */
 class HttpToolsTest {
+
+  private static final class TestResolvedSandbox implements Sandbox, ResolvedHttpReadGuard {
+
+    private final Consumer<SandboxAction> enforcer;
+
+    private TestResolvedSandbox(Consumer<SandboxAction> enforcer) {
+      this.enforcer = enforcer;
+    }
+
+    @Override
+    public void enforce(SandboxAction action) {
+      enforcer.accept(action);
+    }
+
+    @Override
+    public InetAddress[] resolveHttpReadHost(String host) {
+      try {
+        return InetAddress.getAllByName(host);
+      } catch (UnknownHostException e) {
+        throw new SandboxViolationException("无法解析主机: " + host);
+      }
+    }
+  }
 
   private HttpServer server;
   private final List<String> receivedBodies = new ArrayList<>();
@@ -111,6 +136,17 @@ class HttpToolsTest {
   }
 
   @Test
+  @DisplayName("只实现旧 Sandbox 契约时仍可使用 HTTP_REQUEST 写路径")
+  void writeOnlyUsageDoesNotRequireResolvedReadGuard() {
+    Sandbox legacy = action -> {};
+    HttpTools writeOnly = new HttpTools(legacy, RestClient.create());
+
+    String result = writeOnly.httpPost(url(), "{\"city\":\"beijing\"}");
+
+    assertTrue(result.contains("晴"));
+  }
+
+  @Test
   @DisplayName("http_request 拒绝 schema 外方法 TRACE")
   void httpRequestRejectsTrace() {
     IllegalArgumentException ex =
@@ -146,8 +182,11 @@ class HttpToolsTest {
   @Test
   @DisplayName("http_get_命中白名单外域名应被拦下")
   void httpGetOutsideWhitelistIsBlocked() {
-    Sandbox denying = mock(Sandbox.class);
-    doThrow(new SandboxViolationException("域名不在白名单")).when(denying).enforce(any());
+    Sandbox denying =
+        new TestResolvedSandbox(
+            action -> {
+              throw new SandboxViolationException("域名不在白名单");
+            });
     HttpTools guarded = new HttpTools(denying, RestClient.create());
 
     assertThrows(RuntimeException.class, () -> guarded.httpGet(url())); // 课件断言形态
@@ -577,16 +616,17 @@ class HttpToolsTest {
     Path nested = dir.resolve("nested");
     Path target = nested.resolve("payload.bin");
     Sandbox sandbox =
-        action -> {
-          if (action.type() == ActionType.FILE_WRITE) {
-            int n = fileWrites.incrementAndGet();
-            if (n >= 2) {
-              // 复检必须在 createDirectories 之后：此时父目录应已存在
-              assertTrue(Files.isDirectory(nested), "写前复检应发生在 createDirectories 之后");
-              throw new SandboxViolationException("复检拒绝: " + action.target());
-            }
-          }
-        };
+        new TestResolvedSandbox(
+            action -> {
+              if (action.type() == ActionType.FILE_WRITE) {
+                int n = fileWrites.incrementAndGet();
+                if (n >= 2) {
+                  // 复检必须在 createDirectories 之后：此时父目录应已存在
+                  assertTrue(Files.isDirectory(nested), "写前复检应发生在 createDirectories 之后");
+                  throw new SandboxViolationException("复检拒绝: " + action.target());
+                }
+              }
+            });
     HttpTools guarded = new HttpTools(sandbox, RestClient.create());
 
     assertThrows(

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/SandboxDnsResolverTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/SandboxDnsResolverTest.java
@@ -1,0 +1,70 @@
+package io.oryxos.tool.sandbox;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SandboxDnsResolverTest {
+
+  @Test
+  @DisplayName("DNS resolver 把同一次安全校验返回的地址集交给连接层")
+  void returnsDefensiveCopyOfValidatedAddresses() throws Exception {
+    InetAddress approved = InetAddress.getByAddress(new byte[] {(byte) 203, 0, 113, 10});
+    InetAddress[] approvedSet = {approved};
+    AtomicInteger calls = new AtomicInteger();
+    ResolvedHttpReadGuard guard =
+        host -> {
+          assertEquals("safe.example", host);
+          calls.incrementAndGet();
+          return approvedSet;
+        };
+
+    InetAddress[] resolved = new SandboxDnsResolver(guard).resolve("safe.example");
+
+    assertArrayEquals(approvedSet, resolved);
+    assertNotSame(approvedSet, resolved);
+    assertEquals(1, calls.get());
+  }
+
+  @Test
+  @DisplayName("空解析结果必须 fail closed")
+  void rejectsEmptyValidatedAddressSet() {
+    ResolvedHttpReadGuard guard = host -> new InetAddress[0];
+
+    assertThrows(
+        UnknownHostException.class, () -> new SandboxDnsResolver(guard).resolve("empty.example"));
+  }
+
+  @Test
+  @DisplayName("未提供已验证解析能力的 Sandbox 不得打开 HTTP_READ client")
+  void clientRejectsSandboxWithoutResolvedReadGuard() {
+    Sandbox unsupported = action -> {};
+
+    assertThrows(
+        SandboxViolationException.class,
+        () -> PinnedHttpReadClient.open(unsupported, Duration.ofSeconds(1), Duration.ofSeconds(1)));
+  }
+
+  @Test
+  @DisplayName("HTTP_READ client 关闭时释放连接池")
+  void closeReleasesConnectionManager() {
+    PinnedHttpReadClient client =
+        PinnedHttpReadClient.open(
+            new PermissiveSandbox(), Duration.ofSeconds(1), Duration.ofSeconds(1));
+    assertFalse(client.isClosed());
+
+    client.close();
+
+    assertTrue(client.isClosed());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
 
         <!-- Infrastructure libraries -->
         <jackson-bom.version>2.21.5</jackson-bom.version>
+        <httpclient5.version>5.6.4</httpclient5.version>
+        <httpcore5.version>5.4.3</httpcore5.version>
         <log4j2.version>2.25.5</log4j2.version>
         <tomcat.version>10.1.59</tomcat.version>
         <logstash-logback.version>7.4</logstash-logback.version>


### PR DESCRIPTION
## Summary

- add a dedicated `ResolvedHttpReadGuard` capability so the transport receives the exact address set validated by `WhitelistSandbox`
- route `HttpTools` reads and the DuckDuckGo endpoint through an Apache HttpClient 5 `DnsResolver`, while preserving the original URI hostname for `Host`, TLS SNI, and certificate verification
- open and close an isolated HTTP client for every read/redirect hop, with automatic redirects and retries disabled
- keep `HTTP_REQUEST` writes on their existing allowlist-only client so explicitly approved internal write endpoints and legacy write-only `Sandbox` implementations remain compatible

## Readiness

Issue #96 began as a design discussion. The transport-pinning implementation is now complete and ready for maintainer review without changing the existing `Sandbox.enforce(void)` contract. The dependency and API choices remain explicit review focus areas; marking this PR Ready does not imply prior maintainer agreement on those choices.

## Scope

Covered:

- `http_get`
- `http_request` GET
- `fetch_webpage`
- the remote read used by `download_file`
- the real DuckDuckGo search endpoint

Intentionally unchanged:

- `HTTP_REQUEST` POST/PUT/PATCH/DELETE policy
- notify/webhook transports
- Web Skill import fetching
- JVM-wide DNS cache settings

Apache HttpClient is pinned to `httpclient5` 5.6.4 with its compatible `httpcore5` 5.4.3 baseline. This replaces the vulnerable 5.5.2 version selected by the Spring Boot 3.5.16 BOM.

## Verification

- `mvn -Dmaven.repo.local=/private/tmp/oryxos-issue96-m2 -pl oryxos-tool -am -Dtest=SandboxDnsResolverTest,WhitelistSandboxTest,HttpToolsTest,WebSearchToolsTest -Dsurefire.failIfNoSpecifiedTests=false test` — 50 tests passed
- `mvn -Dmaven.repo.local=/private/tmp/oryxos-issue96-m2 clean verify` — all 12 reactor modules passed
- CI `Build & quality gate` — passed on `df09a87`
- CI `OWASP Dependency-Check (CVE scan)` — passed on `df09a87`
- `git diff --check`

The validation uses a non-network TEST-NET address to prove that the Apache resolver returns the exact sandbox-approved address set, plus the existing local HTTP behavior suite. A live DNS-rebinding exploit was not executed.

## Review focus

- whether the dedicated guard is the right seam versus changing `Sandbox`
- whether Apache HttpClient 5 is acceptable for hostname-preserving DNS pinning
- per-hop client lifecycle and performance trade-offs

Addresses #96
