### PR TITLE
fix(workspace): recheck path before file/download read (#285)

### DIFF
--- a/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
@@ -91,6 +91,8 @@ public class WorkspaceApiController {
       throw new ResourceNotFoundException("文件不存在: " + path); // → 404
     }
     try {
+      // 读前复检：与 writeFile / tool 层 read_file 同款——防首次校验到 readString 间被换成外向软链
+      target = resolveWithinRoot(path);
       return ApiResponse.ok(Files.readString(target));
     } catch (IOException e) {
       throw new UncheckedIOException("读取文件失败: " + path, e);
@@ -108,6 +110,8 @@ public class WorkspaceApiController {
     if (!Files.isRegularFile(target)) {
       throw new ResourceNotFoundException("文件不存在: " + path); // → 404
     }
+    // 读前复检：与 file / writeFile 同款——防首次校验到打开附件间被换成外向软链
+    target = resolveWithinRoot(path);
     String filename = String.valueOf(target.getFileName());
     // 文件名可能含中文/空格：用 RFC 5987 编码进 Content-Disposition，避免乱码或截断
     String disposition =

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
@@ -154,6 +154,51 @@ class WorkspaceApiControllerTest {
   }
 
   @Test
+  @DisplayName("file 读前复检路径，阻断目标被换成外向软链")
+  void fileRechecksPathBeforeRead() throws Exception {
+    Assumptions.assumeTrue(
+        FileSystems.getDefault().supportedFileAttributeViews().contains("posix"), "需要 POSIX 软链支持");
+    Path outside = Files.createDirectories(oryxosRoot.resolveSibling("outside-read-recheck"));
+    Files.writeString(outside.resolve("secret.txt"), "leaked");
+    String rel = "agents/demo/notes.md";
+    Path notes = oryxosRoot.resolve(rel);
+    Files.writeString(notes, "inside");
+
+    RealPathBoundary.requireWithin(oryxosRoot, notes.normalize());
+    Files.delete(notes);
+    Files.createSymbolicLink(notes, outside.resolve("secret.txt"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> RealPathBoundary.requireWithin(oryxosRoot, notes.normalize()));
+
+    mvc.perform(get("/api/v1/workspace/file").param("path", rel))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("download 读前复检路径，阻断目标被换成外向软链")
+  void downloadRechecksPathBeforeRead() throws Exception {
+    Assumptions.assumeTrue(
+        FileSystems.getDefault().supportedFileAttributeViews().contains("posix"), "需要 POSIX 软链支持");
+    Path outside = Files.createDirectories(oryxosRoot.resolveSibling("outside-download-recheck"));
+    Files.writeString(outside.resolve("secret.bin"), "leaked");
+    String rel = "agents/demo/output/report.md";
+    Path report = oryxosRoot.resolve(rel);
+    Files.createDirectories(report.getParent());
+    Files.writeString(report, "inside");
+
+    RealPathBoundary.requireWithin(oryxosRoot, report.normalize());
+    Files.delete(report);
+    Files.createSymbolicLink(report, outside.resolve("secret.bin"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> RealPathBoundary.requireWithin(oryxosRoot, report.normalize()));
+
+    mvc.perform(get("/api/v1/workspace/download").param("path", rel))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
   @DisplayName("工作区写入口禁止直写 MEMORY.md（须走 save_memory）")
   void writeMemoryMdIsRejected() throws Exception {
     Path memory = Files.createDirectories(oryxosRoot.resolve("agents/demo"));


### PR DESCRIPTION
## Summary
- Completes the #273 write-side TOCTOU fix for workspace **read** paths: `file` and `download` re-call `resolveWithinRoot` immediately before IO.
- Adds POSIX symlink-escape regressions for both endpoints.

## Test plan
- [x] `WorkspaceApiControllerTest` (new tests skip without POSIX symlink support; CI Linux runs them)
- [ ] CI Build & quality gate
- [ ] CI OWASP Dependency-Check
