### PR TITLE
feat(channel-dingtalk): send outbound replies as markdown

### DIFF
--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkMessageSender.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkMessageSender.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * 钉钉机器人回复：经入站消息携带的 {@code sessionWebhook} POST 文本；出站前过 {@link OutboundGuard}。
+ * 钉钉机器人回复：经入站消息携带的 {@code sessionWebhook} POST markdown（对齐企微出站）；出站前过 {@link OutboundGuard}。
  *
  * <p>群聊 B4：{@code replyToMessageId} 非空时附带 {@code at.atUserIds} 引用提问者（会话内可对应）。
  */
@@ -25,6 +25,8 @@ public class DingTalkMessageSender {
 
   static final int DEFAULT_CHUNK_SIZE = 3500;
   static final String SESSION_WEBHOOK_PREFIX = "https://oapi.dingtalk.com";
+  static final String MSG_TYPE_MARKDOWN = "markdown";
+  static final String DEFAULT_MARKDOWN_TITLE = "OryxOS";
   private static final int HTTP_STATUS_OK_MIN = 200;
   private static final int HTTP_STATUS_OK_MAX_EXCLUSIVE = 300;
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
@@ -71,15 +73,17 @@ public class DingTalkMessageSender {
             ? groupAtUserIds.get(conversationId)
             : null;
     for (String chunk : segment(text == null ? "" : text, chunkSize)) {
-      postText(webhook, chunk, atUserId);
+      postMarkdown(webhook, chunk, atUserId);
     }
   }
 
-  private void postText(String webhook, String content, String atUserId) {
+  private void postMarkdown(String webhook, String content, String atUserId) {
     try {
       ObjectNode body = MAPPER.createObjectNode();
-      body.put("msgtype", "text");
-      body.putObject("text").put("content", content);
+      body.put("msgtype", MSG_TYPE_MARKDOWN);
+      ObjectNode markdown = body.putObject("markdown");
+      markdown.put("title", markdownTitle(content));
+      markdown.put("text", content);
       if (atUserId != null && !atUserId.isBlank()) {
         ObjectNode at = body.putObject("at");
         ArrayNode ids = MAPPER.createArrayNode();
@@ -119,6 +123,26 @@ public class DingTalkMessageSender {
       parts.add(text.substring(i, Math.min(text.length(), i + chunkSize)));
     }
     return parts;
+  }
+
+  /** 钉钉 markdown 必填 title：取首行摘要，过长截断；空内容用默认标题。 */
+  static String markdownTitle(String content) {
+    if (content == null || content.isBlank()) {
+      return DEFAULT_MARKDOWN_TITLE;
+    }
+    String line = content.stripLeading();
+    int newline = line.indexOf('\n');
+    if (newline >= 0) {
+      line = line.substring(0, newline);
+    }
+    line = line.strip();
+    if (line.startsWith("#")) {
+      line = line.replaceFirst("^#+\\s*", "");
+    }
+    if (line.length() > 20) {
+      line = line.substring(0, 20);
+    }
+    return line.isBlank() ? DEFAULT_MARKDOWN_TITLE : line;
   }
 
   /**

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkMessageSender.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkMessageSender.java
@@ -27,6 +27,8 @@ public class DingTalkMessageSender {
   static final String SESSION_WEBHOOK_PREFIX = "https://oapi.dingtalk.com";
   static final String MSG_TYPE_MARKDOWN = "markdown";
   static final String DEFAULT_MARKDOWN_TITLE = "OryxOS";
+  private static final String MARKDOWN_HEADING_PREFIX = "#";
+  private static final int MARKDOWN_TITLE_MAX_LEN = 20;
   private static final int HTTP_STATUS_OK_MIN = 200;
   private static final int HTTP_STATUS_OK_MAX_EXCLUSIVE = 300;
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
@@ -136,11 +138,11 @@ public class DingTalkMessageSender {
       line = line.substring(0, newline);
     }
     line = line.strip();
-    if (line.startsWith("#")) {
+    if (line.startsWith(MARKDOWN_HEADING_PREFIX)) {
       line = line.replaceFirst("^#+\\s*", "");
     }
-    if (line.length() > 20) {
-      line = line.substring(0, 20);
+    if (line.length() > MARKDOWN_TITLE_MAX_LEN) {
+      line = line.substring(0, MARKDOWN_TITLE_MAX_LEN);
     }
     return line.isBlank() ? DEFAULT_MARKDOWN_TITLE : line;
   }

--- a/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkMessageSenderTest.java
+++ b/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkMessageSenderTest.java
@@ -47,8 +47,8 @@ class DingTalkMessageSenderTest {
   }
 
   @Test
-  @DisplayName("sessionWebhook 发送 text 并过 OutboundGuard")
-  void sendTextViaSessionWebhook() throws Exception {
+  @DisplayName("sessionWebhook 发送 markdown 并过 OutboundGuard")
+  void sendMarkdownViaSessionWebhook() throws Exception {
     String webhookUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/hook";
     DingTalkMessageSender sender =
         new DingTalkMessageSender(
@@ -59,9 +59,20 @@ class DingTalkMessageSenderTest {
     assertEquals(webhookUrl, guarded.get());
     assertEquals(1, bodies.size());
     JsonNode body = MAPPER.readTree(bodies.get(0));
-    assertEquals("text", body.path("msgtype").asText());
-    assertEquals("你好", body.path("text").path("content").asText());
+    assertEquals(DingTalkMessageSender.MSG_TYPE_MARKDOWN, body.path("msgtype").asText());
+    assertEquals("你好", body.path("markdown").path("text").asText());
+    assertEquals("你好", body.path("markdown").path("title").asText());
     assertTrue(body.path("at").isMissingNode());
+  }
+
+  @Test
+  @DisplayName("markdown title 取首行并截断")
+  void markdownTitleFromFirstLine() {
+    assertEquals("OryxOS", DingTalkMessageSender.markdownTitle(""));
+    assertEquals("摘要", DingTalkMessageSender.markdownTitle("## 摘要\n正文"));
+    String title = DingTalkMessageSender.markdownTitle("这是一段很长的标题需要被截断到二十字以后的内容");
+    assertTrue(title.length() <= 20);
+    assertTrue(title.startsWith("这是一段很长的标题"));
   }
 
   @Test
@@ -74,6 +85,7 @@ class DingTalkMessageSenderTest {
     sender.send("conv-g", "答", "msg-1");
 
     JsonNode body = MAPPER.readTree(bodies.get(0));
+    assertEquals(DingTalkMessageSender.MSG_TYPE_MARKDOWN, body.path("msgtype").asText());
     assertEquals("staff-9", body.path("at").path("atUserIds").get(0).asText());
   }
 


### PR DESCRIPTION
## Summary

- `DingTalkMessageSender` sessionWebhook 回复由 `text` 改为 `markdown`（对齐企微 `WeComMessageSender`）
- `markdown.title` 取首行摘要（最长 20 字），`markdown.text` 为 Agent 原文
- 群聊 `at.atUserIds`、errcode fail-loud、分段发送逻辑不变

Fixes #ISSUE_NUM

## Test plan

- [x] `mvn -pl oryxos-channel-dingtalk test -Dtest=DingTalk*Test`（25 tests）
- [ ] 真机：钉钉私聊 Bot，确认 `**加粗**`、列表等 MD 渲染
