### PR TITLE
fix(core): SIGTERM 优雅停机 31s → 1s——ContextClosedEvent 关闭 WatchService 令监听循环退出

### DIFF
--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -117,8 +117,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -324,6 +326,21 @@ public class OryxOsRuntime {
     executor.setDaemon(true); // chat 跑完进程要能退出；serve/gateway 常驻靠主线程保活
     executor.initialize();
     return executor;
+  }
+
+  /**
+   * #332：ContextClosedEvent 先于 SmartLifecycle 停机发布（AbstractApplicationContext.doClose 顺序）， 在此关闭两个
+   * WatchService → 监听循环退出 → 执行器「运行中任务数」归零 → 其 stop 回调即时触发， 生命周期停机不再等满 30s latch 超时。不关的话
+   * watchService.take() 无事件/中断/关闭三者不醒。
+   */
+  @Bean
+  ApplicationListener<ContextClosedEvent> watcherGracefulShutdown(
+      WorkspaceWatcher workspaceWatcher,
+      io.oryxos.knowledge.watch.KnowledgeWatcher knowledgeWatcher) {
+    return event -> {
+      workspaceWatcher.stop();
+      knowledgeWatcher.stop();
+    };
   }
 
   /** 30 节：实时监听 .oryxos/agents/——守护线程上跑监听循环，启动后的变更走同一段 register。 */

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/WorkspaceWatcher.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/WorkspaceWatcher.java
@@ -42,6 +42,11 @@ public class WorkspaceWatcher {
   private final Path agentsDir;
   private final Executor watcherExecutor;
 
+  /**
+   * start() 创建、stop() 关闭（volatile：start 在启动线程写、stop 在 Spring 关闭线程读）。 start 失败时保持 null，stop 静默跳过。
+   */
+  private volatile WatchService watchService;
+
   /** {@link WatchKey} → 被监听目录（根目录或某个 Agent 子目录），把事件解析回来源目录。 */
   private final Map<WatchKey, Path> watchedDirs = new ConcurrentHashMap<>();
 
@@ -70,7 +75,24 @@ public class WorkspaceWatcher {
       LOG.warn("WorkspaceWatcher 启动失败，实时监听不可用: {}", sanitize(e.getMessage()));
       return;
     }
+    this.watchService = watchService;
     watcherExecutor.execute(() -> loop(watchService));
+  }
+
+  /**
+   * 关闭 WatchService 令监听循环退出（take() 抛 ClosedWatchServiceException）。 必须在所属执行器的 SmartLifecycle
+   * 停止之前调用——执行器的 stop 回调要等「运行中任务数归零」 才触发（Spring 6.2 ExecutorLifecycleDelegate 语义），监听循环不退出就等满 30s
+   * 超时（#332）。 装配层以 ContextClosedEvent 监听器触发（该事件先于生命周期停机发布）。
+   */
+  public void stop() {
+    WatchService ws = watchService;
+    if (ws != null) {
+      try {
+        ws.close();
+      } catch (IOException e) {
+        LOG.warn("关闭 WorkspaceWatcher 失败: {}", sanitize(e.getMessage()));
+      }
+    }
   }
 
   /** 把目录注册进 WatchService 并记入映射；同一目录重复注册返回同一 {@link WatchKey}（幂等）。 */
@@ -87,6 +109,8 @@ public class WorkspaceWatcher {
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         return;
+      } catch (java.nio.file.ClosedWatchServiceException e) {
+        return; // stop() 关闭了服务：正常退出路径（#332）
       }
       Path dir = watchedDirs.get(key);
       if (dir != null) {

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/watch/KnowledgeWatcher.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/watch/KnowledgeWatcher.java
@@ -36,6 +36,11 @@ public class KnowledgeWatcher {
   private final KnowledgeIndexService indexService;
   private final Executor watcherExecutor;
 
+  /**
+   * start() 创建、stop() 关闭（volatile：start 在启动线程写、stop 在 Spring 关闭线程读）。 start 失败时保持 null，stop 静默跳过。
+   */
+  private volatile WatchService watchService;
+
   /** {@link WatchKey} → 被监听目录（根目录或某个库目录），把事件解析回来源目录。 */
   private final Map<WatchKey, Path> watchedDirs = new ConcurrentHashMap<>();
 
@@ -64,7 +69,24 @@ public class KnowledgeWatcher {
       LOG.warn("KnowledgeWatcher 启动失败，知识库热加载不可用: {}", sanitize(e.getMessage()));
       return;
     }
+    this.watchService = watchService;
     watcherExecutor.execute(() -> loop(watchService));
+  }
+
+  /**
+   * 关闭 WatchService 令监听循环退出（take() 抛 ClosedWatchServiceException）。 必须在所属执行器的 SmartLifecycle
+   * 停止之前调用——执行器的 stop 回调要等「运行中任务数归零」 才触发（Spring 6.2 ExecutorLifecycleDelegate 语义），监听循环不退出就等满 30s
+   * 超时（#332）。 装配层以 ContextClosedEvent 监听器触发（该事件先于生命周期停机发布）。
+   */
+  public void stop() {
+    WatchService ws = watchService;
+    if (ws != null) {
+      try {
+        ws.close();
+      } catch (IOException e) {
+        LOG.warn("关闭 KnowledgeWatcher 失败: {}", sanitize(e.getMessage()));
+      }
+    }
   }
 
   private void registerDir(WatchService watchService, Path dir) throws IOException {
@@ -80,6 +102,8 @@ public class KnowledgeWatcher {
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         return;
+      } catch (java.nio.file.ClosedWatchServiceException e) {
+        return; // stop() 关闭了服务：正常退出路径（#332）
       }
       Path dir = watchedDirs.get(key);
       if (dir != null) {


### PR DESCRIPTION
Fixes #332（含对 issue 中方案 A 的实测修正，详见 issue 评论）。

## 根因（反汇编 Spring 6.2.19 `ExecutorLifecycleDelegate` 实证）

执行器 SmartLifecycle 的 `stop(callback)` 把回调推迟到「运行中任务数归零」；`ContextClosedEvent` 的早期关闭是 graceful `shutdown()`（不中断）；带 `shutdownNow()` 的 destroy 发生在 30s latch 等待**之后**。三条路都叫不醒阻塞在 `watchService.take()` 的监听循环——唯一解是让循环自己退出。

## 修复

- `WorkspaceWatcher` / `KnowledgeWatcher` 增加 `stop()`：关闭 WatchService；循环增加 `ClosedWatchServiceException` 退出路径（JDK 语义：close 后 `take()` 必抛）
- `OryxOsRuntime` 注册 `ContextClosedEvent` 监听器触发两个 `watcher.stop()`——该事件先于 `lifecycleProcessor.onClose()` 发布，保证循环退出先于执行器 stop 阶段，回调即时完成
- 纯增量：不改执行器配置、不改两 watcher 的既有启动链路（`initMethod="start"` 原样）

## 实测（Docker / eclipse-temurin 21，v0.1.4-RELEASE）

| 项 | 修复前 | 修复后 |
| --- | --- | --- |
| `docker stop -t 60` | 31s（30s latch 超时后完成） | **1s** |
| exit code | 143 | 143 |
| `docker stop`（默认 10s 宽限） | 12s 后 SIGKILL（137） | **1s 优雅退出（143）** |
| oryxos-core / oryxos-knowledge 测试 | — | 282 + 32 全绿（含两个 watcher 单测） |

顺带效果：`bin/stop.sh` 的 kill -9 兜底从此不再被触发，PR #331 的 `stop_grace_period: 40s` 可以收紧回默认。
