### PR TITLE
chore(deps): bump pdfbox, commons-lang3, springdoc/swagger-ui (#287)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,15 +24,20 @@
         <spring-ai.version>1.1.8</spring-ai.version>
         <picocli.version>4.7.6</picocli.version>
         <sqlite-jdbc.version>3.53.2.1</sqlite-jdbc.version>
-        <pdfbox.version>3.0.5</pdfbox.version>
+        <pdfbox.version>3.0.8</pdfbox.version>
         <oapi-sdk.version>2.8.5</oapi-sdk.version>
 
         <!-- Infrastructure libraries -->
         <jackson-bom.version>2.21.5</jackson-bom.version>
         <log4j2.version>2.25.5</log4j2.version>
         <tomcat.version>10.1.59</tomcat.version>
+        <!-- CVE-2025-48924: ClassUtils.getClass StackOverflowError before 3.18.0 -->
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <logstash-logback.version>7.4</logstash-logback.version>
-        <springdoc.version>2.6.0</springdoc.version>
+        <!-- Boot 3.5.x line; 2.9+/3.x need Boot 4 -->
+        <springdoc.version>2.8.17</springdoc.version>
+        <!-- springdoc 2.8.17 still ships older swagger-ui; override for DOMPurify CVEs -->
+        <swagger-ui.version>5.32.13</swagger-ui.version>
 
         <!-- Quality / format / security plugins -->
         <spotless.version>2.43.0</spotless.version>
@@ -171,6 +176,11 @@
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
                 <version>${springdoc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars</groupId>
+                <artifactId>swagger-ui</artifactId>
+                <version>${swagger-ui.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary
- OWASP gate is already green after Tomcat 10.1.59; this clears remaining **MEDIUM** scan findings.
- `pdfbox` 3.0.5 → **3.0.8**
- `commons-lang3` 3.17.0 → **3.18.0** (Boot property override)
- `springdoc` 2.6.0 → **2.8.17** (Boot 3.5 line)
- Override `org.webjars:swagger-ui` → **5.32.13** (DOMPurify / swagger-ui CVEs; springdoc 2.8.17 still ships older UI)

## Test plan
- [x] `dependency:tree` shows pdfbox 3.0.8, commons-lang3 3.18.0, swagger-ui 5.32.13
- [x] `oryxos-web` / `oryxos-knowledge` package
- [ ] CI Build & quality gate
- [ ] CI OWASP Dependency-Check (primary verification)
