### PR TITLE
fix(fs): recheck mutation guards before final write (#298)

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -42,6 +42,14 @@ public class FileTools {
     this.sandbox = sandbox;
   }
 
+  /** 写路径保留文件守卫（MEMORY / AdminConfig / Skill·Knowledge / AGENT.md）。 */
+  private static void rejectReservedFileWrites(String path) {
+    MemoryMdGuard.rejectMutation(path);
+    AdminConfigFileGuard.rejectMutation(path);
+    WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
+    WorkspaceMutationGuard.rejectAgentMdDirectWrite(path);
+  }
+
   @Tool(name = "read_file", description = "读取指定路径的文本文件内容")
   public String readFile(@ToolParam(description = "要读取的文件路径") String path) {
     sandbox.enforce(new SandboxAction(ActionType.FILE_READ, path));
@@ -75,6 +83,7 @@ public class FileTools {
       }
       // 写前复检：与 download_file / grep 同款——防首次校验到 writeString 间路径被换成外向软链
       sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
+      rejectReservedFileWrites(path);
       Files.writeString(file, content);
       return "已写入: " + path;
     } catch (IOException e) {
@@ -131,6 +140,7 @@ public class FileTools {
       }
       // 写前复检：与 write_file 同款
       sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
+      rejectReservedFileWrites(path);
       Files.writeString(file, content.replace(oldString, newString));
       return "已编辑: " + path;
     } catch (IOException e) {
@@ -277,6 +287,7 @@ public class FileTools {
         Files.createDirectories(parent);
       }
       sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
+      rejectReservedFileWrites(path);
       Files.writeString(file, content, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
       return "已追加到: " + path;
     } catch (IOException e) {
@@ -335,6 +346,8 @@ public class FileTools {
       // 变更前复检：与 write_file 同款——防 createDirectories 窗口内目标父路径被换成外向软链
       sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, from));
       sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, to));
+      rejectReservedFileWrites(from);
+      rejectReservedFileWrites(to);
       Files.move(src, dst, StandardCopyOption.REPLACE_EXISTING);
       return "已移动: " + from + " -> " + to;
     } catch (IOException e) {
@@ -371,6 +384,7 @@ public class FileTools {
       // 变更前复检：与 write_file 同款——防校验到 copy 间路径被换成外向软链
       sandbox.enforce(new SandboxAction(ActionType.FILE_READ, from));
       sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, to));
+      rejectReservedFileWrites(to);
       Files.copy(src, dst, StandardCopyOption.REPLACE_EXISTING);
       return "已复制: " + from + " -> " + to;
     } catch (IOException e) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -358,6 +358,10 @@ public class HttpTools {
       // 写前复检：与 write_file 同款——createDirectories 之后、Files.write 之前。
       // 复检若放在建目录前，通过后父路径仍可被换成外向软链，写出白名单。
       sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
+      MemoryMdGuard.rejectMutation(path);
+      AdminConfigFileGuard.rejectMutation(path);
+      WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
+      WorkspaceMutationGuard.rejectAgentMdDirectWrite(path);
       Files.write(file, bytes);
       return "已下载到: " + path + "（" + bytes.length + " 字节）";
     } catch (IOException e) {

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
@@ -174,8 +174,28 @@ public class WorkspaceApiController {
       if (parent != null) {
         Files.createDirectories(parent);
       }
-      // 写前复检：与 write_file / download_file 同款——防首次校验到 writeString 间父路径被换成外向软链
+      // 写前复检：防首次校验到 writeString 间路径被换成外向软链，或换成仍在 root 内的保留文件
       target = resolveWithinRoot(path);
+      MemoryMdGuard.rejectMutation(target);
+      AdminConfigFileGuard.rejectMutation(target);
+      WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(target.toString());
+      if (isAgentSkillsPath(target)) {
+        throw new IllegalArgumentException("Agent skills/ 是绑定视图，禁止从工作区入口写入");
+      }
+      if (isAgentKnowledgePath(target)) {
+        throw new IllegalArgumentException("Agent knowledge/ 是绑定视图，禁止从工作区入口写入");
+      }
+      if (RealPathBoundary.isWithin(oryxosRoot.resolve(SKILLS_DIR), target)) {
+        throw new IllegalArgumentException("共享 Skill 实体只能通过 Skill 管理入口更新");
+      }
+      if (RealPathBoundary.isWithin(oryxosRoot.resolve(KNOWLEDGE_DIR), target)) {
+        throw new IllegalArgumentException("共享 Knowledge 实体只能通过 Knowledge 管理入口更新");
+      }
+      Path agentDirRecheck = agentDirOfAgentFile(target);
+      if (agentDirRecheck != null) {
+        lifecycle.update(String.valueOf(agentDirRecheck.getFileName()), content);
+        return ApiResponse.ok(null);
+      }
       Files.writeString(target, content);
     } catch (IOException e) {
       throw new UncheckedIOException("写入文件失败: " + path, e);


### PR DESCRIPTION
## Summary
- `FileTools` / `HttpTools.downloadFile`: after final sandbox enforce, re-run MEMORY / AdminConfig / Skill·Knowledge / AGENT.md guards
- `WorkspaceApiController.writeFile`: after second `resolveWithinRoot`, re-run reserved-path checks and re-route `AGENT.md` via `lifecycle.update`

Fixes #298

## Test plan
- [x] Local compile (`oryxos-tool`, `oryxos-web`)
- [ ] CI Build & quality gate