### PR TITLE
fix(channel-dingtalk): 重连时复用 MessageSender，保留 sessionWebhook 映射

### DIFF
--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkChannelAdapter.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkChannelAdapter.java
@@ -116,6 +116,8 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
     if (stream != null) {
       stream.closeQuietly();
     }
+    sender = null;
+    normalizer = null;
     state = ChannelStatus.State.DISCONNECTED;
   }
 
@@ -148,8 +150,7 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
   }
 
   private void connectLocked() throws Exception {
-    normalizer = new DingTalkEventNormalizer(config.name());
-    sender = new DingTalkMessageSender(guard, DingTalkMessageSender.DEFAULT_CHUNK_SIZE);
+    ensureOutboundStack();
     DingTalkStreamClient client =
         new DingTalkStreamClient(
             config.appId(),
@@ -159,6 +160,16 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
             this::handleDisconnected);
     client.connect(START_TIMEOUT);
     streamRef.set(client);
+  }
+
+  /** 懒初始化出站组件；重连复用同一 {@link DingTalkMessageSender} 以保留 sessionWebhook 映射（#338 后续）。 */
+  private void ensureOutboundStack() {
+    if (normalizer == null) {
+      normalizer = new DingTalkEventNormalizer(config.name());
+    }
+    if (sender == null) {
+      sender = new DingTalkMessageSender(guard, DingTalkMessageSender.DEFAULT_CHUNK_SIZE);
+    }
   }
 
   private void handleDisconnected() {

--- a/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkChannelAdapterLifecycleTest.java
+++ b/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkChannelAdapterLifecycleTest.java
@@ -1,8 +1,16 @@
 package io.oryxos.channel.dingtalk;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
+import io.oryxos.core.channel.ChannelConfig;
+import io.oryxos.core.channel.InboundMessageService;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -21,5 +29,31 @@ class DingTalkChannelAdapterLifecycleTest {
   @DisplayName("重连退避：负 attempt 按 0 处理")
   void reconnectDelayClampsNegativeAttempt() {
     assertTrue(DingTalkChannelAdapter.reconnectDelayMs(-1) >= 2_000L);
+  }
+
+  @Test
+  @DisplayName("重连路径复用 MessageSender，sessionWebhook 映射不丢失")
+  void outboundStackReusedAcrossReconnectInit() throws Exception {
+    ChannelConfig config =
+        new ChannelConfig("ops-dingtalk", "dingtalk", "cid", "csec", "demo-agent", true);
+    DingTalkChannelAdapter adapter =
+        new DingTalkChannelAdapter(
+            config,
+            new ProfileRegistry(),
+            mock(InboundMessageService.class),
+            (OutboundGuard) url -> {});
+
+    Method ensure = DingTalkChannelAdapter.class.getDeclaredMethod("ensureOutboundStack");
+    ensure.setAccessible(true);
+    Field senderField = DingTalkChannelAdapter.class.getDeclaredField("sender");
+    senderField.setAccessible(true);
+
+    ensure.invoke(adapter);
+    DingTalkMessageSender first = (DingTalkMessageSender) senderField.get(adapter);
+    first.rememberSession("conv-1", "https://oapi.dingtalk.com/robot/send?token=t", null);
+
+    ensure.invoke(adapter);
+    DingTalkMessageSender second = (DingTalkMessageSender) senderField.get(adapter);
+    assertSame(first, second);
   }
 }


### PR DESCRIPTION
## Summary
- #338 重连路径不再每次 `new DingTalkMessageSender`，避免 `sessionWebhooks` 被清空导致慢回复失败
- `stop()` 清空出站栈，保证下次 `start()` 状态干净
- 单测覆盖 `ensureOutboundStack` 二次调用复用同一实例

Fixes #339

## Test plan
- [x] `mvn -pl oryxos-channel-dingtalk -am test -Dtest=DingTalk*Test -Dsurefire.failIfNoSpecifiedTests=false`