### PR TITLE
fix(knowledge): skip symlinks and enforce realpath boundary in KB scan

### DIFF
--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/KnowledgeIndexService.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/KnowledgeIndexService.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -260,17 +261,42 @@ public class KnowledgeIndexService {
     return units;
   }
 
-  /** 重建/对账用：列出库内全部受支持文档；不支持、空、超限的跳过并告警（Edge Cases）。 */
+  /**
+   * 重建/对账用：列出库内全部受支持文档；软链、真实路径越界、不支持、空、超限的跳过并告警（Edge Cases）。
+   *
+   * <p>软链一律不跟随：库内的链接文件可能指向库外（channels.yaml、oryxos.db 等），跟随扫描会把外部敏感内容 切分、向量化入库再被检索命中；{@code
+   * Files.walk} 本身不带 {@code FOLLOW_LINKS}（目录链不深入），这里再以 NOFOLLOW 拦掉叶子链接， 并对真实路径做库内边界复检（防祖先目录被换成软链等
+   * TOCTOU），与工作区文件入口同一套判定口径。
+   */
   List<Path> listSupportedFiles(Path kbDir) {
     try (Stream<Path> walk = Files.walk(kbDir)) {
-      return walk.filter(Files::isRegularFile)
+      return walk.filter(this::isContentRegularFile)
           .filter(file -> !KnowledgeManifest.FILE.equals(String.valueOf(file.getFileName())))
+          .filter(file -> withinKb(kbDir, file))
           .filter(this::scannable)
           .sorted()
           .toList();
     } catch (IOException e) {
       throw new UncheckedIOException("扫描知识库目录失败: " + kbDir, e);
     }
+  }
+
+  /** 知识库内容只收真实普通文件：文件/目录软链一律拒绝（带告警），其余按 NOFOLLOW 普通文件判定。 */
+  private boolean isContentRegularFile(Path file) {
+    if (Files.isSymbolicLink(file)) {
+      LOG.warn("跳过软链接（知识库内容不跟随软链）: {}", sanitize(String.valueOf(file)));
+      return false;
+    }
+    return Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS);
+  }
+
+  /** 词法在库内不代表真实在库内：真实路径越界（软链逃逸 / 祖先目录被换）的文件跳过并告警，绝不索引。 */
+  private boolean withinKb(Path kbDir, Path file) {
+    if (RealPathBoundary.isWithin(kbDir, file)) {
+      return true;
+    }
+    LOG.warn("跳过真实路径越出知识库的文件（疑似软链逃逸）: {}", sanitize(String.valueOf(file)));
+    return false;
   }
 
   private boolean scannable(Path file) {

--- a/oryxos-knowledge/src/test/java/io/oryxos/knowledge/contract/KnowledgeBackendContractTest.java
+++ b/oryxos-knowledge/src/test/java/io/oryxos/knowledge/contract/KnowledgeBackendContractTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -171,6 +172,77 @@ class KnowledgeBackendContractTest {
   }
 
   @Test
+  void reconcileSkipsFileSymlinkPointingOutsideKb() throws IOException {
+    // 库内文件软链指向库外敏感文件（模拟 channels.yaml / oryxos.db 泄露通道）：
+    // 对账扫描不得跟随，外部内容不得进索引、不可被检索
+    Path outside = Files.createDirectories(root.resolveSibling("outside-kb"));
+    Files.writeString(outside.resolve("secret.md"), "# 外部机密\n\n凭证 SUPERSECRET-TOKEN 内容。");
+    assumeSymlink(root.resolve("ops").resolve("escape.md"), Path.of("../../outside-kb/secret.md"));
+
+    indexService.reconcile("ops");
+    runBackground();
+
+    assertTrue(
+        backend.status("ops").stream().noneMatch(s -> s.relPath().contains("escape")),
+        "软链文件不得登记为文档");
+    assertTrue(
+        retrieve("SUPERSECRET", 5, "ops").stream()
+            .noneMatch(h -> h.content().contains("SUPERSECRET")),
+        "库外凭证内容不得被检索命中");
+    assertFalse(retrieve("磁盘告警", 5, "ops").isEmpty(), "库内真实文档照常对账索引，不受跳过影响");
+  }
+
+  @Test
+  void rebuildSucceedsAndSkipsSymlinkContent() throws IOException {
+    indexReady();
+    Path outside = Files.createDirectories(root.resolveSibling("outside-rebuild"));
+    Files.writeString(outside.resolve("secret.md"), "# 外部机密\n\nREBUILDSECRET 凭证内容。");
+    assumeSymlink(
+        root.resolve("ops").resolve("escape.md"), Path.of("../../outside-rebuild/secret.md"));
+
+    backend.rebuild("ops"); // 软链跳过而非解析失败：重建整体成功，新代不含泄露内容
+
+    assertTrue(
+        backend.status("ops").stream().noneMatch(s -> s.relPath().contains("escape")),
+        "软链文件不得进入新代");
+    assertTrue(
+        retrieve("REBUILDSECRET", 5, "ops").stream()
+            .noneMatch(h -> h.content().contains("REBUILDSECRET")),
+        "库外凭证内容不得被检索命中");
+    assertFalse(retrieve("磁盘告警", 5, "ops").isEmpty(), "库内真实文档重建后照常服务");
+  }
+
+  @Test
+  void directorySymlinkOutsideIsNotTraversed() throws IOException {
+    Path outside = Files.createDirectories(root.resolveSibling("outside-dir"));
+    Files.writeString(outside.resolve("dirsecret.md"), "# 目录外机密\n\nLINKDIRSECRET 内容。");
+    assumeSymlink(root.resolve("ops").resolve("linkdir"), Path.of("../../outside-dir"));
+
+    indexService.reconcile("ops");
+    runBackground();
+
+    assertTrue(
+        backend.status("ops").stream().noneMatch(s -> s.relPath().contains("linkdir")),
+        "目录软链不得被深入遍历");
+    assertTrue(
+        retrieve("LINKDIRSECRET", 5, "ops").stream()
+            .noneMatch(h -> h.content().contains("LINKDIRSECRET")),
+        "目录软链后的库外内容不得被检索命中");
+  }
+
+  @Test
+  void importDocumentRejectsSymlinkEscapingKb() throws IOException {
+    Path outside = Files.createDirectories(root.resolveSibling("outside-import"));
+    Files.writeString(outside.resolve("secret.md"), "# 外部机密\n\nIMPORTSECRET 内容。");
+    assumeSymlink(
+        root.resolve("ops").resolve("escape.md"), Path.of("../../outside-import/secret.md"));
+
+    // 单文件导入走 RealPathBoundary：真实路径越界即拒绝，不登记半完成状态
+    assertThrows(IllegalArgumentException.class, () -> backend.importDocument("ops", "escape.md"));
+    assertTrue(backend.status("ops").isEmpty());
+  }
+
+  @Test
   void multiKbRetrievalAggregatesToGlobalTopK() {
     indexReady();
     createKb("faq", "产品FAQ");
@@ -234,6 +306,15 @@ class KnowledgeBackendContractTest {
       Files.writeString(root.resolve(kb).resolve(relPath), content);
     } catch (IOException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  /** 建软链；无软链权限的环境（Windows 非管理员）整条用例跳过，Linux CI 正常执行。 */
+  private void assumeSymlink(Path link, Path target) {
+    try {
+      Files.createSymbolicLink(link, target);
+    } catch (IOException | UnsupportedOperationException e) {
+      Assumptions.assumeTrue(false, "当前环境无法创建软链: " + e.getMessage());
     }
   }
 


### PR DESCRIPTION
## 背景

\KnowledgeIndexService.listSupportedFiles\ 在扫描知识库目录时默认跟随软链（\Files.walk\ 默认语义 + \Files.isRegularFile\ 跟随链接），且对扫描到的文件不做真实路径边界校验。攻击者若能在知识库目录内放置软链（\scape.md -> ../../outside/secret.md\，或整个目录软链），库外敏感文件（凭证、系统配置等）会被分块、向量化并进入 Agent 知识检索，造成内容泄露。

## 改动

- **不跟随软链**：扫描显式跳过符号链接（文件软链不索引、目录软链不深入遍历，悬空软链同样跳过），并输出告警日志。
- **RealPath 边界兜底**：每个候选文件经 \RealPathBoundary.isWithin(kbDir, file)\ 校验真实路径，解析后越出知识库根目录的文件跳过（防 TOCTOU / 链接替换竞态）。
- 库内真实文件索引、对账、重建行为不变。

## 测试

契约测试 \KnowledgeBackendContractTest\ 新增 4 例（软链用例经 \ssumeCanSymlink\ 在不支持平台跳过，Linux CI 执行）：

- \econcileSkipsFileSymlinkPointingOutsideKb\：对账跳过指向库外的文件软链——软链不登记为文档、密文内容检索不可命中、库内真实文档正常索引。
- \ebuildSucceedsAndSkipsSymlinkContent\：双缓冲重建整体成功，新代不含软链泄露内容，库内文档重建后照常服务。
- \directorySymlinkOutsideIsNotTraversed\：指向库外的目录软链不被遍历，其内容不可检索。
- \importDocumentRejectsSymlinkEscapingKb\：直接导入逃逸软链路径被 RealPath 校验可读地拒绝。

- [x] \mvn spotless:apply\
- [x] \mvn install -DskipTests\ 全模块构建 + PMD 通过
- [x] oryxos-knowledge 目标测试全绿（Windows 软链用例跳过，行为与 #310 既有约定一致）

## 关联

与写侧守卫 PR（\ix/skill-knowledge-symlink-guard\、\ix/guard-symlink-bypass\）互补：那些 PR 覆盖 Skill/Knowledge 目录的**写入/变更**守卫，本 PR 修复的是知识索引的**读取/扫描**路径，文件无重叠。