### PR TITLE
fix(fs): AdminConfig / AGENT.md guards reject symlink aliases (#292)

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/fs/AdminConfigFileGuard.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/fs/AdminConfigFileGuard.java
@@ -13,8 +13,8 @@ import java.util.Set;
  * <p>覆盖 {@code channels.yaml}（{@code ChannelAdminService}）与 {@code mcp_servers.yaml}（{@code
  * McpServerAdminService}）。
  *
- * <p>除词法路径段检查外，还会经 {@link RealPathBoundary} 解析已存在祖先的真实路径，避免 {@code alias.yaml →
- * channels.yaml} 这类软链绕过（对齐 {@code MemoryMdGuard}）。
+ * <p>除词法路径段检查外，还会经 {@link RealPathBoundary} 解析已存在祖先的真实路径，避免 {@code alias.yaml → channels.yaml}
+ * 这类软链绕过（对齐 {@code MemoryMdGuard}）。
  */
 public final class AdminConfigFileGuard {
 

--- a/oryxos-core/src/main/java/io/oryxos/core/fs/AdminConfigFileGuard.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/fs/AdminConfigFileGuard.java
@@ -1,5 +1,8 @@
 package io.oryxos.core.fs;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Set;
@@ -9,6 +12,9 @@ import java.util.Set;
  *
  * <p>覆盖 {@code channels.yaml}（{@code ChannelAdminService}）与 {@code mcp_servers.yaml}（{@code
  * McpServerAdminService}）。
+ *
+ * <p>除词法路径段检查外，还会经 {@link RealPathBoundary} 解析已存在祖先的真实路径，避免 {@code alias.yaml →
+ * channels.yaml} 这类软链绕过（对齐 {@code MemoryMdGuard}）。
  */
 public final class AdminConfigFileGuard {
 
@@ -16,11 +22,28 @@ public final class AdminConfigFileGuard {
 
   private AdminConfigFileGuard() {}
 
+  public static void rejectMutation(String path) {
+    if (path == null || path.isBlank()) {
+      return;
+    }
+    rejectLexical(path);
+    rejectResolved(Path.of(path));
+  }
+
+  /** 对已解析（常为绝对）路径做词法 + 真实路径双重检查；Workspace 等入口应在边界投影后再调。 */
+  public static void rejectMutation(Path path) {
+    if (path == null) {
+      return;
+    }
+    rejectLexical(path.toString());
+    rejectResolved(path);
+  }
+
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",
       justification =
           "Reserved filenames are ASCII; Locale.ROOT fold matches case-insensitive filesystems.")
-  public static void rejectMutation(String path) {
+  private static void rejectLexical(String path) {
     if (path == null || path.isBlank()) {
       return;
     }
@@ -30,6 +53,34 @@ public final class AdminConfigFileGuard {
       if (RESERVED_LOWER.contains(lower)) {
         throw new IllegalArgumentException("拒绝直接改写管理配置（请用 Channel / MCP 管理入口）: " + path);
       }
+    }
+  }
+
+  private static void rejectResolved(Path path) {
+    rejectSymlinkLeafTarget(path);
+    Path projected;
+    try {
+      projected = RealPathBoundary.project(path).projectedReal();
+    } catch (UncheckedIOException | IllegalArgumentException e) {
+      return;
+    }
+    rejectLexical(projected.toString());
+  }
+
+  private static void rejectSymlinkLeafTarget(Path path) {
+    Path absolute = path.toAbsolutePath().normalize();
+    if (!Files.isSymbolicLink(absolute)) {
+      return;
+    }
+    try {
+      Path linkTarget = Files.readSymbolicLink(absolute);
+      rejectLexical(linkTarget.toString());
+      Path parent = absolute.getParent();
+      if (parent != null) {
+        rejectLexical(parent.resolve(linkTarget).normalize().toString());
+      }
+    } catch (IOException ignored) {
+      // 读链失败则保守放行词法已通过的路径；真实写入仍受沙箱约束
     }
   }
 }

--- a/oryxos-core/src/main/java/io/oryxos/core/fs/WorkspaceMutationGuard.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/fs/WorkspaceMutationGuard.java
@@ -106,6 +106,10 @@ public final class WorkspaceMutationGuard {
     rejectAgentMdLexical(projected.toString());
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "AGENT.md is ASCII; Locale.ROOT fold matches case-insensitive filesystems for symlink leaf names.")
   private static void rejectAgentMdSymlinkLeaf(Path path) {
     Path absolute = path.toAbsolutePath().normalize();
     if (!Files.isSymbolicLink(absolute)) {

--- a/oryxos-core/src/main/java/io/oryxos/core/fs/WorkspaceMutationGuard.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/fs/WorkspaceMutationGuard.java
@@ -1,5 +1,8 @@
 package io.oryxos.core.fs;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,11 +55,30 @@ public final class WorkspaceMutationGuard {
   /**
    * 拒绝文件工具直写 {@code agents/<name>/AGENT.md}——须走 {@code AgentLifecycleService.update} （校验 + 重注册
    * schedules）。
+   *
+   * <p>除词法检查外，经 {@link RealPathBoundary} 复检，避免 {@code notes.md → AGENT.md} 软链绕过。
    */
+  public static void rejectAgentMdDirectWrite(String path) {
+    if (path == null || path.isBlank()) {
+      return;
+    }
+    rejectAgentMdLexical(path);
+    rejectAgentMdResolved(Path.of(path));
+  }
+
+  /** 对已解析路径做词法 + 真实路径双重检查。 */
+  public static void rejectAgentMdDirectWrite(Path path) {
+    if (path == null) {
+      return;
+    }
+    rejectAgentMdLexical(path.toString());
+    rejectAgentMdResolved(path);
+  }
+
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",
       justification = "AGENT.md is ASCII; Locale.ROOT fold matches case-insensitive filesystems.")
-  public static void rejectAgentMdDirectWrite(String path) {
+  private static void rejectAgentMdLexical(String path) {
     if (path == null || path.isBlank()) {
       return;
     }
@@ -70,6 +92,38 @@ public final class WorkspaceMutationGuard {
     if (fileIdx == segs.size() - 1 && AGENT_MD.equals(segs.get(fileIdx))) {
       throw new IllegalArgumentException(
           "拒绝直接改写 AGENT.md，请通过 Agent 管理 / lifecycle.update: " + path);
+    }
+  }
+
+  private static void rejectAgentMdResolved(Path path) {
+    rejectAgentMdSymlinkLeaf(path);
+    Path projected;
+    try {
+      projected = RealPathBoundary.project(path).projectedReal();
+    } catch (UncheckedIOException | IllegalArgumentException e) {
+      return;
+    }
+    rejectAgentMdLexical(projected.toString());
+  }
+
+  private static void rejectAgentMdSymlinkLeaf(Path path) {
+    Path absolute = path.toAbsolutePath().normalize();
+    if (!Files.isSymbolicLink(absolute)) {
+      return;
+    }
+    try {
+      Path linkTarget = Files.readSymbolicLink(absolute);
+      Path fileName = linkTarget.getFileName();
+      if (fileName != null && AGENT_MD.equals(fileName.toString().toLowerCase(Locale.ROOT))) {
+        throw new IllegalArgumentException(
+            "拒绝直接改写 AGENT.md，请通过 Agent 管理 / lifecycle.update: " + path);
+      }
+      Path parent = absolute.getParent();
+      if (parent != null) {
+        rejectAgentMdLexical(parent.resolve(linkTarget).normalize().toString());
+      }
+    } catch (IOException ignored) {
+      // 读链失败则保守放行词法已通过的路径
     }
   }
 

--- a/oryxos-core/src/test/java/io/oryxos/core/fs/AdminConfigFileGuardTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/fs/AdminConfigFileGuardTest.java
@@ -2,11 +2,18 @@ package io.oryxos.core.fs;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class AdminConfigFileGuardTest {
+
+  @TempDir Path temp;
 
   @Test
   @DisplayName("拒绝 channels.yaml / mcp_servers.yaml 直写（大小写不敏感）")
@@ -42,5 +49,36 @@ class AdminConfigFileGuardTest {
     assertDoesNotThrow(() -> AdminConfigFileGuard.rejectMutation("channels.yaml.bak"));
     assertDoesNotThrow(() -> AdminConfigFileGuard.rejectMutation(null));
     assertDoesNotThrow(() -> AdminConfigFileGuard.rejectMutation("  "));
+    assertDoesNotThrow(() -> AdminConfigFileGuard.rejectMutation((Path) null));
+  }
+
+  @Test
+  @DisplayName("软链叶子指向 channels.yaml 时拒绝")
+  void rejectsSymlinkLeafToChannelsYaml() throws IOException {
+    Path reserved = temp.resolve("channels.yaml");
+    Files.writeString(reserved, "channels: []\n");
+    Path alias = temp.resolve("alias.yaml");
+    assumeCanSymlink(alias, reserved);
+
+    assertThrows(IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectMutation(alias));
+    assertThrows(
+        IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectMutation(alias.toString()));
+  }
+
+  @Test
+  @DisplayName("悬空软链目标词法为 mcp_servers.yaml 时也拒绝")
+  void rejectsDanglingSymlinkNamedMcpServers() throws IOException {
+    Path alias = temp.resolve("alias.yaml");
+    assumeCanSymlink(alias, Path.of("mcp_servers.yaml"));
+
+    assertThrows(IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectMutation(alias));
+  }
+
+  private static void assumeCanSymlink(Path link, Path target) {
+    try {
+      Files.createSymbolicLink(link, target);
+    } catch (IOException | UnsupportedOperationException e) {
+      assumeTrue(false, "当前环境无法创建软链: " + e.getMessage());
+    }
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/fs/AdminConfigFileGuardTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/fs/AdminConfigFileGuardTest.java
@@ -47,7 +47,7 @@ class AdminConfigFileGuardTest {
   void allowsOrdinaryPaths() {
     assertDoesNotThrow(() -> AdminConfigFileGuard.rejectMutation("agents/demo/notes.md"));
     assertDoesNotThrow(() -> AdminConfigFileGuard.rejectMutation("channels.yaml.bak"));
-    assertDoesNotThrow(() -> AdminConfigFileGuard.rejectMutation(null));
+    assertDoesNotThrow(() -> AdminConfigFileGuard.rejectMutation((String) null));
     assertDoesNotThrow(() -> AdminConfigFileGuard.rejectMutation("  "));
     assertDoesNotThrow(() -> AdminConfigFileGuard.rejectMutation((Path) null));
   }
@@ -62,7 +62,8 @@ class AdminConfigFileGuardTest {
 
     assertThrows(IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectMutation(alias));
     assertThrows(
-        IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectMutation(alias.toString()));
+        IllegalArgumentException.class,
+        () -> AdminConfigFileGuard.rejectMutation(alias.toString()));
   }
 
   @Test

--- a/oryxos-core/src/test/java/io/oryxos/core/fs/WorkspaceMutationGuardTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/fs/WorkspaceMutationGuardTest.java
@@ -72,7 +72,8 @@ class WorkspaceMutationGuardTest {
     assumeCanSymlink(alias, agentMd);
 
     assertThrows(
-        IllegalArgumentException.class, () -> WorkspaceMutationGuard.rejectAgentMdDirectWrite(alias));
+        IllegalArgumentException.class,
+        () -> WorkspaceMutationGuard.rejectAgentMdDirectWrite(alias));
     assertThrows(
         IllegalArgumentException.class,
         () -> WorkspaceMutationGuard.rejectAgentMdDirectWrite(alias.toString()));
@@ -85,7 +86,8 @@ class WorkspaceMutationGuardTest {
     assumeCanSymlink(alias, Path.of("AGENT.md"));
 
     assertThrows(
-        IllegalArgumentException.class, () -> WorkspaceMutationGuard.rejectAgentMdDirectWrite(alias));
+        IllegalArgumentException.class,
+        () -> WorkspaceMutationGuard.rejectAgentMdDirectWrite(alias));
   }
 
   private static void assumeCanSymlink(Path link, Path target) {

--- a/oryxos-core/src/test/java/io/oryxos/core/fs/WorkspaceMutationGuardTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/fs/WorkspaceMutationGuardTest.java
@@ -2,11 +2,18 @@ package io.oryxos.core.fs;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class WorkspaceMutationGuardTest {
+
+  @TempDir Path temp;
 
   @Test
   @DisplayName("拒绝共享 skills/knowledge 与 Agent 绑定视图下的内容写")
@@ -51,6 +58,42 @@ class WorkspaceMutationGuardTest {
         () -> WorkspaceMutationGuard.rejectAgentMdDirectWrite("agents/demo/notes.md"));
     assertDoesNotThrow(
         () -> WorkspaceMutationGuard.rejectAgentMdDirectWrite("agents/demo/skills/AGENT.md"));
+    assertDoesNotThrow(() -> WorkspaceMutationGuard.rejectAgentMdDirectWrite((Path) null));
+  }
+
+  @Test
+  @DisplayName("软链叶子指向 AGENT.md 时拒绝")
+  void rejectsSymlinkLeafToAgentMd() throws IOException {
+    Path agentDir = temp.resolve("agents").resolve("demo");
+    Files.createDirectories(agentDir);
+    Path agentMd = agentDir.resolve("AGENT.md");
+    Files.writeString(agentMd, "name: demo\n");
+    Path alias = agentDir.resolve("notes.md");
+    assumeCanSymlink(alias, agentMd);
+
+    assertThrows(
+        IllegalArgumentException.class, () -> WorkspaceMutationGuard.rejectAgentMdDirectWrite(alias));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> WorkspaceMutationGuard.rejectAgentMdDirectWrite(alias.toString()));
+  }
+
+  @Test
+  @DisplayName("悬空软链目标名为 AGENT.md 时也拒绝")
+  void rejectsDanglingSymlinkNamedAgentMd() throws IOException {
+    Path alias = temp.resolve("notes.md");
+    assumeCanSymlink(alias, Path.of("AGENT.md"));
+
+    assertThrows(
+        IllegalArgumentException.class, () -> WorkspaceMutationGuard.rejectAgentMdDirectWrite(alias));
+  }
+
+  private static void assumeCanSymlink(Path link, Path target) {
+    try {
+      Files.createSymbolicLink(link, target);
+    } catch (IOException | UnsupportedOperationException e) {
+      assumeTrue(false, "当前环境无法创建软链: " + e.getMessage());
+    }
   }
 
   @Test

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
@@ -143,12 +143,13 @@ public class WorkspaceApiController {
     if (path == null || path.isBlank()) {
       throw new IllegalArgumentException("path 为空"); // → 400
     }
-    // 先词法拦直写；再投影真实路径后复检——notes.md→MEMORY.md 软链只在投影后能看见
+    // 先词法拦直写；再投影真实路径后复检——notes.md→MEMORY.md / alias→channels.yaml 软链只在投影后能看见
     MemoryMdGuard.rejectMutation(path);
     AdminConfigFileGuard.rejectMutation(path);
     WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
     Path target = resolveWithinRoot(path);
     MemoryMdGuard.rejectMutation(target);
+    AdminConfigFileGuard.rejectMutation(target);
     if (isAgentSkillsPath(target)) {
       throw new IllegalArgumentException("Agent skills/ 是绑定视图，禁止从工作区入口写入");
     }


### PR DESCRIPTION
## Summary
- Align `AdminConfigFileGuard` with `MemoryMdGuard` (symlink leaf + RealPathBoundary)
- Same realpath recheck for `WorkspaceMutationGuard.rejectAgentMdDirectWrite` (FileTools path)
- Workspace write re-calls AdminConfig guard after `resolveWithinRoot`

Fixes #292

## Test plan
- [x] Symlink / dangling symlink unit tests (assume symlink available)
- [ ] CI Build & quality gate