### PR TITLE
fix(channel-wecom): 群聊回复引用原消息 replyToMessageId (B4)

### DIFF
--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
@@ -139,7 +139,7 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
     if (active == null) {
       throw new IllegalStateException("渠道 " + config.name() + " 未启动，无法发送回复");
     }
-    active.send(chatId, text);
+    active.send(chatId, text, replyToMessageId);
   }
 
   private void handleFrame(JsonNode root) {

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComMessageSender.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComMessageSender.java
@@ -13,7 +13,8 @@ import java.util.function.Consumer;
 /**
  * 企微回复发送器：优先 {@code aibot_send_msg}（markdown）主动推送；出站前过 {@link OutboundGuard}。
  *
- * <p>智能机器人长连接要求会话内曾有用户消息后才能主动推送——入站编排路径天然满足。
+ * <p>智能机器人长连接要求会话内曾有用户消息后才能主动推送——入站编排路径天然满足。群聊 B4：{@code replyToMessageId} 非空时在 body 附带 {@code
+ * quote.msgid}，使回复与用户提问可对应。
  */
 public class WeComMessageSender {
 
@@ -42,6 +43,11 @@ public class WeComMessageSender {
   }
 
   public void send(String chatId, String text) {
+    send(chatId, text, null);
+  }
+
+  /** 发送 markdown 回复；群聊 {@code replyToMessageId} 非空时附带 {@code quote.msgid}（契约 B4）。 */
+  public void send(String chatId, String text, String replyToMessageId) {
     guard.check(outboundUrl);
     int chatType = chatTypes.getOrDefault(chatId, 0);
     for (String chunk : segment(text == null ? "" : text, chunkSize)) {
@@ -53,6 +59,9 @@ public class WeComMessageSender {
       body.put("chatid", chatId);
       if (chatType > 0) {
         body.put("chat_type", chatType);
+      }
+      if (replyToMessageId != null && !replyToMessageId.isBlank()) {
+        body.putObject("quote").put("msgid", replyToMessageId);
       }
       body.put("msgtype", "markdown");
       body.set("markdown", markdown);

--- a/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComMessageSenderTest.java
+++ b/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComMessageSenderTest.java
@@ -34,6 +34,33 @@ class WeComMessageSenderTest {
   }
 
   @Test
+  @DisplayName("群聊回复带 quote.msgid 引用原消息")
+  void sendWithReplyToMessageIdIncludesQuote() {
+    List<ObjectNode> frames = new ArrayList<>();
+    WeComMessageSender sender =
+        new WeComMessageSender(frames::add, url -> {}, WeComChannelAdapter.OUTBOUND_URL, 100);
+    sender.rememberChatType("g1", 2);
+    sender.send("g1", "答", "msg-42");
+
+    assertEquals(1, frames.size());
+    var body = frames.get(0).path("body");
+    assertEquals("msg-42", body.path("quote").path("msgid").asText());
+    assertEquals(2, body.path("chat_type").asInt());
+  }
+
+  @Test
+  @DisplayName("私聊回复不带 quote")
+  void sendWithoutReplyToMessageIdOmitsQuote() {
+    List<ObjectNode> frames = new ArrayList<>();
+    WeComMessageSender sender =
+        new WeComMessageSender(frames::add, url -> {}, WeComChannelAdapter.OUTBOUND_URL, 100);
+    sender.send("u1", "答", null);
+
+    assertEquals(1, frames.size());
+    assertTrue(frames.get(0).path("body").path("quote").isMissingNode());
+  }
+
+  @Test
   @DisplayName("超长文本分段")
   void segmentsLongText() {
     List<ObjectNode> frames = new ArrayList<>();


### PR DESCRIPTION
Closes #322

## 变更

- `WeComChannelAdapter.sendReply` 将 `replyToMessageId` 传给 sender
- `WeComMessageSender` 在 `replyToMessageId` 非空时，`aibot_send_msg` body 附带 `quote.msgid`
- 私聊 `replyToMessageId == null` 行为不变
- 补充 `WeComMessageSenderTest` 引用/非引用用例

## 测试

- [x] `mvn -pl oryxos-channel-wecom -am test -Dtest=WeComMessageSenderTest,WeComChannelContractTest,WeComEventNormalizerTest`
- [x] SpotBugs 通过