### PR TITLE
fix(profile): require notify_channels type at load (#305)

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -174,6 +174,10 @@ public class ProfileLoader {
             "Profile " + profileName + " 的 notify_channels 存在非对象条目: " + item);
       }
       String type = asString(entry.get("type"));
+      if (type == null || type.isBlank()) {
+        throw new ProfileValidationException(
+            "Profile " + profileName + " 的 notify_channels 缺少 type");
+      }
       // type 之外的键都是渠道特定配置（如 webhook 的 url）
       Map<String, String> config = new LinkedHashMap<>();
       for (Map.Entry<String, Object> kv : entry.entrySet()) {

--- a/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
@@ -263,6 +263,52 @@ class ProfileLoaderTest {
   }
 
   @Test
+  void notify_channels缺少type时报错点名() throws IOException {
+    write(
+        "missing-notify-type.yaml",
+        """
+        name: missing-notify-type
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        notify_channels:
+          - url: https://example.com/hook
+        """);
+
+    ProfileValidationException ex =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("missing-notify-type.yaml")));
+
+    assertTrue(ex.getMessage().contains("missing-notify-type"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("notify_channels"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("type"), ex.getMessage());
+  }
+
+  @Test
+  void notify_channels空type时报错点名() throws IOException {
+    write(
+        "blank-notify-type.yaml",
+        """
+        name: blank-notify-type
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        notify_channels:
+          - type: ""
+            url: https://example.com/hook
+        """);
+
+    ProfileValidationException ex =
+        assertThrows(
+            ProfileValidationException.class,
+            () -> loader().parse(profilesDir.resolve("blank-notify-type.yaml")));
+
+    assertTrue(ex.getMessage().contains("blank-notify-type"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("type"), ex.getMessage());
+  }
+
+  @Test
   void notify_channels合法对象仍可加载() throws IOException {
     write(
         "ok-notify.yaml",


### PR DESCRIPTION
## Summary
- Reject missing/blank `notify_channels[].type` in `ProfileLoader.toNotifyChannels`
- Align with schedules key/cron validation and admin Notify CRUD

Fixes #305

## Test plan
- [x] Unit tests for missing and blank type
- [ ] CI