### PR TITLE
release: 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,51 @@
 本文件记录 OryxOS 的版本变更。格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [0.1.4-RELEASE] - 2026-08-31
+
+### Added
+- 本地知识库：解析/切分/向量化索引与双路召回检索（`feat(knowledge)`，#202/#205）。
+- 长期记忆语义召回：配置 `embedding.*` 后三路加权融合（015，#207）。
+- 飞书 IM 入站渠道（017，#235）。
+- 企业微信 AI 机器人长连接入站（#289/#290）；群回复引用原消息（#323）；断线自动重连（#319）。
+- 钉钉 Stream 入站渠道 Runtime 装配与部署文档（#328）。
+- REST API Key 认证：`/api/v1` 机器调用门禁（018，#249）。
+- SSE 流式响应：三端点打字机 + CLI/管理台消费面（019，#263）。
+- Tool Policy 工具策略：全局/Agent 级 allow/deny 治理层（020，#315）。
+- SMTP 邮件通知渠道与 SMTP 端点白名单（#246）。
+- 钉钉/飞书富文本与卡片通知格式（#248）；企业微信 Markdown 通知（#234）。
+
+### Fixed
+- API Key 过滤器覆盖 `/api/v2` 端点（#311）。
+- 知识库索引跳过软链并强制 realpath 边界（#313）。
+- 拦截对管理配置与 SQLite 库文件的读取（#312）。
+- Profile 加载时 realpath 复检与 fail-loud（#309）。
+- `make_dir` 绑定槽位防软链别名绕过（#64da84d）。
+- IM 厂商 notify/inbound 默认 `http.allowed_domains` 对齐（#321）。
+- 厂商 webhook 2xx 业务错误 fail-loud（#316/#317）。
+- 文件工具写前 mutation guard 复检、Skill/Knowledge/AGENT.md 写保护强化（#273/#297–#308 等）。
+- Profile YAML 严格校验：cron/ZoneId、列表字段类型、notify_channels/schedules 对象形态（#265–#267/#281–#296）。
+- MCP `mcp_servers.yaml` 畸形配置 fail-loud（#271）。
+- `WorkspaceWatcher` 对 `AGENT.md` 大小写不敏感（#243）。
+- 无触发足迹时归档记忆修复（#208）。
+- Windows 测试：路径分隔符与软链/POSIX 假设守卫（#262/#310）。
+- 管理台登录页静态资源 401 白屏（018 配套）。
+- 依赖升级：Tomcat 10.1.59、pdfbox、commons-lang3、springdoc/swagger-ui（#277/#287）。
+
+### Security
+- HTTP DNS rebinding：绑定已校验 DNS 解析结果（#278）。
+- SSRF：IPv6 Teredo/6to4/ISATAP/IPv4-compatible 嵌入地址展开后私网拦截（#253/#269/#279/#280）。
+- HTTP 重定向跨域剥离 `Authorization`/`Cookie`/`Api-Key`/`Private-Token`/`X-Access-Token`/`Deploy-Token` 等凭证（#241/#259/#291/#294）。
+- HTTP 302 重定向剥离 `Content-Type` 等 body 头（#275）。
+- 拒绝向 `channels.yaml`/`mcp_servers.yaml`/共享 Skill 实体直接写入（#237/#238/#239）。
+- `MEMORY.md` 软链别名变异拦截（#251）。
+- `http_request` 拒绝不支持的方法（#257）。
+
+### Docs
+- 路线图 v0.2/v0.3 交付状态与 HITL/Tool Policy 调整。
+- SMTP 与通知白名单文档同步。
+- README 版本徽章升级至 0.1.4。
+
 ## [0.1.3-RELEASE] - 2026-08-18
 
 ### Added
@@ -119,6 +164,7 @@
 - Web REST API（`/api/v1`）与 CLI 子命令（`init`/`chat`/`serve`/`gateway` 等）。
 - SQLite 持久化与 `tool_invocations` / `llm_calls` 审计表 Day-One 写入。
 
+[0.1.4-RELEASE]: https://github.com/oryx-labs/oryxos/compare/v0.1.3-RELEASE...v0.1.4-RELEASE
 [0.1.3-RELEASE]: https://github.com/oryx-labs/oryxos/compare/v0.1.2-RELEASE...v0.1.3-RELEASE
 [0.1.2-RELEASE]: https://github.com/oryx-labs/oryxos/compare/v0.1.1-RELEASE...v0.1.2-RELEASE
 [0.1.1-RELEASE]: https://github.com/oryx-labs/oryxos/compare/v0.1.0-RELEASE...v0.1.1-RELEASE

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/oryx-labs/oryxos/releases"><img src="https://img.shields.io/badge/version-0.1.3-orange?style=flat-square" alt="version"/></a>
+  <a href="https://github.com/oryx-labs/oryxos/releases"><img src="https://img.shields.io/badge/version-0.1.4-orange?style=flat-square" alt="version"/></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-native-8A2BE2?style=flat-square" alt="MCP native"/></a>
   <a href="https://www.apache.org/licenses/LICENSE-2.0"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0"/></a>
 </p>

--- a/oryxos-boot/pom.xml
+++ b/oryxos-boot/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.3-RELEASE</version>
+        <version>0.1.4-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-boot</artifactId>

--- a/oryxos-channel-cli/pom.xml
+++ b/oryxos-channel-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.3-RELEASE</version>
+        <version>0.1.4-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-channel-cli</artifactId>

--- a/oryxos-channel-dingtalk/pom.xml
+++ b/oryxos-channel-dingtalk/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.3-RELEASE</version>
+        <version>0.1.4-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-channel-dingtalk</artifactId>

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkStreamClient.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkStreamClient.java
@@ -239,7 +239,7 @@ final class DingTalkStreamClient implements WebSocket.Listener {
     body.put("clientId", clientId);
     body.put("clientSecret", clientSecret);
     body.set("subscriptions", subscriptions);
-    body.put("ua", "oryxos-channel-dingtalk/0.1.3-RELEASE");
+    body.put("ua", "oryxos-channel-dingtalk/0.1.4-RELEASE");
     HttpClient client = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
     HttpRequest request =
         HttpRequest.newBuilder()

--- a/oryxos-channel-feishu/pom.xml
+++ b/oryxos-channel-feishu/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.3-RELEASE</version>
+        <version>0.1.4-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-channel-feishu</artifactId>

--- a/oryxos-channel-wecom/pom.xml
+++ b/oryxos-channel-wecom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.3-RELEASE</version>
+        <version>0.1.4-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-channel-wecom</artifactId>

--- a/oryxos-cli/pom.xml
+++ b/oryxos-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.3-RELEASE</version>
+        <version>0.1.4-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-cli</artifactId>

--- a/oryxos-core/pom.xml
+++ b/oryxos-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.3-RELEASE</version>
+        <version>0.1.4-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-core</artifactId>

--- a/oryxos-knowledge/pom.xml
+++ b/oryxos-knowledge/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.3-RELEASE</version>
+        <version>0.1.4-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-knowledge</artifactId>

--- a/oryxos-memory/pom.xml
+++ b/oryxos-memory/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.3-RELEASE</version>
+        <version>0.1.4-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-memory</artifactId>

--- a/oryxos-provider/pom.xml
+++ b/oryxos-provider/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.3-RELEASE</version>
+        <version>0.1.4-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-provider</artifactId>

--- a/oryxos-storage/pom.xml
+++ b/oryxos-storage/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.3-RELEASE</version>
+        <version>0.1.4-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-storage</artifactId>

--- a/oryxos-tool/pom.xml
+++ b/oryxos-tool/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.3-RELEASE</version>
+        <version>0.1.4-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-tool</artifactId>

--- a/oryxos-web/pom.xml
+++ b/oryxos-web/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.3-RELEASE</version>
+        <version>0.1.4-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-web</artifactId>

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -151,7 +151,7 @@ const overviewCards = computed(() => [
 const overview = {
   tagline: '装在你自己基础设施上的分布式 AI Agent 操作系统 —— 统一底座运行多个业务 Agent',
   status: '运行中',
-  version: 'v0.1.3 · RELEASE',
+  version: 'v0.1.4 · RELEASE',
   capabilities: [
     { name: '对接 LLM', desc: '显式 Provider 映射，多家协议统一' },
     { name: 'ReAct 循环', desc: '自实现推理–行动循环，完全可控' },

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.oryxos</groupId>
     <artifactId>oryxos</artifactId>
-    <version>0.1.3-RELEASE</version>
+    <version>0.1.4-RELEASE</version>
     <packaging>pom</packaging>
 
     <name>OryxOS</name>

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -12,7 +12,7 @@ install.ps1 — Windows 下安装 OryxOS CLI（构建 jar + 注册 PowerShell �
 
 说明：
   • 幂等可重复运行：$PROFILE 中旧函数块（begin/end 标记之间）会被替换为最新版本。
-    • jar 文件名带版本号（如 oryxos-boot-0.1.3-RELEASE.jar），函数内用通配符动态
+    • jar 文件名带版本号（如 oryxos-boot-0.1.4-RELEASE.jar），函数内用通配符动态
     解析最新产物，且排除 spring-boot repackage 留下的 *.jar.original。
 #>
 

--- a/specs/013-overview-dynamic-data/data-model.md
+++ b/specs/013-overview-dynamic-data/data-model.md
@@ -74,7 +74,7 @@ public SessionStats stats() {
 const overview = reactive({
   tagline: '装在你自己基础设施上的分布式 AI Agent 操作系统...',
   status: '运行中',
-  version: 'v0.1.3 · RELEASE',
+  version: 'v0.1.4 · RELEASE',
   stats: {
     agents: { value: null, loading: true, error: null },
     tools: { value: null, loading: true, error: null },


### PR DESCRIPTION
## Summary

- Bump all Maven modules from `0.1.3-RELEASE` to `0.1.4-RELEASE`
- Add `CHANGELOG.md` section for 0.1.4 (knowledge base, semantic memory recall, Feishu/WeCom/DingTalk channels, REST API Key, SSE streaming, Tool Policy, SMTP/rich notify, and security hardening since 0.1.3)
- Sync README version badge, admin overview version (`App.vue`), `install.ps1` example jar name, DingTalk UA string, and spec data-model example

Merging this PR triggers [`.github/workflows/release.yml`](.github/workflows/release.yml) to build `dist/oryxos-0.1.4-RELEASE.tar.gz` and publish GitHub Release `v0.1.4-RELEASE`.

> **Note:** If Release workflow fails with 403 on fork PRs (see [#185](https://github.com/oryx-labs/oryxos/pull/185) / [#186](https://github.com/oryx-labs/oryxos/pull/186)), cherry-pick or fast-forward this commit onto an `oryx-labs/oryxos` same-repo branch and merge with title `release: 0.1.4`.

## Test plan

- [x] `mvn clean verify` passed locally on `release/0.1.4`
- [ ] CI green on this PR
- [ ] After merge: Actions **Release** job succeeds
- [ ] GitHub Release `v0.1.4-RELEASE` published with tarball asset


Made with [Cursor](https://cursor.com)