### PR TITLE
fix(notify): 3xx without Location must not silent-succeed (#302)

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyPoster.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyPoster.java
@@ -56,7 +56,7 @@ public final class NotifyPoster {
       if (resp.getStatusCode().is3xxRedirection()) {
         String location = resp.getHeaders().getFirst("Location");
         if (location == null || location.isBlank()) {
-          return;
+          throw new IllegalStateException("通知推送收到重定向但缺少 Location: " + current);
         }
         if (switchesToGet(resp.getStatusCode().value())) {
           hopMethod = HttpMethod.GET;

--- a/oryxos-tool/src/test/java/io/oryxos/tool/notify/WebhookNotifyAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/notify/WebhookNotifyAdapterTest.java
@@ -205,4 +205,35 @@ class WebhookNotifyAdapterTest {
       sink.stop(0);
     }
   }
+
+  @Test
+  @DisplayName("302 无 Location 时不得静默成功")
+  void redirect302WithoutLocationFailsLoud() throws IOException {
+    HttpServer entry = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    try {
+      entry.createContext(
+          "/",
+          exchange -> {
+            exchange.getRequestBody().readAllBytes();
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+          });
+      entry.start();
+
+      WebhookNotifyAdapter guarded =
+          new WebhookNotifyAdapter(
+              new NotifyPoster(
+                  new WhitelistSandbox(
+                      new FileSandboxProperties(List.of()),
+                      new ShellSandboxProperties(List.of()),
+                      new HttpSandboxProperties(List.of("localhost", "127.0.0.1")))));
+      String start = "http://localhost:" + entry.getAddress().getPort() + "/";
+
+      IllegalStateException ex =
+          assertThrows(IllegalStateException.class, () -> guarded.send(webhookTarget(start), "x"));
+      assertTrue(ex.getMessage().contains("Location"), ex.getMessage());
+    } finally {
+      entry.stop(0);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- `NotifyPoster.postJson` throws when a 3xx hop has empty/missing Location
- Regression test via WebhookNotifyAdapter

Fixes #302

## Test plan
- [x] `WebhookNotifyAdapterTest#redirect302WithoutLocationFailsLoud`
- [ ] CI