### PR TITLE
fix(web): cover /api/v2 endpoints with API key filter

### DIFF
--- a/oryxos-web/src/main/java/io/oryxos/web/config/ApiKeyFilterConfig.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/config/ApiKeyFilterConfig.java
@@ -12,12 +12,16 @@ import org.springframework.core.Ordered;
 /**
  * ApiKeyAuthFilter 注册（018-rest-api-key）。
  *
- * <p>{@code addUrlPatterns("/api/v1/*")} 精确限定只拦 REST API；与 012 {@code AuthFilterConfig} 的 {@code
- * /admin/*} 模式互不重叠，{@code /admin/**} 与静态资源天然不受影响（FR-002）。豁免路径（health/auth 子树/OPTIONS） 在 filter
- * 内部判定（{@link ApiKeyAuthFilter}）。
+ * <p>{@code addUrlPatterns("/api/v1/*", "/api/v2/*")} 精确限定只拦 REST API（含 v2 调度端点，新增 API
+ * 版本时必须同步在此登记，否则该版本整棵子树匿名可达）；与 012 {@code AuthFilterConfig} 的 {@code /admin/*} 模式互不重叠，{@code
+ * /admin/**} 与静态资源天然不受影响（FR-002）。豁免路径（health/auth 子树/OPTIONS） 在 filter 内部判定（{@link
+ * ApiKeyAuthFilter}）。
  */
 @Configuration
 public class ApiKeyFilterConfig {
+
+  /** 受 API Key 门禁保护的 REST API 版本前缀；新增版本必须在此登记。 */
+  static final String[] PROTECTED_URL_PATTERNS = {"/api/v1/*", "/api/v2/*"};
 
   @Bean
   FilterRegistrationBean<ApiKeyAuthFilter> apiKeyAuthFilter(
@@ -28,7 +32,7 @@ public class ApiKeyFilterConfig {
     FilterRegistrationBean<ApiKeyAuthFilter> registration = new FilterRegistrationBean<>();
     registration.setFilter(
         new ApiKeyAuthFilter(apiKeyService, sessionService, properties, objectMapper));
-    registration.addUrlPatterns("/api/v1/*");
+    registration.addUrlPatterns(PROTECTED_URL_PATTERNS);
     registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 11);
     return registration;
   }

--- a/oryxos-web/src/main/java/io/oryxos/web/security/ApiKeyAuthFilter.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/ApiKeyAuthFilter.java
@@ -22,8 +22,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 /**
  * REST API Key 认证过滤器（018-rest-api-key）。
  *
- * <p>仅拦 {@code /api/v1/**}（由 {@code ApiKeyFilterConfig} 的 {@code FilterRegistrationBean} 限定 URL
- * 模式）；与 012 的 {@code BasicAuthFilter}（只拦 {@code /admin/*}）URL 模式互不重叠，两扇门各管各的（FR-002）。
+ * <p>拦 {@code /api/v1/**} 与 {@code /api/v2/**}（由 {@code ApiKeyFilterConfig} 的 {@code
+ * FilterRegistrationBean} 限定 URL 模式，{@code PROTECTED_URL_PATTERNS} 是唯一登记处）；与 012 的 {@code
+ * BasicAuthFilter}（只拦 {@code /admin/*}）URL 模式互不重叠，两扇门各管各的（FR-002）。
  *
  * <p>豁免（filter 内判定，契约见 specs/018 contracts/auth-contract.md §1）：
  *

--- a/oryxos-web/src/test/java/io/oryxos/web/config/ApiKeyFilterConfigTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/config/ApiKeyFilterConfigTest.java
@@ -1,0 +1,40 @@
+package io.oryxos.web.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.storage.ApiKeyService;
+import io.oryxos.storage.WebSessionService;
+import io.oryxos.web.security.ApiKeyAuthFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+
+/**
+ * 钉死 ApiKeyAuthFilter 的 URL 注册模式：所有 REST API 版本前缀都必须在 {@code
+ * ApiKeyFilterConfig.PROTECTED_URL_PATTERNS} 登记。曾遗漏 {@code /api/v2/*}——v2 调度端点（含立即触发 Agent 的 {@code
+ * POST /api/v2/schedules/{id}/run}）在 apikey.enabled=true 时仍匿名可达。
+ */
+class ApiKeyFilterConfigTest {
+
+  @Test
+  @DisplayName("注册模式覆盖/api/v1与/api/v2_两版本子树都在门禁内")
+  void registration_coversBothApiVersions() {
+    ApiKeyFilterConfig config = new ApiKeyFilterConfig();
+    FilterRegistrationBean<ApiKeyAuthFilter> registration =
+        config.apiKeyAuthFilter(
+            mock(ApiKeyService.class),
+            mock(WebSessionService.class),
+            new WebApiKeyProperties(),
+            new ObjectMapper());
+
+    assertThat(registration.getUrlPatterns()).containsExactlyInAnyOrder("/api/v1/*", "/api/v2/*");
+  }
+
+  @Test
+  @DisplayName("登记常量本身包含v2_防止回退")
+  void protectedPatterns_containV2() {
+    assertThat(ApiKeyFilterConfig.PROTECTED_URL_PATTERNS).contains("/api/v2/*");
+  }
+}

--- a/oryxos-web/src/test/java/io/oryxos/web/security/ApiKeyAuthFilterTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/security/ApiKeyAuthFilterTest.java
@@ -32,9 +32,9 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  * 018 验收 harness：ApiKeyAuthFilterTest——路径裁决表钉死（contracts/auth-contract.md §1）。用 standalone MockMvc
- * + stub controller 映射 /api/v1/**（filter 放行后要有 handler），按注册模式 addFilter(filter, "/api/v1/*")。mock
- * ApiKeyService/WebSessionService。守：flag 关放行、双请求头等效、401 统一响应不可区分、 豁免（OPTIONS/health/auth
- * 子树）、session 互认、多 Key 吊销互不影响。
+ * + stub controller 映射 /api/v1/** 与 /api/v2/**（filter 放行后要有 handler），按注册模式 addFilter(filter,
+ * "/api/v1/*", "/api/v2/*")。mock ApiKeyService/WebSessionService。守：flag 关放行、双请求头等效、401 统一响应不可区分、
+ * 豁免（OPTIONS/health/auth 子树）、v2 调度子树无凭据 401、session 互认、多 Key 吊销互不影响。
  */
 class ApiKeyAuthFilterTest {
 
@@ -65,6 +65,18 @@ class ApiKeyAuthFilterTest {
     public String login() {
       return "login";
     }
+
+    @GetMapping("/api/v2/schedules")
+    @ResponseBody
+    public String v2Schedules() {
+      return "v2";
+    }
+
+    @PostMapping("/api/v2/schedules/{id}/run")
+    @ResponseBody
+    public String v2Run() {
+      return "triggered";
+    }
   }
 
   @BeforeEach
@@ -76,7 +88,7 @@ class ApiKeyAuthFilterTest {
         new ApiKeyAuthFilter(apiKeyService, sessionService, properties, new ObjectMapper());
     mvc =
         MockMvcBuilders.standaloneSetup(new StubController())
-            .addFilter(filter, "/api/v1/*")
+            .addFilter(filter, "/api/v1/*", "/api/v2/*")
             .build();
   }
 
@@ -184,6 +196,30 @@ class ApiKeyAuthFilterTest {
     properties.setEnabled(true);
     mvc.perform(post("/api/v1/auth/login")).andExpect(status().isOk());
     verify(apiKeyService, never()).verify(anyString());
+  }
+
+  @Test
+  @DisplayName("enabled=true_/api/v2/schedules无凭据_401（v2调度子树在门禁内）")
+  void v2SchedulesNoCredentials_401() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(get("/api/v2/schedules")).andExpect(status().isUnauthorized());
+    verify(apiKeyService, never()).verify(anyString());
+  }
+
+  @Test
+  @DisplayName("enabled=true_POST/api/v2/schedules/{id}/run无凭据_401（禁止匿名触发Agent）")
+  void v2RunNoCredentials_401() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(post("/api/v2/schedules/sched-1/run")).andExpect(status().isUnauthorized());
+    verify(apiKeyService, never()).verify(anyString());
+  }
+
+  @Test
+  @DisplayName("enabled=true_/api/v2带正确Key_200")
+  void v2WithCorrectKey_200() throws Exception {
+    properties.setEnabled(true);
+    when(apiKeyService.verify(GOOD_KEY)).thenReturn(true);
+    mvc.perform(get("/api/v2/schedules").header("X-API-Key", GOOD_KEY)).andExpect(status().isOk());
   }
 
   @Test


### PR DESCRIPTION
## 动机

`ApiKeyAuthFilter` 的注册（`ApiKeyFilterConfig`）只把过滤器挂在 `/api/v1/*`，而调度 v2 端点 `ScheduleV2ApiController` 挂在 `/api/v2`：

- `GET /api/v2/schedules`（列出全部调度，泄漏 Agent 名/cron/任务配置）
- `POST /api/v2/schedules/{id}/run`（**立即触发 Agent 执行**，携带该 Agent 的全部工具权限：文件/Shell/HTTP/MCP）
- `GET /api/v2/schedules/{id}/executions`
- `PUT /api/v2/schedules/{id}`（启用/停用调度）
- `POST /api/v2/agents/{profileName}/schedules/{key}/run`

即使运维按文档开启 `oryxos.web.apikey.enabled=true`，v2 整棵子树仍然匿名可达——v1 同款端点在门禁内、v2 漏登记。`ScheduleV2ApiController` 上的 `SuppressFBWarnings` 注释自称 "internal-only"，但没有任何代码强制。内网任意主机（或被攻陷的办公网主机）可不带凭据远程驱动 Agent。

## 改动范围

- **生产代码**（2 个文件，改动极小）：
  - `ApiKeyFilterConfig`：URL 模式从 `/api/v1/*` 改为 `/api/v1/*` + `/api/v2/*`，抽成 `PROTECTED_URL_PATTERNS` 常量作为唯一登记处，注释注明「新增 API 版本必须同步登记，否则整棵子树匿名可达」。
  - `ApiKeyAuthFilter`：仅更新类注释（原注释写「仅拦 /api/v1/**」已过时）；过滤器内豁免逻辑（OPTIONS / `/api/v1/health` / `/api/v1/auth/**`）不涉及 v2，无需改动。
- **测试**（2 个文件）：
  - 新增 `ApiKeyFilterConfigTest`：直接对注册 bean 断言 URL 模式恰好包含 v1+v2（根因回归钉死，防止以后再漏登记）。
  - `ApiKeyAuthFilterTest`：stub controller 增加 v2 端点，filter 按双版本模式挂载；新增 3 个用例——v2 列表无凭据 401、v2 `run` 无凭据 401、v2 带正确 Key 200。

## 平台行为矩阵

| 平台 | apikey.enabled=false（默认） | apikey.enabled=true |
|---|---|---|
| Linux/macOS/Windows | 行为不变（过滤器直接放行） | v1 行为不变；**v2 由匿名可达改为要求 API Key 或有效管理台 session**，未携带凭据返回统一 401（与 v1 完全相同的响应体/挑战头，防探测） |

BasicAuthFilter（`/admin/*`）模式不重叠，管理台 SPA 不受影响；v2 无 health/auth 类豁免端点。

## 本地实测（Windows 11，Temurin JDK 21.0.12 + Maven 3.9.16）

- `mvn spotless:apply`、`mvn install -DskipTests -Dfrontend.skip=true`：通过。
- `mvn -pl oryxos-web test -Dfrontend.skip=true`：Tests run 206，新增/修改的 17 个认证用例全部通过（`ApiKeyAuthFilterTest` 15/15、`ApiKeyFilterConfigTest` 2/2）。
- 7 个失败用例（`WorkspaceApiControllerTest` 软链 2 个、`AgentSkillBindingApiTest`/`AgentKnowledgeBindingApiTest`/`SkillApiControllerTest`/`KnowledgeApiControllerTest` 软链相关 5 个）为本机非管理员 Windows 无法创建符号链接导致的**既有主线问题**，与本改动无关，已由 #310 的 assume 探针处理（待合并）。
