### PR TITLE
docs: update demo agent model example to deepseek-v4-flash

### DIFF
--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -88,7 +88,7 @@ OryxOS ships with three demo agents under `.oryxos/agents/` that show the model 
 | `daily-tech-digest` | Pulls headlines from `hn.algolia.com`, reads an on-demand skill file, and notifies a digest |
 | `github-daily` | Runs a trusted local Python script via `shell` and notifies a GitHub trending report (requires explicitly allowing `python3`) |
 
-All three use provider `deepseek` / `deepseek-chat` and reference a notify channel by name.
+All three use provider `deepseek` / `deepseek-v4-flash` and reference a notify channel by name.
 
 > `github-daily` is an opt-in trusted-script demo. `python3` is deliberately absent from the default shell whitelist because an interpreter grants arbitrary code execution. Review the script before explicitly adding `python3`; do not enable it for untrusted agent input.
 

--- a/website/zh/docs/quick-start.md
+++ b/website/zh/docs/quick-start.md
@@ -117,7 +117,7 @@ OryxOS 在 `.oryxos/agents/` 下自带三个 Demo Agent 演示这套模型：
 | `daily-tech-digest` | 从 `hn.algolia.com` 拉头条，按需读取 skill 文件，推送科技日报 |
 | `github-daily` | 用 `shell` 跑受信任的本地 Python 脚本，推送 GitHub 热门日报（需显式允许 `python3`） |
 
-三者都用 Provider `deepseek` / `deepseek-chat`，并按名引用通知渠道。
+三者都用 Provider `deepseek` / `deepseek-v4-flash`，并按名引用通知渠道。
 
 > `github-daily` 是需要主动启用的受信任脚本 Demo。默认 shell 白名单刻意不包含 `python3`，因为解释器等同于任意代码执行能力。显式加入前请先审查脚本，不要对不受信任的 Agent 输入开放。
 


### PR DESCRIPTION
Quick Start still mentioned the deprecated deepseek-chat model after the default examples moved to deepseek-v4-flash in code and CHANGELOG.