### PR TITLE
fix(profile): reject non-object schedules entries (#283)

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -193,7 +193,7 @@ public class ProfileLoader {
     for (Object item : list) {
       Map<String, Object> entry = asMap(item);
       if (entry == null) {
-        continue;
+        throw new ProfileValidationException("Profile " + source + " 的 schedules 存在非对象条目: " + item);
       }
       String legacyId = asString(entry.get("id"));
       String configuredKey = asString(entry.get("key"));

--- a/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
@@ -240,6 +240,29 @@ class ProfileLoaderTest {
   }
 
   @Test
+  void schedules条目非对象时报错点名() throws IOException {
+    write(
+        "scalar-sched.yaml",
+        """
+        name: scalar-sched
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - morning
+        """);
+
+    ProfileValidationException ex =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("scalar-sched.yaml")));
+
+    assertTrue(ex.getMessage().contains("scalar-sched"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("schedules"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("非对象条目"), ex.getMessage());
+  }
+
+  @Test
   void notify_channels合法对象仍可加载() throws IOException {
     write(
         "ok-notify.yaml",
@@ -256,6 +279,27 @@ class ProfileLoaderTest {
     Profile profile = loader().parse(profilesDir.resolve("ok-notify.yaml"));
     assertEquals(1, profile.notifyChannels().size());
     assertEquals("webhook", profile.notifyChannels().get(0).type());
+  }
+
+  @Test
+  void schedules合法对象仍可加载() throws IOException {
+    write(
+        "ok-sched.yaml",
+        """
+        name: ok-sched
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - key: morning
+            name: Morning job
+            cron: "0 0 8 * * *"
+            message: hi
+        """);
+
+    Profile profile = loader().parse(profilesDir.resolve("ok-sched.yaml"));
+    assertEquals(1, profile.schedules().size());
+    assertEquals("morning", profile.schedules().get(0).key());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- `ProfileLoader.toSchedules` no longer silently `continue`s on non-map list items (e.g. `- morning`); throws `ProfileValidationException` instead — same class of silent misconfig as #281.
- Adds unit tests for scalar rejection and valid object load.

## Test plan
- [x] `ProfileLoaderTest#schedules条目非对象时报错点名`
- [x] `ProfileLoaderTest#schedules合法对象仍可加载`
- [ ] CI Build & quality gate
- [ ] CI OWASP Dependency-Check
