### PR TITLE
fix(fs): FileTools delete/move/make_dir honor Skill/Knowledge ban (#301)

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -259,6 +259,7 @@ public class FileTools {
   public String makeDir(@ToolParam(description = "要创建的目录路径") String path) {
     MemoryMdGuard.rejectMutation(path);
     AdminConfigFileGuard.rejectMutation(path);
+    WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
     WorkspaceMutationGuard.rejectBindSlotCreate(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     try {
@@ -299,6 +300,7 @@ public class FileTools {
   public String deleteFile(@ToolParam(description = "要删除的文件路径") String path) {
     MemoryMdGuard.rejectMutation(path);
     AdminConfigFileGuard.rejectMutation(path);
+    WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
     WorkspaceMutationGuard.rejectBindLinkDetach(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
     Path file = Path.of(path);
@@ -320,6 +322,7 @@ public class FileTools {
       @ToolParam(description = "源路径") String from, @ToolParam(description = "目标路径") String to) {
     MemoryMdGuard.rejectMutation(from);
     AdminConfigFileGuard.rejectMutation(from);
+    WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(from);
     WorkspaceMutationGuard.rejectBindLinkDetach(from);
     MemoryMdGuard.rejectMutation(to);
     AdminConfigFileGuard.rejectMutation(to);

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -200,6 +200,18 @@ class FileToolsTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> tools.makeDir(dir.resolve("agents/demo/skills/report").toString()));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> tools.makeDir(dir.resolve("skills/occupied").toString()));
+    Path skillMd = dir.resolve("skills/report/SKILL.md");
+    Files.createDirectories(skillMd.getParent());
+    Files.writeString(skillMd, "keep\n");
+    assertThrows(IllegalArgumentException.class, () -> tools.deleteFile(skillMd.toString()));
+    assertTrue(Files.exists(skillMd), "共享 Skill 实体不得被 delete_file 删除");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> tools.moveFile(skillMd.toString(), dir.resolve("other-stolen.md").toString()));
+    assertTrue(Files.exists(skillMd), "共享 Skill 实体不得被 move_file 挪走");
     Path link = dir.resolve("agents/demo/skills/report");
     Files.createDirectories(link.getParent());
     Path body = dir.resolve("skills/report");


### PR DESCRIPTION
## Summary
- Call `rejectSkillKnowledgeContentWrite` from `delete_file`, `make_dir`, and `move_file(from)`
- Tests: shared SKILL.md delete/move rejected; `make_dir(skills/occupied)` rejected

Fixes #301

## Test plan
- [x] `FileToolsTest#fileToolsRejectSkillKnowledgeAndAgentMd`
- [ ] CI