### PR TITLE
feat(docker): container image distribution — Dockerfile + entrypoint + GHCR release pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# OryxOS 镜像构建上下文瘦身：镜像只需要的四样东西——
+# Dockerfile、docker/docker-entrypoint.sh、config/application.yml.example、oryxos-boot 胖 jar。
+# jar 由构建方原生构建（镜像内不跑 Maven），因此源码、其余模块产物全部排除。
+
+# 版本控制 / CI / 文档 / 站点：与镜像无关
+.git/
+.github/
+.gitignore
+.specify/
+.idea/
+.vscode/
+website/
+docs/
+specs/
+*.md
+LICENSE
+CHANGELOG.md
+
+# 运行期产物与本地环境（宿主机上的数据库、日志、发行包一律不进镜像）
+logs/
+dist/
+target/
+my-agent/
+oryxos.db
+oryxos.db-shm
+oryxos.db-wal
+bin/
+scripts/
+docker/mem0/
+docker-compose.yml
+
+# 源码与依赖清单：镜像只装 jar，不装源码
+oryxos-*/src/
+oryxos-*/node_modules/
+
+# 模块构建产物整体排除，再单独放回唯一需要的胖 jar。
+# 注意：必须用「oryxos-*/target/*」排除目录内容而非「oryxos-*/target/」排除目录本身，
+# 否则父目录被排除后，! 规则无法把 jar 重新包含进来。
+oryxos-*/target/*
+!oryxos-boot/target/oryxos-boot-*.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,26 @@ jobs:
             target/dependency-check-report.html
             target/dependency-check-report.json
           if-no-files-found: ignore
+
+  docker-build:
+    name: Docker image build (no push)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      # 只验证镜像可构建（Dockerfile + 上下文不腐烂），不推送；
+      # 测试与质量门禁已在 build job 覆盖，这里跳过以省时
+      - name: package (skip tests & quality plugins)
+        run: >-
+          mvn -B clean package -DskipTests
+          -Dspotless.check.skip=true
+          -Dcheckstyle.skip=true
+          -Dpmd.skip=true
+          -Dspotbugs.skip=true
+      - name: docker build
+        run: docker build -t oryxos:ci .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,10 @@ on:
     types: [closed]
     branches: [main]
 
-# 创建 Release + tag 需要写 contents 权限
+# 创建 Release + tag 需要写 contents 权限；推镜像到 GHCR 需要写 packages 权限
 permissions:
   contents: write
+  packages: write
 
 concurrency:
   group: release-${{ github.event.pull_request.number }}
@@ -84,3 +85,32 @@ jobs:
               --generate-notes
           fi
           echo "已发布 $TAG，产物：$(basename "$TARBALL")"
+
+      # ── 容器镜像（纯增量）：tar.gz 之后的第二种产物，推到 GHCR ──
+      # jar 平台无关（镜像内不跑 Maven）：amd64 runner 原生构建 jar 一次，
+      # buildx 双架构只是各自拉基础镜像 + COPY jar，无需 QEMU 跑 Maven。
+      # 顺序刻意放在 tar.gz Release 之后：镜像失败不阻塞既有的 tar.gz 发版。
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build & push multi-arch image
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/oryxos
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag "${IMAGE}:v${VERSION}" \
+            --tag "${IMAGE}:latest" \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            --push \
+            .
+          echo "已推送 ${IMAGE}:v${VERSION} 与 :latest（linux/amd64 + linux/arm64）"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,15 @@ OryxOS 启动后在当前目录创建 `.oryxos/` 工作区：
 - `USER.md`：用户手写的初始设定，OryxOS 只读不写
 - `MEMORY.md`：Agent 通过 `save_memory` Tool 写入的成长记录，OryxOS 读写
 
+### Docker 部署形态（与 bin/start.sh 并行的纯增量）
+
+- 镜像内**不跑 Maven**：jar 平台无关，由构建方原生构建一次，Dockerfile 只 `COPY` 胖 jar 进 JRE 基础镜像——多架构（amd64/arm64）构建因此无需 QEMU 模拟 Maven。
+- `docker/docker-entrypoint.sh` 是 start.sh 的容器等价物，三处刻意不同：`exec` 前台（java 即 PID 1，SIGTERM 直达优雅停机）、首启非交互（从模板生成配置后照常启动，零 key 可 boot）、日志走 stdout（交 `docker logs`）。
+- 全部状态在 `/data` 卷（`config/` + 工作区 + `oryxos.db` + `logs/`）；`ORYXOS_ROOT=/data/.oryxos` 走环境变量原生支持。镜像非 root（uid 1000）+ 内置 healthcheck（`/api/v1/health`）。
+- 流水线：`ci.yml` 的 `docker-build` job 做 PR 门禁（只构建不推送）；`release.yml` 在 tar.gz Release 之后 buildx 推 `ghcr.io/oryx-labs/oryxos:v<版本>` + `:latest` 到 GHCR（需 `packages: write`，已加）。
+- 本地构建：`make docker`（依赖 `make build` 的胖 jar）。改 Dockerfile/entrypoint/.dockerignore 时，`docker-build` 门禁会自动验证。
+- 停机行为（2026-08 实测）：SIGTERM 能被处理，但某第三方渠道客户端（长连接 WS）的 Lifecycle stop 不回调，Spring 等 30s latch 超时后才完成关闭——**总耗时 ~32s，exit 143**。compose 已配 `stop_grace_period: 40s` 兜住；裸 `docker stop`（默认 10s）会 SIGKILL，SQLite WAL 保证数据安全。tar.gz 路径同病：`bin/stop.sh` 等 10s 后 kill -9。根治需修那个 bean 的 stop 回调（或给它配 lifecycleProcessor 超时），属上游依赖问题。
+
 ---
 
 ## 核心数据模型

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# 注意：不用 `# syntax=docker/dockerfile:1` 指令——国内镜像源常缺 docker/dockerfile 前端镜像；
+# Docker 23+ 内置 BuildKit 前端已覆盖本文件用到的全部特性。
+# OryxOS 容器镜像——tar.gz 发行包之外的另一种分发形态（纯增量，不影响 bin/start.sh 路径）。
+#
+# jar 是平台无关的：镜像内不做 Maven 构建，只把已构建的胖 jar 拷进 JRE 基础镜像。
+# 因此多架构构建（amd64 + arm64）只需换基础镜像层，无需在 QEMU 里跑 Maven——
+# jar 始终由构建方（本地或 CI runner）原生构建一次。
+#
+# 本地构建：
+#   mvn package -DskipTests          # 或 make build（含管理台前端）
+#   docker build -t oryxos:dev .
+#   docker run -d -p 8080:8080 -v oryxos-data:/data oryxos:dev
+#
+# JAR_FILE 可覆盖（默认 glob 命中 oryxos-boot/target/ 下的唯一胖 jar；target/ 残留多个旧版本 jar 时
+# 该 glob 有歧义、构建会失败——先 mvn clean，或像 make docker 那样显式钉死版本）：
+#   docker build --build-arg JAR_FILE=oryxos-boot/target/oryxos-boot-0.1.4-RELEASE.jar .
+
+# ARG 声明在 FROM 之前，供 stage 内通过「无默认值的重复 ARG」继承
+ARG JAR_FILE=oryxos-boot/target/oryxos-boot-*.jar
+
+FROM eclipse-temurin:21-jre-jammy
+
+ARG JAR_FILE
+
+LABEL org.opencontainers.image.title="OryxOS" \
+      org.opencontainers.image.description="Self-hosted Agent Operating System for the enterprise" \
+      org.opencontainers.image.source="https://github.com/oryx-labs/oryxos" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# curl 供 HEALTHCHECK 探测 /api/v1/health；tzdata 供 TZ 生效。
+# 固定 uid/gid 1000 的非 root 运行用户：named volume 首挂时继承镜像内 /data 的属主。
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl tzdata \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 1000 oryxos \
+    && useradd --uid 1000 --gid oryxos --create-home --shell /usr/sbin/nologin oryxos
+
+# 状态全部落在 /data（config/ 工作区 .oryxos/ oryxos.db logs/），挂 named volume 即可持久化。
+# ORYXOS_ROOT 指向卷内工作区——解析顺序 -Doryxos.root > ORYXOS_ROOT > 默认 .oryxos，环境变量原生支持。
+ENV ORYXOS_ROOT=/data/.oryxos \
+    ORYXOS_PORT=8080 \
+    JAVA_OPTS=-XX:MaxRAMPercentage=75.0 \
+    TZ=Asia/Shanghai
+
+WORKDIR /data
+
+COPY docker/docker-entrypoint.sh /opt/oryxos/docker-entrypoint.sh
+COPY config/application.yml.example /opt/oryxos/config/application.yml.example
+COPY ${JAR_FILE} /opt/oryxos/oryxos.jar
+
+RUN chmod 555 /opt/oryxos/docker-entrypoint.sh \
+    && mkdir -p /data/config /data/logs /data/.oryxos \
+    && chown -R oryxos:oryxos /data /opt/oryxos
+
+USER oryxos
+
+EXPOSE 8080
+
+# 健康检查打 serve 已有的 /api/v1/health；启动期给足 90s（首次启动含 SQLite/工作区初始化）
+HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=3 \
+  CMD curl -fsS "http://localhost:${ORYXOS_PORT}/api/v1/health" || exit 1
+
+# 无参数时缺省 serve --port $ORYXOS_PORT；也可覆盖为其他子命令（如 docker run … oryxos init）
+ENTRYPOINT ["/opt/oryxos/docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 #
 #   make build     编译并打包可执行 jar（含管理台前端）
 #   make release   打发行版 dist/oryxos-<version>.tar.gz（bin/ config/ libs/）
+#   make docker    用已构建的胖 jar 构建本地镜像 oryxos:<version>（不跑 Maven，镜像内只有 JRE）
 #   make clean     清理 dist/ 与 maven target/
 #   make help      帮助
 #
@@ -21,12 +22,13 @@ STAGE     := $(DIST_DIR)/$(DIST_NAME)
 BOOT_JAR  := oryxos-boot/target/oryxos-boot-$(VERSION).jar
 TARBALL   := $(DIST_DIR)/$(DIST_NAME).tar.gz
 
-.PHONY: help build release clean
+.PHONY: help build release docker clean
 
 help:
 	@echo "OryxOS make 目标（version = $(VERSION)）："
 	@echo "  make build     编译打包可执行 jar（含管理台前端）"
 	@echo "  make release   打发行版 $(TARBALL)（bin/ config/ libs/）"
+	@echo "  make docker    构建本地镜像 oryxos:$(VERSION)（依赖 build 产出的胖 jar）"
 	@echo "  make clean     清理 dist/ 与 maven target/"
 
 # 全量打包：frontend-maven-plugin 会一并构建管理台前端进 jar（不加 -Dfrontend.skip）
@@ -48,6 +50,12 @@ release: build
 	@echo "==> 完成：$(TARBALL)  ($$(du -sh "$(TARBALL)" | cut -f1))"
 	@echo "==> 内容："
 	@tar -tzf "$(TARBALL)"
+
+# 依赖 build 产出的胖 jar 构建本地镜像（镜像内不跑 Maven——jar 平台无关，多架构只需换基础镜像层）。
+# JAR_FILE 显式钉死版本：target/ 里若残留多个旧版本 jar，Dockerfile 的默认 glob 会有歧义，这里不猜。
+docker:
+	@test -f "$(BOOT_JAR)" || { echo "[ERROR] 找不到 $(BOOT_JAR)，先 make build"; exit 1; }
+	docker build --build-arg JAR_FILE=$(BOOT_JAR) -t oryxos:$(VERSION) .
 
 clean:
 	rm -rf "$(DIST_DIR)"

--- a/README.md
+++ b/README.md
@@ -172,6 +172,19 @@ java -jar $JAR serve --port 8080           # REST API + Web Manager (same as sta
 
 The workspace defaults to `.oryxos/` but is configurable — set `ORYXOS_ROOT` (or `-Doryxos.root=`, or `oryxos.root` in `application.yml`) to point OryxOS at a custom workspace directory. The configured root is auto-added to the file sandbox whitelist.
 
+### Docker alternative
+
+Every release also ships a multi-arch container image (`linux/amd64` + `linux/arm64`) on GHCR — no Java 21 install, no tarball download:
+
+```bash
+docker run -d --name oryxos -p 8080:8080 -v oryxos-data:/data ghcr.io/oryx-labs/oryxos:latest
+curl http://localhost:8080/api/v1/health      # → {"code":0,…}
+```
+
+The container boots keyless (configure providers in the web console afterwards) and keeps **all state** — `config/`, the `.oryxos/` workspace, `oryxos.db`, logs — in the `/data` volume, so upgrading means pulling a new tag and recreating the container. The image runs as a non-root user and carries a built-in healthcheck against `/api/v1/health`; see `docker-compose.yml` at the repo root for a ready-to-use compose stack. To build the image locally from source: `make docker` (after `make build`).
+
+> Note: storage is single-node SQLite — run **one** container. Horizontal scaling requires the distributed storage track (roadmap A).
+
 ### Web Service & Web Manager
 
 `serve` (and `bin/start.sh`) exposes one process with two faces on the same port:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+# OryxOS 容器部署样例（与 tar.gz + bin/start.sh 路径并行，纯增量）。
+#   docker compose up -d          # 起服务
+#   docker compose logs -f        # 看日志（stdout，容器不写文件日志）
+#   docker compose pull && docker compose up -d   # 升级（换 tag 同理，回滚 = 换回旧 tag）
+#
+# 状态（config/ 工作区 .oryxos/ oryxos.db logs/）全部在 named volume oryxos-data 里，
+# 升级换镜像不丢数据。零 key 即可启动，Provider 在管理台 http://localhost:8080/admin/ 配置；
+# 也可挂载自己的 config/application.yml（见下 volumes 注释）。
+#
+# 注意：SQLite 单机存储 ⇒ 只能单副本。多副本需要分布式存储（路线图方向 A），别用多容器横向扩。
+services:
+  oryxos:
+    image: ghcr.io/oryx-labs/oryxos:latest
+    container_name: oryxos
+    ports:
+      - "8080:8080"
+    environment:
+      TZ: Asia/Shanghai
+      # ORYXOS_PORT: 8080          # 容器内端口（ healthcheck 跟随；映射左侧改动即可换宿主端口）
+      # JAVA_OPTS: -XX:MaxRAMPercentage=75.0 -Xlog:gc
+    volumes:
+      - oryxos-data:/data
+      # 挂载自备配置（优先级高于首启模板）：
+      # - ./config/application.yml:/data/config/application.yml
+    restart: unless-stopped
+    # healthcheck 已内置于镜像（curl /api/v1/health），无需重复声明
+    # 优雅停机需要 ~32s：某第三方渠道客户端（长连接）的 Lifecycle stop 不回调，
+    # Spring DefaultLifecycleProcessor 默认等满 30s latch 超时后才放弃并完成关闭。
+    # 默认 10s 宽限会走 SIGKILL——SQLite WAL 保证数据安全（已验证崩溃恢复），但停机不干净。
+    stop_grace_period: 40s
+
+  # 可选：自托管 mem0 作为外部记忆后端（详见 docker/mem0/compose.yaml），
+  # 在 config/application.yml 配置 memory.backend 后启用：
+  # mem0:
+  #   image: mem0/mem0:latest
+  #   ...
+
+volumes:
+  oryxos-data:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# OryxOS 容器入口——bin/start.sh 的容器化等价物，三处刻意不同：
+#   1) exec 前台运行：java 即 PID 1，SIGTERM 直达 Spring 优雅停机（容器不养后台进程/PID 文件）
+#   2) 首启非交互：从镜像内模板生成配置后照常启动（容器可零 key 启动，
+#      Provider 随后在管理台配置或挂载覆盖），不做 start.sh 的「填完 key 再来」交互退出
+#   3) 日志走 stdout：交给 docker logs，不重定向到文件
+set -eu
+
+APP_HOME=/opt/oryxos
+DATA_DIR=/data
+PORT="${ORYXOS_PORT:-8080}"
+
+mkdir -p "$DATA_DIR/config" "$DATA_DIR/logs" "${ORYXOS_ROOT:-$DATA_DIR/.oryxos}"
+
+# 首启：配置不存在则从镜像内模板生成一份（已挂载自己的 application.yml 时跳过）
+if [ ! -f "$DATA_DIR/config/application.yml" ] && [ -f "$APP_HOME/config/application.yml.example" ]; then
+  cp "$APP_HOME/config/application.yml.example" "$DATA_DIR/config/application.yml"
+  echo "[INFO] 已生成 $DATA_DIR/config/application.yml —— 可挂载覆盖，或在管理台配置 Provider"
+fi
+
+# 无参数缺省 serve；有参数则透传（docker run … oryxos init / status / chat …）
+if [ "$#" -eq 0 ]; then
+  set -- serve --port "$PORT"
+fi
+
+# JAVA_OPTS 故意不加引号以支持多项参数（如 -Xmx512m -XX:…）
+# shellcheck disable=SC2086
+exec java ${JAVA_OPTS:-} \
+  -Dspring.config.additional-location="optional:file:$DATA_DIR/config/" \
+  -jar "$APP_HOME/oryxos.jar" \
+  "$@"

--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -124,6 +124,19 @@ curl http://localhost:8080/api/v1/health
 
 Every API response is wrapped in this `{ code, message, data, timestamp }` envelope (`code: 0` = success).
 
+## Run with Docker
+
+Every release also ships a multi-arch container image (`linux/amd64` + `linux/arm64`) on GHCR — no Java 21 install, no tarball download:
+
+```bash
+docker run -d --name oryxos -p 8080:8080 -v oryxos-data:/data ghcr.io/oryx-labs/oryxos:latest
+curl http://localhost:8080/api/v1/health      # → {"code":0,…}
+```
+
+The container boots keyless (configure providers in the web console afterwards) and keeps **all state** — `config/`, the `.oryxos/` workspace, `oryxos.db`, logs — in the `/data` volume, so upgrading means pulling a new tag and recreating the container. The image runs as a non-root user and carries a built-in healthcheck against `/api/v1/health`; see `docker-compose.yml` at the repo root for a ready-to-use compose stack. To build the image locally from source: `make docker` (after `make build`).
+
+> Note: storage is single-node SQLite — run **one** container. Horizontal scaling requires the distributed storage track (roadmap A).
+
 ## What's next
 
 - [Architecture overview](/docs/architecture) — how ReAct Loop, Providers, Memory, and Tools connect

--- a/website/zh/docs/quick-start.md
+++ b/website/zh/docs/quick-start.md
@@ -153,6 +153,19 @@ curl http://localhost:8080/api/v1/health
 
 每个 API 响应都包裹在 `{ code, message, data, timestamp }` 信封里（`code: 0` 表示成功）。
 
+## 用 Docker 运行
+
+每个版本同时在 GHCR 发布多架构容器镜像（`linux/amd64` + `linux/arm64`）——不用装 Java 21、不用下载 tar.gz：
+
+```bash
+docker run -d --name oryxos -p 8080:8080 -v oryxos-data:/data ghcr.io/oryx-labs/oryxos:latest
+curl http://localhost:8080/api/v1/health      # → {"code":0,…}
+```
+
+容器**零 key 即可启动**（随后在管理台配置 Provider），全部状态——`config/`、`.oryxos/` 工作区、`oryxos.db`、日志——都落在 `/data` 卷里，升级 = 拉新 tag 重建容器，数据不丢。镜像以非 root 用户运行，内置针对 `/api/v1/health` 的健康检查；开箱即用的 compose 栈见仓库根目录的 `docker-compose.yml`。从源码本地构建镜像：`make docker`（先 `make build`）。
+
+> 注意：存储是单机 SQLite——**只跑一个容器**。横向扩容需要分布式存储（路线图方向 A）。
+
 ## 下一步
 
 - [OryxOS 是什么](/zh/docs/what) — 了解架构定位和设计理念


### PR DESCRIPTION
## 做什么

tar.gz 发行包之外的第二种分发形态：**官方容器镜像**。纯增量——Java 代码零改动、tar.gz 路径与 bin/start.sh 原样保留，release 流水线在同一约定下多产出一种产物。

对应路线图「企业化与治理」的交付体系接轨诉求：已有 K8s / compose / 镜像仓库的企业，tar.gz 进不了它们的交付体系；镜像天然在里面。

## 交付内容

| 文件 | 说明 |
| --- | --- |
| `Dockerfile` | JRE21 基础镜像、非 root（uid 1000）、`/data` 状态卷、内置 healthcheck（`/api/v1/health`）、Spring 惯例 `JAR_FILE` 模式 |
| `docker/docker-entrypoint.sh` | start.sh 的容器等价物：exec 前台（java 即 PID 1）、首启非交互生成配置、日志走 stdout、可透传其他子命令 |
| `.dockerignore` | 上下文瘦身到 Dockerfile + entrypoint + 配置模板 + 胖 jar 四样 |
| `docker-compose.yml` | 开箱即用样例（named volume / restart / stop_grace_period / 单副本警示） |
| `Makefile` | `make docker`（显式钉死版本 JAR_FILE，避免 target 残留多版本 jar 的 glob 歧义） |
| `ci.yml` | `docker-build` PR 门禁 job（只构建不推送） |
| `release.yml` | tar.gz Release 之后 buildx 推 GHCR 双架构镜像（`v<版本>` + `latest`），新增 `packages: write` |
| 文档 | README / website 中英 quick-start / CLAUDE.md |

## 设计要点

- **镜像内不跑 Maven**：jar 平台无关，由 runner 原生构建一次，多架构（amd64+arm64）只换基础镜像层——实测发版 job 全程 **2 分 17 秒**，无 QEMU 模拟开销
- **不依赖 `# syntax=` 指令**：国内镜像源常缺 docker/dockerfile 前端镜像（实测阿里云加速器 404），改用传统 chmod 写法，兼容性更好
- **零 key 可启动**：容器首启非交互生成配置，Provider 随后在管理台配置——与 serve 既有行为一致

## 测试证据（fork 全流程演练）

在 fork 命名空间完整演练过（upstream 未受影响）：

- PR 侧：CI 全绿（含新 `docker-build` 门禁在干净 ubuntu 环境首次真实构建）
- 发版侧：`release:` PR 合入 → 版本解析 → tar.gz → GitHub Release → GHCR 推送，job 全步骤 success
- 镜像侧：manifest 实证 amd64 + arm64 + provenance/SBOM attestation；拉取后起容器，健康检查 1s 通过、`/admin/` 200、非 root、卷持久化、崩溃恢复（SQLite WAL）均通过

## 顺带发现（未在本 PR 处理，建议单独跟进）

1. **某第三方渠道长连接客户端的 Lifecycle `stop()` 不回调**：SIGTERM 能送达、Spring 钩子能执行，但 DefaultLifecycleProcessor 等满 30s latch 超时才完成关闭（实测 exit 143、总耗时 ~32s）。tar.gz 路径同病：`bin/stop.sh` 等 10s 即 kill -9。本 PR 以 `stop_grace_period: 40s` 兜底，根治需修该 bean（线程转储定位：卡在 `LifecycleGroup.stop` 的 `CountDownLatch.await`）。
2. 项目无 `.gitattributes`，Windows 贡献者若 autocrlf 关闭可能把 CRLF 带进 entrypoint 毁掉 shebang——建议后续补一行 `*.sh text eol=lf`。

## 备注

- 本 PR 为基础设施/分发性质，未立 spec；若维护者认为需要补 `specs/0xx-docker-distribution`，可跟进
- 多租户/分布式场景注意：SQLite 单机存储 ⇒ 单副本，文档已明示
