### PR TITLE
test(core): assume-guards for symlink/POSIX tests on unsupported platforms

### DIFF
--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleSkillBindingTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleSkillBindingTest.java
@@ -21,6 +21,7 @@ import io.oryxos.core.skill.SkillCatalog;
 import io.oryxos.core.skill.SkillLoader;
 import io.oryxos.core.skill.SkillRegistry;
 import io.oryxos.core.skill.SkillStore;
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -55,6 +56,7 @@ class AgentLifecycleSkillBindingTest {
 
   @Test
   void directCreateAndGeneratedSidecarNeverPersistLegacySkills() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     AgentLifecycleService service = service(bindings, new InstalledSkillCatalog(skillRegistry));
     service.create("direct", "直接创建", List.of("required"));
     assertTrue(Files.isSymbolicLink(root.resolve("agents/direct/skills/required")));
@@ -147,6 +149,7 @@ class AgentLifecycleSkillBindingTest {
 
   @Test
   void existingSaveRestoresFilesAndBindingsWhenBindingCommitFails() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     AgentLifecycleService initial = service(bindings, new InstalledSkillCatalog(skillRegistry));
     initial.create("existing", "旧描述", List.of("required"));
     Path markdown = root.resolve("agents/existing/AGENT.md");

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentStoreTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentStoreTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -84,6 +85,7 @@ class AgentStoreTest {
   @Test
   @DisplayName("write/writeAll 拒绝经父链接逃逸及占用 skills 保留命名空间")
   void writesRejectSymlinkEscapeAndReservedSkills() throws IOException {
+    SymlinkAssumptions.assumeSymlinksSupported(oryxosRoot);
     Path outside = Files.createDirectories(oryxosRoot.resolveSibling("agent-store-outside"));
     Path agent = Files.createDirectories(oryxosRoot.resolve("agents/demo"));
     Files.createSymbolicLink(agent.resolve("escape"), outside);

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/ChannelConfigLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/ChannelConfigLoaderTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
@@ -35,6 +36,7 @@ class ChannelConfigLoaderTest {
   @Test
   @DisplayName("loadRaw 保留 ${ENV} 字面量；save 回写后字面量原样落盘且权限收紧 rw-------")
   void rawKeepsPlaceholdersAndSaveRestrictsPermission() throws Exception {
+    SymlinkAssumptions.assumePosixSupported();
     write(
         """
         channels:

--- a/oryxos-core/src/test/java/io/oryxos/core/context/ContextLoaderKnowledgeTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/context/ContextLoaderKnowledgeTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.oryxos.core.knowledge.KnowledgeBindingService;
 import io.oryxos.core.knowledge.KnowledgeWorkspaceFixture;
 import io.oryxos.core.profile.Profile;
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -34,6 +35,7 @@ class ContextLoaderKnowledgeTest {
 
   @Test
   void injectsOnlyMetadataAndGuidanceForBoundBases() {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     bindings.bind("assistant", "ops-manual");
 
     String context = loader.load(profile(List.of("retrieve_knowledge", "read_file")));
@@ -53,6 +55,7 @@ class ContextLoaderKnowledgeTest {
 
   @Test
   void noInjectionWhenToolNotDeclared() {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     bindings.bind("assistant", "ops-manual");
     String context = loader.load(profile(List.of("read_file")));
     assertFalse(context.contains("ops-manual"), "未声明检索工具的 Agent 不注入（注入了也无法使用）");
@@ -60,6 +63,7 @@ class ContextLoaderKnowledgeTest {
 
   @Test
   void brokenBindingIsSkippedWithoutFailingPromptAssembly() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     bindings.bind("assistant", "ops-manual");
     // 制造 dangling：目标库目录被移走
     Path kbDir = root.resolve("knowledge/ops-manual");

--- a/oryxos-core/src/test/java/io/oryxos/core/context/ContextLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/context/ContextLoaderTest.java
@@ -10,6 +10,7 @@ import ch.qos.logback.core.read.ListAppender;
 import io.oryxos.core.profile.Profile;
 import io.oryxos.core.skill.AgentSkillBindingService;
 import io.oryxos.core.skill.SkillLoader;
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -113,6 +114,7 @@ class ContextLoaderTest {
   @Test
   @DisplayName("绑定 Skill 只披露元数据，正文和未绑定项不注入")
   void boundSkillMetadataIsInjectedWithoutBody() throws IOException {
+    SymlinkAssumptions.assumeSymlinksSupported(oryxosRoot);
     writeAgentBody("agent-body");
     Path skill = oryxosRoot.resolve("skills/report-format");
     Files.createDirectories(skill);
@@ -147,6 +149,7 @@ class ContextLoaderTest {
   @Test
   @DisplayName("Skill 描述、解绑和链接修复在下一次 load 立即生效")
   void skillBindingChangesAreReadWithoutCache() throws IOException {
+    SymlinkAssumptions.assumeSymlinksSupported(oryxosRoot);
     writeAgentBody("agent-body");
     Path skill = Files.createDirectories(oryxosRoot.resolve("skills/report-format"));
     Path skillFile = skill.resolve("SKILL.md");

--- a/oryxos-core/src/test/java/io/oryxos/core/context/ProgressiveDisclosureTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/context/ProgressiveDisclosureTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.oryxos.core.profile.Profile;
 import io.oryxos.core.skill.AgentSkillBindingService;
 import io.oryxos.core.skill.SkillLoader;
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -93,6 +94,7 @@ class ProgressiveDisclosureTest {
   @Test
   @DisplayName("绑定 Skill 每轮只注入 name/description/本地路径，不注入正文或未绑定 Skill")
   void boundSkillOnlyDisclosesMetadata() throws IOException {
+    SymlinkAssumptions.assumeSymlinksSupported(oryxosRoot);
     writeBody("按需使用 Skill");
     Path report = oryxosRoot.resolve("skills/report");
     Path hidden = oryxosRoot.resolve("skills/hidden");
@@ -121,6 +123,7 @@ class ProgressiveDisclosureTest {
   @Test
   @DisplayName("零绑定不输出 Skill 标题，多绑定按名称稳定排序并跳过坏链接")
   void zeroAndMultipleBindingsHaveStableMinimalCatalog() throws IOException {
+    SymlinkAssumptions.assumeSymlinksSupported(oryxosRoot);
     writeBody("正文");
     assertFalse(loader.load(profile()).contains("你可以按需使用以下 Skill"));
 

--- a/oryxos-core/src/test/java/io/oryxos/core/fs/RealPathBoundaryTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/fs/RealPathBoundaryTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,6 +27,7 @@ class RealPathBoundaryTest {
 
   @Test
   void rejectsParentLinkEscapeDanglingAndCycle() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(temp);
     Path root = Files.createDirectories(temp.resolve("root"));
     Path outside = Files.createDirectories(temp.resolve("outside"));
     Files.createSymbolicLink(root.resolve("escape"), outside);
@@ -53,6 +55,7 @@ class RealPathBoundaryTest {
 
   @Test
   void rootMayItselfBeASymlink() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(temp);
     Path actual = Files.createDirectories(temp.resolve("actual"));
     Path linkedRoot = temp.resolve("linked-root");
     Files.createSymbolicLink(linkedRoot, actual);

--- a/oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeBindingServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeBindingServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,6 +31,7 @@ class KnowledgeBindingServiceTest {
 
   @Test
   void bindCreatesFixedRelativeLinkAndInspectReturnsMetadata() throws IOException {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     BoundKnowledgeDescriptor bound = service.bind("assistant", "ops");
 
     assertEquals("ops", bound.name());
@@ -51,6 +53,7 @@ class KnowledgeBindingServiceTest {
 
   @Test
   void unbindIsIdempotentAndRefusesUncontrolledEntries() throws IOException {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     service.bind("assistant", "ops");
     service.unbind("assistant", "ops");
     service.unbind("assistant", "ops"); // 幂等
@@ -62,6 +65,7 @@ class KnowledgeBindingServiceTest {
 
   @Test
   void replaceBindingsSwapsWholeSet() {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     service.bind("assistant", "ops");
 
     KnowledgeBindingInspection after = service.replaceBindings("assistant", List.of("faq"));
@@ -73,6 +77,7 @@ class KnowledgeBindingServiceTest {
 
   @Test
   void inspectClassifiesIllegalBindings() throws IOException {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     // 绝对链接 → ESCAPED
     KnowledgeWorkspaceFixture.rawBinding(
         root, "assistant", "abs", root.resolve("knowledge/ops").toAbsolutePath());
@@ -100,6 +105,7 @@ class KnowledgeBindingServiceTest {
 
   @Test
   void escapedRealTargetIsRejectedEvenWithLexicalCompliance() throws IOException {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     // knowledge/evil 目录本身是指向库根之外的软连接：词法合规但真实路径越界
     Path outside = Files.createDirectories(root.resolve("outside"));
     Files.writeString(
@@ -116,6 +122,7 @@ class KnowledgeBindingServiceTest {
 
   @Test
   void referencesAndDeleteProtection() {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     KnowledgeWorkspaceFixture.agent(root, "another");
     service.bind("assistant", "ops");
     service.bind("another", "ops");
@@ -135,6 +142,7 @@ class KnowledgeBindingServiceTest {
 
   @Test
   void reconcileAggregatesIssuesAcrossAgents() {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     KnowledgeWorkspaceFixture.agent(root, "another");
     KnowledgeWorkspaceFixture.rawBinding(
         root, "another", "gone", Path.of("..", "..", "..", "knowledge", "gone"));

--- a/oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeWorkspaceFixture.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/knowledge/KnowledgeWorkspaceFixture.java
@@ -1,5 +1,6 @@
 package io.oryxos.core.knowledge;
 
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -58,7 +59,8 @@ public final class KnowledgeWorkspaceFixture {
       Path linksDir =
           Files.createDirectories(root.resolve("agents").resolve(agentName).resolve("knowledge"));
       Path link = linksDir.resolve(kbName);
-      Files.createSymbolicLink(link, Path.of("..", "..", "..", "knowledge", kbName));
+      SymlinkAssumptions.createSymbolicLinkOrAssume(
+          link, Path.of("..", "..", "..", "knowledge", kbName));
       return link;
     } catch (IOException e) {
       throw new UncheckedIOException(e);
@@ -71,7 +73,7 @@ public final class KnowledgeWorkspaceFixture {
       Path linksDir =
           Files.createDirectories(root.resolve("agents").resolve(agentName).resolve("knowledge"));
       Path link = linksDir.resolve(entryName);
-      Files.createSymbolicLink(link, target);
+      SymlinkAssumptions.createSymbolicLinkOrAssume(link, target);
       return link;
     } catch (IOException e) {
       throw new UncheckedIOException(e);

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillBindingServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillBindingServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -39,6 +40,7 @@ class AgentSkillBindingServiceTest {
   @Test
   @DisplayName("bind 创建固定相对链接且幂等；unbind 只删链接")
   void bindAndUnbind() throws IOException {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     skill("report", "报告规范");
 
     AgentSkillBinding first = bindings.bind("ops", "report");
@@ -62,6 +64,7 @@ class AgentSkillBindingServiceTest {
   @Test
   @DisplayName("扫描分类 dangling、escaped、invalid-target、name-mismatch、stale-reference")
   void reconcileClassifiesAllIssueTypes() throws IOException {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     skill("good", "合法");
     skill("other", "另一个");
     Files.createDirectories(root.resolve("agents/ops/skills"));
@@ -88,6 +91,7 @@ class AgentSkillBindingServiceTest {
   @Test
   @DisplayName("绝对链接和普通文件不能伪装成绑定")
   void invalidBindingsNeverBecomeVisible() throws IOException {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     skill("good", "合法");
     Files.createDirectories(root.resolve("agents/ops/skills"));
     Files.createSymbolicLink(
@@ -109,6 +113,7 @@ class AgentSkillBindingServiceTest {
   @Test
   @DisplayName("replace 全量预校验，失败不改变现有绑定")
   void replacePrevalidatesBeforeMutation() throws IOException {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     skill("good", "合法");
     bindings.bind("ops", "good");
 
@@ -123,6 +128,7 @@ class AgentSkillBindingServiceTest {
   @Test
   @DisplayName("归档 Agent 的固定相对链接仍被计为结构化引用")
   void archivedReferencesAreProtected() throws IOException {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     skill("report", "报告");
     bindings.bind("ops", "report");
     Files.createDirectories(root.resolve("archive"));

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillMigrationServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillMigrationServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.oryxos.core.agent.AgentMarkdown;
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -18,6 +19,7 @@ class AgentSkillMigrationServiceTest {
 
   @Test
   void validLegacyFieldMigratesOnceAndPreservesOtherText() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     SkillWorkspaceFixture fixture = new SkillWorkspaceFixture(root);
     Path agent = fixture.agent("ops", "description: keep\nskills:\n  - report\n");
     fixture.skill("report", "报告");
@@ -35,6 +37,7 @@ class AgentSkillMigrationServiceTest {
 
   @Test
   void quotedLegacyFieldMigratesWithoutResidue() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     SkillWorkspaceFixture fixture = new SkillWorkspaceFixture(root);
     Path agent = fixture.agent("quoted", "\"skills\":\n- report\n");
     fixture.skill("report", "报告");
@@ -66,6 +69,7 @@ class AgentSkillMigrationServiceTest {
 
   @Test
   void migrationUnionsExistingLinksAndOneFailureDoesNotBlockOtherAgents() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     SkillWorkspaceFixture fixture = new SkillWorkspaceFixture(root);
     fixture.skill("existing", "已有");
     fixture.skill("legacy", "旧配置");

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillReconciliationTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/AgentSkillReconciliationTest.java
@@ -3,6 +3,7 @@ package io.oryxos.core.skill;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -15,6 +16,7 @@ class AgentSkillReconciliationTest {
 
   @Test
   void classifiesFiveIssuesWhileKeepingValidArchivedLinksClean() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     SkillWorkspaceFixture fixture = new SkillWorkspaceFixture(root);
     Path active = fixture.agent("active", "skills:\n  - report\n");
     fixture.skill("report", "报告");

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillArchiveServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillArchiveServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Clock;
@@ -18,6 +19,7 @@ class SkillArchiveServiceTest {
 
   @Test
   void referencesBlockArchiveThenCompleteDirectoryIsMoved() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     SkillWorkspaceFixture fixture = new SkillWorkspaceFixture(root);
     fixture.agent("ops", "");
     fixture.skill("report", "报告");

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillStoreTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillStoreTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
@@ -16,6 +17,7 @@ class SkillStoreTest {
 
   @Test
   void writeAllRejectsIntermediateSymlinkEscape() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     Path outside = Files.createDirectories(root.resolveSibling("skill-store-outside"));
     Path skill = Files.createDirectories(root.resolve("skills/report"));
     Files.createSymbolicLink(skill.resolve("scripts"), outside);

--- a/oryxos-core/src/test/java/io/oryxos/core/skill/SkillWorkspaceFixture.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/skill/SkillWorkspaceFixture.java
@@ -1,5 +1,6 @@
 package io.oryxos.core.skill;
 
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,7 +32,7 @@ final class SkillWorkspaceFixture {
   Path bind(String agent, String skill) throws IOException {
     Path links = Files.createDirectories(root.resolve("agents").resolve(agent).resolve("skills"));
     Path link = links.resolve(skill);
-    Files.createSymbolicLink(link, Path.of("../../../skills").resolve(skill));
+    SymlinkAssumptions.createSymbolicLinkOrAssume(link, Path.of("../../../skills").resolve(skill));
     return link;
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/testing/SymlinkAssumptions.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/testing/SymlinkAssumptions.java
@@ -1,0 +1,69 @@
+package io.oryxos.core.testing;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * 测试环境能力探针：Windows 非管理员且未开启开发者模式时，{@code Files.createSymbolicLink} 会抛
+ * FileSystemException（「客户端没有所需的特权」），且 Windows 文件系统没有 POSIX 权限 API。
+ *
+ * <p>依赖这两项能力的用例在不支持的环境里通过 JUnit assumption 优雅跳过（标记 skipped 而非 error）， Linux CI 全量运行，避免平台差异造成假红。本类随
+ * core test-jar 发布，供各模块测试复用。
+ */
+public final class SymlinkAssumptions {
+
+  private SymlinkAssumptions() {}
+
+  /**
+   * 探测 {@code dir} 下能否实际创建符号链接（建一条临时探针链接后立即删除）；不能则中断当前测试。
+   *
+   * <p>用于链接由生产代码（绑定服务、迁移服务等）在调用栈深处创建、测试无法逐点 try/catch 的场景。
+   */
+  public static void assumeSymlinksSupported(Path dir) {
+    Path probeDir = null;
+    try {
+      probeDir = Files.createTempDirectory(dir, "symlink-probe-");
+      Path target = Files.createFile(probeDir.resolve("target"));
+      Files.createSymbolicLink(probeDir.resolve("link"), target);
+    } catch (IOException | UnsupportedOperationException e) {
+      assumeTrue(false, "当前环境不支持创建符号链接，跳过该用例: " + e.getMessage());
+    } finally {
+      if (probeDir != null) {
+        deleteQuietly(probeDir.resolve("link"));
+        deleteQuietly(probeDir.resolve("target"));
+        deleteQuietly(probeDir);
+      }
+    }
+  }
+
+  /**
+   * 创建符号链接；环境不支持时中断当前测试（标记 skipped）。替代测试里直接调 {@code Files.createSymbolicLink} 后让 IOException 冒泡成
+   * error 的写法。
+   */
+  public static void createSymbolicLinkOrAssume(Path link, Path target) {
+    try {
+      Files.createSymbolicLink(link, target);
+    } catch (IOException | UnsupportedOperationException e) {
+      assumeTrue(false, "当前环境无法创建符号链接，跳过该用例: " + e.getMessage());
+    }
+  }
+
+  /** POSIX 文件权限 API（{@code Files.getPosixFilePermissions} 等）仅类 Unix 可用；不支持则跳过。 */
+  public static void assumePosixSupported() {
+    assumeTrue(
+        FileSystems.getDefault().supportedFileAttributeViews().contains("posix"),
+        "当前文件系统不支持 POSIX 权限 API，跳过该用例");
+  }
+
+  private static void deleteQuietly(Path path) {
+    try {
+      Files.deleteIfExists(path);
+    } catch (IOException ignored) {
+      // 探针清理失败无所谓，@TempDir 会统一回收
+    }
+  }
+}

--- a/oryxos-knowledge/pom.xml
+++ b/oryxos-knowledge/pom.xml
@@ -43,6 +43,14 @@
             <artifactId>spotbugs-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- 测试复用 core 的 SymlinkAssumptions 环境探针（软链/POSIX 用例在 Windows 无权限时优雅 skip） -->
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/oryxos-knowledge/src/test/java/io/oryxos/knowledge/contract/StubRemoteBackendContractTest.java
+++ b/oryxos-knowledge/src/test/java/io/oryxos/knowledge/contract/StubRemoteBackendContractTest.java
@@ -14,6 +14,7 @@ import io.oryxos.core.knowledge.model.Citation;
 import io.oryxos.core.knowledge.model.KnowledgeCapabilities;
 import io.oryxos.core.knowledge.model.KnowledgeHit;
 import io.oryxos.core.knowledge.model.KnowledgeQuery;
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -39,6 +40,8 @@ class StubRemoteBackendContractTest {
 
   @BeforeEach
   void setUp() throws IOException {
+    // setUp 经 bindings.bind 建固定相对软链；Windows 无建链权限时整类用例优雅跳过（Linux CI 照常）
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     Path kbRoot = Files.createDirectories(root.resolve("knowledge"));
     Path remote = Files.createDirectories(kbRoot.resolve("remote-kb"));
     Files.writeString(

--- a/oryxos-tool/pom.xml
+++ b/oryxos-tool/pom.xml
@@ -52,6 +52,14 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- 测试复用 core 的 SymlinkAssumptions 环境探针（软链/POSIX 用例在 Windows 无权限时优雅 skip） -->
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/SandboxPathFixture.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/SandboxPathFixture.java
@@ -1,5 +1,6 @@
 package io.oryxos.tool.sandbox;
 
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -24,28 +25,28 @@ final class SandboxPathFixture {
 
   Path parentEscape() throws IOException {
     Path link = allowed.resolve("escape");
-    Files.createSymbolicLink(link, outside);
+    SymlinkAssumptions.createSymbolicLinkOrAssume(link, outside);
     return link;
   }
 
   Path dangling() throws IOException {
     Path link = allowed.resolve("dangling");
-    Files.createSymbolicLink(link, Path.of("missing"));
+    SymlinkAssumptions.createSymbolicLinkOrAssume(link, Path.of("missing"));
     return link;
   }
 
   Path multiHopEscape() throws IOException {
-    Files.createSymbolicLink(allowed.resolve("second"), outside);
+    SymlinkAssumptions.createSymbolicLinkOrAssume(allowed.resolve("second"), outside);
     Path first = allowed.resolve("first");
-    Files.createSymbolicLink(first, Path.of("second"));
+    SymlinkAssumptions.createSymbolicLinkOrAssume(first, Path.of("second"));
     return first;
   }
 
   Path[] cycle() throws IOException {
     Path one = allowed.resolve("one");
     Path two = allowed.resolve("two");
-    Files.createSymbolicLink(one, Path.of("two"));
-    Files.createSymbolicLink(two, Path.of("one"));
+    SymlinkAssumptions.createSymbolicLinkOrAssume(one, Path.of("two"));
+    SymlinkAssumptions.createSymbolicLinkOrAssume(two, Path.of("one"));
     return new Path[] {one, two};
   }
 }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxPersistenceTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxPersistenceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.oryxos.core.sandbox.SandboxWhitelist.Category;
 import io.oryxos.core.sandbox.SandboxWhitelistStore;
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -87,6 +88,7 @@ class WhitelistSandboxPersistenceTest {
   @Test
   @DisplayName("恢复悬空软连接白名单不阻断启动且访问仍失败关闭")
   void constructorToleratesDanglingPersistedFileRoot(@TempDir Path temp) throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(temp);
     Path dangling = temp.resolve("dangling-root");
     Files.createSymbolicLink(dangling, temp.resolve("missing"));
     FakeStore store = new FakeStore();

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WhitelistSandboxTest.java
@@ -3,6 +3,7 @@ package io.oryxos.tool.sandbox;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.oryxos.core.testing.SymlinkAssumptions;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -67,6 +68,7 @@ class WhitelistSandboxTest {
     @Test
     @DisplayName("白名单内软连接指向外部时，读与不存在目标写均拒绝")
     void symlinkEscapeIsBlocked(@TempDir Path allowed) throws IOException {
+      SymlinkAssumptions.assumeSymlinksSupported(allowed);
       Path outside = Files.createTempDirectory("oryxos-sandbox-outside-");
       Files.writeString(outside.resolve("secret.txt"), "secret");
       Files.createSymbolicLink(allowed.resolve("escape"), outside);
@@ -89,6 +91,7 @@ class WhitelistSandboxTest {
     @Test
     @DisplayName("合法 Agent Skill 软连接指向同一白名单根时可读")
     void controlledSkillSymlinkIsAllowed(@TempDir Path allowed) throws IOException {
+      SymlinkAssumptions.assumeSymlinksSupported(allowed);
       Path shared = allowed.resolve("skills/report");
       Path local = allowed.resolve("agents/ops/skills");
       Files.createDirectories(shared);
@@ -129,6 +132,7 @@ class WhitelistSandboxTest {
     @Test
     @DisplayName("白名单按真实最小根判断，链接的 lexical 位置不能扩大授权")
     void symlinkUsesRealTargetRoot(@TempDir Path workspace) throws IOException {
+      SymlinkAssumptions.assumeSymlinksSupported(workspace);
       Path shared = Files.createDirectories(workspace.resolve("skills/report"));
       Path local = Files.createDirectories(workspace.resolve("agents/ops/skills"));
       Files.writeString(shared.resolve("SKILL.md"), "body");

--- a/oryxos-web/pom.xml
+++ b/oryxos-web/pom.xml
@@ -65,6 +65,14 @@
             <artifactId>oryxos-knowledge</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- 测试复用 core 的 SymlinkAssumptions 环境探针（软链/POSIX 用例在 Windows 无权限时优雅 skip） -->
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/AgentKnowledgeBindingApiTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/AgentKnowledgeBindingApiTest.java
@@ -19,6 +19,7 @@ import io.oryxos.core.memory.MemoryService;
 import io.oryxos.core.profile.Profile;
 import io.oryxos.core.profile.ProfileRegistry;
 import io.oryxos.core.session.SessionManager;
+import io.oryxos.core.testing.SymlinkAssumptions;
 import io.oryxos.web.GlobalExceptionHandler;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -70,6 +71,7 @@ class AgentKnowledgeBindingApiTest {
   @Test
   @DisplayName("bind → get 可见；unbind → 清空；replace 整体替换")
   void bindingCrudAndReplace() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     mvc.perform(put("/api/v1/agents/ops/knowledge/ops-manual"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.bindings[0].name").value("ops-manual"))
@@ -101,6 +103,7 @@ class AgentKnowledgeBindingApiTest {
   @Test
   @DisplayName("创建 Agent 携带 knowledgeBindings → 绑定同步建立（FR-018 路径一）")
   void createWithKnowledgeBindings() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     mvc.perform(
             post("/api/v1/agents")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/AgentSkillBindingApiTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/AgentSkillBindingApiTest.java
@@ -21,6 +21,7 @@ import io.oryxos.core.session.SessionManager;
 import io.oryxos.core.skill.AgentSkillBindingService;
 import io.oryxos.core.skill.SkillCatalogEntry;
 import io.oryxos.core.skill.SkillMetadataReader;
+import io.oryxos.core.testing.SymlinkAssumptions;
 import io.oryxos.web.GlobalExceptionHandler;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -76,6 +77,7 @@ class AgentSkillBindingApiTest {
 
   @Test
   void bindingCrudReplaceAndAgentViewUseLiveLinks() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     mvc.perform(put("/api/v1/agents/ops/skills/report"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.bindings[0].name").value("report"))

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/KnowledgeApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/KnowledgeApiControllerTest.java
@@ -19,6 +19,7 @@ import io.oryxos.core.knowledge.KnowledgeServiceImpl;
 import io.oryxos.core.knowledge.model.KnowledgeCapabilities;
 import io.oryxos.core.knowledge.model.KnowledgeHit;
 import io.oryxos.core.knowledge.model.KnowledgeQuery;
+import io.oryxos.core.testing.SymlinkAssumptions;
 import io.oryxos.knowledge.LocalKnowledgeBackend;
 import io.oryxos.knowledge.index.KnowledgeIndexService;
 import io.oryxos.knowledge.store.InMemoryChunkStore;
@@ -148,6 +149,7 @@ class KnowledgeApiControllerTest {
   @Test
   @DisplayName("删除被 Agent 引用的库 → 409 + 引用清单；解绑后可删（FR-011）")
   void deleteIsReferenceProtected() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(root);
     createBase("ops-manual", "运维手册");
     Files.writeString(
         Files.createDirectories(root.resolve("agents/ops")).resolve("AGENT.md"),

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/SkillApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/SkillApiControllerTest.java
@@ -13,6 +13,7 @@ import io.oryxos.core.skill.SkillLoader;
 import io.oryxos.core.skill.SkillRegistry;
 import io.oryxos.core.skill.SkillService;
 import io.oryxos.core.skill.SkillStore;
+import io.oryxos.core.testing.SymlinkAssumptions;
 import io.oryxos.web.GlobalExceptionHandler;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -162,6 +163,7 @@ class SkillApiControllerTest {
   @Test
   @DisplayName("活跃或归档 Agent 引用阻止归档并返回结构化 409")
   void referencedSkillReturnsStructuredConflict() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(oryxosRoot);
     Path agent = Files.createDirectories(oryxosRoot.resolve("agents/ops"));
     Files.writeString(agent.resolve("AGENT.md"), "---\nname: ops\n---\nbody");
     SkillStore store = new SkillStore(oryxosRoot);

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.oryxos.core.fs.RealPathBoundary;
+import io.oryxos.core.testing.SymlinkAssumptions;
 import io.oryxos.web.GlobalExceptionHandler;
 import java.io.IOException;
 import java.nio.file.FileSystems;
@@ -104,6 +105,7 @@ class WorkspaceApiControllerTest {
   @Test
   @DisplayName("read/download/write 均拒绝经父软连接逃逸，tree 把链接作为叶节点")
   void symlinkEscapeIsRejectedAndTreeDoesNotFollow() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(oryxosRoot);
     Path outside = Files.createDirectories(oryxosRoot.resolveSibling("outside-workspace"));
     Files.writeString(outside.resolve("secret.txt"), "SECRET");
     Files.createSymbolicLink(oryxosRoot.resolve("agents/demo/escape"), outside);
@@ -356,6 +358,7 @@ class WorkspaceApiControllerTest {
   @Test
   @DisplayName("工作区读取悬空软连接返回 400 而非 500")
   void danglingLinkReturnsBadRequest() throws Exception {
+    SymlinkAssumptions.assumeSymlinksSupported(oryxosRoot);
     Files.createSymbolicLink(
         oryxosRoot.resolve("agents/demo/dangling"), Path.of("../../skills/missing"));
 


### PR DESCRIPTION
## 背景

在 Windows 非管理员且未开启开发者模式的环境下：

- `Files.createSymbolicLink` 抛 `FileSystemException`（「客户端没有所需的特权」）；
- Windows 文件系统没有 POSIX 权限 API（`Files.getPosixFilePermissions` 抛 `UnsupportedOperationException`）。

主线既有测试中直接建软链或断言 POSIX 权限的用例在该环境下直接报 **error**；部分夹具（如 `KnowledgeWorkspaceFixture`）把 `IOException` 包成 `UncheckedIOException`，还会级联拖垮同模块其余用例。Linux CI 不受影响，但 Windows 开发者本地 `mvn test` 一片假红。

## 改动

**仅测试层，生产代码零改动。**

1. 新增 `io.oryxos.core.testing.SymlinkAssumptions`（随 core test-jar 发布，复用既有 maven-jar-plugin test-jar 机制）：
   - `assumeSymlinksSupported(Path dir)`：运行时探针——实际建一条临时软链验证权限，能力齐全时零影响；不支持时 JUnit assumption 中止（skipped 而非 error）。比 `@DisabledOnOs(OS.WINDOWS)` 更精确：Windows 管理员 / 开发者模式下软链可用时用例照常运行。
   - `createSymbolicLinkOrAssume(link, target)`：包裹测试 / 夹具中的直接建链。
   - `assumePosixSupported()`：探测 POSIX 文件属性视图。
2. 三类接入方式：
   - 测试 / 夹具直接 `Files.createSymbolicLink` → 改走 `createSymbolicLinkOrAssume`（`SandboxPathFixture`、`SkillWorkspaceFixture`、`KnowledgeWorkspaceFixture`）；
   - 软链由生产代码在调用栈深处创建（`bindings.bind` / 迁移服务 / Agent 服务建链 / REST API 写入）→ 测试方法首行（`StubRemoteBackendContractTest` 在 `@BeforeEach` 首行）前置 `assumeSymlinksSupported(root)`；
   - POSIX 权限断言（`ChannelConfigLoaderTest` 的 rw------- 断言）→ `assumePosixSupported()`。
3. `oryxos-tool` / `oryxos-web` / `oryxos-knowledge` 以 `<type>test-jar</type>` 依赖复用该探针（与 channel-feishu / wecom 消费 core test-jar 的既有样板一致）。
4. 既有平台保护一律保持不动：`@DisabledOnOs`、三个 Guard 测试的私有 `assumeCanSymlink`、`FileToolsTest` 内联 assume、`WorkspaceApiControllerTest` 既有 4 处 POSIX / try-catch 保护。

## 新增跳过用例清单（Windows 无权限环境，共 47 个）

- **core（31）**：RealPathBoundaryTest ×2、AgentStoreTest ×1、SkillStoreTest ×1、AgentLifecycleSkillBindingTest ×2、ContextLoaderTest ×2、ProgressiveDisclosureTest ×2、AgentSkillBindingServiceTest ×5、AgentSkillMigrationServiceTest ×3、AgentSkillReconciliationTest ×1、SkillArchiveServiceTest ×1、KnowledgeBindingServiceTest ×7、ContextLoaderKnowledgeTest ×3、ChannelConfigLoaderTest ×1（POSIX）
- **tool（5）**：WhitelistSandboxTest 文件路径白名单 ×4（含经 SandboxPathFixture 间接建链的 dangling / 多跳 / 链接环用例）、WhitelistSandboxPersistenceTest ×1
- **knowledge（4）**：StubRemoteBackendContractTest 整类 4 个（`setUp` 经 `bindings.bind` 建链）
- **web（7）**：WorkspaceApiControllerTest ×2、AgentSkillBindingApiTest ×1、AgentKnowledgeBindingApiTest ×2、SkillApiControllerTest ×1、KnowledgeApiControllerTest ×1

Linux / macOS 能力齐全，探针全部通过，以上用例全量运行——**CI 行为不变**。

## 本地实测（Windows，Temurin JDK 21.0.12 + Maven 3.9.16）

| 模块 | Tests run | Failures | Errors | Skipped |
|------|-----------|----------|--------|---------|
| oryxos-core | 268 | 0 | 0 | 40（含既有平台保护 9） |
| oryxos-tool | 224 | 0 | 0 | 12（含既有 7） |
| oryxos-knowledge | 28 | 0 | 0 | 4 |
| oryxos-web | 201 | 0 | 0 | 11（含既有 4） |

spotless / checkstyle / PMD（方法 ≤80 行）均随 `mvn test` 通过。

## 说明

- 本 PR 是 #309（fs guard realpath recheck）评审时约定的跟进项：当时发现主线既有软链 / POSIX 测试在 Windows 报 error，约定测试层问题另开 PR 处理。
- `SkillBindingIssuesApiTest` 经核只写普通文件、不建链、不调用 bind，无需改动。