### PR TITLE
fix(tool): bound tool IO — smtp timeouts, streaming download cap, output truncation, concurrent mcp maps

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/HttpTools.java
@@ -8,6 +8,8 @@ import io.oryxos.tool.sandbox.PinnedHttpReadClient;
 import io.oryxos.tool.sandbox.Sandbox;
 import io.oryxos.tool.sandbox.SandboxAction;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -35,6 +37,9 @@ public class HttpTools {
 
   /** fetch_webpage 抽取正文的长度上限，防超大页面撑爆上下文。 */
   private static final int FETCH_TEXT_MAX = 20000;
+
+  /** download_file 落盘上限：超限即中止并删半成品——URL 默认放行，模型可触达任意公网大文件，全量缓冲会 OOM。 */
+  private static final long DOWNLOAD_MAX_BYTES = 50L * 1024 * 1024;
 
   private static final String DEFAULT_METHOD = "GET";
 
@@ -73,9 +78,17 @@ public class HttpTools {
   /** HTTP_REQUEST 专用：保留域名白名单语义，不额外拒绝运营者显式批准的内网端点。 */
   private final RestClient writeClient;
 
+  /** 下载落盘上限（可注入便于测试，生产固定 {@link #DOWNLOAD_MAX_BYTES}）。 */
+  private final long downloadMaxBytes;
+
   public HttpTools(Sandbox sandbox, RestClient restClient) {
+    this(sandbox, restClient, DOWNLOAD_MAX_BYTES);
+  }
+
+  HttpTools(Sandbox sandbox, RestClient restClient, long downloadMaxBytes) {
     this.sandbox = Objects.requireNonNull(sandbox, "sandbox 不能为空");
     Objects.requireNonNull(restClient, "restClient 不能为空"); // 保留构造签名，供 Spring 装配
+    this.downloadMaxBytes = downloadMaxBytes;
     JdkClientHttpRequestFactory writeFactory =
         new JdkClientHttpRequestFactory(
             HttpClient.newBuilder()
@@ -343,34 +356,123 @@ public class HttpTools {
     return htmlToText(html);
   }
 
-  @Tool(name = "download_file", description = "下载一个 URL 的内容到指定本地文件路径（URL：默认放行 + SSRF；本地路径：文件白名单）")
+  @Tool(
+      name = "download_file",
+      description = "下载一个 URL 的内容到指定本地文件路径（URL：默认放行 + SSRF；本地路径：文件白名单；超过 50MB 中止）")
   public String downloadFile(
       @ToolParam(description = "要下载的 URL") String url,
       @ToolParam(description = "保存到的本地文件路径") String path) {
-    MemoryMdGuard.rejectMutation(path);
-    AdminConfigFileGuard.rejectMutation(path);
-    WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
-    WorkspaceMutationGuard.rejectAgentMdDirectWrite(path);
-    sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path)); // 先校验落盘路径
-    byte[] data = read(url, byte[].class); // 读远端：放行 + 内网黑名单 + 逐跳重定向重校验
-    byte[] bytes = data == null ? new byte[0] : data;
+    enforceWriteGuards(path); // 先校验落盘路径，被拒就不发起网络请求
+    Path file = Path.of(path);
     try {
-      Path file = Path.of(path);
       Path parent = file.getParent();
       if (parent != null) {
         Files.createDirectories(parent);
       }
-      // 写前复检：与 write_file 同款——createDirectories 之后、Files.write 之前。
-      // 复检若放在建目录前，通过后父路径仍可被换成外向软链，写出白名单。
-      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
-      MemoryMdGuard.rejectMutation(path);
-      AdminConfigFileGuard.rejectMutation(path);
-      WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
-      WorkspaceMutationGuard.rejectAgentMdDirectWrite(path);
-      Files.write(file, bytes);
-      return "已下载到: " + path + "（" + bytes.length + " 字节）";
     } catch (IOException e) {
-      throw new UncheckedIOException("下载写入失败: " + path, e);
+      throw new UncheckedIOException("下载建目录失败: " + path, e);
+    }
+    // 写前复检：与 write_file 同款——createDirectories 之后、写文件之前。
+    // 复检若放在建目录前，通过后父路径仍可被换成外向软链，写出白名单。
+    enforceWriteGuards(path);
+    long bytes = downloadTo(url, file); // 读远端：放行 + 内网黑名单 + 逐跳重定向重校验
+    return "已下载到: " + path + "（" + bytes + " 字节）";
+  }
+
+  /** 落盘路径的全部写守卫：三守卫 + 文件白名单（调用点：下载前与建目录后复检各一次）。 */
+  private void enforceWriteGuards(String path) {
+    MemoryMdGuard.rejectMutation(path);
+    AdminConfigFileGuard.rejectMutation(path);
+    WorkspaceMutationGuard.rejectSkillKnowledgeContentWrite(path);
+    WorkspaceMutationGuard.rejectAgentMdDirectWrite(path);
+    sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, path));
+  }
+
+  /**
+   * 流式下载：手动跟随重定向（每跳重过 {@code HTTP_READ} 校验），响应体边读边写、超 {@link #DOWNLOAD_MAX_BYTES}
+   * 即中止并删半成品——不再全量缓冲进内存。
+   */
+  private long downloadTo(String url, Path file) {
+    String current = url;
+    for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      sandbox.enforce(new SandboxAction(ActionType.HTTP_READ, current)); // 每跳校验
+      String next;
+      try (PinnedHttpReadClient client =
+          PinnedHttpReadClient.open(sandbox, CONNECT_TIMEOUT, READ_TIMEOUT)) {
+        next = streamOneHop(client, current, file);
+      }
+      if (next == null) {
+        try {
+          return Files.size(file); // 本跳已落盘
+        } catch (IOException e) {
+          throw new UncheckedIOException("下载读取落盘信息失败: " + file, e);
+        }
+      }
+      current = URI.create(current).resolve(next).toString();
+    }
+    throw new IllegalStateException("重定向次数过多，拒绝: " + url);
+  }
+
+  /**
+   * 下载一跳：3xx 且带 Location 返回下一跳 URL（不读 body）；否则把响应体流式写入 {@code file} 并返回 null。 4xx/5xx 拒绝落盘（与
+   * retrieve() 的语义对齐，错误页不当成下载内容）。
+   */
+  private String streamOneHop(PinnedHttpReadClient client, String url, Path file) {
+    return client
+        .restClient()
+        .method(HttpMethod.GET)
+        .uri(url)
+        .exchange(
+            (request, response) -> {
+              if (response.getStatusCode().is3xxRedirection()) {
+                String location = response.getHeaders().getFirst("Location");
+                if (location != null && !location.isBlank()) {
+                  response.close();
+                  return location;
+                }
+              }
+              if (response.getStatusCode().isError()) {
+                response.close();
+                throw new IllegalStateException(
+                    "下载失败: HTTP " + response.getStatusCode().value() + " " + url);
+              }
+              try (InputStream in = response.getBody()) {
+                copyBounded(in, file, url, downloadMaxBytes);
+                return null;
+              } catch (IOException e) {
+                throw new UncheckedIOException("下载读取失败: " + url, e);
+              }
+            });
+  }
+
+  /** 边读边写并计数；超上限时中止、关闭流后删除半成品文件（Windows 上打开中的文件删不掉）， 不留部分下载内容被误用。 */
+  private static void copyBounded(InputStream in, Path file, String url, long maxBytes)
+      throws IOException {
+    long total = 0;
+    boolean exceeded = false;
+    try (OutputStream out = Files.newOutputStream(file)) {
+      byte[] buffer = new byte[8192];
+      int n;
+      while ((n = in.read(buffer)) != -1) {
+        total += n;
+        if (total > maxBytes) {
+          exceeded = true;
+          break;
+        }
+        out.write(buffer, 0, n);
+      }
+    }
+    if (exceeded) {
+      deleteQuietly(file);
+      throw new IllegalStateException("下载中止：超过上限 " + maxBytes + " 字节: " + url);
+    }
+  }
+
+  private static void deleteQuietly(Path file) {
+    try {
+      Files.deleteIfExists(file);
+    } catch (IOException e) {
+      // 半成品删不掉不掩盖原始失败——中止异常照常抛出
     }
   }
 

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
@@ -3,7 +3,9 @@ package io.oryxos.tool.builtin;
 import io.oryxos.tool.sandbox.ActionType;
 import io.oryxos.tool.sandbox.Sandbox;
 import io.oryxos.tool.sandbox.SandboxAction;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import java.time.Duration;
@@ -32,6 +34,12 @@ public class ShellTools {
 
   /** 默认超时：30 秒。 */
   static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+
+  /**
+   * 输出保留上限：stdout/stderr 全文会原样回灌模型上下文，白名单内命令（如 cat 大日志）可无界输出撑爆内存与 context
+   * window。超限部分**继续排空但丢弃**——停止读取会让子进程管道写阻塞、被误判超时。
+   */
+  static final int MAX_OUTPUT_BYTES = 64 * 1024;
 
   /** 排空子进程输出的虚拟线程执行器（宪法 VII）：流读取是 IO 等待，虚拟线程天然适配。 */
   @SuppressWarnings("PMD.ThreadPoolCreationRule") // Java 21 虚拟线程无池参数可配，非 P3C 针对的固定线程池反模式。
@@ -72,8 +80,8 @@ public class ShellTools {
     try {
       Process process = processStarter.start(command);
       // 先起并发排空再 waitFor：管道不被写满阻塞，waitFor 只在「命令真没跑完」时超时
-      Future<byte[]> stdout = DRAINER.submit(() -> process.getInputStream().readAllBytes());
-      Future<byte[]> stderr = DRAINER.submit(() -> process.getErrorStream().readAllBytes());
+      Future<BoundedOutput> stdout = DRAINER.submit(() -> drainBounded(process.getInputStream()));
+      Future<BoundedOutput> stderr = DRAINER.submit(() -> drainBounded(process.getErrorStream()));
       boolean finished;
       try {
         finished = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
@@ -88,11 +96,14 @@ public class ShellTools {
             "命令超时（" + timeout.toSeconds() + "s）被终止: " + commandExecutable);
       }
       try {
+        BoundedOutput err = stderr.get();
         if (process.exitValue() != 0) {
-          String err = new String(stderr.get(), outputCharset);
-          throw new IllegalStateException("命令退出码 " + process.exitValue() + ": " + err.trim());
+          String errText = new String(err.retained, outputCharset).trim();
+          throw new IllegalStateException(
+              "命令退出码 " + process.exitValue() + ": " + errText + truncationNote(err));
         }
-        return new String(stdout.get(), outputCharset);
+        BoundedOutput out = stdout.get();
+        return new String(out.retained, outputCharset) + truncationNote(out);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new IllegalStateException("命令执行被中断: " + commandExecutable, e);
@@ -145,5 +156,41 @@ public class ShellTools {
   private static void killTree(Process process) {
     process.descendants().forEach(ProcessHandle::destroyForcibly);
     process.destroyForcibly();
+  }
+
+  /** 有界排空：全程读取（保管道不阻塞），只保留前 {@link #MAX_OUTPUT_BYTES} 字节。截断点可能切开多字节字符， 解码时落为替换符——尾部紧邻截断标注，可接受。 */
+  private static BoundedOutput drainBounded(InputStream in) throws IOException {
+    ByteArrayOutputStream retained = new ByteArrayOutputStream();
+    byte[] buffer = new byte[8192];
+    boolean truncated = false;
+    int n;
+    while ((n = in.read(buffer)) != -1) {
+      if (truncated) {
+        continue; // 已超限：继续排空但丢弃
+      }
+      int room = MAX_OUTPUT_BYTES - retained.size();
+      if (n <= room) {
+        retained.write(buffer, 0, n);
+      } else {
+        retained.write(buffer, 0, room);
+        truncated = true;
+      }
+    }
+    return new BoundedOutput(retained.toByteArray(), truncated);
+  }
+
+  private static String truncationNote(BoundedOutput output) {
+    return output.truncated ? "\n…（输出超过 " + (MAX_OUTPUT_BYTES / 1024) + "KB，已截断）" : "";
+  }
+
+  /** 一路输出（stdout 或 stderr）的保留结果。 */
+  private static final class BoundedOutput {
+    private final byte[] retained;
+    private final boolean truncated;
+
+    private BoundedOutput(byte[] retained, boolean truncated) {
+      this.retained = retained;
+      this.truncated = truncated;
+    }
   }
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/mcp/McpClientService.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/mcp/McpClientService.java
@@ -11,10 +11,10 @@ import io.oryxos.core.mcp.McpServerStatus;
 import io.oryxos.tool.ToolRegistry;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,9 +39,11 @@ public class McpClientService {
   private final Function<McpServerConfig, McpSyncClient> clientFactory;
 
   // 运行时状态（供管理台状态查询 + disconnect 用）：server 名 -> 已连接的客户端 / 它注册过的工具名 / 上次失败原因。
-  private final Map<String, McpSyncClient> activeClients = new LinkedHashMap<>();
-  private final Map<String, List<String>> registeredTools = new LinkedHashMap<>();
-  private final Map<String, String> lastErrors = new LinkedHashMap<>();
+  // 写路径（connect/disconnect）经 McpServerAdminService 串行，但读路径 status() 无锁裸读——必须用并发 Map，
+  // 否则管理台查询与增删并发时 HashMap 结构修改中的 get 是未定义行为。
+  private final Map<String, McpSyncClient> activeClients = new ConcurrentHashMap<>();
+  private final Map<String, List<String>> registeredTools = new ConcurrentHashMap<>();
+  private final Map<String, String> lastErrors = new ConcurrentHashMap<>();
 
   public McpClientService(McpConfigLoader configLoader) {
     this(configLoader, McpClientService::connectDefault);
@@ -81,7 +83,7 @@ public class McpClientService {
         toolNames.add(tool.name());
       }
       activeClients.put(config.name(), client);
-      registeredTools.put(config.name(), toolNames);
+      registeredTools.put(config.name(), List.copyOf(toolNames));
       lastErrors.remove(config.name());
     } catch (RuntimeException e) {
       // 外部依赖失联不拖垮自身启动——只 WARN，OryxOS 照常起（课件守点）。
@@ -92,7 +94,9 @@ public class McpClientService {
       }
       closeQuietly(config.name(), client);
       LOG.warn("MCP server {} 连接失败，跳过它的工具: {}", s(config.name()), s(e.getMessage()));
-      lastErrors.put(config.name(), e.getMessage());
+      // ConcurrentHashMap 不收 null：异常无 message 时落异常类名
+      lastErrors.put(
+          config.name(), e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
     }
   }
 

--- a/oryxos-tool/src/main/java/io/oryxos/tool/mcp/McpToolAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/mcp/McpToolAdapter.java
@@ -20,6 +20,9 @@ public class McpToolAdapter implements OryxTool {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
+  /** 返回内容保留上限：全文原样进 ToolResult 回灌模型上下文，MCP server 可返回无界文本。 */
+  private static final int MAX_CONTENT_CHARS = 64 * 1024;
+
   private final McpSyncClient client;
   private final McpSchema.Tool tool;
 
@@ -69,8 +72,15 @@ public class McpToolAdapter implements OryxTool {
     if (result.content() == null) {
       return "";
     }
-    return result.content().stream()
-        .map(c -> c instanceof McpSchema.TextContent text ? text.text() : String.valueOf(c))
-        .collect(Collectors.joining("\n"));
+    String joined =
+        result.content().stream()
+            .map(c -> c instanceof McpSchema.TextContent text ? text.text() : String.valueOf(c))
+            .collect(Collectors.joining("\n"));
+    return joined.length() > MAX_CONTENT_CHARS
+        ? joined.substring(0, MAX_CONTENT_CHARS)
+            + "\n…（MCP 返回超过 "
+            + (MAX_CONTENT_CHARS / 1024)
+            + "KB，已截断）"
+        : joined;
   }
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/EmailNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/EmailNotifyAdapter.java
@@ -45,6 +45,12 @@ public final class EmailNotifyAdapter implements NotifyChannelAdapter {
   private static final int DEFAULT_SSL_PORT = 465;
   private static final int DEFAULT_STARTTLS_PORT = 587;
 
+  /**
+   * SMTP 三段超时（建连/读/写）：Jakarta Mail 缺省无限阻塞，同步执行模型（宪法 VII）下挂死的 SMTP 端点会把该 virtual thread 连同整个 ReAct
+   * 轮永久卡住——与 HttpTools/MCP 的超时口径对齐。
+   */
+  private static final String SMTP_TIMEOUT_MS = "10000";
+
   /** 凭证环境变量占位的包裹符：{@code ${VAR}} → 读取环境变量 VAR。 */
   private static final String ENV_PREFIX = "${";
 
@@ -74,6 +80,9 @@ public final class EmailNotifyAdapter implements NotifyChannelAdapter {
     Properties props = new Properties();
     props.put("mail.smtp.host", host);
     props.put("mail.smtp.port", String.valueOf(port));
+    props.put("mail.smtp.connectiontimeout", SMTP_TIMEOUT_MS);
+    props.put("mail.smtp.timeout", SMTP_TIMEOUT_MS);
+    props.put("mail.smtp.writetimeout", SMTP_TIMEOUT_MS);
     if (ENCRYPTION_SSL.equals(encryption)) {
       props.put("mail.smtp.ssl.enable", "true");
     } else if (ENCRYPTION_STARTTLS.equals(encryption)) {

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/HttpToolsTest.java
@@ -720,4 +720,36 @@ class HttpToolsTest {
     assertTrue(Files.exists(target));
     assertTrue(Files.readString(target).contains("晴"));
   }
+
+  @Test
+  @DisplayName("download_file 超过大小上限_中止并删除半成品（流式限长，不全量缓冲）")
+  void downloadFileAbortsAndDeletesPartialWhenOverLimit(@TempDir Path dir) throws IOException {
+    HttpServer big = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    try {
+      big.createContext(
+          "/big",
+          exchange -> {
+            byte[] chunk = new byte[8192];
+            exchange.sendResponseHeaders(200, 4L * chunk.length);
+            for (int i = 0; i < 4; i++) {
+              exchange.getResponseBody().write(chunk);
+            }
+            exchange.close();
+          });
+      big.start();
+      // 上限注入 1KB，服务端给 32KB——不必真传 50MB 即可验证限长
+      HttpTools limited = new HttpTools(new PermissiveSandbox(), RestClient.create(), 1024);
+      Path target = dir.resolve("big.bin");
+      String bigUrl = "http://127.0.0.1:" + big.getAddress().getPort() + "/big";
+
+      IllegalStateException ex =
+          assertThrows(
+              IllegalStateException.class, () -> limited.downloadFile(bigUrl, target.toString()));
+
+      assertTrue(ex.getMessage().contains("上限"));
+      assertTrue(Files.notExists(target), "超限后半成品必须删除，不得留部分下载内容");
+    } finally {
+      big.stop(0);
+    }
+  }
 }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/ShellToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/ShellToolsTest.java
@@ -156,6 +156,40 @@ class ShellToolsTest {
     assertTrue(ex.getMessage().contains(errText));
   }
 
+  @Test
+  @DisplayName("stdout 超 64KB_截断并标注（白名单内命令可无界输出，防撑爆内存与上下文窗口）")
+  void stdoutOverLimitIsTruncated() {
+    byte[] big = new byte[ShellTools.MAX_OUTPUT_BYTES + 100];
+    java.util.Arrays.fill(big, (byte) 'a');
+    ShellTools tools =
+        new ShellTools(
+            new PermissiveSandbox(),
+            Duration.ofSeconds(1),
+            command -> new StubProcess(true, big, new byte[0], 0));
+
+    String result = tools.shell("echo", List.of("x"));
+
+    assertTrue(result.contains("已截断"));
+    assertTrue(result.length() < big.length, "截断后必须短于原始输出");
+  }
+
+  @Test
+  @DisplayName("非零退出码且 stderr 超限_截断后仍带标注")
+  void stderrOverLimitIsTruncatedOnFailure() {
+    byte[] big = new byte[ShellTools.MAX_OUTPUT_BYTES + 100];
+    java.util.Arrays.fill(big, (byte) 'e');
+    ShellTools tools =
+        new ShellTools(
+            new PermissiveSandbox(),
+            Duration.ofSeconds(1),
+            command -> new StubProcess(true, new byte[0], big, 1));
+
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> tools.shell("echo", List.of("x")));
+
+    assertTrue(ex.getMessage().contains("已截断"));
+  }
+
   private static ShellTools shellTools(Process process) {
     return new ShellTools(new PermissiveSandbox(), Duration.ofSeconds(1), command -> process);
   }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpToolAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/mcp/McpToolAdapterTest.java
@@ -81,4 +81,18 @@ class McpToolAdapterTest {
     assertTrue(result.retryable(), "网络/限流类失败值得循环再试一次");
     assertTrue(result.errorMessage().contains("rate limited"));
   }
+
+  @Test
+  @DisplayName("返回内容超 64KB_截断并标注（全文回灌模型上下文，无界文本会撑爆窗口）")
+  void oversizedContentIsTruncated() throws Exception {
+    String big = "x".repeat(64 * 1024 + 100);
+    when(client.callTool(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(new McpSchema.CallToolResult(List.of(new McpSchema.TextContent(big)), false));
+
+    ToolResult result = adapter.execute(MAPPER.readTree("{}"));
+
+    assertTrue(result.success());
+    assertTrue(result.content().contains("已截断"));
+    assertTrue(result.content().length() < big.length(), "截断后必须短于原始内容");
+  }
 }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/notify/EmailNotifyAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/notify/EmailNotifyAdapterTest.java
@@ -94,6 +94,23 @@ class EmailNotifyAdapterTest {
   }
 
   @Test
+  @DisplayName("Session 属性：SMTP 建连/读/写三段超时已设置（Jakarta Mail 缺省无限阻塞会永久卡住 ReAct 轮）")
+  void sessionPropertiesIncludeTimeouts() throws Exception {
+    EmailNotifyAdapter adapter = new EmailNotifyAdapter(new PermissiveSandbox());
+
+    try (MockedStatic<Transport> transport = mockStatic(Transport.class)) {
+      adapter.send(target(Map.of()), "hello");
+      ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+      transport.verify(() -> Transport.send(captor.capture()));
+
+      Properties props = captor.getValue().getSession().getProperties();
+      assertEquals("10000", props.getProperty("mail.smtp.connectiontimeout"));
+      assertEquals("10000", props.getProperty("mail.smtp.timeout"));
+      assertEquals("10000", props.getProperty("mail.smtp.writetimeout"));
+    }
+  }
+
+  @Test
   @DisplayName("认证：配置 username 时显式开启 mail.smtp.auth（否则不发 AUTH → 530 未认证）")
   void authEnabledWhenUsernamePresent() throws Exception {
     EmailNotifyAdapter adapter = new EmailNotifyAdapter(new PermissiveSandbox());


### PR DESCRIPTION
## 动机

Review 发现 oryxos-tool 存在四处「无界 IO / 无超时」缺口，在宪法 VII 同步执行模型下都可被放大成 ReAct 循环卡死或 OOM：

1. **SMTP 无超时**：`EmailNotifyAdapter` 只设了 host/port/加密，Jakarta Mail 缺省无限阻塞——挂死/不响应的 SMTP 端点会永久卡住发送线程（项目里 HTTP/MCP 全有超时，SMTP 是唯一漏网）。
2. **download_file 全量缓冲**：`HttpTools.downloadFile` 经 `toEntity(byte[].class)` 把下载体整个读进内存再落盘，无大小上限；URL 侧默认放行（HTTP_READ），模型可触达任意公网大文件 → OOM。
3. **shell 输出无界**：stdout/stderr `readAllBytes()` 无上限且全文回灌模型上下文（`cat` 一个 GB 级日志即爆内存 + context window）；`McpToolAdapter.renderContent` 同样无界拼接。
4. **MCP 运行时状态非线程安全**：`McpClientService` 三个 `LinkedHashMap` 写路径有锁、读路径 `status()` 裸读——管理台查询与增删并发时 HashMap 结构修改中的 get 是未定义行为。

## 改动（5 生产文件 + 4 测试文件，+302/-33）

- `EmailNotifyAdapter`：补 `mail.smtp.connectiontimeout/timeout/writetimeout` 三件套（各 10s，与 HttpTools CONNECT_TIMEOUT 同量级）。
- `HttpTools.downloadFile`：改流式下载——`RestClient.exchange` 边读边写，超 50MB（`DOWNLOAD_MAX_BYTES`）中止并删半成品（先关流再删，Windows 兼容）；4xx/5xx 拒绝落盘（对齐 retrieve() 语义）；重定向逐跳重过 HTTP_READ 校验、跨跳 URL 解析逻辑不变。**路径守卫顺序调整**：先校验再发起网络请求（被拒就不下载），createDirectories 后的写前复检保留——既有 `downloadFileRechecksPathBeforeWrite` 测试断言不变。落盘上限可经包私有构造注入（测试用 1KB 验证，不必真传 50MB）。
- `ShellTools`：有界排空 `drainBounded`——全程读取（防管道写阻塞假超时）但只保留前 64KB，超限部分丢弃并标注「已截断」；stderr 在失败报错中同样适用。
- `McpToolAdapter.renderContent`：超 64KB 截断并标注。
- `McpClientService`：三个状态 map 换 `ConcurrentHashMap`，`registeredTools` 值改不可变 `List.copyOf`；`lastErrors` 对 null message 落异常类名（CHM 不收 null）。

## 行为矩阵

| 场景 | 改动前 | 改动后 |
|---|---|---|
| SMTP 端点挂死 | 永久阻塞 | 10s 超时报错（retryable 语义不变） |
| 下载 ≤50MB | 正常落盘 | 正常落盘（不变） |
| 下载 >50MB | OOM 风险 | 中止 + 删半成品 + 报错 |
| shell 输出 ≤64KB | 原样返回 | 原样返回（不变） |
| shell 输出 >64KB | 全量回灌 | 截断 + 标注 |
| MCP 状态并发读 | UB | 线程安全 |

## 测试

新增 4 用例：SMTP 超时属性钉死（mockStatic Transport 断言 Session props）、shell stdout/stderr 超限截断（StubProcess 替身）、MCP 超限截断、下载超限中止 + 半成品删除（注入 1KB 上限）。既有 239 用例全部保持通过（含 download 复检测试断言不变）。

## 本地验证（Windows）

- `oryxos-tool`：Tests run: 243, Failures: 0, Errors: 0, Skipped: 13（skip 均为 #310 探针的软链用例）
- spotless / checkstyle / PMD 门禁全过