### PR TITLE
fix(profile): reject invalid cron / ZoneId at load (#293)

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.support.CronTrigger;
 import org.yaml.snakeyaml.Yaml;
 
 /**
@@ -224,15 +226,34 @@ public class ProfileLoader {
       if (cron == null || cron.isBlank()) {
         throw new ProfileValidationException("Profile 定时配置 " + key + " 缺少 cron: " + source);
       }
+      String zone = asString(entry.get("zone"));
+      validateCronAndZone(key, cron.strip(), zone, source);
       schedules.add(
           new Profile.ScheduleConfig(
               key,
               name,
               cron.strip(),
-              asString(entry.get("zone")),
+              zone,
               asString(entry.get("message"))));
     }
     return schedules;
+  }
+
+  /** 与 {@code AgentScheduler} 同口径：非法 cron / ZoneId 在加载期失败，避免注册时仅 WARN 跳过。 */
+  private static void validateCronAndZone(String key, String cron, String zone, String source) {
+    ZoneId zoneId;
+    try {
+      zoneId = zone == null || zone.isBlank() ? ZoneId.systemDefault() : ZoneId.of(zone);
+    } catch (RuntimeException e) {
+      throw new ProfileValidationException(
+          "Profile 定时配置 " + key + " 的 zone 无效: " + source + " (" + e.getMessage() + ")");
+    }
+    try {
+      new CronTrigger(cron, zoneId);
+    } catch (RuntimeException e) {
+      throw new ProfileValidationException(
+          "Profile 定时配置 " + key + " 的 cron 无效: " + source + " (" + e.getMessage() + ")");
+    }
   }
 
   private static Profile.Settings toSettings(Map<String, Object> map, String profileName) {

--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -230,11 +230,7 @@ public class ProfileLoader {
       validateCronAndZone(key, cron.strip(), zone, source);
       schedules.add(
           new Profile.ScheduleConfig(
-              key,
-              name,
-              cron.strip(),
-              zone,
-              asString(entry.get("message"))));
+              key, name, cron.strip(), zone, asString(entry.get("message"))));
     }
     return schedules;
   }

--- a/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
@@ -303,6 +303,57 @@ class ProfileLoaderTest {
   }
 
   @Test
+  void schedules非法cron时报错点名() throws IOException {
+    write(
+        "bad-cron.yaml",
+        """
+        name: bad-cron
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - key: morning
+            name: Morning job
+            cron: "0 0 8 * *"
+            message: hi
+        """);
+
+    ProfileValidationException ex =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("bad-cron.yaml")));
+
+    assertTrue(ex.getMessage().contains("morning"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("cron"), ex.getMessage());
+  }
+
+  @Test
+  void schedules非法zone时报错点名() throws IOException {
+    write(
+        "bad-zone.yaml",
+        """
+        name: bad-zone
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        schedules:
+          - key: morning
+            name: Morning job
+            cron: "0 0 8 * * *"
+            zone: Not/AZone
+            message: hi
+        """);
+
+    ProfileValidationException ex =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("bad-zone.yaml")));
+
+    assertTrue(ex.getMessage().contains("morning"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("zone"), ex.getMessage());
+  }
+
+  @Test
   void 引用不存在的provider_报错信息包含该名字() throws IOException {
     write(
         "bad-provider.yaml",


### PR DESCRIPTION
## Summary
- Validate schedule `cron` / `zone` in `ProfileLoader.toSchedules` with the same `CronTrigger` + `ZoneId` rules as `AgentScheduler`
- Fail loud with `ProfileValidationException` instead of WARN-skip at register time

Fixes #293

## Test plan
- [x] Unit tests for invalid cron and invalid zone
- [ ] CI Build & quality gate