### PR TITLE
fix(profile): reject non-object notify_channels entries (#281)

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -119,7 +119,8 @@ public class ProfileLoader {
         asStringList(map.get("tools"), "tools", name),
         asStringList(map.get("mcp_servers"), "mcp_servers", name),
         asStringList(map.get("channels"), "channels", name),
-        toNotifyChannels(requireListOrNull(map.get("notify_channels"), "notify_channels", name)),
+        toNotifyChannels(
+            requireListOrNull(map.get("notify_channels"), "notify_channels", name), name),
         toSchedules(requireListOrNull(map.get("schedules"), "schedules", name), source),
         asStringList(map.get("bootstrap"), "bootstrap", name),
         toSettings(asMap(map.get("settings")), name));
@@ -158,7 +159,8 @@ public class ProfileLoader {
     return new Profile.Identity(asString(map.get("agent_name")), asString(map.get("prompt")));
   }
 
-  private static List<Profile.NotifyChannel> toNotifyChannels(List<Object> list) {
+  private static List<Profile.NotifyChannel> toNotifyChannels(
+      List<Object> list, String profileName) {
     if (list == null) {
       return List.of();
     }
@@ -166,7 +168,8 @@ public class ProfileLoader {
     for (Object item : list) {
       Map<String, Object> entry = asMap(item);
       if (entry == null) {
-        continue;
+        throw new ProfileValidationException(
+            "Profile " + profileName + " 的 notify_channels 存在非对象条目: " + item);
       }
       String type = asString(entry.get("type"));
       // type 之外的键都是渠道特定配置（如 webhook 的 url）

--- a/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
@@ -217,6 +217,48 @@ class ProfileLoaderTest {
   }
 
   @Test
+  void notify_channels条目非对象时报错点名() throws IOException {
+    write(
+        "scalar-notify.yaml",
+        """
+        name: scalar-notify
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        notify_channels:
+          - webhook
+        """);
+
+    ProfileValidationException ex =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("scalar-notify.yaml")));
+
+    assertTrue(ex.getMessage().contains("scalar-notify"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("notify_channels"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("非对象条目"), ex.getMessage());
+  }
+
+  @Test
+  void notify_channels合法对象仍可加载() throws IOException {
+    write(
+        "ok-notify.yaml",
+        """
+        name: ok-notify
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        notify_channels:
+          - type: webhook
+            url: https://example.com/hook
+        """);
+
+    Profile profile = loader().parse(profilesDir.resolve("ok-notify.yaml"));
+    assertEquals(1, profile.notifyChannels().size());
+    assertEquals("webhook", profile.notifyChannels().get(0).type());
+  }
+
+  @Test
   void 引用不存在的provider_报错信息包含该名字() throws IOException {
     write(
         "bad-provider.yaml",


### PR DESCRIPTION
## Summary
- Reject non-map entries inside `notify_channels` with `ProfileValidationException` (was silent `continue`)
- Keep valid `{type, ...}` objects working

Closes #281

## Test plan
- [ ] CI Build & quality gate green
- [ ] CI OWASP green
- [ ] ProfileLoaderTest covers scalar notify entry rejection and valid object load

Made with [Cursor](https://cursor.com)