### PR TITLE
fix(notify): fail loud when vendor webhook returns business error in 2xx body (#316)

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyPoster.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyPoster.java
@@ -1,5 +1,7 @@
 package io.oryxos.tool.notify;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.oryxos.tool.sandbox.ActionType;
 import io.oryxos.tool.sandbox.Sandbox;
 import io.oryxos.tool.sandbox.SandboxAction;
@@ -16,6 +18,9 @@ import org.springframework.web.client.RestClient;
 /**
  * 通知推送共用 HTTP 出口：禁自动重定向，手动逐跳跟随并对<strong>每一跳</strong>过 {@code HTTP_REQUEST} 域名白名单——杜绝「白名单内 webhook
  * 入口 302 到白名单外 / 内网」的绕过（与 {@code HttpTools} 写路径同策略）。
+ *
+ * <p>终跳在 HTTP 2xx 时仍解析飞书 / 企微 / 钉钉常见业务错误码（{@code code}/{@code errcode}/{@code StatusCode}）；非 0
+ * 视为失败。空 body、非 JSON、或无上述字段的通用 webhook 保持兼容。
  */
 public final class NotifyPoster {
 
@@ -25,6 +30,9 @@ public final class NotifyPoster {
   private static final int STATUS_MOVED_PERMANENTLY = 301;
   private static final int STATUS_FOUND = 302;
   private static final int STATUS_SEE_OTHER = 303;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String[] BUSINESS_CODE_FIELDS = {"errcode", "StatusCode", "code"};
+  private static final String[] BUSINESS_MESSAGE_FIELDS = {"errmsg", "msg", "message"};
 
   private final Sandbox sandbox;
   private final RestClient hopClient;
@@ -52,7 +60,7 @@ public final class NotifyPoster {
       if (hopBody != null) {
         spec.contentType(MediaType.APPLICATION_JSON).body(hopBody);
       }
-      ResponseEntity<Void> resp = spec.retrieve().toBodilessEntity();
+      ResponseEntity<String> resp = spec.retrieve().toEntity(String.class);
       if (resp.getStatusCode().is3xxRedirection()) {
         String location = resp.getHeaders().getFirst("Location");
         if (location == null || location.isBlank()) {
@@ -65,9 +73,80 @@ public final class NotifyPoster {
         current = URI.create(current).resolve(location).toString();
         continue;
       }
+      rejectVendorBusinessError(resp.getBody(), current);
       return;
     }
     throw new IllegalStateException("通知推送重定向次数过多，拒绝: " + url);
+  }
+
+  /** 飞书 {@code code}、企微/钉钉 {@code errcode}（及部分钉钉 {@code StatusCode}）非 0 时 fail-loud。缺字段或非数字不判失败。 */
+  static void rejectVendorBusinessError(String responseBody, String url) {
+    if (responseBody == null || responseBody.isBlank()) {
+      return;
+    }
+    final JsonNode root;
+    try {
+      root = MAPPER.readTree(responseBody);
+    } catch (Exception ignored) {
+      // 通用 webhook 可能返回非 JSON；不因此失败
+      return;
+    }
+    if (root == null || !root.isObject()) {
+      return;
+    }
+    for (String field : BUSINESS_CODE_FIELDS) {
+      JsonNode codeNode = root.get(field);
+      if (codeNode == null || codeNode.isNull() || !codeNode.isValueNode()) {
+        continue;
+      }
+      Long code = asBusinessCode(codeNode);
+      if (code == null) {
+        continue;
+      }
+      if (code != 0L) {
+        throw new IllegalStateException(
+            "通知推送业务失败 " + field + "=" + code + messageSuffix(root) + ": " + sanitizeUrl(url));
+      }
+      // 命中约定字段且为 0：已确认成功口径，不再用其它同义字段覆盖
+      return;
+    }
+  }
+
+  private static Long asBusinessCode(JsonNode node) {
+    if (node.isNumber()) {
+      return node.longValue();
+    }
+    if (node.isTextual()) {
+      String text = node.asText().strip();
+      if (text.isEmpty()) {
+        return null;
+      }
+      try {
+        return Long.parseLong(text);
+      } catch (NumberFormatException ignored) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  private static String messageSuffix(JsonNode root) {
+    for (String field : BUSINESS_MESSAGE_FIELDS) {
+      JsonNode msg = root.get(field);
+      if (msg != null && msg.isTextual() && !msg.asText().isBlank()) {
+        return " (" + field + "=" + sanitizeMessage(msg.asText()) + ")";
+      }
+    }
+    return "";
+  }
+
+  private static String sanitizeMessage(String value) {
+    String flat = value.replace('\r', ' ').replace('\n', ' ').strip();
+    return flat.length() <= 200 ? flat : flat.substring(0, 200);
+  }
+
+  private static String sanitizeUrl(String url) {
+    return url == null ? "" : url.replace('\r', '_').replace('\n', '_');
   }
 
   private static boolean switchesToGet(int status) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyPoster.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyPoster.java
@@ -1,5 +1,6 @@
 package io.oryxos.tool.notify;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.oryxos.tool.sandbox.ActionType;
@@ -87,7 +88,7 @@ public final class NotifyPoster {
     final JsonNode root;
     try {
       root = MAPPER.readTree(responseBody);
-    } catch (Exception ignored) {
+    } catch (JsonProcessingException ignored) {
       // 通用 webhook 可能返回非 JSON；不因此失败
       return;
     }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
@@ -35,6 +35,7 @@ class VendorNotifyAdapterTest {
   private HttpServer server;
   private final List<ReceivedRequest> received = new ArrayList<>();
   private volatile int responseStatus = 200;
+  private volatile String responseBody = "";
   private NotifyPoster poster;
 
   @BeforeEach
@@ -57,7 +58,14 @@ class VendorNotifyAdapterTest {
   private void record(HttpExchange exchange) throws IOException {
     String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
     received.add(new ReceivedRequest(exchange.getRequestURI().getQuery(), body));
-    exchange.sendResponseHeaders(responseStatus, -1);
+    byte[] payload = responseBody.getBytes(StandardCharsets.UTF_8);
+    if (!responseBody.isEmpty()) {
+      exchange.getResponseHeaders().add("Content-Type", "application/json; charset=utf-8");
+    }
+    exchange.sendResponseHeaders(responseStatus, payload.length);
+    if (payload.length > 0) {
+      exchange.getResponseBody().write(payload);
+    }
     exchange.close();
   }
 
@@ -293,6 +301,64 @@ class VendorNotifyAdapterTest {
 
     assertThrows(
         RestClientResponseException.class, () -> new WeComNotifyAdapter(poster).send(target, "hi"));
+  }
+
+  @Test
+  @DisplayName("企微：HTTP 200 + errcode≠0 业务失败上抛")
+  void wecomBusinessErrorIn2xxBodyFailsLoud() {
+    responseBody = "{\"errcode\":93017,\"errmsg\":\"invalid webhook url\"}";
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                new WeComNotifyAdapter(poster)
+                    .send(new NotifyTarget("wecom", Map.of("url", url())), "hi"));
+    assertTrue(ex.getMessage().contains("errcode=93017"));
+    assertTrue(ex.getMessage().contains("invalid webhook url"));
+    assertEquals(1, received.size());
+  }
+
+  @Test
+  @DisplayName("飞书：HTTP 200 + code≠0 业务失败上抛")
+  void feishuBusinessErrorIn2xxBodyFailsLoud() {
+    responseBody = "{\"code\":19021,\"msg\":\"sign match fail\"}";
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                new FeishuNotifyAdapter(poster)
+                    .send(new NotifyTarget("feishu", Map.of("url", url())), "hi"));
+    assertTrue(ex.getMessage().contains("code=19021"));
+    assertTrue(ex.getMessage().contains("sign match fail"));
+  }
+
+  @Test
+  @DisplayName("钉钉：HTTP 200 + errcode≠0 业务失败上抛")
+  void dingTalkBusinessErrorIn2xxBodyFailsLoud() {
+    responseBody = "{\"errcode\":310000,\"errmsg\":\"关键词不匹配\"}";
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                new DingTalkNotifyAdapter(poster)
+                    .send(new NotifyTarget("dingtalk", Map.of("url", url())), "hi"));
+    assertTrue(ex.getMessage().contains("errcode=310000"));
+  }
+
+  @Test
+  @DisplayName("厂商 webhook：HTTP 200 + 业务码=0 视为成功")
+  void vendorBusinessCodeZeroSucceeds() {
+    responseBody = "{\"errcode\":0,\"errmsg\":\"ok\"}";
+    new WeComNotifyAdapter(poster).send(new NotifyTarget("wecom", Map.of("url", url())), "hi");
+    assertEquals(1, received.size());
+  }
+
+  @Test
+  @DisplayName("通用 webhook：无业务错误字段的 JSON 不误伤")
+  void genericWebhookJsonWithoutBusinessCodeSucceeds() {
+    responseBody = "{\"content\":\"accepted\"}";
+    new WebhookNotifyAdapter(poster).send(new NotifyTarget("webhook", Map.of("url", url())), "hi");
+    assertEquals(1, received.size());
   }
 
   @Test


### PR DESCRIPTION
Parse Feishu/WeCom/DingTalk webhook JSON codes after HTTP success so silent notification failures surface to agents.

## Summary
- `NotifyPoster` 在 HTTP 2xx 终跳解析飞书 / 企微 / 钉钉业务错误码（`code` / `errcode` / `StatusCode`）
- 业务码 ≠ 0 抛带点名原因的异常；空 body、非 JSON、无上述字段的通用 webhook 不误伤
- `VendorNotifyAdapterTest` 补 200+业务失败 / 业务码=0 / 通用 JSON 用例

Closes #316

## Test plan
- [x] `mvn -pl oryxos-tool -am test -Dtest=VendorNotifyAdapterTest,WebhookNotifyAdapterTest`
- [ ] CI 全绿