### PR TITLE
fix(channel-feishu): close ws client when start fails to avoid ghost reconnect

### DIFF
--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
@@ -118,8 +118,15 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
               .onReconnecting(() -> state = ChannelStatus.State.DISCONNECTED)
               .onReconnected(() -> state = ChannelStatus.State.CONNECTED)
               .build();
-      ws.start();
-      ws.awaitReady(READY_TIMEOUT_MS);
+      try {
+        ws.start();
+        ws.awaitReady(READY_TIMEOUT_MS);
+      } catch (Exception e) {
+        // start/awaitReady 失败的 ws.Client 不会交给 wsClient 字段，stop() 永远碰不到它；
+        // autoReconnect 已开启，不就地 close 会留下永久后台重连的幽灵连接 + 线程泄漏
+        closeQuietly(ws);
+        throw e;
+      }
       wsClient = ws;
       state = ChannelStatus.State.CONNECTED;
       lastError = null;
@@ -135,14 +142,19 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
   public synchronized void stop() {
     com.lark.oapi.ws.Client ws = wsClient;
     if (ws != null) {
-      try {
-        ws.close();
-      } catch (RuntimeException e) {
-        LOG.warn("飞书渠道 {} 断开时异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
-      }
+      closeQuietly(ws);
       wsClient = null;
     }
     state = ChannelStatus.State.DISCONNECTED;
+  }
+
+  /** 关闭 WS 客户端，异常仅告警不上抛——断开路径的异常不影响调用方语义。 */
+  private void closeQuietly(com.lark.oapi.ws.Client ws) {
+    try {
+      ws.close();
+    } catch (RuntimeException e) {
+      LOG.warn("飞书渠道 {} 断开时异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
+    }
   }
 
   /**


### PR DESCRIPTION
## 动机

`FeishuChannelAdapter.start()` 里 `ws.start()` 之后才 `awaitReady(READY_TIMEOUT_MS)` 探测就绪，`wsClient = ws` 赋值在最后。若 `awaitReady` 超时（或对端 reset）抛异常：

- 已 `start()` 且 `autoReconnect(true)` 的 SDK 客户端没有被 `close()`；
- 字段未赋值，`stop()` 读 `wsClient == null` 永远碰不到它；
- 外层 `ChannelAdminService.startOne()` 对 start 失败的适配器只 `registerOffline`、不 register，也没有任何外层能再关掉它。

后果：一次启动超时 = 一条永远后台重连的幽灵长连接 + SDK 线程泄漏，且事件还会投递给一个「已下线」的适配器。与 #342/#344（dingtalk WS 生命周期）属同类问题的另一面。

## 改动（生产代码 1 文件，+19/-7）

`FeishuChannelAdapter.java`：
- `ws.start()` / `awaitReady` 包进内层 try，失败时先 `closeQuietly(ws)` 就地销毁再重抛——`ws` 只在就绪成功后交给 `wsClient` 字段；
- `stop()` 的内联 try/catch close 提取为 `closeQuietly` 复用，语义不变（断开异常只告警不上抛）。

行为矩阵：启动成功路径零变化；启动失败路径从「泄漏一条幽灵连接」变为「就地关闭」。

## 测试说明

未加新用例：`ws.Client` 在 `start()` 内联构造，模拟 `awaitReady` 超时需要引入工厂 seam 或 mock SDK  final 类，为 3 行修复改类结构得不偿失；既有契约测试（`FeishuChannelContractTest` 9 个用例）覆盖 start 前置校验与状态语义，全部通过。若评审认为值得加 seam 补回归测试，请指出。

## 本地验证（Windows）

- `oryxos-channel-feishu`：Tests run: 23, Failures: 0, Errors: 0, Skipped: 0
- spotless / checkstyle / PMD 门禁全过