### PR TITLE
fix(config): align default http.allowed_domains for IM vendor notify/inbound

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -88,8 +88,10 @@ shell:
 http:
   allowed_domains:
     - api.deepseek.com          # Provider 端点（精确匹配）
-    - "*.feishu.cn"             # 飞书 webhook（通配真子域）
-    - openws.work.weixin.qq.com # 企微智能机器人长连接
+    - "*.feishu.cn"             # 飞书 webhook + SDK（open.feishu.cn）
+    - openws.work.weixin.qq.com # 企微智能机器人长连接入站
+    - qyapi.weixin.qq.com       # 企微群机器人 webhook 通知
+    - oapi.dingtalk.com         # 钉钉自定义机器人 webhook 通知
     - api.open-meteo.com        # 天气 Agent 免 key 天气源（31 节 Demo 一）
     - hn.algolia.com            # 科技日报 Agent 新闻源（31 节 Demo 二）
     - api.github.com            # GitHub 日报脚本子进程网络（31 节 Demo 三）

--- a/oryxos-boot/src/main/resources/application.yml
+++ b/oryxos-boot/src/main/resources/application.yml
@@ -54,8 +54,10 @@ shell:
 http:
   allowed_domains:
     - api.deepseek.com      # Provider 端点（精确匹配）
-    - "*.feishu.cn"         # 飞书 webhook（通配真子域）
-    - openws.work.weixin.qq.com # 企微智能机器人长连接
+    - "*.feishu.cn"         # 飞书 webhook + SDK（open.feishu.cn）
+    - openws.work.weixin.qq.com # 企微智能机器人长连接入站
+    - qyapi.weixin.qq.com   # 企微群机器人 webhook 通知
+    - oapi.dingtalk.com     # 钉钉自定义机器人 webhook 通知
     - api.open-meteo.com    # 天气 Agent（免 key 天气源，31 节 Demo 一）
     - hn.algolia.com        # 科技日报 Agent 新闻源（免 key JSON，31 节 Demo 二）
     - api.github.com        # GitHub 日报脚本走子进程网络；列此便于审计与将来收口（31 节 Demo 三 §信任边界）


### PR DESCRIPTION
Closes #320

## Summary

- Add `qyapi.weixin.qq.com` (WeCom group robot notify) and `oapi.dingtalk.com` (DingTalk custom robot notify) to jar default and `config/application.yml.example`
- Keep `openws.work.weixin.qq.com` (WeCom WS inbound) and `*.feishu.cn` alongside them so all three IM vendor write paths work out of the box

## Changes

| File | What |
|------|------|
| `oryxos-boot/src/main/resources/application.yml` | +2 vendor notify domains |
| `config/application.yml.example` | same alignment |

## Test plan

- [x] Config-only change; no Java logic touched
- [ ] CI green