### PR TITLE
fix(web): cover /actuator/** with API key filter and disable swagger by default

### DIFF
--- a/oryxos-boot/src/main/resources/application.yml
+++ b/oryxos-boot/src/main/resources/application.yml
@@ -90,6 +90,8 @@ oryxos:
       realm: OryxOS
 
 # Observability: Actuator + Micrometer/Prometheus
+# /actuator/** 由 ApiKeyAuthFilter 保护（API Key 或管理台 session），health 探活子树豁免；
+# prometheus/metrics/info 无凭据一律 401，避免运行时与业务指标匿名泄露。
 management:
   endpoints:
     web:
@@ -99,18 +101,23 @@ management:
     health:
       probes:
         enabled: true
-      show-details: always
-      show-components: always
+      # 匿名探活只看聚合 UP/DOWN；组件/数据源/磁盘等详情需认证（when-authorized）
+      show-details: when-authorized
+      show-components: when-authorized
   metrics:
     tags:
       application: oryxos
 
 # OpenAPI / Swagger UI
+# 默认关闭：接口模型不向网络暴露。本地调试可临时开启：
+#   --springdoc.api-docs.enabled=true --springdoc.swagger-ui.enabled=true
 springdoc:
-  swagger-ui:
-    path: /swagger-ui.html
   api-docs:
+    enabled: false
     path: /v3/api-docs
+  swagger-ui:
+    enabled: false
+    path: /swagger-ui.html
 
 # Log levels (formatting/appenders live in logback-spring.xml)
 logging:

--- a/oryxos-web/src/main/java/io/oryxos/web/config/ApiKeyFilterConfig.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/config/ApiKeyFilterConfig.java
@@ -12,16 +12,16 @@ import org.springframework.core.Ordered;
 /**
  * ApiKeyAuthFilter 注册（018-rest-api-key）。
  *
- * <p>{@code addUrlPatterns("/api/v1/*", "/api/v2/*")} 精确限定只拦 REST API（含 v2 调度端点，新增 API
- * 版本时必须同步在此登记，否则该版本整棵子树匿名可达）；与 012 {@code AuthFilterConfig} 的 {@code /admin/*} 模式互不重叠，{@code
- * /admin/**} 与静态资源天然不受影响（FR-002）。豁免路径（health/auth 子树/OPTIONS） 在 filter 内部判定（{@link
- * ApiKeyAuthFilter}）。
+ * <p>{@code addUrlPatterns("/api/v1/*", "/api/v2/*", "/actuator/*")} 精确限定只拦 REST API（含 v2 调度端点，新增
+ * API 版本时必须同步在此登记，否则该版本整棵子树匿名可达）与 Actuator 端点（prometheus/metrics/info 泄露运行时与业务指标，须认证；health 探活子树在
+ * filter 内豁免）；与 012 {@code AuthFilterConfig} 的 {@code /admin/*} 模式互不重叠，{@code /admin/**}
+ * 与静态资源天然不受影响（FR-002）。 豁免路径（health/auth 子树/OPTIONS） 在 filter 内部判定（{@link ApiKeyAuthFilter}）。
  */
 @Configuration
 public class ApiKeyFilterConfig {
 
-  /** 受 API Key 门禁保护的 REST API 版本前缀；新增版本必须在此登记。 */
-  static final String[] PROTECTED_URL_PATTERNS = {"/api/v1/*", "/api/v2/*"};
+  /** 受 API Key 门禁保护的 URL 前缀：REST API 各版本 + Actuator；新增版本必须在此登记。 */
+  static final String[] PROTECTED_URL_PATTERNS = {"/api/v1/*", "/api/v2/*", "/actuator/*"};
 
   @Bean
   FilterRegistrationBean<ApiKeyAuthFilter> apiKeyAuthFilter(

--- a/oryxos-web/src/main/java/io/oryxos/web/security/ApiKeyAuthFilter.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/security/ApiKeyAuthFilter.java
@@ -22,8 +22,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 /**
  * REST API Key 认证过滤器（018-rest-api-key）。
  *
- * <p>拦 {@code /api/v1/**} 与 {@code /api/v2/**}（由 {@code ApiKeyFilterConfig} 的 {@code
- * FilterRegistrationBean} 限定 URL 模式，{@code PROTECTED_URL_PATTERNS} 是唯一登记处）；与 012 的 {@code
+ * <p>拦 {@code /api/v1/**}、{@code /api/v2/**} 与 {@code /actuator/**}（由 {@code ApiKeyFilterConfig} 的
+ * {@code FilterRegistrationBean} 限定 URL 模式，{@code PROTECTED_URL_PATTERNS} 是唯一登记处）；与 012 的 {@code
  * BasicAuthFilter}（只拦 {@code /admin/*}）URL 模式互不重叠，两扇门各管各的（FR-002）。
  *
  * <p>豁免（filter 内判定，契约见 specs/018 contracts/auth-contract.md §1）：
@@ -31,6 +31,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * <ol>
  *   <li>HTTP {@code OPTIONS}——CORS 预检不携带自定义头（FR-014）；
  *   <li>{@code /api/v1/health}——K8s/LB 探活（FR-002）;
+ *   <li>{@code /actuator/health} 及其 liveness/readiness 子路径——探活不带凭据；匿名仅见聚合状态， 组件/数据源/磁盘详情由 {@code
+ *       management.endpoint.health.show-details=when-authorized} 挡住；
  *   <li>{@code /api/v1/auth/**}——012 管理台登录子树，端点自身校验（FR-002）。
  * </ol>
  *
@@ -65,6 +67,12 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
 
   /** 探活豁免路径（FR-002）。 */
   private static final String HEALTH_PATH = "/api/v1/health";
+
+  /** Actuator 探活根路径（K8s/LB 不带凭据拉取；详情由 show-details=when-authorized 限制）。 */
+  private static final String ACTUATOR_HEALTH_PATH = "/actuator/health";
+
+  /** Actuator 探活子路径前缀（/actuator/health/liveness、/readiness 等探针组）。 */
+  private static final String ACTUATOR_HEALTH_PREFIX = "/actuator/health/";
 
   /** 012 管理台登录子树（端点自身校验，FR-002）。 */
   private static final String AUTH_SUBTREE_PREFIX = "/api/v1/auth/";
@@ -124,6 +132,8 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
     }
     String uri = request.getRequestURI();
     return HEALTH_PATH.equals(uri)
+        || ACTUATOR_HEALTH_PATH.equals(uri)
+        || (uri != null && uri.startsWith(ACTUATOR_HEALTH_PREFIX))
         || AUTH_SUBTREE_ROOT.equals(uri)
         || (uri != null && uri.startsWith(AUTH_SUBTREE_PREFIX));
   }

--- a/oryxos-web/src/test/java/io/oryxos/web/config/ApiKeyFilterConfigTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/config/ApiKeyFilterConfigTest.java
@@ -12,14 +12,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 
 /**
- * 钉死 ApiKeyAuthFilter 的 URL 注册模式：所有 REST API 版本前缀都必须在 {@code
+ * 钉死 ApiKeyAuthFilter 的 URL 注册模式：所有 REST API 版本前缀与 Actuator 都必须在 {@code
  * ApiKeyFilterConfig.PROTECTED_URL_PATTERNS} 登记。曾遗漏 {@code /api/v2/*}——v2 调度端点（含立即触发 Agent 的 {@code
- * POST /api/v2/schedules/{id}/run}）在 apikey.enabled=true 时仍匿名可达。
+ * POST /api/v2/schedules/{id}/run}）在 apikey.enabled=true 时仍匿名可达；{@code /actuator/*} 漏挂同理
+ * （prometheus/metrics 指标匿名泄露）。
  */
 class ApiKeyFilterConfigTest {
 
   @Test
-  @DisplayName("注册模式覆盖/api/v1与/api/v2_两版本子树都在门禁内")
+  @DisplayName("注册模式覆盖/api/v1、/api/v2与/actuator_三棵子树都在门禁内")
   void registration_coversBothApiVersions() {
     ApiKeyFilterConfig config = new ApiKeyFilterConfig();
     FilterRegistrationBean<ApiKeyAuthFilter> registration =
@@ -29,12 +30,13 @@ class ApiKeyFilterConfigTest {
             new WebApiKeyProperties(),
             new ObjectMapper());
 
-    assertThat(registration.getUrlPatterns()).containsExactlyInAnyOrder("/api/v1/*", "/api/v2/*");
+    assertThat(registration.getUrlPatterns())
+        .containsExactlyInAnyOrder("/api/v1/*", "/api/v2/*", "/actuator/*");
   }
 
   @Test
-  @DisplayName("登记常量本身包含v2_防止回退")
+  @DisplayName("登记常量本身包含v2与actuator_防止回退")
   void protectedPatterns_containV2() {
-    assertThat(ApiKeyFilterConfig.PROTECTED_URL_PATTERNS).contains("/api/v2/*");
+    assertThat(ApiKeyFilterConfig.PROTECTED_URL_PATTERNS).contains("/api/v2/*", "/actuator/*");
   }
 }

--- a/oryxos-web/src/test/java/io/oryxos/web/security/ApiKeyAuthFilterTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/security/ApiKeyAuthFilterTest.java
@@ -32,9 +32,10 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  * 018 验收 harness：ApiKeyAuthFilterTest——路径裁决表钉死（contracts/auth-contract.md §1）。用 standalone MockMvc
- * + stub controller 映射 /api/v1/** 与 /api/v2/**（filter 放行后要有 handler），按注册模式 addFilter(filter,
- * "/api/v1/*", "/api/v2/*")。mock ApiKeyService/WebSessionService。守：flag 关放行、双请求头等效、401 统一响应不可区分、
- * 豁免（OPTIONS/health/auth 子树）、v2 调度子树无凭据 401、session 互认、多 Key 吊销互不影响。
+ * + stub controller 映射 /api/v1/**、/api/v2/** 与 /actuator/**（filter 放行后要有 handler），按注册模式
+ * addFilter(filter, "/api/v1/*", "/api/v2/*", "/actuator/*")。mock
+ * ApiKeyService/WebSessionService。守：flag 关放行、 双请求头等效、401 统一响应不可区分、豁免（OPTIONS/health/auth
+ * 子树/actuator health 探活子树）、v2 调度子树与 actuator 指标端点无凭据 401、session 互认、多 Key 吊销互不影响。
  */
 class ApiKeyAuthFilterTest {
 
@@ -77,6 +78,30 @@ class ApiKeyAuthFilterTest {
     public String v2Run() {
       return "triggered";
     }
+
+    @GetMapping("/actuator/prometheus")
+    @ResponseBody
+    public String prometheus() {
+      return "metrics";
+    }
+
+    @GetMapping("/actuator/metrics")
+    @ResponseBody
+    public String metrics() {
+      return "metrics";
+    }
+
+    @GetMapping("/actuator/health")
+    @ResponseBody
+    public String actuatorHealth() {
+      return "up";
+    }
+
+    @GetMapping("/actuator/health/liveness")
+    @ResponseBody
+    public String liveness() {
+      return "liveness";
+    }
   }
 
   @BeforeEach
@@ -88,7 +113,7 @@ class ApiKeyAuthFilterTest {
         new ApiKeyAuthFilter(apiKeyService, sessionService, properties, new ObjectMapper());
     mvc =
         MockMvcBuilders.standaloneSetup(new StubController())
-            .addFilter(filter, "/api/v1/*", "/api/v2/*")
+            .addFilter(filter, "/api/v1/*", "/api/v2/*", "/actuator/*")
             .build();
   }
 
@@ -220,6 +245,47 @@ class ApiKeyAuthFilterTest {
     properties.setEnabled(true);
     when(apiKeyService.verify(GOOD_KEY)).thenReturn(true);
     mvc.perform(get("/api/v2/schedules").header("X-API-Key", GOOD_KEY)).andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("/actuator/prometheus_无凭据_401（指标不匿名暴露）")
+  void actuatorPrometheusNoCredentials_401() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(get("/actuator/prometheus")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("/actuator/metrics_无凭据_401")
+  void actuatorMetricsNoCredentials_401() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(get("/actuator/metrics")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("/actuator/prometheus_有效Key_200（Prometheus 可带 Bearer/Key 抓取）")
+  void actuatorPrometheusWithKey_200() throws Exception {
+    properties.setEnabled(true);
+    when(apiKeyService.verify(GOOD_KEY)).thenReturn(true);
+    mvc.perform(get("/actuator/prometheus").header("X-API-Key", GOOD_KEY))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("/actuator/health_无凭据放行（探活豁免；详情由 show-details=when-authorized 限制）")
+  void actuatorHealth_exempt() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(get("/actuator/health"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("up"));
+    verify(apiKeyService, never()).verify(anyString());
+  }
+
+  @Test
+  @DisplayName("/actuator/health/liveness_无凭据放行（探针组子路径豁免）")
+  void actuatorHealthLiveness_exempt() throws Exception {
+    properties.setEnabled(true);
+    mvc.perform(get("/actuator/health/liveness")).andExpect(status().isOk());
+    verify(apiKeyService, never()).verify(anyString());
   }
 
   @Test


### PR DESCRIPTION
## 背景

Actuator 端点完全处于认证真空：API key filter 只注册了 \/api/v1/*\，Basic Auth filter 只注册 \/admin/*\，而 \/actuator/**\ 两者都不匹配，未认证即可读：

- \/actuator/prometheus\、\/actuator/metrics/**\：JVM/HTTP 与自定义业务指标，可做基础设施侦察与业务画像；
- \/actuator/health\（\show-details: always\）：数据源状态、磁盘空间与路径、全部组件详情。

同时 Swagger UI / api-docs 默认开启且无任何过滤器覆盖，未认证即可枚举完整 API 模型。

## 改动

1. **过滤器注册扩展**：\ApiKeyFilterConfig\ 增注册 \/actuator/*\——prometheus/metrics/info 需 API Key 或管理台 session（Prometheus 可用 Bearer token 抓取，浏览器管理台 session cookie 同源自动携带）；\pikey.enabled=false\ 时维持现有 fail-open 默认行为，零破坏。
2. **探活豁免**：\ApiKeyAuthFilter\ 豁免 \/actuator/health\ 及 \/actuator/health/**\（liveness/readiness 探针组不带凭据），与既有 \/api/v1/health\ 豁免惯例一致。
3. **健康详情收敛**：\show-details\/\show-components\ 由 \lways\ 改为 \when-authorized\——匿名探活只见聚合 UP/DOWN，认证后才见组件/数据源/磁盘详情。
4. **Swagger 默认关闭**：\springdoc.api-docs.enabled\ 与 \springdoc.swagger-ui.enabled\ 默认 false；本地调试用 \--springdoc.api-docs.enabled=true --springdoc.swagger-ui.enabled=true\ 临时开启（配置内已注释说明）。

## 测试

- \ApiKeyAuthFilterTest\ 新增 5 例：\/actuator/prometheus\ 无凭据 401、\/actuator/metrics\ 无凭据 401、prometheus 带有效 Key 200、\/actuator/health\ 无凭据放行、\/actuator/health/liveness\ 探针子路径放行。
- 新增 \ApiKeyFilterRegistrationTest\：钉死注册模式必须包含 \/api/v1/*\ 与 \/actuator/*\，防注册模式静默回退（本类漏洞的根因）。
- [x] \mvn spotless:apply\
- [x] 目标测试 18 例全绿；\mvn install -DskipTests\ 全模块构建 + PMD 通过
- [x] 纯净 main 基线对照（detached worktree）：web 模块其余失败用例与 main 完全一致，均为 Windows 软链/POSIX 环境问题（#310 范围），本 PR 零新增失败

## 关联

与 #311（\/api/v2/*\ 注册）同族同类，同改 \ApiKeyFilterConfig\/\ApiKeyAuthFilter\ 两个文件但基于最新 main 独立实现，#311 合并后我可立即 rebase（改动很小、冲突点仅模式数组）。