### PR TITLE
fix(ssrf): unwrap ISATAP embedded IPv4 before private-range checks (#279)

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WhitelistSandbox.java
@@ -319,8 +319,8 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
 
   /**
    * 对解析结果做 SSRF 分类。IPv4-mapped（{@code ::ffff:0:0/96}）、NAT64 知名前缀（{@code 64:ff9b::/96}）、6to4（{@code
-   * 2002::/16}）、Teredo（{@code 2001:0000::/32}）与已弃用的 IPv4-compatible（{@code ::/96}）先展开嵌入
-   * IPv4，再套用回环/链路本地/站点内网/CGNAT 等判定。
+   * 2002::/16}）、Teredo（{@code 2001:0000::/32}）、ISATAP（IID {@code 0000:5EFE}/{@code 0200:5EFE}）与已弃用的
+   * IPv4-compatible（{@code ::/96}）先展开嵌入 IPv4，再套用回环/链路本地/站点内网/CGNAT 等判定。
    */
   private static boolean isBlockedSsrfAddress(InetAddress addr) {
     InetAddress effective = unwrapEmbeddedIpv4(addr);
@@ -337,8 +337,8 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
   }
 
   /**
-   * 若为 IPv4-mapped / NAT64 / 6to4 / Teredo / IPv4-compatible，返回嵌入的 IPv4；否则原样返回。JDK 常把 mapped
-   * 字面量直接解成 {@link java.net.Inet4Address}，此展开主要兜住仍以 16 字节返回的形态与隧道前缀。
+   * 若为 IPv4-mapped / NAT64 / 6to4 / Teredo / ISATAP / IPv4-compatible，返回嵌入的 IPv4；否则原样返回。JDK 常把
+   * mapped 字面量直接解成 {@link java.net.Inet4Address}，此展开主要兜住仍以 16 字节返回的形态与隧道前缀。
    */
   private static InetAddress unwrapEmbeddedIpv4(InetAddress addr) {
     byte[] b = addr.getAddress();
@@ -381,6 +381,15 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
         (byte) (~b[EMBEDDED_IPV4_TAIL_OFFSET + 3] & 0xFF)
       };
     }
+    if (isIsatapInterfaceId(b)) {
+      // RFC 5214：IID 0000:5EFE / 0200:5EFE，IPv4 在末 32 位（不取反）
+      return new byte[] {
+        b[EMBEDDED_IPV4_TAIL_OFFSET],
+        b[EMBEDDED_IPV4_TAIL_OFFSET + 1],
+        b[EMBEDDED_IPV4_TAIL_OFFSET + 2],
+        b[EMBEDDED_IPV4_TAIL_OFFSET + 3]
+      };
+    }
     return NO_EMBEDDED_IPV4;
   }
 
@@ -400,6 +409,18 @@ public final class WhitelistSandbox implements Sandbox, SandboxWhitelist {
         && (b[1] & 0xFF) == 0x01
         && (b[2] & 0xFF) == 0x00
         && (b[3] & 0xFF) == 0x00;
+  }
+
+  /**
+   * ISATAP 接口标识（RFC 5214 §6.1）：字节 8–11 为 {@code 0000:5EFE}，或 u 位置位时的 {@code 0200:5EFE}；嵌入 IPv4 在字节
+   * 12–15。
+   */
+  private static boolean isIsatapInterfaceId(byte[] b) {
+    int b8 = b[8] & 0xFF;
+    return (b8 == 0x00 || b8 == 0x02)
+        && b[9] == 0
+        && (b[10] & 0xFF) == 0x5E
+        && (b[11] & 0xFF) == 0xFE;
   }
 
   /** NAT64 知名前缀 {@code 64:ff9b::/96}（RFC 6052）。 */

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
@@ -306,6 +306,8 @@ class WhitelistSandboxTest {
             "http://[2002:a9fe:a9fe::1]/x", // 6to4 → 169.254.169.254
             "http://[::a9fe:a9fe]/x", // IPv4-compatible → 169.254.169.254
             "http://[2001::5601:5601]/x", // Teredo → 169.254.169.254
+            "http://[2001:db8::5efe:a9fe:a9fe]/x", // ISATAP → 169.254.169.254
+            "http://[2001:db8::200:5efe:a9fe:a9fe]/x", // ISATAP u-bit → 169.254.169.254
             "http://localhost/x"
           }) {
         assertThrows(
@@ -329,6 +331,20 @@ class WhitelistSandboxTest {
     void teredoPublicIpv4Allowed() {
       assertDoesNotThrow(
           () -> sb.enforce(new SandboxAction(ActionType.HTTP_READ, "http://[2001::f7f7:f7f7]/x")));
+    }
+
+    @Test
+    @DisplayName("ISATAP 嵌入公网 IPv4 仍放行")
+    void isatapPublicIpv4Allowed() {
+      assertDoesNotThrow(
+          () ->
+              sb.enforce(
+                  new SandboxAction(ActionType.HTTP_READ, "http://[2001:db8::5efe:808:808]/x")));
+      assertDoesNotThrow(
+          () ->
+              sb.enforce(
+                  new SandboxAction(
+                      ActionType.HTTP_READ, "http://[2001:db8::200:5efe:808:808]/x")));
     }
   }
 

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
@@ -234,7 +234,7 @@ public class SkillApiController {
   }
 
   /**
-   * IPv4-mapped / NAT64 / 6to4 / Teredo / IPv4-compatible 先展开嵌入 IPv4，再套用内网/元数据判定；与 {@code
+   * IPv4-mapped / NAT64 / 6to4 / Teredo / ISATAP / IPv4-compatible 先展开嵌入 IPv4，再套用内网/元数据判定；与 {@code
    * WhitelistSandbox} 读路径 SSRF 兜底对齐。
    */
   private static boolean isBlockedSsrfAddress(InetAddress addr) {
@@ -289,6 +289,14 @@ public class SkillApiController {
         (byte) (~b[EMBEDDED_IPV4_TAIL_OFFSET + 1] & 0xFF),
         (byte) (~b[EMBEDDED_IPV4_TAIL_OFFSET + 2] & 0xFF),
         (byte) (~b[EMBEDDED_IPV4_TAIL_OFFSET + 3] & 0xFF)
+      };
+    }
+    if (isIsatapInterfaceId(b)) {
+      return new byte[] {
+        b[EMBEDDED_IPV4_TAIL_OFFSET],
+        b[EMBEDDED_IPV4_TAIL_OFFSET + 1],
+        b[EMBEDDED_IPV4_TAIL_OFFSET + 2],
+        b[EMBEDDED_IPV4_TAIL_OFFSET + 3]
       };
     }
     return NO_EMBEDDED_IPV4;
@@ -351,6 +359,15 @@ public class SkillApiController {
         && (b[1] & 0xFF) == 0x01
         && (b[2] & 0xFF) == 0x00
         && (b[3] & 0xFF) == 0x00;
+  }
+
+  /** ISATAP IID {@code 0000:5EFE} / {@code 0200:5EFE}（RFC 5214 §6.1）。 */
+  private static boolean isIsatapInterfaceId(byte[] b) {
+    int b8 = b[8] & 0xFF;
+    return (b8 == 0x00 || b8 == 0x02)
+        && b[9] == 0
+        && (b[10] & 0xFF) == 0x5E
+        && (b[11] & 0xFF) == 0xFE;
   }
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/SkillImportSsrfGuardTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/SkillImportSsrfGuardTest.java
@@ -59,7 +59,9 @@ class SkillImportSsrfGuardTest {
           "http://[64:ff9b::100.64.1.1]/x",
           "http://[2002:a9fe:a9fe::1]/latest/meta-data/",
           "http://[::a9fe:a9fe]/x",
-          "http://[2001::5601:5601]/latest/meta-data/"
+          "http://[2001::5601:5601]/latest/meta-data/",
+          "http://[2001:db8::5efe:a9fe:a9fe]/latest/meta-data/",
+          "http://[2001:db8::200:5efe:a9fe:a9fe]/x"
         }) {
       assertThrows(
           IllegalArgumentException.class,
@@ -81,5 +83,16 @@ class SkillImportSsrfGuardTest {
   void teredoPublicIpv4Allowed() {
     assertDoesNotThrow(
         () -> SkillApiController.guardPublicHost(URI.create("http://[2001::f7f7:f7f7]/x")));
+  }
+
+  @Test
+  @DisplayName("ISATAP 嵌入公网 IPv4 仍放行")
+  void isatapPublicIpv4Allowed() {
+    assertDoesNotThrow(
+        () -> SkillApiController.guardPublicHost(URI.create("http://[2001:db8::5efe:808:808]/x")));
+    assertDoesNotThrow(
+        () ->
+            SkillApiController.guardPublicHost(
+                URI.create("http://[2001:db8::200:5efe:808:808]/x")));
   }
 }


### PR DESCRIPTION
## Summary
- Unwrap ISATAP (RFC 5214) IID `0000:5EFE` / `0200:5EFE` embedded IPv4 before SSRF private/metadata checks
- Align `WhitelistSandbox` and `SkillApiController` guards
- Tests: block metadata via ISATAP; allow ISATAP embedding public 8.8.8.8

Closes #279

## Test plan
- [ ] CI Build & quality gate green
- [ ] CI OWASP green
- [ ] WhitelistSandboxTest / SkillImportSsrfGuardTest cover ISATAP block + allow cases

Made with [Cursor](https://cursor.com)