### PR TITLE
fix(channel-wecom): clear WS error state and auto-reconnect after disconnect

### DIFF
--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
@@ -10,6 +10,10 @@ import io.oryxos.core.channel.OutboundGuard;
 import io.oryxos.core.profile.ProfileRegistry;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +38,9 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
   private static final String CMD_AIBOT_MSG_CALLBACK = "aibot_msg_callback";
 
   private static final Duration START_TIMEOUT = Duration.ofSeconds(20);
+  private static final long RECONNECT_BASE_MS = 2_000L;
+  private static final long RECONNECT_MAX_MS = 60_000L;
+  private static final int RECONNECT_MAX_SHIFT = 5;
 
   private final ChannelConfig config;
   private final ProfileRegistry profileRegistry;
@@ -45,6 +52,10 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
   private volatile WeComEventNormalizer normalizer;
   private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
   private volatile String lastError;
+  private volatile boolean running;
+  private volatile ScheduledExecutorService reconnectScheduler;
+  private volatile ScheduledFuture<?> reconnectFuture;
+  private int reconnectAttempt;
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "EI_EXPOSE_REP2",
@@ -83,28 +94,17 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
           "渠道 " + config.name() + " 绑定的 Agent " + config.agent() + " 不存在");
     }
     guard.check(OUTBOUND_URL);
+    running = true;
+    reconnectAttempt = 0;
+    cancelReconnectLocked();
     try {
-      normalizer = new WeComEventNormalizer(config.name());
-      WeComWsClient client =
-          new WeComWsClient(
-              config.appId(),
-              config.appSecret(),
-              WeComWsClient.DEFAULT_WS_URL,
-              this::handleFrame,
-              () -> {
-                if (state != ChannelStatus.State.ERROR) {
-                  state = ChannelStatus.State.DISCONNECTED;
-                }
-              });
-      sender =
-          new WeComMessageSender(
-              client::sendJson, guard, OUTBOUND_URL, WeComMessageSender.DEFAULT_CHUNK_SIZE);
-      client.connectAndSubscribe(START_TIMEOUT);
-      wsRef.set(client);
+      connectLocked();
       state = ChannelStatus.State.CONNECTED;
       lastError = null;
       LOG.info("企微渠道 {} 长连接已建立（Agent: {}）", sanitize(config.name()), sanitize(config.agent()));
     } catch (Exception e) {
+      running = false;
+      shutdownReconnectSchedulerLocked();
       state = ChannelStatus.State.ERROR;
       lastError = "长连接建立失败: " + sanitize(e.getMessage());
       throw new IllegalStateException("渠道 " + config.name() + " " + lastError, e);
@@ -113,6 +113,9 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
 
   @Override
   public synchronized void stop() {
+    running = false;
+    cancelReconnectLocked();
+    shutdownReconnectSchedulerLocked();
     WeComWsClient ws = wsRef.getAndSet(null);
     if (ws != null) {
       ws.closeQuietly();
@@ -140,6 +143,111 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
       throw new IllegalStateException("渠道 " + config.name() + " 未启动，无法发送回复");
     }
     active.send(chatId, text);
+  }
+
+  /** 供单测校验退避间隔，不触网。 */
+  static long reconnectDelayMs(int attempt) {
+    int capped = Math.min(Math.max(attempt, 0), RECONNECT_MAX_SHIFT);
+    return Math.min(RECONNECT_BASE_MS * (1L << capped), RECONNECT_MAX_MS);
+  }
+
+  private void connectLocked() throws Exception {
+    normalizer = new WeComEventNormalizer(config.name());
+    WeComWsClient client =
+        new WeComWsClient(
+            config.appId(),
+            config.appSecret(),
+            WeComWsClient.DEFAULT_WS_URL,
+            this::handleFrame,
+            this::handleDisconnected);
+    sender =
+        new WeComMessageSender(
+            client::sendJson, guard, OUTBOUND_URL, WeComMessageSender.DEFAULT_CHUNK_SIZE);
+    client.connectAndSubscribe(START_TIMEOUT);
+    wsRef.set(client);
+  }
+
+  private void handleDisconnected() {
+    boolean shouldReconnect;
+    synchronized (this) {
+      if (!running || state == ChannelStatus.State.ERROR) {
+        return;
+      }
+      wsRef.set(null);
+      state = ChannelStatus.State.DISCONNECTED;
+      shouldReconnect = true;
+    }
+    if (shouldReconnect) {
+      LOG.warn("企微渠道 {} 长连接断开，将自动重连", sanitize(config.name()));
+      scheduleReconnect();
+    }
+  }
+
+  private void scheduleReconnect() {
+    synchronized (this) {
+      if (!running || reconnectFuture != null) {
+        return;
+      }
+      long delayMs = reconnectDelayMs(reconnectAttempt);
+      reconnectFuture =
+          reconnectScheduler().schedule(this::attemptReconnect, delayMs, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private void attemptReconnect() {
+    synchronized (this) {
+      reconnectFuture = null;
+      if (!running) {
+        return;
+      }
+      try {
+        connectLocked();
+        reconnectAttempt = 0;
+        state = ChannelStatus.State.CONNECTED;
+        lastError = null;
+        LOG.info("企微渠道 {} 长连接已恢复", sanitize(config.name()));
+      } catch (Exception e) {
+        reconnectAttempt++;
+        lastError = "长连接重连失败: " + sanitize(e.getMessage());
+        LOG.warn("企微渠道 {} 重连失败（第 {} 次）: {}", sanitize(config.name()), reconnectAttempt, lastError);
+        scheduleReconnect();
+      }
+    }
+  }
+
+  private ScheduledExecutorService reconnectScheduler() {
+    ScheduledExecutorService scheduler = reconnectScheduler;
+    if (scheduler == null) {
+      ScheduledThreadPoolExecutor pool =
+          new ScheduledThreadPoolExecutor(
+              1,
+              r -> {
+                Thread t = new Thread(r, "wecom-reconnect-" + config.name());
+                t.setDaemon(true);
+                return t;
+              });
+      pool.setRemoveOnCancelPolicy(true);
+      reconnectScheduler = pool;
+      return pool;
+    }
+    return scheduler;
+  }
+
+  private void cancelReconnectLocked() {
+    ScheduledFuture<?> pending = reconnectFuture;
+    if (pending != null) {
+      pending.cancel(false);
+      reconnectFuture = null;
+    }
+  }
+
+  private void shutdownReconnectSchedulerLocked() {
+    cancelReconnectLocked();
+    ScheduledExecutorService scheduler = reconnectScheduler;
+    if (scheduler != null) {
+      scheduler.shutdownNow();
+      reconnectScheduler = null;
+    }
   }
 
   private void handleFrame(JsonNode root) {

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
@@ -209,7 +209,11 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
       } catch (Exception e) {
         reconnectAttempt++;
         lastError = "长连接重连失败: " + sanitize(e.getMessage());
-        LOG.warn("企微渠道 {} 重连失败（第 {} 次）: {}", sanitize(config.name()), reconnectAttempt, lastError);
+        LOG.warn(
+            "企微渠道 {} 重连失败（第 {} 次）: {}",
+            sanitize(config.name()),
+            reconnectAttempt,
+            sanitize(lastError));
         scheduleReconnect();
       }
     }
@@ -222,7 +226,7 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
           new ScheduledThreadPoolExecutor(
               1,
               r -> {
-                Thread t = new Thread(r, "wecom-reconnect-" + config.name());
+                Thread t = new Thread(r, "wecom-reconnect-" + sanitize(config.name()));
                 t.setDaemon(true);
                 return t;
               });

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComWsClient.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComWsClient.java
@@ -163,10 +163,8 @@ final class WeComWsClient implements WebSocket.Listener {
 
   @Override
   public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
-    closed.set(true);
-    subscribed.set(false);
-    stopHeartbeat();
-    subscribeLatch.countDown();
+    markDisconnected();
+    socket.set(null);
     onDisconnected.run();
     return null;
   }
@@ -176,9 +174,17 @@ final class WeComWsClient implements WebSocket.Listener {
     LOG.warn("企微长连接错误: {}", sanitize(error == null ? null : error.getMessage()));
     if (!subscribed.get()) {
       subscribeError = error == null ? "unknown" : error.getMessage();
-      subscribeLatch.countDown();
     }
+    markDisconnected();
+    socket.set(null);
     onDisconnected.run();
+  }
+
+  private void markDisconnected() {
+    closed.set(true);
+    subscribed.set(false);
+    stopHeartbeat();
+    subscribeLatch.countDown();
   }
 
   private void handleText(String raw) {

--- a/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComChannelAdapterLifecycleTest.java
+++ b/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComChannelAdapterLifecycleTest.java
@@ -1,0 +1,25 @@
+package io.oryxos.channel.wecom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WeComChannelAdapterLifecycleTest {
+
+  @Test
+  @DisplayName("重连退避：指数增长并封顶")
+  void reconnectDelayUsesExponentialBackoffWithCap() {
+    assertEquals(2_000L, WeComChannelAdapter.reconnectDelayMs(0));
+    assertEquals(4_000L, WeComChannelAdapter.reconnectDelayMs(1));
+    assertEquals(8_000L, WeComChannelAdapter.reconnectDelayMs(2));
+    assertEquals(60_000L, WeComChannelAdapter.reconnectDelayMs(10));
+  }
+
+  @Test
+  @DisplayName("重连退避：负 attempt 按 0 处理")
+  void reconnectDelayClampsNegativeAttempt() {
+    assertTrue(WeComChannelAdapter.reconnectDelayMs(-1) >= 2_000L);
+  }
+}

--- a/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComWsClientTest.java
+++ b/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComWsClientTest.java
@@ -1,0 +1,35 @@
+package io.oryxos.channel.wecom;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WeComWsClientTest {
+
+  @Test
+  @DisplayName("onError 后清除订阅态，status 不应再报 CONNECTED")
+  void onErrorClearsSubscriptionState() throws Exception {
+    AtomicBoolean disconnected = new AtomicBoolean(false);
+    WeComWsClient client =
+        new WeComWsClient(
+            "bot",
+            "secret",
+            WeComWsClient.DEFAULT_WS_URL,
+            node -> {},
+            () -> disconnected.set(true));
+    var subscribed = WeComWsClient.class.getDeclaredField("subscribed");
+    subscribed.setAccessible(true);
+    ((java.util.concurrent.atomic.AtomicBoolean) subscribed.get(client)).set(true);
+    var closed = WeComWsClient.class.getDeclaredField("closed");
+    closed.setAccessible(true);
+    ((java.util.concurrent.atomic.AtomicBoolean) closed.get(client)).set(false);
+
+    client.onError(null, new RuntimeException("connection reset"));
+
+    assertFalse(client.isSubscribed());
+    assertTrue(disconnected.get());
+  }
+}


### PR DESCRIPTION
Closes #318

## Problem

- `WeComWsClient.onError` did not clear `subscribed` / `closed` or stop the heartbeat, so `status()` could still report `CONNECTED` after a connection failure.
- Unlike Feishu inbound, WeCom had no automatic reconnect after WebSocket disconnect.

## Changes

- Extract `markDisconnected()` and call it from both `onError` and `onClose` so error paths match normal close cleanup.
- `WeComChannelAdapter` schedules exponential backoff reconnects (2s start, 60s cap) when the WS drops; `stop()` cancels pending reconnect tasks.
- Add `WeComWsClientTest` and `WeComChannelAdapterLifecycleTest`.

## Test plan

- [x] `mvn -pl oryxos-channel-wecom -am test -Dtest=WeComWsClientTest,WeComChannelAdapterLifecycleTest,WeComMessageSenderTest,WeComEventNormalizerTest`