### PR TITLE
fix(fs): rejectBindSlotCreate 补真实路径与软链叶子三检

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/fs/WorkspaceMutationGuard.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/fs/WorkspaceMutationGuard.java
@@ -185,11 +185,31 @@ public final class WorkspaceMutationGuard {
   /**
    * 拒绝 {@code make_dir} 占用绑定槽（agents 下 skills/knowledge 叶子及其子路径）。建成真目录后 bind 无法落软链；允许只建 skills 或
    * knowledge 父目录本身。
+   *
+   * <p>除词法检查外，经 {@link RealPathBoundary} 复检并检查叶子软链目标，避免 {@code output/skills →
+   * agents/<name>/skills} 这类别名目录建目录后投影到绑定槽（与内容写 / AGENT.md 守卫同款三检）。
    */
+  public static void rejectBindSlotCreate(String path) {
+    if (path == null || path.isBlank()) {
+      return;
+    }
+    rejectBindSlotLexical(path);
+    rejectBindSlotResolved(Path.of(path));
+  }
+
+  /** 对已解析路径做词法 + 真实路径双重检查。 */
+  public static void rejectBindSlotCreate(Path path) {
+    if (path == null) {
+      return;
+    }
+    rejectBindSlotLexical(path.toString());
+    rejectBindSlotResolved(path);
+  }
+
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",
       justification = "Reserved path segments are ASCII; Locale.ROOT fold is intentional.")
-  public static void rejectBindSlotCreate(String path) {
+  private static void rejectBindSlotLexical(String path) {
     if (path == null || path.isBlank()) {
       return;
     }
@@ -209,7 +229,43 @@ public final class WorkspaceMutationGuard {
     }
   }
 
-  /** 拒绝 {@code delete_file}/{@code move_file} 拆掉绑定叶子软链——须走 BindingService.unbind。 */
+  private static void rejectBindSlotResolved(Path path) {
+    rejectBindSlotSymlinkLeaf(path);
+    Path projected;
+    try {
+      projected = RealPathBoundary.project(path).projectedReal();
+    } catch (UncheckedIOException | IllegalArgumentException e) {
+      return;
+    }
+    rejectBindSlotLexical(projected.toString());
+  }
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "skills/knowledge segment names are ASCII; Locale.ROOT fold matches case-insensitive filesystems.")
+  private static void rejectBindSlotSymlinkLeaf(Path path) {
+    Path absolute = path.toAbsolutePath().normalize();
+    if (!Files.isSymbolicLink(absolute)) {
+      return;
+    }
+    try {
+      Path linkTarget = Files.readSymbolicLink(absolute);
+      rejectBindSlotLexical(linkTarget.toString());
+      Path parent = absolute.getParent();
+      if (parent != null) {
+        rejectBindSlotLexical(parent.resolve(linkTarget).normalize().toString());
+      }
+    } catch (IOException ignored) {
+      // 读链失败则保守放行词法已通过的路径
+    }
+  }
+
+  /**
+   * 拒绝 {@code delete_file}/{@code move_file} 拆掉绑定叶子软链——须走 BindingService.unbind。
+   *
+   * <p>保护对象是链接槽位本身（删除/移动作用于链接而非其目标），词法检查即为正确语义，不做真实路径投影。
+   */
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",
       justification = "Reserved path segments are ASCII; Locale.ROOT fold is intentional.")

--- a/oryxos-core/src/test/java/io/oryxos/core/fs/WorkspaceMutationGuardTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/fs/WorkspaceMutationGuardTest.java
@@ -144,6 +144,54 @@ class WorkspaceMutationGuardTest {
   }
 
   @Test
+  @DisplayName("经别名目录建目录投影到绑定槽时拒绝（父目录换链 TOCTOU）")
+  void rejectsMkdirViaSymlinkedAliasIntoBindSlot() throws IOException {
+    Files.createDirectories(temp.resolve("agents").resolve("demo").resolve("skills"));
+    Files.createDirectories(temp.resolve("output"));
+    Path linkedDir = temp.resolve("output").resolve("skills");
+    assumeCanSymlink(linkedDir, Path.of("../agents/demo/skills"));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> WorkspaceMutationGuard.rejectBindSlotCreate(linkedDir.resolve("report").toString()));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> WorkspaceMutationGuard.rejectBindSlotCreate(linkedDir.resolve("report")));
+    // 别名只投影到 skills 父目录本身时仍放行（与词法口径一致：只禁占叶子槽）
+    assertDoesNotThrow(() -> WorkspaceMutationGuard.rejectBindSlotCreate(linkedDir));
+  }
+
+  @Test
+  @DisplayName("悬空软链叶子目标词法命中绑定树时也拒绝")
+  void rejectsDanglingSymlinkLeafIntoBindSlot() throws IOException {
+    Files.createDirectories(temp.resolve("output"));
+    Path link = temp.resolve("output").resolve("slot");
+    assumeCanSymlink(link, Path.of("../agents/demo/skills/report"));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> WorkspaceMutationGuard.rejectBindSlotCreate(link.toString()));
+    assertThrows(
+        IllegalArgumentException.class, () -> WorkspaceMutationGuard.rejectBindSlotCreate(link));
+  }
+
+  @Test
+  @DisplayName("指向普通文件/目录的软链放行（不误伤绑定槽守卫）")
+  void allowsOrdinarySymlinkTargetsForBindSlot() throws IOException {
+    Files.writeString(temp.resolve("notes.md"), "notes\n");
+    Path fileAlias = temp.resolve("alias.md");
+    assumeCanSymlink(fileAlias, Path.of("notes.md"));
+    Files.createDirectories(temp.resolve("plaindir"));
+    Files.createDirectories(temp.resolve("output"));
+    Path dirAlias = temp.resolve("output").resolve("plain");
+    assumeCanSymlink(dirAlias, Path.of("../plaindir"));
+
+    assertDoesNotThrow(() -> WorkspaceMutationGuard.rejectBindSlotCreate(fileAlias));
+    assertDoesNotThrow(() -> WorkspaceMutationGuard.rejectBindSlotCreate(fileAlias.toString()));
+    assertDoesNotThrow(() -> WorkspaceMutationGuard.rejectBindSlotCreate(dirAlias.resolve("sub")));
+  }
+
+  @Test
   @DisplayName("拒绝 delete/move 拆 bind 叶子")
   void rejectBindLinkDetach() {
     assertThrows(


### PR DESCRIPTION
## 动机

按评审建议 rebase 到最新 main（`1dce950`）并逐文件比对：原 PR 的其余改动已由 #295 / #299 / #300 / #303 / #308（fs 守卫三检与前后复检）、#286（workspace 读复检）、#296 / #282 / #284 / #306（Profile fail-loud）覆盖。**rebase 后仅剩的真实增量**：

`WorkspaceMutationGuard.rejectBindSlotCreate` 作为独立 public 守卫仍是**纯词法检查**，与 #295 / #299 建立的同族三检口径（词法 + 叶子软链目标含悬空链 + `RealPathBoundary` 投影复检）不一致。

**调用点现状（重要，供定级参考）**：唯一生产调用点 `FileTools.make_dir` 在本守卫之前已调用带三检的 `rejectSkillKnowledgeContentWrite`——别名目录（`output/tmp → agents/<n>/skills`）下建目录经投影命中 `underAgentBindTree`，main 现状即拒绝；悬空叶子链也由内容守卫叶子检查覆盖（内容守卫拒绝集是绑定槽守卫的超集）。因此本补丁**对当前调用点行为不变**，定位是守卫一致性 / 纵深防御：新测试固化的是该守卫的独立契约，未来新增建目录入口（如 REST mkdir 端点）直接调用即受保护，不依赖调用方记得叠加内容守卫。

## 改动范围（仅 2 个文件，+106/-2）

- `rejectBindSlotCreate`：拆出 `rejectBindSlotLexical`；补叶子软链目标检查（含悬空链）+ `RealPathBoundary` 投影复检，与 `rejectSkillKnowledgeContentWrite` / `rejectAgentMdDirectWrite` 同款；新增 `Path` 重载对齐同类守卫 API
- `rejectBindLinkDetach`：保持纯词法（保护的是链接槽位本身，删除/移动作用于链接而非目标，投影语义不适用），补注释说明取舍
- 测试新增 3 用例：别名目录建目录投影占槽（String/Path 双入口）、悬空链目标命中绑定树、指向普通文件/目录的软链放行（不误伤）

## 平台行为矩阵

| 平台 | 行为 |
|------|------|
| Linux / macOS CI | 新用例全量执行 |
| Windows 无软链权限 | 经本类既有 `assumeCanSymlink` skip（与类内既有软链用例口径一致） |

## 本地实测（Windows 非管理员，无软链权限）

| 范围 | Tests run | Failures | Errors | Skipped |
|------|-----------|----------|--------|---------|
| WorkspaceMutationGuardTest（目标类） | 11 | 0 | 0 | 7 |
| oryxos-core 全模块（本分支） | 271 | 2 | 29 | 12 |
| oryxos-core 全模块（main 基线，同机对照） | 268 | 2 | 29 | 9 |

模块级差异恰为新增 3 用例（Windows 下 skip）；2F/29E 与 main 基线逐项一致，均为既有 Windows 软链环境问题（#310 处理中），与本次增量无关。spotless / checkstyle / PMD 门禁全过。