### PR TITLE
fix(fs): guard reads of admin config and SQLite db files

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/fs/AdminConfigFileGuard.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/fs/AdminConfigFileGuard.java
@@ -8,26 +8,36 @@ import java.util.Locale;
 import java.util.Set;
 
 /**
- * 管理台热更配置只能经 AdminService 落盘——文件工具 / Workspace / download_file 直写会绕过校验与断连重连。
+ * 系统保留文件守卫：管理台热更配置与 SQLite 数据库只能经专用管理入口读写——文件工具 / Workspace 直写会绕过校验与断连重连，通用读入口（read_file / grep /
+ * workspace file·download）直接吐原文会泄露 channels.yaml / mcp_servers.yaml 里的渠道与 MCP 凭证、oryxos.db
+ * 里的全量持久化数据。
  *
- * <p>覆盖 {@code channels.yaml}（{@code ChannelAdminService}）与 {@code mcp_servers.yaml}（{@code
- * McpServerAdminService}）。
+ * <p>覆盖 {@code channels.yaml}（{@code ChannelAdminService}）、{@code mcp_servers.yaml}（{@code
+ * McpServerAdminService}）与 {@code oryxos.db} 家族（含 SQLite 侧车 {@code -wal}/{@code -shm}/ {@code
+ * -journal} 与备份副本——同源数据，同样敏感）。
  *
  * <p>除词法路径段检查外，还会经 {@link RealPathBoundary} 解析已存在祖先的真实路径，避免 {@code alias.yaml → channels.yaml}
  * 这类软链绕过（对齐 {@code MemoryMdGuard}）。
  */
 public final class AdminConfigFileGuard {
 
-  private static final Set<String> RESERVED_LOWER = Set.of("channels.yaml", "mcp_servers.yaml");
+  private static final Set<String> RESERVED_CONFIG_LOWER =
+      Set.of("channels.yaml", "mcp_servers.yaml");
+
+  /** SQLite 主库文件名（小写）；侧车/备份以 {@code oryxos.db-} / {@code oryxos.db.} 起头。 */
+  private static final String DB_FILE_LOWER = "oryxos.db";
 
   private AdminConfigFileGuard() {}
+
+  // —— 写侧：既有入口，语义不变（保留集合扩展到 DB 家族）——
 
   public static void rejectMutation(String path) {
     if (path == null || path.isBlank()) {
       return;
     }
-    rejectLexical(path);
-    rejectResolved(Path.of(path));
+    if (hitsReserved(Path.of(path))) {
+      throw new IllegalArgumentException("拒绝直接改写系统保留文件（管理配置 / 数据库请走 Channel、MCP 等对应管理入口）: " + path);
+    }
   }
 
   /** 对已解析（常为绝对）路径做词法 + 真实路径双重检查；Workspace 等入口应在边界投影后再调。 */
@@ -35,52 +45,101 @@ public final class AdminConfigFileGuard {
     if (path == null) {
       return;
     }
-    rejectLexical(path.toString());
-    rejectResolved(path);
+    if (hitsReserved(path)) {
+      throw new IllegalArgumentException("拒绝直接改写系统保留文件（管理配置 / 数据库请走 Channel、MCP 等对应管理入口）: " + path);
+    }
+  }
+
+  // —— 读侧：通用文件读入口（workspace file/download、read_file、copy_file 源、grep 遍历）——
+
+  public static void rejectRead(String path) {
+    if (path == null || path.isBlank()) {
+      return;
+    }
+    if (hitsReserved(Path.of(path))) {
+      throw new IllegalArgumentException(
+          "拒绝直接读取系统保留文件原文（管理配置含凭证、oryxos.db 含全量数据，请走对应管理入口）: " + path);
+    }
+  }
+
+  /** 对已解析（常为绝对）路径做词法 + 真实路径双重检查；Workspace 等入口应在边界投影后再调。 */
+  public static void rejectRead(Path path) {
+    if (path == null) {
+      return;
+    }
+    if (hitsReserved(path)) {
+      throw new IllegalArgumentException(
+          "拒绝直接读取系统保留文件原文（管理配置含凭证、oryxos.db 含全量数据，请走对应管理入口）: " + path);
+    }
+  }
+
+  /**
+   * 读侧保留文件判定（不抛异常）：grep/glob 这类批量遍历入口据此跳过保留文件，而不是让整次搜索失败。 与 {@link #rejectRead(Path)} 共用同一套词法 +
+   * 软链叶子 + 真实路径投影判定，不会出现口径分叉。
+   */
+  public static boolean isReservedRead(Path path) {
+    return hitsReserved(path);
   }
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",
       justification =
           "Reserved filenames are ASCII; Locale.ROOT fold matches case-insensitive filesystems.")
-  private static void rejectLexical(String path) {
-    if (path == null || path.isBlank()) {
-      return;
+  private static boolean hitsReserved(Path path) {
+    if (path == null) {
+      return false;
     }
-    // 任意路径段命中即可：write_file("…/channels.yaml/x") 会 createDirectories 把配置名建成目录
+    if (matchesReserved(path.toString())) {
+      return true;
+    }
+    if (symlinkLeafHitsReserved(path)) {
+      return true;
+    }
+    try {
+      Path projected = RealPathBoundary.project(path).projectedReal();
+      return matchesReserved(projected.toString());
+    } catch (UncheckedIOException | IllegalArgumentException e) {
+      // 真实路径无法解析（悬空链/链接环/IO 失败）：词法与叶子已过，保守放行——边界仍由沙箱/Workspace 投影兜底
+      return false;
+    }
+  }
+
+  /** 任意路径段命中保留名即可：写侧防 {@code …/channels.yaml/x} 把配置名建成目录，读侧同款段扫描。 */
+  private static boolean matchesReserved(String path) {
+    if (path == null || path.isBlank()) {
+      return false;
+    }
     for (Path segment : Path.of(path)) {
       String lower = segment.toString().toLowerCase(Locale.ROOT);
-      if (RESERVED_LOWER.contains(lower)) {
-        throw new IllegalArgumentException("拒绝直接改写管理配置（请用 Channel / MCP 管理入口）: " + path);
+      if (RESERVED_CONFIG_LOWER.contains(lower) || isDbFamily(lower)) {
+        return true;
       }
     }
+    return false;
   }
 
-  private static void rejectResolved(Path path) {
-    rejectSymlinkLeafTarget(path);
-    Path projected;
-    try {
-      projected = RealPathBoundary.project(path).projectedReal();
-    } catch (UncheckedIOException | IllegalArgumentException e) {
-      return;
-    }
-    rejectLexical(projected.toString());
+  /** oryxos.db 主库与 SQLite 侧车/备份（-wal/-shm/-journal、.bak 等）同源数据，一并保留。 */
+  private static boolean isDbFamily(String lowerSegment) {
+    return DB_FILE_LOWER.equals(lowerSegment)
+        || lowerSegment.startsWith(DB_FILE_LOWER + "-")
+        || lowerSegment.startsWith(DB_FILE_LOWER + ".");
   }
 
-  private static void rejectSymlinkLeafTarget(Path path) {
+  private static boolean symlinkLeafHitsReserved(Path path) {
     Path absolute = path.toAbsolutePath().normalize();
     if (!Files.isSymbolicLink(absolute)) {
-      return;
+      return false;
     }
     try {
       Path linkTarget = Files.readSymbolicLink(absolute);
-      rejectLexical(linkTarget.toString());
-      Path parent = absolute.getParent();
-      if (parent != null) {
-        rejectLexical(parent.resolve(linkTarget).normalize().toString());
+      if (matchesReserved(linkTarget.toString())) {
+        return true;
       }
-    } catch (IOException ignored) {
-      // 读链失败则保守放行词法已通过的路径；真实写入仍受沙箱约束
+      Path parent = absolute.getParent();
+      return parent != null && matchesReserved(parent.resolve(linkTarget).normalize().toString());
+    } catch (IOException e) {
+      // 读链失败则保守放行词法已通过的路径；真实读取仍受沙箱/边界投影约束
+      return false;
     }
   }
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/fs/AdminConfigFileGuardTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/fs/AdminConfigFileGuardTest.java
@@ -75,6 +75,99 @@ class AdminConfigFileGuardTest {
     assertThrows(IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectMutation(alias));
   }
 
+  @Test
+  @DisplayName("读侧拒绝 channels.yaml / mcp_servers.yaml / oryxos.db 原文（大小写不敏感）")
+  void rejectReadBlocksReservedFiles() {
+    assertThrows(
+        IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectRead("channels.yaml"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AdminConfigFileGuard.rejectRead(".oryxos/Channels.YAML"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AdminConfigFileGuard.rejectRead(".oryxos/mcp_servers.yaml"));
+    assertThrows(
+        IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectRead("ORYXOS.DB"));
+  }
+
+  @Test
+  @DisplayName("读侧拒绝 SQLite 侧车/备份（-wal/-shm/-journal/.bak 同源数据）")
+  void rejectReadBlocksSqliteSidecars() {
+    assertThrows(
+        IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectRead("oryxos.db-wal"));
+    assertThrows(
+        IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectRead("oryxos.db-shm"));
+    assertThrows(
+        IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectRead("oryxos.db-journal"));
+    assertThrows(
+        IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectRead("oryxos.db.bak"));
+  }
+
+  @Test
+  @DisplayName("读侧普通路径放行；配置名 .bak 后缀不拦，DB 家族前缀仍拦")
+  void rejectReadAllowsOrdinaryPaths() {
+    assertDoesNotThrow(() -> AdminConfigFileGuard.rejectRead("agents/demo/notes.md"));
+    assertDoesNotThrow(() -> AdminConfigFileGuard.rejectRead("channels.yaml.bak"));
+    assertDoesNotThrow(() -> AdminConfigFileGuard.rejectRead("output/oryxos-report.md"));
+    assertDoesNotThrow(() -> AdminConfigFileGuard.rejectRead((String) null));
+    assertDoesNotThrow(() -> AdminConfigFileGuard.rejectRead("  "));
+    assertDoesNotThrow(() -> AdminConfigFileGuard.rejectRead((Path) null));
+  }
+
+  @Test
+  @DisplayName("写侧同步拒绝 oryxos.db 家族（自定义布局下防通用写入口毁库）")
+  void rejectMutationBlocksDbFamily() {
+    assertThrows(
+        IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectMutation("oryxos.db"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AdminConfigFileGuard.rejectMutation(".oryxos/oryxos.db-wal"));
+  }
+
+  @Test
+  @DisplayName("读侧拒绝经软链别名读 channels.yaml（词法 + 叶子目标双重）")
+  void rejectReadBlocksSymlinkAliasToChannelsYaml() throws IOException {
+    Path reserved = temp.resolve("channels.yaml");
+    Files.writeString(reserved, "channels: []\n");
+    Path alias = temp.resolve("alias.yaml");
+    assumeCanSymlink(alias, reserved);
+
+    assertThrows(IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectRead(alias));
+    assertThrows(
+        IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectRead(alias.toString()));
+  }
+
+  @Test
+  @DisplayName("读侧拒绝悬空软链指向 mcp_servers.yaml")
+  void rejectReadBlocksDanglingSymlinkToMcpServers() throws IOException {
+    Path alias = temp.resolve("alias.yaml");
+    assumeCanSymlink(alias, Path.of("mcp_servers.yaml"));
+
+    assertThrows(IllegalArgumentException.class, () -> AdminConfigFileGuard.rejectRead(alias));
+  }
+
+  @Test
+  @DisplayName("isReservedRead 判定与 rejectRead 同口径")
+  void isReservedReadMatchesThrowingCheck() throws IOException {
+    org.junit.jupiter.api.Assertions.assertTrue(
+        AdminConfigFileGuard.isReservedRead(temp.resolve("mcp_servers.yaml")));
+    org.junit.jupiter.api.Assertions.assertTrue(
+        AdminConfigFileGuard.isReservedRead(temp.resolve("oryxos.db")));
+    org.junit.jupiter.api.Assertions.assertFalse(
+        AdminConfigFileGuard.isReservedRead(temp.resolve("agents/demo/notes.md")));
+    org.junit.jupiter.api.Assertions.assertFalse(AdminConfigFileGuard.isReservedRead(null));
+
+    Path reserved = temp.resolve("channels.yaml");
+    Files.writeString(reserved, "channels: []\n");
+    Path alias = temp.resolve("alias.yaml");
+    try {
+      Files.createSymbolicLink(alias, reserved);
+    } catch (IOException | UnsupportedOperationException e) {
+      assumeTrue(false, "当前环境无法创建软链: " + e.getMessage());
+    }
+    org.junit.jupiter.api.Assertions.assertTrue(AdminConfigFileGuard.isReservedRead(alias));
+  }
+
   private static void assumeCanSymlink(Path link, Path target) {
     try {
       Files.createSymbolicLink(link, target);

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -52,14 +52,17 @@ public class FileTools {
 
   @Tool(name = "read_file", description = "读取指定路径的文本文件内容")
   public String readFile(@ToolParam(description = "要读取的文件路径") String path) {
+    // 保留文件原文（channels.yaml/mcp_servers.yaml 凭证、oryxos.db 数据）禁止经通用读入口吐出
+    AdminConfigFileGuard.rejectRead(path);
     sandbox.enforce(new SandboxAction(ActionType.FILE_READ, path));
     Path file = Path.of(path);
     if (!Files.isRegularFile(file)) {
       throw new IllegalArgumentException("文件不存在或不是普通文件: " + path);
     }
     try {
-      // 读前复检：与 write_file 同款——防首次校验到 readString 间路径被换成外向软链
+      // 读前复检：与 write_file 同款——防首次校验到 readString 间路径被换成外向软链或保留文件
       sandbox.enforce(new SandboxAction(ActionType.FILE_READ, path));
+      AdminConfigFileGuard.rejectRead(path);
       return Files.readString(file);
     } catch (IOException e) {
       throw new UncheckedIOException("读取文件失败: " + path, e);
@@ -159,6 +162,7 @@ public class FileTools {
     }
     Pattern regex = Pattern.compile(pattern);
     List<String> matches = new ArrayList<>();
+    int skippedReserved = 0;
     try {
       // Skill 绑定等「目录软链」：walk 默认不跟随，需先解析到真实目录；嵌套文件软链仍靠 NOFOLLOW 跳过
       Path walkRoot = resolveDirectorySymlink(root);
@@ -168,6 +172,11 @@ public class FileTools {
             matches.add("...（已达 " + MAX_MATCHES + " 条上限，结果截断）");
             break;
           }
+          // 保留文件（凭证配置 / SQLite 库）不进搜索内容：跳过而非整次失败，与软链叶子同款过滤
+          if (AdminConfigFileGuard.isReservedRead(file)) {
+            skippedReserved++;
+            continue;
+          }
           // 纵深防御：每个实际读取的文件再过一次文件白名单（防根校验到读取间符号链接被替换）
           sandbox.enforce(new SandboxAction(ActionType.FILE_READ, file.toString()));
           appendMatches(file, regex, matches);
@@ -175,6 +184,9 @@ public class FileTools {
       }
     } catch (IOException e) {
       throw new UncheckedIOException("搜索失败: " + path, e);
+    }
+    if (skippedReserved > 0) {
+      matches.add("...（已跳过 " + skippedReserved + " 个系统保留文件，凭证配置与数据库不参与搜索）");
     }
     return matches.isEmpty() ? "（无匹配）" : String.join("\n", matches);
   }
@@ -368,6 +380,8 @@ public class FileTools {
   @Tool(name = "copy_file", description = "复制文件（源读 + 目标写，都过白名单，目标已存在则覆盖）")
   public String copyFile(
       @ToolParam(description = "源路径") String from, @ToolParam(description = "目标路径") String to) {
+    // 源是保留文件（凭证配置 / SQLite 库）时拒绝：复制成普通文件即绕过读侧守卫泄露原文
+    AdminConfigFileGuard.rejectRead(from);
     MemoryMdGuard.rejectMutation(to);
     AdminConfigFileGuard.rejectMutation(to);
     WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(to);
@@ -394,6 +408,7 @@ public class FileTools {
       // 变更前复检：与 write_file 同款——防校验到 copy 间路径被换成外向软链
       sandbox.enforce(new SandboxAction(ActionType.FILE_READ, from));
       sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, to));
+      AdminConfigFileGuard.rejectRead(from);
       rejectReservedFileWrites(to);
       Files.copy(src, dst, StandardCopyOption.REPLACE_EXISTING);
       return "已复制: " + from + " -> " + to;

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -308,6 +308,65 @@ class FileToolsTest {
   }
 
   @Test
+  @DisplayName("read_file 拒绝读取 channels.yaml / mcp_servers.yaml / oryxos.db 原文")
+  void readFileRejectsReservedFiles() throws IOException {
+    Path channels = dir.resolve("channels.yaml");
+    Path mcp = dir.resolve("mcp_servers.yaml");
+    Path db = dir.resolve("oryxos.db");
+    Path wal = dir.resolve("oryxos.db-wal");
+    Files.writeString(channels, "token: SECRET-CHANNEL\n");
+    Files.writeString(mcp, "KEY: SECRET-MCP\n");
+    Files.writeString(db, "fake sqlite bytes SECRET-DB");
+    Files.writeString(wal, "fake wal bytes SECRET-WAL");
+
+    assertThrows(IllegalArgumentException.class, () -> tools.readFile(channels.toString()));
+    assertThrows(IllegalArgumentException.class, () -> tools.readFile(mcp.toString()));
+    assertThrows(IllegalArgumentException.class, () -> tools.readFile(db.toString()));
+    assertThrows(IllegalArgumentException.class, () -> tools.readFile(wal.toString()));
+  }
+
+  @Test
+  @DisplayName("read_file 拒绝经软链别名读 channels.yaml")
+  void readFileRejectsSymlinkAliasToReserved() throws IOException {
+    Path channels = dir.resolve("channels.yaml");
+    Files.writeString(channels, "token: SECRET-CHANNEL\n");
+    Path alias = dir.resolve("alias.yaml");
+    try {
+      Files.createSymbolicLink(alias, channels.getFileName());
+    } catch (IOException | UnsupportedOperationException e) {
+      Assumptions.assumeTrue(false, "当前环境无法创建软链: " + e.getMessage());
+    }
+
+    assertThrows(IllegalArgumentException.class, () -> tools.readFile(alias.toString()));
+  }
+
+  @Test
+  @DisplayName("copy_file 拒绝把保留文件复制成普通文件（防复制即泄露）")
+  void copyFileRejectsReservedSource() throws IOException {
+    Path channels = dir.resolve("channels.yaml");
+    Files.writeString(channels, "token: SECRET-CHANNEL\n");
+    Path leak = dir.resolve("leak.txt");
+
+    assertThrows(
+        IllegalArgumentException.class, () -> tools.copyFile(channels.toString(), leak.toString()));
+    assertFalse(Files.exists(leak), "拒绝后不得留下泄露副本");
+  }
+
+  @Test
+  @DisplayName("grep 跳过保留文件：凭证内容不进结果，普通文件照常命中并给出跳过提示")
+  void grepSkipsReservedFiles() throws IOException {
+    Files.writeString(dir.resolve("channels.yaml"), "token: SECRET-CHANNEL\n");
+    Files.writeString(dir.resolve("a.txt"), "normal needle line\n");
+
+    String result = tools.grep("SECRET|needle", dir.toString());
+
+    assertTrue(result.contains("a.txt:1:normal needle line"), result);
+    assertFalse(result.contains("SECRET-CHANNEL"), "保留文件内容不得出现在搜索结果: " + result);
+    assertFalse(result.contains("channels.yaml"), "保留文件名不得出现在命中行: " + result);
+    assertTrue(result.contains("已跳过"), "应提示跳过了保留文件: " + result);
+  }
+
+  @Test
   @DisplayName("write_file 落盘前复检 FILE_WRITE（防校验窗口内路径逃逸）")
   void writeFileRechecksPathBeforeWrite() {
     AtomicInteger fileWrites = new AtomicInteger();

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/WorkspaceApiController.java
@@ -86,13 +86,19 @@ public class WorkspaceApiController {
   /** 读文件文本；防目录穿越：越界 → 400，不存在 → 404。 */
   @GetMapping("/file")
   public ApiResponse<String> file(@RequestParam String path) {
+    // 先词法拦保留文件原文（channels.yaml/mcp_servers.yaml 凭证、oryxos.db 全量数据）；
+    // 再投影真实路径后复检——alias.yaml→channels.yaml 软链只在投影后能看见
+    AdminConfigFileGuard.rejectRead(path);
     Path target = resolveWithinRoot(path);
+    AdminConfigFileGuard.rejectRead(target);
     if (!Files.isRegularFile(target)) {
       throw new ResourceNotFoundException("文件不存在: " + path); // → 404
     }
     try {
       // 读前复检：与 writeFile / tool 层 read_file 同款——防首次校验到 readString 间被换成外向软链
+      // 或换成仍在 root 内的保留文件
       target = resolveWithinRoot(path);
+      AdminConfigFileGuard.rejectRead(target);
       return ApiResponse.ok(Files.readString(target));
     } catch (IOException e) {
       throw new UncheckedIOException("读取文件失败: " + path, e);
@@ -106,12 +112,17 @@ public class WorkspaceApiController {
    */
   @GetMapping("/download")
   public ResponseEntity<Resource> download(@RequestParam String path) {
+    // 同 file：保留文件原文（凭证配置 / SQLite 库）禁止经附件流下载
+    AdminConfigFileGuard.rejectRead(path);
     Path target = resolveWithinRoot(path);
+    AdminConfigFileGuard.rejectRead(target);
     if (!Files.isRegularFile(target)) {
       throw new ResourceNotFoundException("文件不存在: " + path); // → 404
     }
     // 读前复检：与 file / writeFile 同款——防首次校验到打开附件间被换成外向软链
+    // 或换成仍在 root 内的保留文件
     target = resolveWithinRoot(path);
+    AdminConfigFileGuard.rejectRead(target);
     String filename = String.valueOf(target.getFileName());
     // 文件名可能含中文/空格：用 RFC 5987 编码进 Content-Disposition，避免乱码或截断
     String disposition =

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/WorkspaceApiControllerTest.java
@@ -260,6 +260,47 @@ class WorkspaceApiControllerTest {
   }
 
   @Test
+  @DisplayName("file/download 禁止读取 channels.yaml / mcp_servers.yaml / oryxos.db 原文")
+  void readReservedFilesIsRejected() throws Exception {
+    Files.writeString(oryxosRoot.resolve("channels.yaml"), "channels: [{token: SECRET-CHANNEL}]\n");
+    Files.writeString(
+        oryxosRoot.resolve("mcp_servers.yaml"), "servers: [{env: {KEY: SECRET-MCP}}]\n");
+    Files.writeString(oryxosRoot.resolve("oryxos.db"), "fake sqlite bytes SECRET-DB");
+    Files.writeString(oryxosRoot.resolve("oryxos.db-wal"), "fake wal bytes SECRET-WAL");
+
+    mvc.perform(get("/api/v1/workspace/file").param("path", "channels.yaml"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(400));
+    mvc.perform(get("/api/v1/workspace/file").param("path", "mcp_servers.yaml"))
+        .andExpect(status().isBadRequest());
+    mvc.perform(get("/api/v1/workspace/file").param("path", "oryxos.db"))
+        .andExpect(status().isBadRequest());
+    mvc.perform(get("/api/v1/workspace/file").param("path", "oryxos.db-wal"))
+        .andExpect(status().isBadRequest());
+    mvc.perform(get("/api/v1/workspace/download").param("path", "channels.yaml"))
+        .andExpect(status().isBadRequest());
+    mvc.perform(get("/api/v1/workspace/download").param("path", "oryxos.db"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("file/download 禁止经软链别名读 channels.yaml（投影后复检）")
+  void readViaSymlinkAliasToAdminConfigIsRejected() throws Exception {
+    Files.writeString(oryxosRoot.resolve("channels.yaml"), "token: SECRET-CHANNEL\n");
+    Path alias = oryxosRoot.resolve("agents/demo/alias.yaml");
+    try {
+      Files.createSymbolicLink(alias, Path.of("../../channels.yaml"));
+    } catch (IOException | UnsupportedOperationException e) {
+      Assumptions.assumeTrue(false, "当前环境无法创建软链: " + e.getMessage());
+    }
+
+    mvc.perform(get("/api/v1/workspace/file").param("path", "agents/demo/alias.yaml"))
+        .andExpect(status().isBadRequest());
+    mvc.perform(get("/api/v1/workspace/download").param("path", "agents/demo/alias.yaml"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
   @DisplayName("工作区写入口禁止写 Agent skills 绑定视图")
   void writeThroughAgentSkillsIsRejected() throws Exception {
     mvc.perform(


### PR DESCRIPTION
## 背景

通用文件**读**入口此前不经过 `AdminConfigFileGuard`（该守卫只拦写），导致 Agent 与工作台用户可直接读取系统敏感文件原文：

- `channels.yaml` / `mcp_servers.yaml`：渠道与 MCP 服务凭证（热更配置本应只走 Channel/MCP 管理入口）；
- `oryxos.db`：SQLite 全量持久化数据，含 `-wal` / `-shm` / `-journal` 侧车与备份副本（同源数据，同样敏感）。

泄露路径：`GET /api/v1/workspace/file`、`GET /api/v1/workspace/download`、工具 `read_file`、`copy_file`（复制成普通文件即泄露）、`grep`（遍历命中即出现在结果里）。软链别名（`alias.yaml → channels.yaml`）还会绕过纯词法检查。

## 改动

**core/fs — `AdminConfigFileGuard`**
- 新增 `rejectRead(String)` / `rejectRead(Path)` 与批量入口用的 `isReservedRead(Path)`（不抛异常），与写侧共用同一套「词法路径段扫描 + 软链叶子目标（含悬空链）+ `RealPathBoundary` 投影」三重判定，不产生口径分叉；
- 保留集合扩展 `oryxos.db` 家族（`oryxos.db` 精确名 + `oryxos.db-` / `oryxos.db.` 前缀覆盖侧车/备份）；写侧同步覆盖，防止自定义布局下经通用写入口毁库；
- 原写侧逻辑重构为布尔判定（`hitsReserved` / `matchesReserved` / `symlinkLeafHitsReserved`），语义不变。

**web — `WorkspaceApiController`**
- `file` / `download`：入口词法拦截 → `resolveWithinRoot` 投影后复检 → 读前 TOCTOU 复检（对齐既有写侧复检模式），越权读返回 400。

**tool — `FileTools`**
- `read_file`：入口与读前复检各加一次 `rejectRead`；
- `copy_file`：源路径 `rejectRead`（入口 + copy 前复检），拒绝后不留泄露副本；
- `grep`：遍历时 `isReservedRead` 跳过保留文件（跳过而非整次搜索失败），末尾给出跳过数量提示；凭证内容与保留文件名均不进结果。

## 测试

- `AdminConfigFileGuardTest`（+8 例）：读侧保留文件与大小写不敏感、SQLite 侧车/备份、普通路径负例（`channels.yaml.bak` 不拦、普通目录放行、null/blank）、写侧 DB 家族、软链别名与悬空链、`isReservedRead` 与 `rejectRead` 同口径；
- `WorkspaceApiControllerTest`（+2 例）：file/download 直读保留文件返回 400（含 db/-wal）；软链别名投影后拒绝 400；
- `FileToolsTest`（+4 例）：`read_file` 拒绝保留文件与软链别名；`copy_file` 拒绝保留源且不留副本；`grep` 跳过保留文件、凭证内容/文件名不进结果且有跳过提示。

软链相关用例在无软链权限环境（如 Windows 非管理员）经 assume 自动跳过，Linux CI 行为不变。

## 验证

- `mvn install -DskipTests` 全模块编译 + PMD + spotless 通过；
- Windows 本地：`AdminConfigFileGuardTest` 12 例（5 软链跳过）、`FileToolsTest` 39 例（7 跳过）0 失败；`WorkspaceApiControllerTest` 新增用例通过/正确跳过。
- Windows 全量套件中其余软链/POSIX 报错为**主线既有问题**，与本 PR 无关（已用 stash 在基线上复现同样失败），由待合入的 #310 统一修复。
