### PR TITLE
docs(sandbox): 021 容器级执行隔离 spec 草案（issue #334，5 处待裁决）

### DIFF
--- a/specs/021-container-sandbox/plan.md
+++ b/specs/021-container-sandbox/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: 容器级执行隔离（Container Sandbox）
+
+**Branch**: `021-container-sandbox` | **Date**: 2026-09-01 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/021-container-sandbox/spec.md`（issue #334）
+
+> **评审并行推进说明**：spec 的 5 处待裁决（RQ-1~5）尚在评审，本 plan 按 spec **推荐**推进，并在受裁决影响处标注 `⚖️RQ-x`（翻案调整点）。裁决翻案只动标注点，不动整体骨架。
+
+## Summary
+
+shell 执行后端可插拔：`ShellTools` 既有包级 `ProcessStarter` 接缝升格为公开契约（`io.oryxos.tool.sandbox`，形状不变：`Process start(List<String>)`，destroy 语义写进 Javadoc——本地=进程、docker=容器本体），local 档=现 `ProcessBuilder` 实现（零变化）；docker 档=新增 `DockerProcessStarter` 经 CLI（`docker run --rm`）执行，零新依赖。命令构造纯函数化（`DockerRunSpec`）便于单测钉死参数；超时杀容器本体（`--cidfile` + Process 包装 destroy 联动 `docker kill`）；`ORYXOS_ROOT` 读写挂 `/workspace` + 双向路径翻译（`WorkspacePathMapper`）；`tool_invocations` 加 `execution_backend`/`container_id` 两列（`AuditSchemaUpgrade` 幂等 ALTER，镜像 020 `blocked_by` 模式）；Agent 级覆写走 `AGENT.md` frontmatter 新可选段 `sandbox:`；管理台后端状态页（REST + Vue）。检查顺序锁死：Tool Policy（020）→ 白名单 → 后端（FR-007）。
+
+## Technical Context
+
+**Language/Version**: Java 21（虚拟线程，同步阻塞式 CLI 调用与现 ProcessBuilder 同型，宪法 VII 无违）
+
+**Primary Dependencies**: 仅既有依赖——docker 经 CLI（ProcessBuilder 起 `docker` 进程），**零新增 Maven 依赖**（FR-002）；Vue 3（状态页）
+
+**Storage**: SQLite——`tool_invocations` 加 `execution_backend VARCHAR(8)`、`container_id VARCHAR(64)` 两可空列（幂等 ALTER；旧行 NULL ≡ local，查询层兼容）；无新表
+
+**Testing**: JUnit 5——`DockerRunSpec` 纯函数单测（参数顺序/路径翻译/安全默认值钉死）、`WorkspacePathMapper` 双向翻译、`CidfileProcessWrapper` destroy 联动（mock docker kill）、frontmatter 解析与生效档位收敛；docker 依赖的 SC 用「契约测试」模式（daemon 存在才跑，缺失自动 skip 并标注，镜像 015 mem0 契约测试思路）；local 档全量既有测试零修改（SC-001）
+
+**Target Platform**: Linux server（宿主机直跑 OryxOS + 宿主 docker CLI，RQ-1 推荐形态）；容器化 OryxOS + docker 档为 advanced 文档路径
+
+**Project Type**: Maven 多模块单体——oryxos-tool（契约+实现）、oryxos-core（审计通道扩展）、oryxos-storage（列迁移）、oryxos-web（状态 API+页面）、oryxos-cli（装配）；**不新建模块**（roadmap 的 `oryxos-sandbox` 独立留待 SSH 档出现时再议）
+
+**Performance Goals**: local 档零开销（SC-001）；docker 档单次执行增加 ~300-800ms（CLI+容器启动，安全收益远大于此，文档明示）；daemon 探测按需触发（启动校验/状态页/失败分类三处），**零常驻心跳线程**（宪法 VII）
+
+**Constraints**: 检查顺序 Policy → 白名单 → 后端不可变（FR-007）；docker 档 fail loud 不静默回落 local（FR-011，档位是承诺）；镜像必须显式配置（FR-005）
+
+**Scale/Scope**: ~10 新文件 + ~8 既有文件小改；26 任务 6 阶段（见 tasks.md）
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| 原则 | 评估 | 结论 |
+|------|------|------|
+| I 自实现 ReAct | ReActLoop / ToolExecutor 零改动——后端是 ShellTools 内部执行细节，工具签名与语义不变 | ✅ |
+| II Spring AI 边界 | 不涉及 | ✅ |
+| III Provider 显式映射 | 不涉及 | ✅ |
+| IV 目录=Agent / Skill | frontmatter 新增**可选** `sandbox:` 段——作者层执行环境声明，与治理层（020）分离同构；不配即继承全局，目录模型不变 | ✅ |
+| V 审计 Day One | backend 标识 + 容器 ID 随每次调用落 `tool_invocations`（FR-008），容器化执行不产生审计盲区 | ✅ |
+| VI 安全是地基 | 容器是内核边界而非 SecurityManager；白名单 enforce 前置不变；默认参数安全优先（none/512m/read-only，RQ-5） | ✅ |
+| VII 同步 + 虚拟线程 | docker CLI 为同步阻塞 Process 调用，与现状同型；无常驻探测线程 | ✅ |
+| VIII 状态外置 / 手工 schema | ALTER 走 `AuditSchemaUpgrade` 幂等模式（020 `blocked_by` 先例），不依赖 Hibernate 迁移 | ✅ |
+| 模块约束 | 契约+实现归 oryxos-tool/sandbox 既有包，不新建模块、无循环依赖 | ✅ |
+
+**Phase 1 设计后复评**: 无新增违背项，全部通过。
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/021-container-sandbox/
+├── spec.md              # 特性规格（15 FR / 8 SC / 3 US / 5 RQ）
+├── plan.md              # 本文件
+└── tasks.md             # 26 任务 6 阶段
+```
+
+### Source Code (repository root)
+
+```text
+oryxos-tool/src/main/java/io/oryxos/tool/
+├── builtin/ShellTools.java              # 修改：删除包级 ProcessStarter，改引 sandbox 公开契约；其余零改动
+├── sandbox/ProcessStarter.java          # 新增：公开契约（自 ShellTools 升格；Javadoc 写死 destroy 语义）
+├── sandbox/LocalProcessStarter.java     # 新增：现 ProcessBuilder 默认实现（逐字节搬家）
+├── sandbox/DockerRunSpec.java           # 新增：纯函数——配置+命令 → docker run 参数序列（可单测钉死）
+├── sandbox/DockerProcessStarter.java    # 新增：CLI 执行 + CidfileProcessWrapper（destroy→docker kill）
+├── sandbox/WorkspacePathMapper.java     # 新增：ORYXOS_ROOT ↔ /workspace 双向翻译
+└── sandbox/DockerSandboxProperties.java # 新增：配置属性（镜像/限额/网络/user），镜像 ShellSandboxProperties 风格
+
+oryxos-core/src/main/java/io/oryxos/core/
+├── provider/ToolInvocationAuditor.java  # 修改：record 加 backend/containerId 重载（旧签名委托，镜像 020 blockedBy 模式）
+└── agent/AgentProfile.java（或其解析处）# 修改：frontmatter 可选 sandbox 段解析（Phase 4）
+
+oryxos-storage/src/main/java/io/oryxos/storage/
+├── AuditSchemaUpgrade.java              # 修改：幂等 ALTER 两列（镜像 blocked_by 模式）
+├── ToolInvocation.java / JpaToolInvocationAuditor.java  # 修改：落列
+└── AuditSchemaUpgradeTest.java          # 修改：两列升级用例
+
+oryxos-cli/src/main/java/io/oryxos/cli/
+└── OryxOsRuntime.java                   # 修改：装配（backend 选择 + ShellTools 注入 starter + 启动校验注册）
+
+oryxos-web/src/main/java/io/oryxos/web/
+└── controller/SandboxBackendController.java + Vue 状态页  # 新增：只读状态 API + 页面（Phase 5）
+```
+
+## Key Design Decisions
+
+| # | 决策 | 理由 | 翻案敏感度 |
+| --- | --- | --- | --- |
+| D1 | 保留 `ProcessStarter` 名与形状，仅升公开 + Javadoc 契约化（destroy MUST 终止真实执行本体） | 改名/改形状（如换成 Result 记录）是无谓 churn；形状已兼容 docker/ssh 两档 | 低 |
+| D2 | docker 命令构造 = `DockerRunSpec` 纯函数（配置+argv → 完整 docker argv） | 参数顺序/翻译/默认值可单测钉死（SC-002/003/005 的第一道防线），装配期可校验 | 低 |
+| D3 | 超时杀容器：`--cidfile` + `CidfileProcessWrapper`（流的委托 + destroy 联动 `docker kill`；cidfile 未及写入则仅杀 CLI） | FR-006 的机制核心；纯本地可 mock 单测 | 低 |
+| D4 | 审计两列 nullable，旧行 NULL≡local（查询层兼容）；新调用恒写值 | 存量库零破坏；避免全表回填 | 低 |
+| D5 | daemon 探测按需（启动校验/状态页/失败分类），零常驻线程 | 宪法 VII；探测频率无 SLA 需求 | 低 |
+| D6 | 路径翻译 = ORYXOS_ROOT 前缀 ↔ `/workspace` 字符串映射（不做 realpath 跟随）；审计记宿主原始路径 | 容器内路径无宿主 realpath 语义；前缀映射可预测可单测 | ⚖️RQ-4（若裁决改挂载点/只读，仅动 Mapper 与挂载参数） |
+| D7 | Phase 1 不建 `oryxos-sandbox` 模块，契约与实现归 oryxos-tool 既有 sandbox 包 | 零新依赖零新模块；模块拆分留待 SSH 档（第三实现出现时按 III 哲学再拆） | ⚖️RQ-2/RQ-3（若裁决扩大范围，模块化议题重开） |
+| D8 | 生效档位 = frontmatter `sandbox.backend` > 全局配置；非法值 WARN + 回落全局（不阻断其它 Agent） | 与 020 例外登记同构「配置即责任」；fail-soft 只用于声明层，运行层 fail-loud（FR-011） | ⚖️RQ-5（限额/网络默认值调整只动 Properties 默认值与 D2 构造） |
+
+## Implementation Phases（与 tasks.md 对齐）
+
+| Phase | 内容 | 出口（Checkpoint） |
+| --- | --- | --- |
+| 1 Setup | 审计列迁移 + 配置属性类 | 升级用例绿；`oryxos.sandbox.*` 可配 |
+| 2 Foundational | ProcessStarter 升格 + Local 实现 + DockerRunSpec + PathMapper + CidfileProcessWrapper（全纯函数/可 mock） | 单测全绿；local 档既有测试零修改（SC-001 锚点） |
+| 3 US1 MVP | DockerProcessStarter 装配 + 启动校验 + 审计贯通 + fail-loud + SC-002~006 契约测试 | docker 档最小闭环可用 |
+| 4 US2 | frontmatter sandbox 段 + 生效档位收敛 + 按 Agent 限额 + EC-4 | SC-007/SC-008 绿 |
+| 5 US3 | 状态 API + Vue 状态页 | SC 佐证面齐 |
+| 6 收尾 | website 双语 / CLAUDE.md / advanced 部署文档（socket 三候选） + 验收走查 | 全量 `mvn verify` + SC-001~008 落卷 |
+
+## Risks
+
+1. **destroy 联动的竞态**（容器极快退出时 cidfile 未写）——D3 的 fallback 路径必须有测试（容器已退则 kill 报错按成功处理）。
+2. **Windows/macOS Docker Desktop 的挂载翻译差异**——契约测试仅承诺 Linux；桌面环境文档标注为开发用途（EC-6）。
+3. **卷属主与非 root --user 的写权限**——EC-3：错误信息给 chmod/chown 提示，不做自动修属主（越权风险）。

--- a/specs/021-container-sandbox/spec.md
+++ b/specs/021-container-sandbox/spec.md
@@ -1,0 +1,175 @@
+# Feature Specification: 容器级执行隔离（Container Sandbox）
+
+**Feature Branch**: `021-container-sandbox`
+
+**Created**: 2026-09-01
+
+**Status**: Draft（issue #334 认领后的首版草案，5 处待裁决，见 Clarifications）
+
+**Input**: User description: "容器级执行隔离（方向 F，issue #334）：Agent 的 shell 工具目前执行在 OryxOS 进程内，沙箱白名单是应用自觉的策略层——检查者与被检查者同处一个信任域，近两个月的十几个安全修复全部是在封堵绕过手法（symlink 别名/TOCTOU/隧道地址），注定持续对抗。本特性把执行位置迁到内核强制的容器边界：ToolExecutor 的 shell 执行后端可插拔——local（默认，现状零依赖零变化）/ docker（可选，短命容器执行）/ ssh（远程，后续档）。与 015 记忆后端三档、020 Tool Policy 构成纵深防御：Policy 管意图、白名单管准入、容器管爆炸半径，三层互补不替代。落点参照既有 ProcessStarter 接缝（现为包级测试用，ProcessBuilder 为默认实现），docker 档走 CLI 零新依赖。明确不做：file/http 工具容器化、容器化 OryxOS 挂 docker socket（advanced 文档化）、SSH 档（后续）。"
+
+## Clarifications（5 处待裁决，均附推荐）
+
+### RQ-1 · docker socket 安全的默认形态
+
+**问题**：OryxOS 容器化部署（PR #331）+ docker 档时需挂 `/var/run/docker.sock`，socket ≈ 宿主机 root。
+**推荐**：**Phase 1 只承诺宿主机直跑 OryxOS + docker 档**（OryxOS 进程直接调宿主 docker CLI，无 socket 挂载问题）；容器化 OryxOS + docker 档标注为 advanced 路径，文档给出 socket proxy（Sysbox）/ rootless podman / K8s Job 三种候选与风险说明，不在本期验收范围。
+**理由**：单二进制宿主机直跑是项目当前的典型形态（tar.gz 路径）；socket 挂载的安全设计值得独立特性消化。
+
+### RQ-2 · 生命周期粒度
+
+**问题**：每次工具调用起短命容器（隔离最干净，延迟 ~几百 ms）还是每 Agent 长驻容器（低延迟但隔离变粗、状态延续引入新问题）？
+**推荐**：**Phase 1 只做短命容器（`docker run --rm`）**。长驻容器作为后续优化档（有真实延迟诉求再评估）。
+**理由**：与「爆炸半径最小化」的立项动机一致；长驻容器的状态清理、崩溃恢复、复用隔离是另一整个问题域。
+
+### RQ-3 · 后端覆盖范围
+
+**问题**：只有 shell 走后端，还是 file / http 工具也进容器？
+**推荐**：**Phase 1 仅 shell**。file 工具继续本地直操作（工作区在卷/磁盘上，挂进容器后容器内写入对 file 工具天然可见，见 FR-014）；http 工具维持现状（其沙箱是域名白名单 + DNS pinning，与执行位置正交）。
+**理由**：shell 是真正的任意代码执行面；file/http 的既有防线与执行位置无关，容器化它们的收益远小于成本。
+
+### RQ-4 · 工作区挂载与路径映射
+
+**问题**：Agent 的脚本/文件在容器内如何可见？路径如何双向翻译？
+**推荐**：**`ORYXOS_ROOT` 整体只读挂载？否——读写挂载到容器内固定路径 `/workspace`**。入参中的工作区绝对路径翻译为 `/workspace/...`；审计记录保留宿主路径；容器输出里出现的 `/workspace/...` 反译回宿主路径（便于模型与用户理解）。
+**理由**：Agent 的典型用法是「执行工作区里的脚本并读写产出」，只读挂载会砍掉一半场景；固定挂载点让翻译规则可预测、可测试。
+
+### RQ-5 · 资源限额默认值
+
+**问题**：cgroup 限额（--memory / --cpus）默认开还是默认关？
+**推荐**：**默认开启**：`--memory 512m --cpus 1.0`，全局配置可调，按 Agent 可覆写；另默认 `--network none`（需要联网的 shell 场景显式配置打开）与 `--read-only` + `--tmpfs /tmp`。
+**理由**：「安全是地基」原则下默认值应安全优先而非性能优先；网络默认隔离与 http 工具的域名白名单形成一致的纵深口径。
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - docker 档最小闭环：shell 命令在短命容器里执行 (Priority: P1)
+
+管理员在 `config/application.yml` 配置 `oryxos.sandbox.backend: docker` 与执行镜像后重启。此后所有 Agent 的 `shell` 调用：白名单与 Tool Policy 照常前置（意图与准入检查一个不少），实际执行发生在 `docker run --rm` 的短命容器里——工作区挂载在 `/workspace` 双向可见，命令结束后容器销毁不留痕迹，审计记录多出「backend=docker + 容器 ID」。未配置 backend 的部署一切与现状完全一致（local 档零回归）。
+
+**Why this priority**: 本特性的本体——把执行位置从「应用自觉」迁到「内核强制」。全局最小闭环独立可用，不依赖任何按 Agent 配置。
+
+**Independent Test**: 配 docker 档 → 让 Agent 执行 `cat /etc/os-release`：返回容器发行版而非宿主的；执行 `touch /workspace/.oryxos/tmp-marker`：宿主侧文件工具立即可见该文件；`docker ps -a` 过滤无残留容器；审计含容器 ID。改回 local（或不配）→ 同命令返回宿主发行版，全量既有测试零修改通过。
+
+**Acceptance Scenarios**:
+
+1. **Given** backend=docker 且镜像已配置，**When** Agent 调用 `shell`，**Then** 命令在容器内执行（容器内文件系统视角），工作区路径入参被翻译为 `/workspace/...`，命令结束后容器被 `--rm` 清理。
+2. **Given** 同上，**When** 容器内命令写 `/workspace` 下文件，**Then** 宿主侧该文件立即存在且 file 工具可读（双向映射）。
+3. **Given** 同上，**When** 命令执行超过工具超时，**Then** 容器被终止（不泄漏，见 FR-006），调用按既有超时语义失败。
+4. **Given** backend=docker 但 docker daemon 不可用，**When** Agent 调用 shell，**Then** 返回清晰错误（含排障提示）、审计留痕、OryxOS 进程不崩；**不静默回落 local**。
+5. **Given** 未配置 backend（默认 local），**When** 任意 Agent 任意工具调用，**Then** 行为与本 feature 之前完全一致（回归零破坏）。
+6. **Given** shell 命令试图访问网络（如 curl），**When** 默认 `--network none`，**Then** 连接失败（网络默认隔离）。
+
+---
+
+### User Story 2 - 按 Agent 覆写与资源限额 (Priority: P2)
+
+全局 docker 档之下，运维 Agent（ops-agent）需要原生机能（如访问宿主 docker CLI 本身）：其 `AGENT.md` frontmatter 写 `sandbox: local`，仅它回落本地执行。反向：全局 local 的保守部署里，单个处理外部输入的 Agent 可单独 `sandbox: docker` 收紧。资源限额同理可按 Agent 覆写——给跑批 Agent 更大的 `--memory`。
+
+**Why this priority**: 全局一刀切必然产生例外（与 020 US2 的 exempt 同构）；依赖 US1 的后端框架，故 P2。
+
+**Independent Test**: 全局 docker + ops-agent 配 `sandbox: local` → 该 Agent `cat /etc/os-release` 返回宿主发行版，其余 Agent 返回容器的；Agent A 配 `sandbox.docker.memory: 1g` → 该 Agent 容器的 Memory Limit 为 1g（`docker inspect` 验证），其余为默认值。
+
+**Acceptance Scenarios**:
+
+1. **Given** 全局 docker 且 Agent X frontmatter `sandbox: local`，**When** X 调用 shell，**Then** 本地执行（与现状一致）；其余 Agent 仍走容器。
+2. **Given** 全局 local 且 Agent Y frontmatter `sandbox: docker`（含镜像继承全局配置），**When** Y 调用 shell，**Then** 容器内执行。
+3. **Given** Agent 级覆写了 memory/cpus，**When** 其容器启动，**Then** cgroup 限额按 Agent 值生效（`docker inspect` 可证）。
+4. **Given** frontmatter 的 sandbox 值非法（未知档位/拼写错误），**When** Agent 加载，**Then** 启动期清晰告警并按全局档执行（不静默、不阻断其它 Agent）。
+
+---
+
+### User Story 3 - 管理台后端状态页 (Priority: P3)
+
+管理员在管理台看到执行后端的全局档位、docker 可用性探测结果（daemon 活着吗、CLI 版本）、当前生效镜像与资源限额默认值、各 Agent 的覆写一览。只读为主，改配置仍走 application.yml / Agent 目录（GitOps 路径不动）。
+
+**Why this priority**: 「配置即责任」要成立，配置结果必须可见——回答「现在命令到底在哪执行」。纯可视化增强，不影响 US1/US2 正确性。
+
+**Independent Test**: 配 docker 档 + 停掉 daemon → 状态页档位显示 docker 但可用性标红；Agent 覆写列表与 frontmatter 实际内容一致。
+
+**Acceptance Scenarios**:
+
+1. **Given** backend=docker 且 daemon 正常，**When** 打开状态页，**Then** 显示档位、daemon 可达、镜像 digest、默认限额。
+2. **Given** daemon 停止，**When** 打开状态页，**Then** 可用性标红并给出排障提示（与 SC-006 的运行时错误口径一致）。
+
+## Edge Cases
+
+1. 镜像配置了但本地不存在：启动校验尝试预拉取；失败则启动报错（fail loud，不进「配置了却静默不生效」状态）。
+2. 白名单允许的命令在镜像内不存在（如 alpine 无 bash）：错误信息须指明「容器内未找到」，区别于宿主语义。
+3. 工作区挂载与容器内 uid 映射：容器内 root/非 root 写卷的权限差异——执行用户固定非 root（`--user`），文档明示卷属主要求。
+4. docker CLI 不在 PATH：启动校验即报错（档位为 docker 时）。
+5. 并发多次 shell 调用：多个短命容器并存，无共享状态；超时清理不误伤他人容器（按容器 ID 精确 kill）。
+6. Windows / macOS Docker Desktop：挂载路径翻译经 Docker Desktop 的文件共享层，行为差异文档化（开发环境为主，生产形态是 Linux）。
+7. Agent 声明 docker 档但全局未配镜像：按「镜像缺失」fail loud 口径（EC-1），不隐式选默认镜像。
+8. 超长输出：容器 stdout/stderr 经现有 ShellTools 的截断与字符集处理，行为不变。
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+需求用语约定：MUST = 必须满足；MUST NOT = 必须禁止。FR/US/SC 编号为稳定标识符。
+
+| # | 需求 | 备注 |
+| --- | --- | --- |
+| FR-001 | 现有包级 `ProcessStarter`（ShellTools 内）MUST 升格为公开扩展点（迁至 `io.oryxos.tool.sandbox`），local 档 = 现 `ProcessBuilder` 实现为默认，行为逐字节不变 | 接缝已存在，升格即可 |
+| FR-002 | docker 档 MUST 以 `docker run --rm` 短命容器执行白名单校验后的命令，经 CLI 调用（ProcessBuilder 起 docker 进程），MUST NOT 引入 docker SDK / 新运行时依赖 | 宪法「零仪式」同源 |
+| FR-003 | `ORYXOS_ROOT` MUST 读写挂载到容器内固定路径 `/workspace`；shell 入参中的工作区绝对路径 MUST 翻译为 `/workspace/...`，审计 MUST 记录宿主原始路径 | RQ-4 |
+| FR-004 | docker 档默认安全参数 MUST 生效：`--network none`、`--read-only` + `--tmpfs /tmp`、`--memory 512m`、`--cpus 1.0`、非 root `--user`；各项 MUST 可配置覆写 | RQ-5 |
+| FR-005 | 档位为 docker 时 MUST 显式配置执行镜像（`oryxos.sandbox.docker.image`）；启动校验 MUST 验证 CLI 存在 + daemon 可达 + 镜像可用（必要时预拉取），任一失败 fail loud | EC-1/4/7 |
+| FR-006 | 工具超时 MUST 终止容器本体而非仅杀 docker CLI 进程（如 `--cidfile` + destroy 联动 `docker kill`）；MUST NOT 留下泄漏容器 | SC-004 |
+| FR-007 | 既有检查顺序 MUST 不变：Tool Policy（020，事前不可见/事中拒绝）→ 白名单 enforce → 后端执行；后端 MUST NOT 跳过或替代前两层 | 三层互补 |
+| FR-008 | `tool_invocations` 审计 MUST 记录执行后端标识（local/docker）与容器 ID（docker 档）；local 档记录与本 feature 之前一致 + backend=local | 兼容既有查询 |
+| FR-009 | 全局配置 MUST 支持 `oryxos.sandbox.backend: local|docker`（默认 local）与 `oryxos.sandbox.docker.*`（image/memory/cpus/network/user/tmpfs） | |
+| FR-010 | Agent MUST 可经 AGENT.md frontmatter（`sandbox.backend` + 限额覆写）覆写全局档位；非法值告警并回落全局（EC） | US2 |
+| FR-011 | docker 不可用（daemon 停止/CLI 缺失）时 MUST 以清晰错误失败并留审计，MUST NOT 静默回落 local 执行 | 安全语义：档位是承诺 |
+| FR-012 | 管理台 MUST 提供后端状态页：档位、daemon 探测、镜像信息、默认限额、Agent 覆写一览（只读） | US3 |
+| FR-013 | local 档（含未配置）MUST 保持全量既有行为：既有测试零修改通过 | SC-001 |
+| FR-014 | file 工具维持本地直操作；容器内对 `/workspace` 的写入对 file 工具 MUST 立即可见（同一文件系统），路径语义文档化 | RQ-3 |
+| FR-015 | http 工具、MCP 工具的执行位置 MUST NOT 因本特性改变 | RQ-3 |
+
+### Key Entities
+
+```yaml
+# config/application.yml（新增段）
+oryxos:
+  sandbox:
+    backend: local            # local | docker，默认 local
+    docker:
+      image: ""               # 必填（backend=docker 时），如 python:3.12-alpine
+      memory: 512m
+      cpus: "1.0"
+      network: none           # none | default | <自定义网络名>
+      user: "65534:65534"     # 非root执行用户（nobody）
+```
+
+```yaml
+# AGENT.md frontmatter（新增可选字段）
+sandbox:
+  backend: docker             # 覆写全局档位
+  docker:
+    memory: 1g                # 按Agent覆写限额
+```
+
+审计字段：`tool_invocations` 增加 `execution_backend`（local/docker）与 `container_id`（nullable）。
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+| # | 验收标准 |
+| --- | --- |
+| SC-001 | 未配置 backend 的部署：全量既有测试零修改通过；shell 执行路径与现状逐字节一致（local 零回归） |
+| SC-002 | docker 档下 `cat /etc/os-release` 返回容器发行版≠宿主；执行后 `docker ps -a` 无残留容器 |
+| SC-003 | 容器内 `touch /workspace/.oryxos/marker` 后，宿主侧 file 工具读取成功（双向映射） |
+| SC-004 | 制造超时（如 `sleep 600` + 短超时）：调用失败且 `docker ps -a` 无泄漏容器（终止联动生效） |
+| SC-005 | 默认网络隔离：容器内 `curl/wget` 外网失败（`--network none`） |
+| SC-006 | 停 daemon 后调用 shell：返回含排障提示的错误、审计留痕、进程存活；恢复 daemon 后自动恢复（无需重启 OryxOS） |
+| SC-007 | 审计页可按 backend 筛选；docker 记录含容器 ID |
+| SC-008 | 全局 docker + 单 Agent `sandbox: local`：两 Agent 同命令返回宿主/容器两种发行版（覆写生效） |
+
+## Assumptions
+
+1. Phase 1 目标形态：OryxOS 直跑宿主机（tar.gz / `make docker` 之外的本地路径），宿主有 docker CLI；容器化 OryxOS + docker 档为 advanced（socket 安全设计独立消化，RQ-1）。
+2. docker 档不引入任何新 Maven 依赖（CLI 经 ProcessBuilder 调用，复用 ShellTools 既有超时/字符集/输出截断）。
+3. 白名单与 Tool Policy 的行为、配置、审计口径零改动（FR-007 只约束顺序不变）。
+4. SSH 远程档、file/http 容器化、每 Agent 长驻容器、镜像管理台——均为后续档/后续特性，本期不做（见 Input）。
+5. `--user` 非 root 与卷属主的配合：默认 `nobody`，卷属主不匹配导致写失败时错误信息给出 chmod/chown 提示（文档 + EC-3）。

--- a/specs/021-container-sandbox/tasks.md
+++ b/specs/021-container-sandbox/tasks.md
@@ -1,0 +1,98 @@
+# Tasks: 容器级执行隔离（Container Sandbox）
+
+**Input**: Design documents from `/specs/021-container-sandbox/`（spec.md + plan.md）
+
+**Prerequisites**: spec.md（15 FR / 8 SC / 3 US / 5 RQ）、plan.md（D1~D8 设计决策）
+
+**Tests**: 包含测试任务——质量门禁要求核心逻辑单测覆盖；「local 零回归」（SC-001）与「超时杀容器」（SC-004/FR-006）必须测试钉死；docker 依赖的验收用契约测试模式（daemon 缺失自动 skip 并标注，镜像 015 mem0 契约测试思路）。
+
+**Organization**: 契约与纯函数层一次成型在 Foundational（Phase 2），三个故事承载消费面——US1（docker 档最小闭环）为 MVP，US2（按 Agent 覆写）、US3（状态页）依次叠加。裁决翻案敏感任务已标 `⚖️RQ-x`。
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: 可并行（不同文件、无未完成依赖）
+- **[Story]**: 所属用户故事（US1/US2/US3），基础设施任务标 [F]
+
+## Path Conventions
+
+Maven 多模块单体——oryxos-tool（契约+实现）/ oryxos-core（审计通道）/ oryxos-storage（列迁移）/ oryxos-cli（装配）/ oryxos-web（状态页）。
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: 存储与配置地基
+
+- [ ] T001 [P] [F] 修改 `oryxos-storage/.../AuditSchemaUpgrade.java`：幂等 ALTER 为 `tool_invocations` 加 `execution_backend VARCHAR(8)`、`container_id VARCHAR(64)` 两可空列（PRAGMA table_info 检查模式，镜像 020 `blocked_by` 先例）；`AuditSchemaUpgradeTest` 追加两列升级用例
+- [ ] T002 [P] [F] 新建 `oryxos-tool/.../sandbox/DockerSandboxProperties.java`：`image/memory/cpus/network/user`（默认 `512m`/`1.0`/`none`/`65534:65534`）+ 全局 `oryxos.sandbox.backend`（`local|docker`，默认 local）；镜像 ShellSandboxProperties 的属性类风格；配套绑定测试（默认值钉死，SC-001 锚点）
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: 契约升格 + 四个纯函数/可 mock 组件——所有消费面的公共依赖
+
+**⚠️ CRITICAL**: 本阶段完成前不得开始任何用户故事
+
+- [ ] T003 [F] 新建 `oryxos-tool/.../sandbox/ProcessStarter.java` 公开接口（自 ShellTools 包级升格，形状不变 `Process start(List<String>)`）；**Javadoc 写死契约**：`destroy()` MUST 终止真实执行本体（本地=进程 / docker=容器），超时语义依赖此条（FR-006 的契约化）；修改 `ShellTools.java` 删除包级定义改引公开版
+- [ ] T004 [P] [F] 新建 `oryxos-tool/.../sandbox/LocalProcessStarter.java`：现 ShellTools 内 ProcessBuilder 默认实现逐字节搬家（含既有 SuppressFBWarnings 注释跟随）；ShellTools 构造注入点不变——**搬运不改行为**（SC-001 的第一道防线）
+- [ ] T005 [P] [F] 新建 `oryxos-tool/.../sandbox/WorkspacePathMapper.java`（⚖️RQ-4）：`toContainer(hostPath)` / `toHost(containerPath)` / `isWorkspacePath(host)`——ORYXOS_ROOT 前缀 ↔ `/workspace` 纯字符串映射，不做 realpath；单测：双向翻译、非工作区路径直通、相对路径直通、尾分隔符归一
+- [ ] T006 [F] 新建 `oryxos-tool/.../sandbox/DockerRunSpec.java`（⚖️RQ-5）：纯函数 `List<String> build(DockerSandboxProperties props, Path workspaceRoot, List<String> command)` → 完整 docker argv（`run --rm --cidfile <tmp> -v <root>:/workspace --network ? --memory ? --cpus ? --read-only --tmpfs /tmp --user ? <image> <cmd…>`，命令内工作区路径经 T05 翻译）；单测钉死：参数顺序、默认安全参数全在场（SC-005 的防线）、入参翻译、自定义网络/限额覆写
+- [ ] T007 [F] 新建 `oryxos-tool/.../sandbox/CidfileProcessWrapper.java`：包装 docker CLI Process——流委托；`destroy()` 读 cidfile → `docker kill <id>`（容器已退/无 cidfile 则仅杀 CLI，kill 报错按成功处理，plan 风险 1）；单测 mock docker kill 断言联动与 fallback 两分支
+- [ ] T008 [P] [F] 修改 `oryxos-core/.../ToolInvocationAuditor.java`：`record` 加 `executionBackend`/`containerId` 重载（旧签名委托 `local`/null，镜像 020 blockedBy 模式）；`ToolInvocation` + `JpaToolInvocationAuditor` 落列（依赖 T001）
+
+**Checkpoint**: 全部单测绿 + local 档既有全量测试零修改通过（SC-001 在实现层的第一道验收）
+
+---
+
+## Phase 3: User Story 1 - docker 档最小闭环 (Priority: P1) 🎯 MVP
+
+**Goal**: 全局切 docker 档，shell 在短命容器执行，白名单/Policy 照常前置，审计带后端标识，docker 故障 fail loud
+
+- [ ] T009 [US1] 新建 `oryxos-tool/.../sandbox/DockerProcessStarter.java`：组合 T006+T007——build argv → 起 docker CLI → CidfileProcessWrapper 包装返回；docker 失败分类（CLI 缺失 / daemon 不可达 / 镜像缺失）转结构化错误信息（FR-011 口径：含排障提示，不回落 local）
+- [ ] T010 [US1] 修改 `oryxos-cli/.../OryxOsRuntime.java` 装配：按 `oryxos.sandbox.backend` 选择 starter（local→T004 / docker→T009）注入 ShellTools（现 `new ShellTools(sandbox)` 单点改）；**检查顺序不变**：ShellTools 内 sandbox.enforce 仍先于 starter（FR-007 无需改动即成立，测试钉死）
+- [ ] T011 [US1] 新建 `oryxos-web/.../security/DockerBackendStartupCheck.java`（镜像 020 ToolPolicyStartupCheck：ApplicationRunner + @ConditionalOnWebApplication）：backend=docker 时校验 CLI 存在 / `docker info` 可达 / 镜像存在（必要时 `docker pull` 预拉取，FR-005），任一失败 fail loud；配套单测三分支
+- [ ] T012 [US1] ShellTools 审计贯通（依赖 T008/T009）：shell 调用记录 backend 标识与容器 ID（从 wrapper 取 cidfile 内容）；local 档记录 `local`
+- [ ] T013 [US1] 契约测试 `DockerProcessStarterIT`（daemon 存在才跑，缺失 skip+标注）：SC-002（容器发行版≠宿主 + `--rm` 零残留）、SC-003（容器内写 /workspace 宿主可见）、SC-004（sleep 超时→无泄漏容器）、SC-005（network=none 下外网失败）、SC-006（停 daemon→结构化错误+进程存活+恢复后自愈）
+
+**Checkpoint**: MVP 演示走查（spec US1 Independent Test 全步）可录
+
+---
+
+## Phase 4: User Story 2 - 按 Agent 覆写与限额 (Priority: P2)
+
+**Goal**: frontmatter `sandbox:` 段覆写全局档位与限额；非法值告警回落
+
+- [ ] T014 [P] [US2] frontmatter 解析：AgentProfile（或其解析处）加可选 `sandbox.backend` + `sandbox.docker.{memory,cpus}`；非法档位值→加载 WARN + 回落全局（EC-4 口径：不静默、不阻断其它 Agent）；单测覆盖合法/非法/缺省三态
+- [ ] T015 [US2] 生效配置收敛（D8）：`EffectiveSandboxConfig resolve(global, agent)`——frontmatter 覆写优先、未配继承全局；DockerRunSpec 接收生效配置（T010 装配点改为按 Agent 解析后传入）；单测钉死收敛优先级
+- [ ] T016 [US2] 契约测试补充 SC-007（审计按 backend 筛选含容器 ID）、SC-008（两 Agent 同命令宿主/容器两种发行版）
+
+**Checkpoint**: US2 独立验收全步绿
+
+---
+
+## Phase 5: User Story 3 - 管理台后端状态页 (Priority: P3)
+
+**Goal**: 档位/daemon 探测/镜像/限额/覆写一览，只读
+
+- [ ] T017 [P] [US3] 新建 `oryxos-web/.../controller/SandboxBackendController.java`：GET 状态（档位、daemon 可达性+CLI 版本按需探测 D5、镜像 digest、默认限额、Agent 覆写一览）；REST 单测（mock 探测器）
+- [ ] T018 [US3] Vue 状态页：镜像 020 策略页版式——daemon 标红态与 SC-006 错误口径一致；中英文案
+
+**Checkpoint**: US3 验收场景两步可在管理台复现
+
+---
+
+## Phase 6: 文档与验收走查
+
+**Purpose**: 文档同步 + 全量门禁 + SC 落卷（017「真机验收落卷」先例）
+
+- [ ] T019 [P] [F] website 双语文档：新增/扩展 sandbox 页——backend 配置、路径映射语义（FR-014：file 工具与容器内写入互见）、超时行为、advanced 部署（容器化 OryxOS + socket 三候选风险表，⚖️RQ-1 文档化承诺）
+- [ ] T020 [P] [F] CLAUDE.md：宪法六补充容器边界与白名单的关系表述 + 工作区结构标注 `/workspace` 映射；README feature 列表一句话
+- [ ] T021 [F] 验收走查 quickstart（镜像 020 V1~V7 形式）：SC-001~008 逐步操作录证；`mvn verify` 全量门禁绿；EC-1~8 逐条过（桌面环境差异 EC-6 允许文档化豁免）
+- [ ] T022 [F] 真机验收落卷：验收报告（020 acceptance-report.md 先例）——实测数据（执行延迟对比 local/docker、超时终止、恢复自愈）入卷
+
+---
+
+## 任务统计
+
+26 项任务按 6 阶段组织（T001~T022 编号顺排，其中 T013/T016 为多场景契约测试合编）；US1 为 MVP 独立可交付，US2/US3 依次叠加，文档收尾贯穿。


### PR DESCRIPTION
021 spec 草案（issue #334 认领交付物）。体例对齐 020，含 15 FR / 8 SC / 3 US，以及 **5 处待裁决项（RQ-1~5，均附推荐与理由）**——期望评审先收敛裁决，再进 plan。

## 核心设计

- **落点是现成的**：`ShellTools` 已有包级 `ProcessStarter` 接缝（默认实现即 `ProcessBuilder`），升格为公开扩展点即可——local 档零变化（FR-001/013）
- **docker 档零新依赖**：经 CLI（`docker run --rm`）执行，复用 ShellTools 既有超时/字符集/截断；不引 docker SDK（FR-002）
- **三层纵深防御锁死顺序**：Tool Policy → 白名单 → 后端，本特性只加不改（FR-007）
- **超时必须杀容器本体**：`--cidfile` + destroy 联动 `docker kill`，防「杀了 CLI 漏了容器」（FR-006，SC-004 专门验收）

## 5 处待裁决（摘要，详见 spec Clarifications）

| # | 问题 | 推荐 |
| --- | --- | --- |
| RQ-1 | docker socket 安全形态 | Phase 1 只承诺宿主机直跑 + docker 档；容器化 OryxOS + socket 挂载标 advanced 文档化 |
| RQ-2 | 容器生命周期 | 仅短命容器（--rm）；每 Agent 长驻后续档 |
| RQ-3 | 后端覆盖范围 | 仅 shell；file/http 维持现状（与执行位置正交） |
| RQ-4 | 工作区映射 | ORYXOS_ROOT 读写挂 `/workspace`，路径双向翻译，审计记宿主路径 |
| RQ-5 | 资源限额 | 默认开启：512m / 1.0 CPU / network=none / read-only+tmpfs / 非 root |

各裁决项都给了替代方案与取舍理由，欢迎直接改推荐——草案阶段的目的是收敛，不是固守。
