### PR TITLE
feat(channel-dingtalk): Stream 连接 + Adapter 生命周期 + sessionWebhook 回复 (2/3)

### DIFF
--- a/oryxos-channel-dingtalk/pom.xml
+++ b/oryxos-channel-dingtalk/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.oryxos</groupId>
+        <artifactId>oryxos</artifactId>
+        <version>0.1.3-RELEASE</version>
+    </parent>
+
+    <artifactId>oryxos-channel-dingtalk</artifactId>
+    <name>OryxOS Channel DingTalk</name>
+    <description>DingTalk bot inbound IM channel: Stream mode long connection and reply</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/ChannelDingtalkModule.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/ChannelDingtalkModule.java
@@ -1,0 +1,7 @@
+package io.oryxos.channel.dingtalk;
+
+/** Marker for the DingTalk inbound channel module (not Spring-scanned; wired in OryxOsRuntime). */
+public final class ChannelDingtalkModule {
+
+  private ChannelDingtalkModule() {}
+}

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkChannelAdapter.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkChannelAdapter.java
@@ -1,0 +1,158 @@
+package io.oryxos.channel.dingtalk;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.channel.ChannelConfig;
+import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.InboundChannelAdapter;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageService;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 钉钉机器人入站适配器：一实例 = 一个应用的一条 Stream 长连接（对称飞书/企微）。
+ *
+ * <p>凭证映射：{@code app_id} = ClientId，{@code app_secret} = ClientSecret。
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
+    justification = "stream/normalizer/sender 在 start() 内初始化；sendReply 有显式空判。")
+public class DingTalkChannelAdapter implements InboundChannelAdapter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DingTalkChannelAdapter.class);
+
+  public static final String TYPE = "dingtalk";
+
+  private static final Duration START_TIMEOUT = Duration.ofSeconds(20);
+
+  private final ChannelConfig config;
+  private final ProfileRegistry profileRegistry;
+  private final InboundMessageService inboundMessageService;
+  private final OutboundGuard guard;
+
+  private final AtomicReference<DingTalkStreamClient> streamRef = new AtomicReference<>();
+  private volatile DingTalkMessageSender sender;
+  private volatile DingTalkEventNormalizer normalizer;
+  private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
+  private volatile String lastError;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "协作者均为 Runtime 装配的单例，共享引用正是意图")
+  public DingTalkChannelAdapter(
+      ChannelConfig config,
+      ProfileRegistry profileRegistry,
+      InboundMessageService inboundMessageService,
+      OutboundGuard guard) {
+    this.config = config;
+    this.profileRegistry = profileRegistry;
+    this.inboundMessageService = inboundMessageService;
+    this.guard = guard;
+  }
+
+  @Override
+  public String name() {
+    return config.name();
+  }
+
+  @Override
+  public String type() {
+    return TYPE;
+  }
+
+  @Override
+  public String boundAgent() {
+    return config.agent();
+  }
+
+  @Override
+  public synchronized void start() {
+    config.validateCredentialsResolved();
+    if (profileRegistry.get(config.agent()).isEmpty()) {
+      throw new IllegalArgumentException(
+          "渠道 " + config.name() + " 绑定的 Agent " + config.agent() + " 不存在");
+    }
+    guard.check(DingTalkStreamClient.API_BASE_URL);
+    guard.check(DingTalkMessageSender.SESSION_WEBHOOK_PREFIX);
+    try {
+      normalizer = new DingTalkEventNormalizer(config.name());
+      sender = new DingTalkMessageSender(guard, DingTalkMessageSender.DEFAULT_CHUNK_SIZE);
+      DingTalkStreamClient client =
+          new DingTalkStreamClient(
+              config.appId(),
+              config.appSecret(),
+              guard,
+              this::handleBotMessage,
+              () -> {
+                if (state != ChannelStatus.State.ERROR) {
+                  state = ChannelStatus.State.DISCONNECTED;
+                }
+              });
+      client.connect(START_TIMEOUT);
+      streamRef.set(client);
+      state = ChannelStatus.State.CONNECTED;
+      lastError = null;
+      LOG.info("钉钉渠道 {} Stream 已建立（Agent: {}）", sanitize(config.name()), sanitize(config.agent()));
+    } catch (Exception e) {
+      state = ChannelStatus.State.ERROR;
+      lastError = "Stream 连接失败: " + sanitize(e.getMessage());
+      throw new IllegalStateException("渠道 " + config.name() + " " + lastError, e);
+    }
+  }
+
+  @Override
+  public synchronized void stop() {
+    DingTalkStreamClient stream = streamRef.getAndSet(null);
+    if (stream != null) {
+      stream.closeQuietly();
+    }
+    state = ChannelStatus.State.DISCONNECTED;
+  }
+
+  @Override
+  public ChannelStatus status() {
+    if (state == ChannelStatus.State.ERROR) {
+      return ChannelStatus.error(config.name(), TYPE, config.agent(), lastError);
+    }
+    DingTalkStreamClient stream = streamRef.get();
+    if (stream == null || !stream.isConnected()) {
+      return ChannelStatus.ok(
+          config.name(), TYPE, config.agent(), ChannelStatus.State.DISCONNECTED);
+    }
+    return ChannelStatus.ok(config.name(), TYPE, config.agent(), ChannelStatus.State.CONNECTED);
+  }
+
+  @Override
+  public void sendReply(String chatId, String text, String replyToMessageId) {
+    DingTalkMessageSender active = sender;
+    if (active == null) {
+      throw new IllegalStateException("渠道 " + config.name() + " 未启动，无法发送回复");
+    }
+    active.send(chatId, text, replyToMessageId);
+  }
+
+  private void handleBotMessage(JsonNode body) {
+    try {
+      String conversationId = body.path("conversationId").asText(null);
+      String sessionWebhook = body.path("sessionWebhook").asText(null);
+      String atUserId = body.path("senderStaffId").asText(null);
+      if (atUserId == null || atUserId.isBlank()) {
+        atUserId = body.path("senderId").asText(null);
+      }
+      sender.rememberSession(conversationId, sessionWebhook, atUserId);
+      Optional<InboundMessage> msg = normalizer.normalize(body);
+      msg.ifPresent(m -> inboundMessageService.onMessage(m, this));
+    } catch (RuntimeException e) {
+      LOG.error("钉钉渠道 {} 事件处理异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
+    }
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizer.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizer.java
@@ -22,6 +22,7 @@ public class DingTalkEventNormalizer {
   private static final String CONVERSATION_SINGLE = "1";
   private static final String CONVERSATION_GROUP = "2";
   private static final String MSG_TEXT = "text";
+  private static final String FIELD_IN_AT_LIST = "isInAtList";
   private static final Pattern LEADING_AT = Pattern.compile("^@\\S+\\s*");
 
   private final String channelName;
@@ -52,7 +53,7 @@ public class DingTalkEventNormalizer {
       LOG.warn("钉钉未知 conversationType={}，已丢弃", sanitize(conversationType));
       return Optional.empty();
     }
-    if (group && !body.path("isInAtList").asBoolean(false)) {
+    if (group && !body.path(FIELD_IN_AT_LIST).asBoolean(false)) {
       LOG.debug("钉钉群消息未 @ 机器人，已丢弃");
       return Optional.empty();
     }

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizer.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizer.java
@@ -1,0 +1,94 @@
+package io.oryxos.channel.dingtalk;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 钉钉 Stream 机器人回调 {@code /v1.0/im/bot/messages/get} data → 归一化 {@link InboundMessage}。
+ *
+ * <p>群聊：平台只推送 @ 机器人的消息，{@code isInAtList=true}；正文前导 {@code @xxx} 占位剥离。 单聊：{@code
+ * conversationType=1}，回复目标为 {@code conversationId}。
+ */
+public class DingTalkEventNormalizer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DingTalkEventNormalizer.class);
+
+  static final String CHANNEL_TYPE = "dingtalk";
+  private static final String CONVERSATION_SINGLE = "1";
+  private static final String CONVERSATION_GROUP = "2";
+  private static final String MSG_TEXT = "text";
+  private static final Pattern LEADING_AT = Pattern.compile("^@\\S+\\s*");
+
+  private final String channelName;
+
+  public DingTalkEventNormalizer(String channelName) {
+    this.channelName = channelName;
+  }
+
+  /** 归一化一条机器人消息回调 data；结构不完整返回 empty。 */
+  public Optional<InboundMessage> normalize(JsonNode body) {
+    if (body == null || !body.isObject()) {
+      return Optional.empty();
+    }
+    String msgId = text(body, "msgId");
+    String conversationType = text(body, "conversationType");
+    String conversationId = text(body, "conversationId");
+    String senderId = text(body, "senderId");
+    if (senderId == null || senderId.isBlank()) {
+      senderId = text(body, "senderStaffId");
+    }
+    if (msgId == null || conversationType == null || conversationId == null || senderId == null) {
+      LOG.warn("钉钉消息缺关键字段（msgId/conversationType/conversationId/senderId），已丢弃");
+      return Optional.empty();
+    }
+    boolean single = CONVERSATION_SINGLE.equals(conversationType);
+    boolean group = CONVERSATION_GROUP.equals(conversationType);
+    if (!single && !group) {
+      LOG.warn("钉钉未知 conversationType={}，已丢弃", sanitize(conversationType));
+      return Optional.empty();
+    }
+    if (group && !body.path("isInAtList").asBoolean(false)) {
+      LOG.debug("钉钉群消息未 @ 机器人，已丢弃");
+      return Optional.empty();
+    }
+    String msgtype = text(body, "msgtype");
+    boolean textual = MSG_TEXT.equals(msgtype);
+    String content = "";
+    if (textual) {
+      content = body.path("text").path("content").asText("");
+      if (group) {
+        content = LEADING_AT.matcher(content).replaceFirst("");
+      }
+      content = content.strip();
+    }
+    return Optional.of(
+        new InboundMessage(
+            CHANNEL_TYPE,
+            channelName,
+            msgId,
+            single ? ChatKind.P2P : ChatKind.GROUP,
+            senderId,
+            conversationId,
+            content,
+            textual,
+            group));
+  }
+
+  private static String text(JsonNode node, String field) {
+    JsonNode v = node.get(field);
+    if (v == null || v.isNull()) {
+      return null;
+    }
+    String s = v.asText();
+    return s == null || s.isBlank() ? null : s;
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkMessageSender.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkMessageSender.java
@@ -23,6 +23,8 @@ public class DingTalkMessageSender {
 
   static final int DEFAULT_CHUNK_SIZE = 3500;
   static final String SESSION_WEBHOOK_PREFIX = "https://oapi.dingtalk.com";
+  private static final int HTTP_STATUS_OK_MIN = 200;
+  private static final int HTTP_STATUS_OK_MAX_EXCLUSIVE = 300;
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -91,7 +93,8 @@ public class DingTalkMessageSender {
               .build();
       HttpResponse<String> response =
           httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-      if (response.statusCode() < 200 || response.statusCode() >= 300) {
+      if (response.statusCode() < HTTP_STATUS_OK_MIN
+          || response.statusCode() >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
         throw new IllegalStateException(
             "钉钉 sessionWebhook 回复失败 HTTP " + response.statusCode() + ": " + response.body());
       }

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkMessageSender.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkMessageSender.java
@@ -1,0 +1,115 @@
+package io.oryxos.channel.dingtalk;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.OutboundGuard;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 钉钉机器人回复：经入站消息携带的 {@code sessionWebhook} POST 文本；出站前过 {@link OutboundGuard}。
+ *
+ * <p>群聊 B4：{@code replyToMessageId} 非空时附带 {@code at.atUserIds} 引用提问者（会话内可对应）。
+ */
+public class DingTalkMessageSender {
+
+  static final int DEFAULT_CHUNK_SIZE = 3500;
+  static final String SESSION_WEBHOOK_PREFIX = "https://oapi.dingtalk.com";
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final HttpClient httpClient;
+  private final OutboundGuard guard;
+  private final int chunkSize;
+  private final Map<String, String> sessionWebhooks = new ConcurrentHashMap<>();
+  private final Map<String, String> groupAtUserIds = new ConcurrentHashMap<>();
+
+  public DingTalkMessageSender(OutboundGuard guard, int chunkSize) {
+    this(HttpClient.newBuilder().connectTimeout(REQUEST_TIMEOUT).build(), guard, chunkSize);
+  }
+
+  DingTalkMessageSender(HttpClient httpClient, OutboundGuard guard, int chunkSize) {
+    this.httpClient = httpClient;
+    this.guard = guard;
+    this.chunkSize = chunkSize <= 0 ? DEFAULT_CHUNK_SIZE : chunkSize;
+  }
+
+  /** 记录会话 webhook 与群聊 @ 目标（senderStaffId 优先）。 */
+  public void rememberSession(String conversationId, String sessionWebhook, String atUserId) {
+    if (conversationId != null && !conversationId.isBlank()) {
+      if (sessionWebhook != null && !sessionWebhook.isBlank()) {
+        sessionWebhooks.put(conversationId, sessionWebhook);
+      }
+      if (atUserId != null && !atUserId.isBlank()) {
+        groupAtUserIds.put(conversationId, atUserId);
+      }
+    }
+  }
+
+  public void send(String conversationId, String text, String replyToMessageId) {
+    String webhook = sessionWebhooks.get(conversationId);
+    if (webhook == null || webhook.isBlank()) {
+      throw new IllegalStateException("钉钉会话 " + conversationId + " 无 sessionWebhook，无法回复");
+    }
+    guard.check(webhook);
+    String atUserId =
+        replyToMessageId != null && !replyToMessageId.isBlank()
+            ? groupAtUserIds.get(conversationId)
+            : null;
+    for (String chunk : segment(text == null ? "" : text, chunkSize)) {
+      postText(webhook, chunk, atUserId);
+    }
+  }
+
+  private void postText(String webhook, String content, String atUserId) {
+    try {
+      ObjectNode body = MAPPER.createObjectNode();
+      body.put("msgtype", "text");
+      body.putObject("text").put("content", content);
+      if (atUserId != null && !atUserId.isBlank()) {
+        ObjectNode at = body.putObject("at");
+        ArrayNode ids = MAPPER.createArrayNode();
+        ids.add(atUserId);
+        at.set("atUserIds", ids);
+        at.put("isAtAll", false);
+      }
+      String payload = MAPPER.writeValueAsString(body);
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(webhook))
+              .timeout(REQUEST_TIMEOUT)
+              .header("Content-Type", "application/json")
+              .POST(HttpRequest.BodyPublishers.ofString(payload))
+              .build();
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() < 200 || response.statusCode() >= 300) {
+        throw new IllegalStateException(
+            "钉钉 sessionWebhook 回复失败 HTTP " + response.statusCode() + ": " + response.body());
+      }
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("钉钉 sessionWebhook 回复失败: " + e.getMessage(), e);
+    }
+  }
+
+  static List<String> segment(String text, int chunkSize) {
+    if (text.isEmpty()) {
+      return List.of("");
+    }
+    List<String> parts = new ArrayList<>();
+    for (int i = 0; i < text.length(); i += chunkSize) {
+      parts.add(text.substring(i, Math.min(text.length(), i + chunkSize)));
+    }
+    return parts;
+  }
+}

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkStreamClient.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkStreamClient.java
@@ -38,6 +38,8 @@ final class DingTalkStreamClient implements WebSocket.Listener {
   private static final String TOPIC_PING = "ping";
   private static final String TOPIC_DISCONNECT = "disconnect";
   private static final String ACK_BOT_DATA = "{\"response\": null}";
+  private static final int HTTP_STATUS_OK_MIN = 200;
+  private static final int HTTP_STATUS_OK_MAX_EXCLUSIVE = 300;
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private final String clientId;
@@ -248,7 +250,8 @@ final class DingTalkStreamClient implements WebSocket.Listener {
             .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body)))
             .build();
     HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-    if (response.statusCode() < 200 || response.statusCode() >= 300) {
+    if (response.statusCode() < HTTP_STATUS_OK_MIN
+        || response.statusCode() >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
       throw new IllegalStateException(
           "钉钉 Stream 注册失败 HTTP " + response.statusCode() + ": " + response.body());
     }

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkStreamClient.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkStreamClient.java
@@ -1,0 +1,285 @@
+package io.oryxos.channel.dingtalk;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.OutboundGuard;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** 钉钉 Stream WebSocket：注册 ticket、收帧、ACK、机器人消息回调。 */
+final class DingTalkStreamClient implements WebSocket.Listener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DingTalkStreamClient.class);
+
+  static final String TOPIC_BOT_MESSAGE = "/v1.0/im/bot/messages/get";
+  static final String OPEN_CONNECTION_PATH = "/v1.0/gateway/connections/open";
+  static final String API_BASE_URL = "https://api.dingtalk.com";
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(20);
+  private static final String TYPE_CALLBACK = "CALLBACK";
+  private static final String TYPE_SYSTEM = "SYSTEM";
+  private static final String TOPIC_PING = "ping";
+  private static final String TOPIC_DISCONNECT = "disconnect";
+  private static final String ACK_BOT_DATA = "{\"response\": null}";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final String clientId;
+  private final String clientSecret;
+  private final OutboundGuard guard;
+  private final Consumer<JsonNode> onBotMessage;
+  private final Runnable onDisconnected;
+
+  private final AtomicReference<WebSocket> socket = new AtomicReference<>();
+  private final AtomicBoolean connected = new AtomicBoolean(false);
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final StringBuilder textBuf = new StringBuilder();
+  private final CountDownLatch openLatch = new CountDownLatch(1);
+  private volatile String openError;
+
+  DingTalkStreamClient(
+      String clientId,
+      String clientSecret,
+      OutboundGuard guard,
+      Consumer<JsonNode> onBotMessage,
+      Runnable onDisconnected) {
+    this.clientId = Objects.requireNonNull(clientId);
+    this.clientSecret = Objects.requireNonNull(clientSecret);
+    this.guard = Objects.requireNonNull(guard);
+    this.onBotMessage = Objects.requireNonNull(onBotMessage);
+    this.onDisconnected = onDisconnected == null ? () -> {} : onDisconnected;
+  }
+
+  void connect(Duration timeout) throws Exception {
+    closed.set(false);
+    guard.check(API_BASE_URL);
+    URI wsUri = openWebSocketUri();
+    HttpClient client = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    CompletableFuture<WebSocket> future =
+        client.newWebSocketBuilder().connectTimeout(CONNECT_TIMEOUT).buildAsync(wsUri, this);
+    WebSocket ws = future.get(timeout.toSeconds(), TimeUnit.SECONDS);
+    socket.set(ws);
+    if (!openLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+      closeQuietly();
+      throw new IllegalStateException("钉钉 Stream 连接超时（WebSocket 未就绪）");
+    }
+    if (openError != null) {
+      closeQuietly();
+      throw new IllegalStateException("钉钉 Stream 连接失败: " + openError);
+    }
+    if (!connected.get()) {
+      closeQuietly();
+      throw new IllegalStateException("钉钉 Stream 连接失败（未知原因）");
+    }
+  }
+
+  boolean isConnected() {
+    return connected.get() && !closed.get();
+  }
+
+  void closeQuietly() {
+    closed.set(true);
+    connected.set(false);
+    openLatch.countDown();
+    WebSocket ws = socket.getAndSet(null);
+    if (ws != null) {
+      try {
+        ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").join();
+      } catch (RuntimeException ignored) {
+        // ignore
+      }
+    }
+  }
+
+  @Override
+  public void onOpen(WebSocket webSocket) {
+    connected.set(true);
+    openLatch.countDown();
+    webSocket.request(1);
+  }
+
+  @Override
+  public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+    textBuf.append(data);
+    if (last) {
+      String raw = textBuf.toString();
+      textBuf.setLength(0);
+      handleText(webSocket, raw);
+    }
+    webSocket.request(1);
+    return null;
+  }
+
+  @Override
+  public CompletionStage<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
+    webSocket.request(1);
+    return null;
+  }
+
+  @Override
+  public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+    markDisconnected();
+    onDisconnected.run();
+    return null;
+  }
+
+  @Override
+  public void onError(WebSocket webSocket, Throwable error) {
+    LOG.warn("钉钉 Stream 连接错误: {}", sanitize(error == null ? null : error.getMessage()));
+    if (!connected.get()) {
+      openError = error == null ? "unknown" : error.getMessage();
+      openLatch.countDown();
+    }
+    markDisconnected();
+    onDisconnected.run();
+  }
+
+  void dispatchFrameForTest(String raw, WebSocket webSocket) {
+    handleText(webSocket, raw);
+  }
+
+  private void handleText(WebSocket webSocket, String raw) {
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(raw);
+    } catch (JacksonException e) {
+      LOG.warn("钉钉 Stream 帧 JSON 解析失败，已忽略");
+      return;
+    }
+    String type = root.path("type").asText("");
+    JsonNode headers = root.path("headers");
+    String messageId = headers.path("messageId").asText("");
+    String topic = headers.path("topic").asText("");
+    if (TYPE_SYSTEM.equals(type)) {
+      handleSystem(webSocket, topic, messageId, root.path("data").asText(""));
+      return;
+    }
+    if (TYPE_CALLBACK.equals(type) && TOPIC_BOT_MESSAGE.equals(topic)) {
+      handleBotMessage(webSocket, messageId, root.path("data").asText(""));
+    }
+  }
+
+  private void handleSystem(WebSocket webSocket, String topic, String messageId, String dataRaw) {
+    if (TOPIC_PING.equals(topic)) {
+      try {
+        ObjectNode data = MAPPER.createObjectNode();
+        data.put("opaque", extractOpaque(dataRaw));
+        sendAck(webSocket, messageId, MAPPER.writeValueAsString(data));
+      } catch (JacksonException e) {
+        sendAck(webSocket, messageId, "{\"opaque\":\"\"}");
+      }
+      return;
+    }
+    if (TOPIC_DISCONNECT.equals(topic)) {
+      LOG.info("钉钉 Stream 服务端请求断开: {}", sanitize(dataRaw));
+      markDisconnected();
+      onDisconnected.run();
+    }
+  }
+
+  private void handleBotMessage(WebSocket webSocket, String messageId, String dataRaw) {
+    sendAck(webSocket, messageId, ACK_BOT_DATA);
+    if (dataRaw == null || dataRaw.isBlank()) {
+      return;
+    }
+    try {
+      JsonNode data = MAPPER.readTree(dataRaw);
+      onBotMessage.accept(data);
+    } catch (JacksonException e) {
+      LOG.warn("钉钉机器人消息 data 解析失败，已忽略");
+    } catch (RuntimeException e) {
+      LOG.error("钉钉机器人消息处理异常: {}", sanitize(e.getMessage()));
+    }
+  }
+
+  private void sendAck(WebSocket webSocket, String messageId, String dataJson) {
+    if (webSocket == null || messageId == null || messageId.isBlank()) {
+      return;
+    }
+    try {
+      ObjectNode headers = MAPPER.createObjectNode();
+      headers.put("messageId", messageId);
+      headers.put("contentType", "application/json");
+      ObjectNode ack = MAPPER.createObjectNode();
+      ack.put("code", 200);
+      ack.put("message", "OK");
+      ack.set("headers", headers);
+      ack.put("data", dataJson);
+      webSocket.sendText(MAPPER.writeValueAsString(ack), true);
+    } catch (Exception e) {
+      LOG.warn("钉钉 Stream ACK 发送失败: {}", sanitize(e.getMessage()));
+    }
+  }
+
+  private URI openWebSocketUri() throws Exception {
+    ObjectNode subscription = MAPPER.createObjectNode();
+    subscription.put("topic", TOPIC_BOT_MESSAGE);
+    subscription.put("type", "CALLBACK");
+    ArrayNode subscriptions = MAPPER.createArrayNode();
+    subscriptions.add(subscription);
+    ObjectNode body = MAPPER.createObjectNode();
+    body.put("clientId", clientId);
+    body.put("clientSecret", clientSecret);
+    body.set("subscriptions", subscriptions);
+    body.put("ua", "oryxos-channel-dingtalk/0.1.3-RELEASE");
+    HttpClient client = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(API_BASE_URL + OPEN_CONNECTION_PATH))
+            .timeout(CONNECT_TIMEOUT)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body)))
+            .build();
+    HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() < 200 || response.statusCode() >= 300) {
+      throw new IllegalStateException(
+          "钉钉 Stream 注册失败 HTTP " + response.statusCode() + ": " + response.body());
+    }
+    JsonNode json = MAPPER.readTree(response.body());
+    String endpoint = json.path("endpoint").asText(null);
+    String ticket = json.path("ticket").asText(null);
+    if (endpoint == null || endpoint.isBlank() || ticket == null || ticket.isBlank()) {
+      throw new IllegalStateException("钉钉 Stream 注册响应缺少 endpoint/ticket");
+    }
+    String separator = endpoint.contains("?") ? "&" : "?";
+    return URI.create(endpoint + separator + "ticket=" + ticket);
+  }
+
+  private void markDisconnected() {
+    closed.set(true);
+    connected.set(false);
+    openLatch.countDown();
+  }
+
+  private static String extractOpaque(String dataRaw) {
+    if (dataRaw == null || dataRaw.isBlank()) {
+      return "";
+    }
+    try {
+      return MAPPER.readTree(dataRaw).path("opaque").asText("");
+    } catch (JacksonException e) {
+      return "";
+    }
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkChannelContractTest.java
+++ b/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkChannelContractTest.java
@@ -1,0 +1,54 @@
+package io.oryxos.channel.dingtalk;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageServiceContractTestBase;
+
+/** 契约测试集·钉钉档：经 {@link DingTalkEventNormalizer} 产出归一化消息，复用 B1~B10。 */
+class DingTalkChannelContractTest extends InboundMessageServiceContractTestBase {
+
+  private final DingTalkEventNormalizer normalizer = new DingTalkEventNormalizer("contract-chan");
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Override
+  protected String channelType() {
+    return "dingtalk";
+  }
+
+  @Override
+  protected InboundMessage p2pMessage(String messageId, String content) {
+    return normalizer.normalize(body(messageId, "1", "text", content, false)).orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage groupMessage(String messageId, String content) {
+    return normalizer
+        .normalize(body(messageId, "2", "text", "@Bot " + content, true))
+        .orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage nonTextualMessage(String messageId) {
+    return normalizer.normalize(body(messageId, "1", "picture", null, false)).orElseThrow();
+  }
+
+  private ObjectNode body(
+      String msgId, String conversationType, String msgtype, String text, boolean inAtList) {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgId", msgId);
+    body.put("conversationType", conversationType);
+    body.put("conversationId", "1".equals(conversationType) ? "conv-p2p-" + msgId : "conv-grp");
+    body.put("senderId", "user-1");
+    body.put("msgtype", msgtype);
+    if ("2".equals(conversationType)) {
+      body.put("isInAtList", inAtList);
+    }
+    if ("text".equals(msgtype) && text != null) {
+      body.putObject("text").put("content", text);
+    } else if ("picture".equals(msgtype)) {
+      body.putObject("content").put("picURL", "https://example/img");
+    }
+    return body;
+  }
+}

--- a/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizerTest.java
+++ b/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizerTest.java
@@ -1,0 +1,98 @@
+package io.oryxos.channel.dingtalk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DingTalkEventNormalizerTest {
+
+  private final DingTalkEventNormalizer normalizer = new DingTalkEventNormalizer("ops-dingtalk");
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  @DisplayName("单聊文本 → P2P，chatId=conversationId")
+  void singleText() {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgId", "m1");
+    body.put("conversationType", "1");
+    body.put("conversationId", "conv-p2p");
+    body.put("senderId", "u1");
+    body.put("msgtype", "text");
+    body.putObject("text").put("content", "hello");
+
+    InboundMessage msg = normalizer.normalize(body).orElseThrow();
+    assertEquals(ChatKind.P2P, msg.chatKind());
+    assertEquals("conv-p2p", msg.chatId());
+    assertEquals("u1", msg.userId());
+    assertEquals("hello", msg.content());
+    assertTrue(msg.textual());
+    assertFalse(msg.mentionedBot());
+  }
+
+  @Test
+  @DisplayName("群聊文本剥离前导 @，mentionedBot=true")
+  void groupTextStripsAt() {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgId", "m2");
+    body.put("conversationType", "2");
+    body.put("conversationId", "conv-grp");
+    body.put("senderId", "u1");
+    body.put("isInAtList", true);
+    body.put("msgtype", "text");
+    body.putObject("text").put("content", "@RobotA 今天天气");
+
+    InboundMessage msg = normalizer.normalize(body).orElseThrow();
+    assertEquals(ChatKind.GROUP, msg.chatKind());
+    assertEquals("conv-grp", msg.chatId());
+    assertEquals("今天天气", msg.content());
+    assertTrue(msg.mentionedBot());
+  }
+
+  @Test
+  @DisplayName("群聊未 @ 机器人 → empty")
+  void groupWithoutAtDiscarded() {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgId", "m2b");
+    body.put("conversationType", "2");
+    body.put("conversationId", "conv-grp");
+    body.put("senderId", "u1");
+    body.put("isInAtList", false);
+    body.put("msgtype", "text");
+    body.putObject("text").put("content", "旁聊");
+
+    assertTrue(normalizer.normalize(body).isEmpty());
+  }
+
+  @Test
+  @DisplayName("非文本仍构造消息但 textual=false")
+  void nonText() {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgId", "m3");
+    body.put("conversationType", "1");
+    body.put("conversationId", "conv-p2p");
+    body.put("senderId", "u1");
+    body.put("msgtype", "picture");
+    body.putObject("content").put("picURL", "https://x");
+
+    InboundMessage msg = normalizer.normalize(body).orElseThrow();
+    assertFalse(msg.textual());
+    assertEquals("", msg.content());
+  }
+
+  @Test
+  @DisplayName("缺字段 → empty")
+  void missingFields() {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgId", "m4");
+    Optional<InboundMessage> msg = normalizer.normalize(body);
+    assertTrue(msg.isEmpty());
+  }
+}

--- a/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkMessageSenderTest.java
+++ b/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkMessageSenderTest.java
@@ -1,0 +1,89 @@
+package io.oryxos.channel.dingtalk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DingTalkMessageSenderTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private HttpServer server;
+  private final List<String> bodies = new ArrayList<>();
+  private final AtomicReference<String> guarded = new AtomicReference<>();
+
+  @BeforeEach
+  void startServer() throws IOException {
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.createContext(
+        "/hook",
+        exchange -> {
+          bodies.add(readBody(exchange));
+          respond(exchange, 200, "{\"errcode\":0}");
+        });
+    server.start();
+  }
+
+  @AfterEach
+  void stopServer() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  @DisplayName("sessionWebhook 发送 text 并过 OutboundGuard")
+  void sendTextViaSessionWebhook() throws Exception {
+    String webhookUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/hook";
+    DingTalkMessageSender sender =
+        new DingTalkMessageSender(
+            target -> guarded.set(target), DingTalkMessageSender.DEFAULT_CHUNK_SIZE);
+    sender.rememberSession("conv-1", webhookUrl, null);
+    sender.send("conv-1", "你好", null);
+
+    assertEquals(webhookUrl, guarded.get());
+    assertEquals(1, bodies.size());
+    JsonNode body = MAPPER.readTree(bodies.get(0));
+    assertEquals("text", body.path("msgtype").asText());
+    assertEquals("你好", body.path("text").path("content").asText());
+    assertTrue(body.path("at").isMissingNode());
+  }
+
+  @Test
+  @DisplayName("群聊 replyToMessageId 非空时附带 atUserIds")
+  void sendWithAtUser() throws Exception {
+    String webhookUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/hook";
+    DingTalkMessageSender sender =
+        new DingTalkMessageSender(target -> {}, DingTalkMessageSender.DEFAULT_CHUNK_SIZE);
+    sender.rememberSession("conv-g", webhookUrl, "staff-9");
+    sender.send("conv-g", "答", "msg-1");
+
+    JsonNode body = MAPPER.readTree(bodies.get(0));
+    assertEquals("staff-9", body.path("at").path("atUserIds").get(0).asText());
+  }
+
+  private static String readBody(HttpExchange exchange) throws IOException {
+    return new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+  }
+
+  private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.sendResponseHeaders(status, bytes.length);
+    exchange.getResponseBody().write(bytes);
+    exchange.close();
+  }
+}

--- a/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkStreamClientTest.java
+++ b/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkStreamClientTest.java
@@ -1,0 +1,85 @@
+package io.oryxos.channel.dingtalk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.http.WebSocket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DingTalkStreamClientTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  @DisplayName("机器人回调帧触发 onBotMessage 并 ACK")
+  void botCallbackDispatchesMessageAndAcks() throws Exception {
+    List<JsonNode> messages = new ArrayList<>();
+    AtomicReference<String> ack = new AtomicReference<>();
+    WebSocket ws = mockWebSocket(ack);
+    DingTalkStreamClient client =
+        new DingTalkStreamClient("id", "secret", url -> {}, messages::add, () -> {});
+    String frame =
+        """
+        {
+          "type": "CALLBACK",
+          "headers": {
+            "topic": "/v1.0/im/bot/messages/get",
+            "messageId": "mid-1"
+          },
+          "data": "{\\"msgId\\":\\"m1\\",\\"conversationType\\":\\"1\\",\\"conversationId\\":\\"c1\\",\\"senderId\\":\\"u1\\",\\"msgtype\\":\\"text\\",\\"text\\":{\\"content\\":\\"hi\\"}}"
+        }
+        """;
+    client.dispatchFrameForTest(frame, ws);
+
+    assertEquals(1, messages.size());
+    assertEquals("m1", messages.get(0).path("msgId").asText());
+    JsonNode ackJson = MAPPER.readTree(ack.get());
+    assertEquals(200, ackJson.path("code").asInt());
+    assertEquals("mid-1", ackJson.path("headers").path("messageId").asText());
+  }
+
+  @Test
+  @DisplayName("ping 帧回 opaque ACK")
+  void pingReturnsOpaqueAck() throws Exception {
+    AtomicReference<String> ack = new AtomicReference<>();
+    WebSocket ws = mockWebSocket(ack);
+    DingTalkStreamClient client =
+        new DingTalkStreamClient("id", "secret", url -> {}, node -> {}, () -> {});
+    String frame =
+        """
+        {
+          "type": "SYSTEM",
+          "headers": {
+            "topic": "ping",
+            "messageId": "ping-1"
+          },
+          "data": "{\\"opaque\\":\\"abc-123\\"}"
+        }
+        """;
+    client.dispatchFrameForTest(frame, ws);
+
+    JsonNode ackJson = MAPPER.readTree(ack.get());
+    assertEquals("abc-123", MAPPER.readTree(ackJson.path("data").asText()).path("opaque").asText());
+  }
+
+  private static WebSocket mockWebSocket(AtomicReference<String> ack) {
+    WebSocket ws = mock(WebSocket.class);
+    when(ws.sendText(anyString(), anyBoolean()))
+        .thenAnswer(
+            inv -> {
+              ack.set(inv.getArgument(0));
+              return CompletableFuture.completedFuture(ws);
+            });
+    return ws;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <module>oryxos-channel-cli</module>
         <module>oryxos-channel-feishu</module>
         <module>oryxos-channel-wecom</module>
+        <module>oryxos-channel-dingtalk</module>
         <module>oryxos-web</module>
         <module>oryxos-storage</module>
         <module>oryxos-cli</module>
@@ -123,6 +124,11 @@
             <dependency>
                 <groupId>io.oryxos</groupId>
                 <artifactId>oryxos-channel-wecom</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.oryxos</groupId>
+                <artifactId>oryxos-channel-dingtalk</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Part of #324（PR 2/3）

## 变更

- `DingTalkStreamClient`：注册 ticket、WebSocket 连接、机器人消息 ACK、ping/disconnect 处理
- `DingTalkChannelAdapter`：`start/stop/status`、`InboundMessageService` 编排接线
- `DingTalkMessageSender`：经 `sessionWebhook` 回复；群聊 B4 用 `at.atUserIds` 关联提问者
- 单测：`DingTalkStreamClientTest`、`DingTalkMessageSenderTest`

## 未包含（PR 3/3）

- `OryxOsRuntime` 工厂注册
- `channels.yaml.example`、部署文档
- `http.allowed_domains` 补 `api.dingtalk.com`

## 测试

- [x] `mvn -pl oryxos-channel-dingtalk -am test`
- [x] SpotBugs 通过