### PR TITLE
feat(channel-dingtalk): 模块骨架 + EventNormalizer + 契约测试 (1/3)

### DIFF
--- a/oryxos-channel-dingtalk/pom.xml
+++ b/oryxos-channel-dingtalk/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.oryxos</groupId>
+        <artifactId>oryxos</artifactId>
+        <version>0.1.3-RELEASE</version>
+    </parent>
+
+    <artifactId>oryxos-channel-dingtalk</artifactId>
+    <name>OryxOS Channel DingTalk</name>
+    <description>DingTalk bot inbound IM channel: Stream mode long connection and reply</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/ChannelDingtalkModule.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/ChannelDingtalkModule.java
@@ -1,0 +1,7 @@
+package io.oryxos.channel.dingtalk;
+
+/** Marker for the DingTalk inbound channel module (not Spring-scanned; wired in OryxOsRuntime). */
+public final class ChannelDingtalkModule {
+
+  private ChannelDingtalkModule() {}
+}

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizer.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizer.java
@@ -22,6 +22,7 @@ public class DingTalkEventNormalizer {
   private static final String CONVERSATION_SINGLE = "1";
   private static final String CONVERSATION_GROUP = "2";
   private static final String MSG_TEXT = "text";
+  private static final String FIELD_IN_AT_LIST = "isInAtList";
   private static final Pattern LEADING_AT = Pattern.compile("^@\\S+\\s*");
 
   private final String channelName;
@@ -52,7 +53,7 @@ public class DingTalkEventNormalizer {
       LOG.warn("钉钉未知 conversationType={}，已丢弃", sanitize(conversationType));
       return Optional.empty();
     }
-    if (group && !body.path("isInAtList").asBoolean(false)) {
+    if (group && !body.path(FIELD_IN_AT_LIST).asBoolean(false)) {
       LOG.debug("钉钉群消息未 @ 机器人，已丢弃");
       return Optional.empty();
     }

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizer.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizer.java
@@ -1,0 +1,94 @@
+package io.oryxos.channel.dingtalk;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 钉钉 Stream 机器人回调 {@code /v1.0/im/bot/messages/get} data → 归一化 {@link InboundMessage}。
+ *
+ * <p>群聊：平台只推送 @ 机器人的消息，{@code isInAtList=true}；正文前导 {@code @xxx} 占位剥离。 单聊：{@code
+ * conversationType=1}，回复目标为 {@code conversationId}。
+ */
+public class DingTalkEventNormalizer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DingTalkEventNormalizer.class);
+
+  static final String CHANNEL_TYPE = "dingtalk";
+  private static final String CONVERSATION_SINGLE = "1";
+  private static final String CONVERSATION_GROUP = "2";
+  private static final String MSG_TEXT = "text";
+  private static final Pattern LEADING_AT = Pattern.compile("^@\\S+\\s*");
+
+  private final String channelName;
+
+  public DingTalkEventNormalizer(String channelName) {
+    this.channelName = channelName;
+  }
+
+  /** 归一化一条机器人消息回调 data；结构不完整返回 empty。 */
+  public Optional<InboundMessage> normalize(JsonNode body) {
+    if (body == null || !body.isObject()) {
+      return Optional.empty();
+    }
+    String msgId = text(body, "msgId");
+    String conversationType = text(body, "conversationType");
+    String conversationId = text(body, "conversationId");
+    String senderId = text(body, "senderId");
+    if (senderId == null || senderId.isBlank()) {
+      senderId = text(body, "senderStaffId");
+    }
+    if (msgId == null || conversationType == null || conversationId == null || senderId == null) {
+      LOG.warn("钉钉消息缺关键字段（msgId/conversationType/conversationId/senderId），已丢弃");
+      return Optional.empty();
+    }
+    boolean single = CONVERSATION_SINGLE.equals(conversationType);
+    boolean group = CONVERSATION_GROUP.equals(conversationType);
+    if (!single && !group) {
+      LOG.warn("钉钉未知 conversationType={}，已丢弃", sanitize(conversationType));
+      return Optional.empty();
+    }
+    if (group && !body.path("isInAtList").asBoolean(false)) {
+      LOG.debug("钉钉群消息未 @ 机器人，已丢弃");
+      return Optional.empty();
+    }
+    String msgtype = text(body, "msgtype");
+    boolean textual = MSG_TEXT.equals(msgtype);
+    String content = "";
+    if (textual) {
+      content = body.path("text").path("content").asText("");
+      if (group) {
+        content = LEADING_AT.matcher(content).replaceFirst("");
+      }
+      content = content.strip();
+    }
+    return Optional.of(
+        new InboundMessage(
+            CHANNEL_TYPE,
+            channelName,
+            msgId,
+            single ? ChatKind.P2P : ChatKind.GROUP,
+            senderId,
+            conversationId,
+            content,
+            textual,
+            group));
+  }
+
+  private static String text(JsonNode node, String field) {
+    JsonNode v = node.get(field);
+    if (v == null || v.isNull()) {
+      return null;
+    }
+    String s = v.asText();
+    return s == null || s.isBlank() ? null : s;
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkChannelContractTest.java
+++ b/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkChannelContractTest.java
@@ -1,0 +1,54 @@
+package io.oryxos.channel.dingtalk;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageServiceContractTestBase;
+
+/** 契约测试集·钉钉档：经 {@link DingTalkEventNormalizer} 产出归一化消息，复用 B1~B10。 */
+class DingTalkChannelContractTest extends InboundMessageServiceContractTestBase {
+
+  private final DingTalkEventNormalizer normalizer = new DingTalkEventNormalizer("contract-chan");
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Override
+  protected String channelType() {
+    return "dingtalk";
+  }
+
+  @Override
+  protected InboundMessage p2pMessage(String messageId, String content) {
+    return normalizer.normalize(body(messageId, "1", "text", content, false)).orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage groupMessage(String messageId, String content) {
+    return normalizer
+        .normalize(body(messageId, "2", "text", "@Bot " + content, true))
+        .orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage nonTextualMessage(String messageId) {
+    return normalizer.normalize(body(messageId, "1", "picture", null, false)).orElseThrow();
+  }
+
+  private ObjectNode body(
+      String msgId, String conversationType, String msgtype, String text, boolean inAtList) {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgId", msgId);
+    body.put("conversationType", conversationType);
+    body.put("conversationId", "1".equals(conversationType) ? "conv-p2p-" + msgId : "conv-grp");
+    body.put("senderId", "user-1");
+    body.put("msgtype", msgtype);
+    if ("2".equals(conversationType)) {
+      body.put("isInAtList", inAtList);
+    }
+    if ("text".equals(msgtype) && text != null) {
+      body.putObject("text").put("content", text);
+    } else if ("picture".equals(msgtype)) {
+      body.putObject("content").put("picURL", "https://example/img");
+    }
+    return body;
+  }
+}

--- a/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizerTest.java
+++ b/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizerTest.java
@@ -1,0 +1,98 @@
+package io.oryxos.channel.dingtalk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DingTalkEventNormalizerTest {
+
+  private final DingTalkEventNormalizer normalizer = new DingTalkEventNormalizer("ops-dingtalk");
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  @DisplayName("单聊文本 → P2P，chatId=conversationId")
+  void singleText() {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgId", "m1");
+    body.put("conversationType", "1");
+    body.put("conversationId", "conv-p2p");
+    body.put("senderId", "u1");
+    body.put("msgtype", "text");
+    body.putObject("text").put("content", "hello");
+
+    InboundMessage msg = normalizer.normalize(body).orElseThrow();
+    assertEquals(ChatKind.P2P, msg.chatKind());
+    assertEquals("conv-p2p", msg.chatId());
+    assertEquals("u1", msg.userId());
+    assertEquals("hello", msg.content());
+    assertTrue(msg.textual());
+    assertFalse(msg.mentionedBot());
+  }
+
+  @Test
+  @DisplayName("群聊文本剥离前导 @，mentionedBot=true")
+  void groupTextStripsAt() {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgId", "m2");
+    body.put("conversationType", "2");
+    body.put("conversationId", "conv-grp");
+    body.put("senderId", "u1");
+    body.put("isInAtList", true);
+    body.put("msgtype", "text");
+    body.putObject("text").put("content", "@RobotA 今天天气");
+
+    InboundMessage msg = normalizer.normalize(body).orElseThrow();
+    assertEquals(ChatKind.GROUP, msg.chatKind());
+    assertEquals("conv-grp", msg.chatId());
+    assertEquals("今天天气", msg.content());
+    assertTrue(msg.mentionedBot());
+  }
+
+  @Test
+  @DisplayName("群聊未 @ 机器人 → empty")
+  void groupWithoutAtDiscarded() {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgId", "m2b");
+    body.put("conversationType", "2");
+    body.put("conversationId", "conv-grp");
+    body.put("senderId", "u1");
+    body.put("isInAtList", false);
+    body.put("msgtype", "text");
+    body.putObject("text").put("content", "旁聊");
+
+    assertTrue(normalizer.normalize(body).isEmpty());
+  }
+
+  @Test
+  @DisplayName("非文本仍构造消息但 textual=false")
+  void nonText() {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgId", "m3");
+    body.put("conversationType", "1");
+    body.put("conversationId", "conv-p2p");
+    body.put("senderId", "u1");
+    body.put("msgtype", "picture");
+    body.putObject("content").put("picURL", "https://x");
+
+    InboundMessage msg = normalizer.normalize(body).orElseThrow();
+    assertFalse(msg.textual());
+    assertEquals("", msg.content());
+  }
+
+  @Test
+  @DisplayName("缺字段 → empty")
+  void missingFields() {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgId", "m4");
+    Optional<InboundMessage> msg = normalizer.normalize(body);
+    assertTrue(msg.isEmpty());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <module>oryxos-channel-cli</module>
         <module>oryxos-channel-feishu</module>
         <module>oryxos-channel-wecom</module>
+        <module>oryxos-channel-dingtalk</module>
         <module>oryxos-web</module>
         <module>oryxos-storage</module>
         <module>oryxos-cli</module>
@@ -123,6 +124,11 @@
             <dependency>
                 <groupId>io.oryxos</groupId>
                 <artifactId>oryxos-channel-wecom</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.oryxos</groupId>
+                <artifactId>oryxos-channel-dingtalk</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Part of #324（PR 1/3）

## 变更

- 新增 `oryxos-channel-dingtalk` 模块（根 `pom.xml` 注册）
- `DingTalkEventNormalizer`：Stream 机器人回调 data → `InboundMessage`
  - `conversationType` 1/2 → 私聊/群聊
  - 群聊要求 `isInAtList=true`，剥离前导 `@`
- `DingTalkChannelContractTest`：B1–B10 契约测试钉钉档
- `DingTalkEventNormalizerTest`：单测

## 未包含（后续 PR）

- Stream WebSocket 连接 + `DingTalkChannelAdapter` 生命周期
- `OryxOsRuntime` 装配、example、文档、白名单

## 测试

- [x] `mvn -pl oryxos-channel-dingtalk -am test -Dtest=DingTalkEventNormalizerTest,DingTalkChannelContractTest`
- [x] SpotBugs 通过