### PR TITLE
feat(channel): WeCom AI bot inbound via long connection (#289)

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -89,6 +89,7 @@ http:
   allowed_domains:
     - api.deepseek.com          # Provider 端点（精确匹配）
     - "*.feishu.cn"             # 飞书 webhook（通配真子域）
+    - openws.work.weixin.qq.com # 企微智能机器人长连接
     - api.open-meteo.com        # 天气 Agent 免 key 天气源（31 节 Demo 一）
     - hn.algolia.com            # 科技日报 Agent 新闻源（31 节 Demo 二）
     - api.github.com            # GitHub 日报脚本子进程网络（31 节 Demo 三）

--- a/config/channels.yaml.example
+++ b/config/channels.yaml.example
@@ -1,11 +1,19 @@
-# OryxOS 入站 IM 渠道配置示例（017）
+# OryxOS 入站 IM 渠道配置示例（017 + 企微）
 # 复制到 .oryxos/channels.yaml 后按需修改；文件权限会被收紧为 rw-------。
 # 凭证一律用 ${ENV_VAR} 占位从环境变量注入，禁止明文写入本文件。
-# 一个条目 = 一个飞书自建应用 = 绑定一个 Agent（多 Agent 即多个应用、多个条目）。
+# 一个条目 = 一个平台应用/机器人 = 绑定一个 Agent。
 channels:
   - name: ops-feishu                    # 渠道名，唯一，[a-zA-Z0-9_-]+
-    type: feishu                        # 渠道类型（当前仅支持 feishu）
-    app_id: ${FEISHU_APP_ID}            # 飞书自建应用 App ID
-    app_secret: ${FEISHU_APP_SECRET}    # 飞书自建应用 App Secret
-    agent: ops-agent                    # 绑定的 Agent（.oryxos/agents/ 下目录名）
-    enabled: true                       # false = 停用（断开连接但保留配置）
+    type: feishu                        # 飞书自建应用长连接
+    app_id: ${FEISHU_APP_ID}
+    app_secret: ${FEISHU_APP_SECRET}
+    agent: ops-agent
+    enabled: true
+
+  # 企微智能机器人长连接（见 docs/WeComChannelSetup.md）
+  # - name: ops-wecom
+  #   type: wecom
+  #   app_id: ${WECOM_BOT_ID}             # BotID
+  #   app_secret: ${WECOM_BOT_SECRET}     # 长连接 Secret
+  #   agent: ops-agent
+  #   enabled: true

--- a/docs/WeComChannelSetup.md
+++ b/docs/WeComChannelSetup.md
@@ -1,0 +1,57 @@
+# 企微智能机器人入站渠道接入指南
+
+本文是 OryxOS 企微入站渠道的部署操作手册。架构对称飞书：以 **WebSocket 长连接** 主动连接企业微信（`wss://openws.work.weixin.qq.com`），**免公网回调地址、免 EncodingAESKey**，服务器只需出方向可达该域名。
+
+> 范围：企业微信 **智能机器人（API 模式 + 长连接）**。群机器人 webhook 出站通知仍走 Notify `type=wecom`，与本入站渠道分离。
+
+## 一、企微侧：创建智能机器人
+
+1. 打开企业微信管理端 →「安全与管理」/「智能机器人」相关入口（以当前企微后台文案为准）。
+2. 创建 **API 模式** 智能机器人，连接方式选择 **「使用长连接」**（不要选「设置接收消息 URL」）。
+3. 记下 **BotID** 与 **长连接 Secret**。
+   - ⚠️ 只经环境变量注入 OryxOS，禁止写入仓库或明文配置文件。
+
+## 二、OryxOS 侧：配置与启动
+
+1. **凭证走环境变量**：
+
+   ```bash
+   export WECOM_BOT_ID=xxxxxxxx
+   export WECOM_BOT_SECRET=xxxxxxxx
+   ```
+
+2. **渠道绑定** `.oryxos/channels.yaml`（模板见 `config/channels.yaml.example`）：
+
+   ```yaml
+   channels:
+     - name: ops-wecom
+       type: wecom
+       app_id: ${WECOM_BOT_ID}          # BotID
+       app_secret: ${WECOM_BOT_SECRET}  # 长连接 Secret
+       agent: ops-agent
+       enabled: true
+   ```
+
+3. **出站域名白名单**：确保 `http.allowed_domains` 包含 `openws.work.weixin.qq.com`（或 `*.work.weixin.qq.com`）。示例配置已写入 `config/application.yml.example`。
+
+4. 启动后查渠道状态：`GET /api/v1/channels/status`，期望 `CONNECTED`。
+
+## 三、使用方式
+
+- **私聊**：在企微中打开该智能机器人会话，直接发文本。
+- **群聊**：将机器人拉入群后 `@机器人 + 问题`；平台只推送 @ 本机器人的群消息。
+
+## 四、与飞书的差异（运维须知）
+
+| | 飞书 | 企微（本渠道） |
+|--|------|----------------|
+| 凭证 | App ID / App Secret | BotID / 长连接 Secret |
+| 连接 | `open.feishu.cn` SDK 长连接 | `openws.work.weixin.qq.com` WebSocket |
+| 回复 | im/v1 messages API | 长连接 `aibot_send_msg`（markdown） |
+| 同一 Bot 连接数 | SDK 管理 | 同时仅一条有效长连接（新连踢旧） |
+
+## 五、非目标（本期不做）
+
+- 自建应用 HTTP 回调 + AES 加解密
+- 流式逐 token 刷屏（Agent 仍整段推理后再回发）
+- 模板卡片 / 富媒体 / HITL

--- a/oryxos-boot/pom.xml
+++ b/oryxos-boot/pom.xml
@@ -45,6 +45,10 @@
         </dependency>
         <dependency>
             <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-channel-wecom</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
             <artifactId>oryxos-web</artifactId>
         </dependency>
         <dependency>

--- a/oryxos-boot/src/main/resources/application.yml
+++ b/oryxos-boot/src/main/resources/application.yml
@@ -55,6 +55,7 @@ http:
   allowed_domains:
     - api.deepseek.com      # Provider 端点（精确匹配）
     - "*.feishu.cn"         # 飞书 webhook（通配真子域）
+    - openws.work.weixin.qq.com # 企微智能机器人长连接
     - api.open-meteo.com    # 天气 Agent（免 key 天气源，31 节 Demo 一）
     - hn.algolia.com        # 科技日报 Agent 新闻源（免 key JSON，31 节 Demo 二）
     - api.github.com        # GitHub 日报脚本走子进程网络；列此便于审计与将来收口（31 节 Demo 三 §信任边界）

--- a/oryxos-channel-wecom/pom.xml
+++ b/oryxos-channel-wecom/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.oryxos</groupId>
+        <artifactId>oryxos</artifactId>
+        <version>0.1.3-RELEASE</version>
+    </parent>
+
+    <artifactId>oryxos-channel-wecom</artifactId>
+    <name>OryxOS Channel WeCom</name>
+    <description>WeCom AI bot inbound IM channel: WebSocket long connection and reply</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/ChannelWecomModule.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/ChannelWecomModule.java
@@ -1,0 +1,7 @@
+package io.oryxos.channel.wecom;
+
+/** Marker for the WeCom inbound channel module (not Spring-scanned; wired in OryxOsRuntime). */
+public final class ChannelWecomModule {
+
+  private ChannelWecomModule() {}
+}

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
@@ -31,6 +31,8 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
   /** OutboundGuard / 白名单用 https 形式主机名（与 wss 同域）。 */
   static final String OUTBOUND_URL = "https://openws.work.weixin.qq.com";
 
+  private static final String CMD_AIBOT_MSG_CALLBACK = "aibot_msg_callback";
+
   private static final Duration START_TIMEOUT = Duration.ofSeconds(20);
 
   private final ChannelConfig config;
@@ -142,7 +144,7 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
 
   private void handleFrame(JsonNode root) {
     String cmd = root.path("cmd").asText("");
-    if (!"aibot_msg_callback".equals(cmd)) {
+    if (!CMD_AIBOT_MSG_CALLBACK.equals(cmd)) {
       return;
     }
     JsonNode body = root.get("body");

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
@@ -1,0 +1,164 @@
+package io.oryxos.channel.wecom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.channel.ChannelConfig;
+import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.InboundChannelAdapter;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageService;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 企微智能机器人入站适配器：一实例 = 一个 Bot 的一条长连接（对称飞书 017）。
+ *
+ * <p>凭证映射：{@code app_id} = BotID，{@code app_secret} = 长连接 Secret。长连接免公网回调、免 EncodingAESKey。
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
+    justification = "ws/normalizer/sender 在 start() 内初始化；sendReply 有显式空判。")
+public class WeComChannelAdapter implements InboundChannelAdapter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WeComChannelAdapter.class);
+
+  public static final String TYPE = "wecom";
+
+  /** OutboundGuard / 白名单用 https 形式主机名（与 wss 同域）。 */
+  static final String OUTBOUND_URL = "https://openws.work.weixin.qq.com";
+
+  private static final Duration START_TIMEOUT = Duration.ofSeconds(20);
+
+  private final ChannelConfig config;
+  private final ProfileRegistry profileRegistry;
+  private final InboundMessageService inboundMessageService;
+  private final OutboundGuard guard;
+
+  private final AtomicReference<WeComWsClient> wsRef = new AtomicReference<>();
+  private volatile WeComMessageSender sender;
+  private volatile WeComEventNormalizer normalizer;
+  private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
+  private volatile String lastError;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "协作者均为 Runtime 装配的单例，共享引用正是意图")
+  public WeComChannelAdapter(
+      ChannelConfig config,
+      ProfileRegistry profileRegistry,
+      InboundMessageService inboundMessageService,
+      OutboundGuard guard) {
+    this.config = config;
+    this.profileRegistry = profileRegistry;
+    this.inboundMessageService = inboundMessageService;
+    this.guard = guard;
+  }
+
+  @Override
+  public String name() {
+    return config.name();
+  }
+
+  @Override
+  public String type() {
+    return TYPE;
+  }
+
+  @Override
+  public String boundAgent() {
+    return config.agent();
+  }
+
+  @Override
+  public synchronized void start() {
+    config.validateCredentialsResolved();
+    if (profileRegistry.get(config.agent()).isEmpty()) {
+      throw new IllegalArgumentException(
+          "渠道 " + config.name() + " 绑定的 Agent " + config.agent() + " 不存在");
+    }
+    guard.check(OUTBOUND_URL);
+    try {
+      normalizer = new WeComEventNormalizer(config.name());
+      WeComWsClient client =
+          new WeComWsClient(
+              config.appId(),
+              config.appSecret(),
+              WeComWsClient.DEFAULT_WS_URL,
+              this::handleFrame,
+              () -> {
+                if (state != ChannelStatus.State.ERROR) {
+                  state = ChannelStatus.State.DISCONNECTED;
+                }
+              });
+      sender =
+          new WeComMessageSender(
+              client::sendJson, guard, OUTBOUND_URL, WeComMessageSender.DEFAULT_CHUNK_SIZE);
+      client.connectAndSubscribe(START_TIMEOUT);
+      wsRef.set(client);
+      state = ChannelStatus.State.CONNECTED;
+      lastError = null;
+      LOG.info("企微渠道 {} 长连接已建立（Agent: {}）", sanitize(config.name()), sanitize(config.agent()));
+    } catch (Exception e) {
+      state = ChannelStatus.State.ERROR;
+      lastError = "长连接建立失败: " + sanitize(e.getMessage());
+      throw new IllegalStateException("渠道 " + config.name() + " " + lastError, e);
+    }
+  }
+
+  @Override
+  public synchronized void stop() {
+    WeComWsClient ws = wsRef.getAndSet(null);
+    if (ws != null) {
+      ws.closeQuietly();
+    }
+    state = ChannelStatus.State.DISCONNECTED;
+  }
+
+  @Override
+  public ChannelStatus status() {
+    if (state == ChannelStatus.State.ERROR) {
+      return ChannelStatus.error(config.name(), TYPE, config.agent(), lastError);
+    }
+    WeComWsClient ws = wsRef.get();
+    if (ws == null || !ws.isSubscribed()) {
+      return ChannelStatus.ok(
+          config.name(), TYPE, config.agent(), ChannelStatus.State.DISCONNECTED);
+    }
+    return ChannelStatus.ok(config.name(), TYPE, config.agent(), ChannelStatus.State.CONNECTED);
+  }
+
+  @Override
+  public void sendReply(String chatId, String text, String replyToMessageId) {
+    WeComMessageSender active = sender;
+    if (active == null) {
+      throw new IllegalStateException("渠道 " + config.name() + " 未启动，无法发送回复");
+    }
+    active.send(chatId, text);
+  }
+
+  private void handleFrame(JsonNode root) {
+    String cmd = root.path("cmd").asText("");
+    if (!"aibot_msg_callback".equals(cmd)) {
+      return;
+    }
+    JsonNode body = root.get("body");
+    try {
+      Optional<InboundMessage> msg = normalizer.normalize(body);
+      msg.ifPresent(
+          m -> {
+            sender.rememberChatType(m.chatId(), WeComEventNormalizer.chatTypeCode(body));
+            inboundMessageService.onMessage(m, this);
+          });
+    } catch (RuntimeException e) {
+      LOG.error("企微渠道 {} 事件处理异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
+    }
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComEventNormalizer.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComEventNormalizer.java
@@ -1,0 +1,103 @@
+package io.oryxos.channel.wecom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 企微智能机器人 {@code aibot_msg_callback} → 归一化 {@link InboundMessage}。
+ *
+ * <p>群聊：平台只推送 @ 本机器人的消息，进入编排时 {@code mentionedBot=true}；正文前导 {@code @xxx} 占位剥离。 单聊：{@code chatid}
+ * 缺省时用发送者 userid 作为回复目标。
+ */
+public class WeComEventNormalizer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WeComEventNormalizer.class);
+
+  static final String CHANNEL_TYPE = "wecom";
+  private static final String CHAT_SINGLE = "single";
+  private static final String CHAT_GROUP = "group";
+  private static final String MSG_TEXT = "text";
+  private static final Pattern LEADING_AT = Pattern.compile("^@\\S+\\s*");
+
+  private final String channelName;
+
+  public WeComEventNormalizer(String channelName) {
+    this.channelName = channelName;
+  }
+
+  /** 归一化一条消息回调；结构不完整返回 empty。 */
+  public Optional<InboundMessage> normalize(JsonNode body) {
+    if (body == null || !body.isObject()) {
+      return Optional.empty();
+    }
+    String msgid = text(body, "msgid");
+    String chattype = text(body, "chattype");
+    String userid = body.path("from").path("userid").asText(null);
+    if (msgid == null || chattype == null || userid == null || userid.isBlank()) {
+      LOG.warn("企微消息缺关键字段（msgid/chattype/from.userid），已丢弃");
+      return Optional.empty();
+    }
+    boolean single = CHAT_SINGLE.equals(chattype);
+    boolean group = CHAT_GROUP.equals(chattype);
+    if (!single && !group) {
+      LOG.warn("企微未知 chattype={}，已丢弃", sanitize(chattype));
+      return Optional.empty();
+    }
+    String chatId = single ? userid : text(body, "chatid");
+    if (chatId == null || chatId.isBlank()) {
+      LOG.warn("企微群消息缺 chatid，已丢弃");
+      return Optional.empty();
+    }
+    String msgtype = text(body, "msgtype");
+    boolean textual = MSG_TEXT.equals(msgtype);
+    String content = "";
+    if (textual) {
+      content = body.path("text").path("content").asText("");
+      if (group) {
+        content = LEADING_AT.matcher(content).replaceFirst("");
+      }
+      content = content.strip();
+    }
+    return Optional.of(
+        new InboundMessage(
+            CHANNEL_TYPE,
+            channelName,
+            msgid,
+            single ? ChatKind.P2P : ChatKind.GROUP,
+            userid,
+            chatId,
+            content,
+            textual,
+            group));
+  }
+
+  /** 会话类型：1 单聊 / 2 群聊；未知返回 0（发送时让平台兼容解析）。 */
+  public static int chatTypeCode(JsonNode body) {
+    String chattype = text(body, "chattype");
+    if (CHAT_SINGLE.equals(chattype)) {
+      return 1;
+    }
+    if (CHAT_GROUP.equals(chattype)) {
+      return 2;
+    }
+    return 0;
+  }
+
+  private static String text(JsonNode node, String field) {
+    JsonNode v = node.get(field);
+    if (v == null || v.isNull()) {
+      return null;
+    }
+    String s = v.asText();
+    return s == null || s.isBlank() ? null : s;
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComMessageSender.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComMessageSender.java
@@ -1,0 +1,77 @@
+package io.oryxos.channel.wecom;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.OutboundGuard;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * 企微回复发送器：优先 {@code aibot_send_msg}（markdown）主动推送；出站前过 {@link OutboundGuard}。
+ *
+ * <p>智能机器人长连接要求会话内曾有用户消息后才能主动推送——入站编排路径天然满足。
+ */
+public class WeComMessageSender {
+
+  static final int DEFAULT_CHUNK_SIZE = 3500;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final Consumer<ObjectNode> transport;
+  private final OutboundGuard guard;
+  private final String outboundUrl;
+  private final int chunkSize;
+  private final Map<String, Integer> chatTypes = new ConcurrentHashMap<>();
+
+  public WeComMessageSender(
+      Consumer<ObjectNode> transport, OutboundGuard guard, String outboundUrl, int chunkSize) {
+    this.transport = transport;
+    this.guard = guard;
+    this.outboundUrl = outboundUrl;
+    this.chunkSize = chunkSize <= 0 ? DEFAULT_CHUNK_SIZE : chunkSize;
+  }
+
+  /** 记录会话类型（1 单聊 / 2 群聊），供后续主动推送。 */
+  public void rememberChatType(String chatId, int chatType) {
+    if (chatId != null && !chatId.isBlank()) {
+      chatTypes.put(chatId, chatType);
+    }
+  }
+
+  public void send(String chatId, String text) {
+    guard.check(outboundUrl);
+    int chatType = chatTypes.getOrDefault(chatId, 0);
+    for (String chunk : segment(text == null ? "" : text, chunkSize)) {
+      ObjectNode headers = MAPPER.createObjectNode();
+      headers.put("req_id", UUID.randomUUID().toString());
+      ObjectNode markdown = MAPPER.createObjectNode();
+      markdown.put("content", chunk);
+      ObjectNode body = MAPPER.createObjectNode();
+      body.put("chatid", chatId);
+      if (chatType > 0) {
+        body.put("chat_type", chatType);
+      }
+      body.put("msgtype", "markdown");
+      body.set("markdown", markdown);
+      ObjectNode frame = MAPPER.createObjectNode();
+      frame.put("cmd", "aibot_send_msg");
+      frame.set("headers", headers);
+      frame.set("body", body);
+      transport.accept(frame);
+    }
+  }
+
+  static List<String> segment(String text, int chunkSize) {
+    if (text.isEmpty()) {
+      return List.of("");
+    }
+    List<String> parts = new ArrayList<>();
+    for (int i = 0; i < text.length(); i += chunkSize) {
+      parts.add(text.substring(i, Math.min(text.length(), i + chunkSize)));
+    }
+    return parts;
+  }
+}

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComWsClient.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComWsClient.java
@@ -1,0 +1,250 @@
+package io.oryxos.channel.wecom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** 企微智能机器人 WebSocket 长连接：订阅鉴权、心跳、收帧、发帧。自动重连由外层适配器控制。 */
+final class WeComWsClient implements WebSocket.Listener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WeComWsClient.class);
+
+  static final String DEFAULT_WS_URL = "wss://openws.work.weixin.qq.com";
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(20);
+  private static final long HEARTBEAT_INTERVAL_SEC = 30;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final String botId;
+  private final String secret;
+  private final String wsUrl;
+  private final Consumer<JsonNode> onFrame;
+  private final Runnable onDisconnected;
+
+  private final AtomicReference<WebSocket> socket = new AtomicReference<>();
+  private final AtomicBoolean subscribed = new AtomicBoolean(false);
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final StringBuilder textBuf = new StringBuilder();
+  private final CountDownLatch subscribeLatch = new CountDownLatch(1);
+  private volatile String subscribeError;
+  private ScheduledExecutorService heartbeat;
+  private ScheduledFuture<?> heartbeatTask;
+
+  WeComWsClient(
+      String botId,
+      String secret,
+      String wsUrl,
+      Consumer<JsonNode> onFrame,
+      Runnable onDisconnected) {
+    this.botId = Objects.requireNonNull(botId);
+    this.secret = Objects.requireNonNull(secret);
+    this.wsUrl = wsUrl == null || wsUrl.isBlank() ? DEFAULT_WS_URL : wsUrl;
+    this.onFrame = Objects.requireNonNull(onFrame);
+    this.onDisconnected = onDisconnected == null ? () -> {} : onDisconnected;
+  }
+
+  void connectAndSubscribe(Duration timeout) throws Exception {
+    closed.set(false);
+    HttpClient client = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    CompletableFuture<WebSocket> future =
+        client
+            .newWebSocketBuilder()
+            .connectTimeout(CONNECT_TIMEOUT)
+            .buildAsync(URI.create(wsUrl), this);
+    WebSocket ws = future.get(timeout.toSeconds(), TimeUnit.SECONDS);
+    socket.set(ws);
+    if (!subscribeLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+      closeQuietly();
+      throw new IllegalStateException("企微长连接订阅超时（未收到 aibot_subscribe 回执）");
+    }
+    if (subscribeError != null) {
+      closeQuietly();
+      throw new IllegalStateException("企微长连接订阅失败: " + subscribeError);
+    }
+    if (!subscribed.get()) {
+      closeQuietly();
+      throw new IllegalStateException("企微长连接订阅失败（未知原因）");
+    }
+  }
+
+  boolean isSubscribed() {
+    return subscribed.get() && !closed.get();
+  }
+
+  void sendJson(ObjectNode frame) {
+    WebSocket ws = socket.get();
+    if (ws == null || closed.get()) {
+      throw new IllegalStateException("企微长连接未建立，无法发送");
+    }
+    try {
+      String payload = MAPPER.writeValueAsString(frame);
+      ws.sendText(payload, true).join();
+    } catch (Exception e) {
+      throw new IllegalStateException("企微长连接发送失败: " + e.getMessage(), e);
+    }
+  }
+
+  void closeQuietly() {
+    closed.set(true);
+    subscribed.set(false);
+    stopHeartbeat();
+    WebSocket ws = socket.getAndSet(null);
+    if (ws != null) {
+      try {
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").join();
+      } catch (RuntimeException ignored) {
+        // ignore
+      }
+    }
+  }
+
+  @Override
+  public void onOpen(WebSocket webSocket) {
+    webSocket.request(1);
+    ObjectNode body = MAPPER.createObjectNode();
+    body.put("bot_id", botId);
+    body.put("secret", secret);
+    ObjectNode headers = MAPPER.createObjectNode();
+    headers.put("req_id", UUID.randomUUID().toString());
+    ObjectNode frame = MAPPER.createObjectNode();
+    frame.put("cmd", "aibot_subscribe");
+    frame.set("headers", headers);
+    frame.set("body", body);
+    try {
+      webSocket.sendText(MAPPER.writeValueAsString(frame), true);
+    } catch (Exception e) {
+      subscribeError = e.getMessage();
+      subscribeLatch.countDown();
+    }
+  }
+
+  @Override
+  public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+    textBuf.append(data);
+    if (last) {
+      String raw = textBuf.toString();
+      textBuf.setLength(0);
+      handleText(raw);
+    }
+    webSocket.request(1);
+    return null;
+  }
+
+  @Override
+  public CompletionStage<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
+    webSocket.request(1);
+    return null;
+  }
+
+  @Override
+  public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+    closed.set(true);
+    subscribed.set(false);
+    stopHeartbeat();
+    subscribeLatch.countDown();
+    onDisconnected.run();
+    return null;
+  }
+
+  @Override
+  public void onError(WebSocket webSocket, Throwable error) {
+    LOG.warn("企微长连接错误: {}", sanitize(error == null ? null : error.getMessage()));
+    if (!subscribed.get()) {
+      subscribeError = error == null ? "unknown" : error.getMessage();
+      subscribeLatch.countDown();
+    }
+    onDisconnected.run();
+  }
+
+  private void handleText(String raw) {
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(raw);
+    } catch (Exception e) {
+      LOG.warn("企微帧 JSON 解析失败，已忽略");
+      return;
+    }
+    if (!subscribed.get() && root.has("errcode")) {
+      int code = root.path("errcode").asInt(-1);
+      if (code == 0) {
+        subscribed.set(true);
+        startHeartbeat();
+        subscribeLatch.countDown();
+      } else {
+        subscribeError = root.path("errmsg").asText("errcode=" + code);
+        subscribeLatch.countDown();
+      }
+      return;
+    }
+    String cmd = root.path("cmd").asText("");
+    if ("pong".equals(cmd) || cmd.isBlank() && root.has("errcode")) {
+      return;
+    }
+    try {
+      onFrame.accept(root);
+    } catch (RuntimeException e) {
+      LOG.error("企微帧处理异常: {}", sanitize(e.getMessage()));
+    }
+  }
+
+  private void startHeartbeat() {
+    stopHeartbeat();
+    heartbeat =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              Thread t = new Thread(r, "wecom-ws-heartbeat");
+              t.setDaemon(true);
+              return t;
+            });
+    heartbeatTask =
+        heartbeat.scheduleAtFixedRate(
+            () -> {
+              try {
+                ObjectNode headers = MAPPER.createObjectNode();
+                headers.put("req_id", UUID.randomUUID().toString());
+                ObjectNode frame = MAPPER.createObjectNode();
+                frame.put("cmd", "ping");
+                frame.set("headers", headers);
+                sendJson(frame);
+              } catch (RuntimeException e) {
+                LOG.warn("企微心跳失败: {}", sanitize(e.getMessage()));
+              }
+            },
+            HEARTBEAT_INTERVAL_SEC,
+            HEARTBEAT_INTERVAL_SEC,
+            TimeUnit.SECONDS);
+  }
+
+  private void stopHeartbeat() {
+    if (heartbeatTask != null) {
+      heartbeatTask.cancel(false);
+      heartbeatTask = null;
+    }
+    if (heartbeat != null) {
+      heartbeat.shutdownNow();
+      heartbeat = null;
+    }
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComWsClient.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComWsClient.java
@@ -1,5 +1,6 @@
 package io.oryxos.channel.wecom;
 
+import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -184,7 +185,7 @@ final class WeComWsClient implements WebSocket.Listener {
     JsonNode root;
     try {
       root = MAPPER.readTree(raw);
-    } catch (Exception e) {
+    } catch (JacksonException e) {
       LOG.warn("企微帧 JSON 解析失败，已忽略");
       return;
     }

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComWsClient.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComWsClient.java
@@ -13,9 +13,9 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -31,6 +31,12 @@ final class WeComWsClient implements WebSocket.Listener {
   static final String DEFAULT_WS_URL = "wss://openws.work.weixin.qq.com";
   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(20);
   private static final long HEARTBEAT_INTERVAL_SEC = 30;
+  private static final String FIELD_ERRCODE = "errcode";
+  private static final String FIELD_ERRMSG = "errmsg";
+  private static final String CMD_AIBOT_SUBSCRIBE = "aibot_subscribe";
+  private static final String CMD_PING = "ping";
+  private static final String CMD_PONG = "pong";
+  private static final int ERRCODE_OK = 0;
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private final String botId;
@@ -73,7 +79,7 @@ final class WeComWsClient implements WebSocket.Listener {
     socket.set(ws);
     if (!subscribeLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
       closeQuietly();
-      throw new IllegalStateException("企微长连接订阅超时（未收到 aibot_subscribe 回执）");
+      throw new IllegalStateException("企微长连接订阅超时（未收到 " + CMD_AIBOT_SUBSCRIBE + " 回执）");
     }
     if (subscribeError != null) {
       closeQuietly();
@@ -125,7 +131,7 @@ final class WeComWsClient implements WebSocket.Listener {
     ObjectNode headers = MAPPER.createObjectNode();
     headers.put("req_id", UUID.randomUUID().toString());
     ObjectNode frame = MAPPER.createObjectNode();
-    frame.put("cmd", "aibot_subscribe");
+    frame.put("cmd", CMD_AIBOT_SUBSCRIBE);
     frame.set("headers", headers);
     frame.set("body", body);
     try {
@@ -182,20 +188,12 @@ final class WeComWsClient implements WebSocket.Listener {
       LOG.warn("企微帧 JSON 解析失败，已忽略");
       return;
     }
-    if (!subscribed.get() && root.has("errcode")) {
-      int code = root.path("errcode").asInt(-1);
-      if (code == 0) {
-        subscribed.set(true);
-        startHeartbeat();
-        subscribeLatch.countDown();
-      } else {
-        subscribeError = root.path("errmsg").asText("errcode=" + code);
-        subscribeLatch.countDown();
-      }
+    if (!subscribed.get() && root.has(FIELD_ERRCODE)) {
+      handleSubscribeAck(root);
       return;
     }
     String cmd = root.path("cmd").asText("");
-    if ("pong".equals(cmd) || cmd.isBlank() && root.has("errcode")) {
+    if (isIgnorableControlFrame(cmd, root)) {
       return;
     }
     try {
@@ -205,15 +203,37 @@ final class WeComWsClient implements WebSocket.Listener {
     }
   }
 
+  private void handleSubscribeAck(JsonNode root) {
+    int code = root.path(FIELD_ERRCODE).asInt(-1);
+    if (code == ERRCODE_OK) {
+      subscribed.set(true);
+      startHeartbeat();
+      subscribeLatch.countDown();
+      return;
+    }
+    subscribeError = root.path(FIELD_ERRMSG).asText(FIELD_ERRCODE + "=" + code);
+    subscribeLatch.countDown();
+  }
+
+  private static boolean isIgnorableControlFrame(String cmd, JsonNode root) {
+    if (CMD_PONG.equals(cmd)) {
+      return true;
+    }
+    return cmd.isBlank() && root.has(FIELD_ERRCODE);
+  }
+
   private void startHeartbeat() {
     stopHeartbeat();
-    heartbeat =
-        Executors.newSingleThreadScheduledExecutor(
+    ScheduledThreadPoolExecutor pool =
+        new ScheduledThreadPoolExecutor(
+            1,
             r -> {
               Thread t = new Thread(r, "wecom-ws-heartbeat");
               t.setDaemon(true);
               return t;
             });
+    pool.setRemoveOnCancelPolicy(true);
+    heartbeat = pool;
     heartbeatTask =
         heartbeat.scheduleAtFixedRate(
             () -> {
@@ -221,7 +241,7 @@ final class WeComWsClient implements WebSocket.Listener {
                 ObjectNode headers = MAPPER.createObjectNode();
                 headers.put("req_id", UUID.randomUUID().toString());
                 ObjectNode frame = MAPPER.createObjectNode();
-                frame.put("cmd", "ping");
+                frame.put("cmd", CMD_PING);
                 frame.set("headers", headers);
                 sendJson(frame);
               } catch (RuntimeException e) {

--- a/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComChannelContractTest.java
+++ b/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComChannelContractTest.java
@@ -1,0 +1,53 @@
+package io.oryxos.channel.wecom;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageServiceContractTestBase;
+
+/** 契约测试集·企微档：经 {@link WeComEventNormalizer} 产出归一化消息，复用 B1~B10。 */
+class WeComChannelContractTest extends InboundMessageServiceContractTestBase {
+
+  private final WeComEventNormalizer normalizer = new WeComEventNormalizer("contract-chan");
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Override
+  protected String channelType() {
+    return "wecom";
+  }
+
+  @Override
+  protected InboundMessage p2pMessage(String messageId, String content) {
+    return normalizer.normalize(body(messageId, "single", "text", content, null)).orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage groupMessage(String messageId, String content) {
+    return normalizer
+        .normalize(body(messageId, "group", "text", "@Bot " + content, "chat-grp"))
+        .orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage nonTextualMessage(String messageId) {
+    return normalizer.normalize(body(messageId, "single", "image", null, null)).orElseThrow();
+  }
+
+  private ObjectNode body(
+      String msgid, String chattype, String msgtype, String text, String chatid) {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgid", msgid);
+    body.put("chattype", chattype);
+    body.put("msgtype", msgtype);
+    body.putObject("from").put("userid", "user-1");
+    if (chatid != null) {
+      body.put("chatid", chatid);
+    }
+    if ("text".equals(msgtype) && text != null) {
+      body.putObject("text").put("content", text);
+    } else if ("image".equals(msgtype)) {
+      body.putObject("image").put("url", "https://example/img");
+    }
+    return body;
+  }
+}

--- a/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComEventNormalizerTest.java
+++ b/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComEventNormalizerTest.java
@@ -1,0 +1,80 @@
+package io.oryxos.channel.wecom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WeComEventNormalizerTest {
+
+  private final WeComEventNormalizer normalizer = new WeComEventNormalizer("ops-wecom");
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  @DisplayName("单聊文本 → P2P，chatId=userid")
+  void singleText() throws Exception {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgid", "m1");
+    body.put("chattype", "single");
+    body.put("msgtype", "text");
+    body.putObject("from").put("userid", "u1");
+    body.putObject("text").put("content", "hello");
+
+    InboundMessage msg = normalizer.normalize(body).orElseThrow();
+    assertEquals(ChatKind.P2P, msg.chatKind());
+    assertEquals("u1", msg.chatId());
+    assertEquals("u1", msg.userId());
+    assertEquals("hello", msg.content());
+    assertTrue(msg.textual());
+    assertFalse(msg.mentionedBot());
+  }
+
+  @Test
+  @DisplayName("群聊文本剥离前导 @，mentionedBot=true")
+  void groupTextStripsAt() throws Exception {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgid", "m2");
+    body.put("chattype", "group");
+    body.put("chatid", "g1");
+    body.put("msgtype", "text");
+    body.putObject("from").put("userid", "u1");
+    body.putObject("text").put("content", "@RobotA 今天天气");
+
+    InboundMessage msg = normalizer.normalize(body).orElseThrow();
+    assertEquals(ChatKind.GROUP, msg.chatKind());
+    assertEquals("g1", msg.chatId());
+    assertEquals("今天天气", msg.content());
+    assertTrue(msg.mentionedBot());
+  }
+
+  @Test
+  @DisplayName("非文本仍构造消息但 textual=false")
+  void nonText() throws Exception {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgid", "m3");
+    body.put("chattype", "single");
+    body.put("msgtype", "image");
+    body.putObject("from").put("userid", "u1");
+    body.putObject("image").put("url", "https://x");
+
+    InboundMessage msg = normalizer.normalize(body).orElseThrow();
+    assertFalse(msg.textual());
+    assertEquals("", msg.content());
+  }
+
+  @Test
+  @DisplayName("缺字段 → empty")
+  void missingFields() throws Exception {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgid", "m4");
+    Optional<InboundMessage> msg = normalizer.normalize(body);
+    assertTrue(msg.isEmpty());
+  }
+}

--- a/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComMessageSenderTest.java
+++ b/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComMessageSenderTest.java
@@ -1,0 +1,54 @@
+package io.oryxos.channel.wecom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WeComMessageSenderTest {
+
+  @Test
+  @DisplayName("发送 markdown 帧并带 chat_type")
+  void sendMarkdownWithChatType() {
+    List<ObjectNode> frames = new ArrayList<>();
+    AtomicReference<String> guarded = new AtomicReference<>();
+    WeComMessageSender sender =
+        new WeComMessageSender(
+            frames::add, url -> guarded.set(url), WeComChannelAdapter.OUTBOUND_URL, 100);
+    sender.rememberChatType("g1", 2);
+    sender.send("g1", "hi");
+
+    assertEquals(WeComChannelAdapter.OUTBOUND_URL, guarded.get());
+    assertEquals(1, frames.size());
+    ObjectNode frame = frames.get(0);
+    assertEquals("aibot_send_msg", frame.path("cmd").asText());
+    assertEquals("g1", frame.path("body").path("chatid").asText());
+    assertEquals(2, frame.path("body").path("chat_type").asInt());
+    assertEquals("markdown", frame.path("body").path("msgtype").asText());
+    assertEquals("hi", frame.path("body").path("markdown").path("content").asText());
+  }
+
+  @Test
+  @DisplayName("超长文本分段")
+  void segmentsLongText() {
+    List<ObjectNode> frames = new ArrayList<>();
+    WeComMessageSender sender =
+        new WeComMessageSender(frames::add, url -> {}, WeComChannelAdapter.OUTBOUND_URL, 4);
+    sender.send("u1", "abcdefgh");
+    assertEquals(2, frames.size());
+    assertEquals("abcd", frames.get(0).path("body").path("markdown").path("content").asText());
+    assertEquals("efgh", frames.get(1).path("body").path("markdown").path("content").asText());
+  }
+
+  @Test
+  @DisplayName("segment 工具方法边界")
+  void segmentHelper() {
+    assertEquals(List.of(""), WeComMessageSender.segment("", 10));
+    assertTrue(WeComMessageSender.segment("abc", 10).equals(List.of("abc")));
+  }
+}

--- a/oryxos-cli/pom.xml
+++ b/oryxos-cli/pom.xml
@@ -34,6 +34,10 @@
         </dependency>
         <dependency>
             <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-channel-wecom</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
             <artifactId>oryxos-provider</artifactId>
         </dependency>
         <dependency>

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -885,6 +885,10 @@ public class OryxOsRuntime {
             io.oryxos.channel.feishu.FeishuChannelAdapter.TYPE,
             resolved ->
                 new io.oryxos.channel.feishu.FeishuChannelAdapter(
+                    resolved, profileRegistry, inboundMessageService, channelOutboundGuard),
+            io.oryxos.channel.wecom.WeComChannelAdapter.TYPE,
+            resolved ->
+                new io.oryxos.channel.wecom.WeComChannelAdapter(
                     resolved, profileRegistry, inboundMessageService, channelOutboundGuard)));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <module>oryxos-tool</module>
         <module>oryxos-channel-cli</module>
         <module>oryxos-channel-feishu</module>
+        <module>oryxos-channel-wecom</module>
         <module>oryxos-web</module>
         <module>oryxos-storage</module>
         <module>oryxos-cli</module>
@@ -112,6 +113,11 @@
             <dependency>
                 <groupId>io.oryxos</groupId>
                 <artifactId>oryxos-channel-feishu</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.oryxos</groupId>
+                <artifactId>oryxos-channel-wecom</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary
- New module `oryxos-channel-wecom`: 企业微信 **智能机器人** WebSocket 长连接入站（对称飞书 017，免公网回调 / AES）。
- Credentials: `app_id` = BotID, `app_secret` = long-connection Secret.
- Reply via `aibot_send_msg` (markdown); OutboundGuard on `https://openws.work.weixin.qq.com`.
- Contract tests B1–B10 + normalizer/sender unit tests; docs + `channels.yaml.example` + whitelist domain.
- Notify `WeComNotifyAdapter` (group webhook) unchanged and separate.

## Test plan
- [x] `WeComEventNormalizerTest` / `WeComMessageSenderTest` / `WeComChannelContractTest`
- [x] `oryxos-cli` / `oryxos-boot` package
- [ ] CI Build & quality gate
- [ ] CI OWASP Dependency-Check
- [ ] Manual: BotID/Secret + channels.yaml `type: wecom` → CONNECTED + P2P/group @
