### PR TITLE
fix(knowledge): close index lifecycle races — orphan chunk recheck, serialized import, degradation flag, recursive watch

### DIFF
--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/LocalKnowledgeBackend.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/LocalKnowledgeBackend.java
@@ -35,6 +35,9 @@ import java.util.stream.Stream;
  */
 public class LocalKnowledgeBackend implements KnowledgeBackend, KnowledgeAdmin {
 
+  private static final org.slf4j.Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(LocalKnowledgeBackend.class);
+
   private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9_-]+");
 
   /** 每路召回候选量与 topK 的倍数：给融合层留足重排空间。 */
@@ -109,7 +112,14 @@ public class LocalKnowledgeBackend implements KnowledgeBackend, KnowledgeAdmin {
         // FR-014：拒绝新旧向量混合比较，关键词路独立服务并提示重建，不静默返回错误排序
         degradedReason = mismatch;
       } else {
-        vectorRoute = vectorRecall(chunks, embedder, query, topK * ROUTE_FACTOR);
+        try {
+          vectorRoute = vectorRecall(chunks, embedder, query, topK * ROUTE_FACTOR);
+        } catch (RuntimeException e) {
+          // embedder bean 在、embed 调用才失败（embedding API 宕机是最常见降级场景）——
+          // 必须 WARN + 逐条标注降级（FR-013），不能静默变成纯关键词结果（与 MemoryRecallEngine 口径一致）
+          LOG.warn("向量检索失败，降级为关键词检索: {}", sanitize(e.getMessage()));
+          degradedReason = "向量检索失败（" + sanitize(e.getMessage()) + "），已降级为关键词检索";
+        }
       }
     }
     List<RetrievalPipeline.Candidate> keywordRoute =
@@ -161,12 +171,8 @@ public class LocalKnowledgeBackend implements KnowledgeBackend, KnowledgeAdmin {
 
   private static List<RetrievalPipeline.Candidate> vectorRecall(
       List<ChunkStore.ChunkRecord> chunks, TextEmbedder embedder, String query, int limit) {
-    float[] queryVector;
-    try {
-      queryVector = embedder.embed(query);
-    } catch (RuntimeException e) {
-      return List.of();
-    }
+    // embed 失败直接上抛：由 retrieveOne 统一 WARN + 标注降级，这里不再静默吞成空结果
+    float[] queryVector = embedder.embed(query);
     return chunks.stream()
         .filter(
             chunk -> chunk.embedding() != null && chunk.embedding().length == queryVector.length)
@@ -177,6 +183,10 @@ public class LocalKnowledgeBackend implements KnowledgeBackend, KnowledgeAdmin {
         .sorted(Comparator.comparingDouble(RetrievalPipeline.Candidate::score).reversed())
         .limit(limit)
         .toList();
+  }
+
+  private static String sanitize(String value) {
+    return value == null || value.isBlank() ? "未知原因" : value.replace('\r', '_').replace('\n', '_');
   }
 
   /** 关键词路：空白分词的包含计数 + 整句包含加权；子串匹配天然覆盖中文（Edge Cases 中英混排）。 */

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/KnowledgeIndexService.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/index/KnowledgeIndexService.java
@@ -76,8 +76,11 @@ public class KnowledgeIndexService {
                 .orElse(0L));
   }
 
-  /** 两段式导入的同步段：校验 + 登记 PENDING + 提交后台索引；返回可查询的初始状态。 */
-  public DocumentStatus importDocument(String kbName, String relPath) {
+  /**
+   * 两段式导入的同步段：校验 + 登记 PENDING + 提交后台索引；返回可查询的初始状态。 synchronized 与 rebuild/reconcile 同款：并发导入（对账 +
+   * 手动）若交错，deleteChunksOf/saveChunks 会翻倍落片段， 后到的新建还可能撞 UNIQUE(kb_name,rel_path,generation) 直接 500。
+   */
+  public synchronized DocumentStatus importDocument(String kbName, String relPath) {
     Path file = requireDocumentFile(kbName, relPath);
     List<ParsedUnit> units = parseValidated(file);
     long generation = activeGeneration(kbName);
@@ -205,7 +208,12 @@ public class KnowledgeIndexService {
     } catch (RuntimeException e) {
       LOG.warn(
           "知识文档索引失败: {}/{}: {}", sanitize(kbName), sanitize(relPath), sanitize(e.getMessage()));
-      store.saveDocument(record.withState(DocumentState.FAILED, readable(e)));
+      // 只在行还在时落 FAILED——索引期间被删除/替换的文档不得因此复活（TOCTOU）
+      ChunkStore.DocumentRecord latest =
+          store.findDocument(kbName, relPath, generation).orElse(null);
+      if (latest != null && latest.id() != null && latest.id() == documentId) {
+        store.saveDocument(record.withState(DocumentState.FAILED, readable(e)));
+      }
     }
   }
 
@@ -230,6 +238,13 @@ public class KnowledgeIndexService {
                 embedder.modelId(),
                 record.generation()));
       }
+    }
+    // TOCTOU 复检：embed 是秒级外部调用，窗口内文档可能已被删除/替换——检索取数不 join
+    // documents 表，此刻若照常落库，已删文档的孤儿片段仍可被召回（违反 SC-006）
+    ChunkStore.DocumentRecord current =
+        store.findDocument(record.kbName(), record.relPath(), record.generation()).orElse(null);
+    if (current == null || current.id() == null || !current.id().equals(record.id())) {
+      throw new IllegalStateException("文档在索引期间被删除或替换，片段放弃落库");
     }
     store.deleteChunksOf(record.id());
     store.saveChunks(chunkRecords);

--- a/oryxos-knowledge/src/main/java/io/oryxos/knowledge/watch/KnowledgeWatcher.java
+++ b/oryxos-knowledge/src/main/java/io/oryxos/knowledge/watch/KnowledgeWatcher.java
@@ -8,8 +8,10 @@ import io.oryxos.core.knowledge.KnowledgeBackendRegistry;
 import io.oryxos.core.knowledge.KnowledgeManifest;
 import io.oryxos.knowledge.index.KnowledgeIndexService;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
@@ -17,13 +19,15 @@ import java.nio.file.WatchService;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 // GitOps 录入路径（FR-010 / US4）：实时监听 .oryxos/knowledge/，库目录/文档的增改删收敛到
 // KnowledgeIndexService.reconcile（指纹去重，重复触发廉价幂等）。骨架照 WorkspaceWatcher 的
-// 「非递归补挂」：根目录盯子库目录增删，每个库目录各自盯文档变更；启动先全量对账（US4 场景 5：
-// 停机期间的目录变更由对账收敛）。基础设施守护线程，不把异步引进请求链路（不违反宪法七）。
+// 「补挂」思路：根目录盯子库目录增删，库目录树递归补挂（WatchService 本身非递归，嵌套子目录
+// 不补挂则其中文档的变更永不投递）；启动先全量对账（US4 场景 5：停机期间的目录变更由对账收敛）。
+// 基础设施守护线程，不把异步引进请求链路（不违反宪法七）。
 /** 实时监听 {@code .oryxos/knowledge/}，把知识库目录变更收敛到索引对账。 */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",
@@ -56,7 +60,7 @@ public class KnowledgeWatcher {
       try (DirectoryStream<Path> children =
           Files.newDirectoryStream(knowledgeDir, Files::isDirectory)) {
         for (Path child : children) {
-          registerDir(watchService, child);
+          watchTreeQuietly(watchService, child); // 含既有嵌套子目录：WatchService 是浅的，必须逐层补挂
           reconcileQuietly(child); // 启动对账：停机期间的增改删在此收敛（FR-010）
         }
       }
@@ -102,20 +106,42 @@ public class KnowledgeWatcher {
   }
 
   // 把一个目录事件收敛到库级动作。包级可见供单测直接调（不依赖真实事件时序）。
-  //  - 根目录事件：子库目录新增（补挂监听 + 对账）与删除（清索引）；
-  //  - 库目录事件：任何文档/清单变更 → 整库对账（指纹去重使其廉价幂等，天然覆盖嵌套子目录文档）。
+  //  - 根目录事件：子库目录新增（递归补挂监听 + 对账）与删除（清索引）；
+  //  - 库目录事件：新建子目录递归补挂（WatchService 非递归，不补挂则嵌套文档改动永不投递），
+  //    任何文档/清单变更 → 整库对账（指纹去重使其廉价幂等）。
   /** 把一个目录事件收敛到库级对账/清理。 */
   void dispatch(WatchService watchService, Path dir, Path changed, WatchEvent.Kind<?> kind) {
     if (knowledgeDir.equals(dir)) {
-      if (kind == ENTRY_CREATE && Files.isDirectory(changed)) {
-        watchDirQuietly(watchService, changed);
+      if (kind == ENTRY_CREATE && Files.isDirectory(changed, LinkOption.NOFOLLOW_LINKS)) {
+        watchTreeQuietly(watchService, changed);
         reconcileQuietly(changed);
       } else if (kind == ENTRY_DELETE) {
         removeBase(changed);
       }
       return;
     }
+    if (kind == ENTRY_CREATE && Files.isDirectory(changed, LinkOption.NOFOLLOW_LINKS)) {
+      watchTreeQuietly(watchService, changed); // 嵌套子目录（可能自带更深层）：整棵补挂
+    }
     reconcileQuietly(dir); // 库目录内任何变更 → 整库对账
+  }
+
+  /** 递归补挂一棵目录树；目录软链不跟随（与索引侧 NOFOLLOW 口径一致），单层失败只告警。 */
+  private void watchTreeQuietly(WatchService watchService, Path root) {
+    try (Stream<Path> walk = Files.walk(root)) {
+      walk.filter(dir -> Files.isDirectory(dir, LinkOption.NOFOLLOW_LINKS))
+          .forEach(dir -> watchDirQuietly(watchService, dir));
+    } catch (IOException | UncheckedIOException e) {
+      LOG.warn(
+          "监听知识库目录树 {} 失败：{}",
+          sanitize(String.valueOf(root.getFileName())),
+          sanitize(e.getMessage()));
+    }
+  }
+
+  /** 单测探针：目录是否已挂监听（真实事件时序不可测，钉注册行为）。 */
+  boolean watching(Path dir) {
+    return watchedDirs.containsValue(dir);
   }
 
   private void watchDirQuietly(WatchService watchService, Path dir) {

--- a/oryxos-knowledge/src/test/java/io/oryxos/knowledge/contract/KnowledgeBackendContractTest.java
+++ b/oryxos-knowledge/src/test/java/io/oryxos/knowledge/contract/KnowledgeBackendContractTest.java
@@ -259,6 +259,71 @@ class KnowledgeBackendContractTest {
   }
 
   @Test
+  void deleteDuringIndexingLeavesNoOrphanChunks() {
+    // TOCTOU 窗口：embed 是秒级外部调用，进行中文档被删——落库前必须复检，否则孤儿片段仍可被召回（SC-006）
+    java.util.concurrent.atomic.AtomicBoolean deleted =
+        new java.util.concurrent.atomic.AtomicBoolean();
+    embedderRef.set(
+        () ->
+            new TextEmbedder() {
+              @Override
+              public float[] embed(String text) {
+                if (deleted.compareAndSet(false, true)) {
+                  backend.deleteDocument("ops", "disk-alert.md"); // embed 进行中删除文档
+                }
+                return new float[16];
+              }
+
+              @Override
+              public String modelId() {
+                return "test/v1";
+              }
+
+              @Override
+              public int dimensions() {
+                return 16;
+              }
+            });
+
+    backend.importDocument("ops", "disk-alert.md");
+    runBackground();
+
+    assertTrue(backend.status("ops").isEmpty(), "索引期间被删的文档不得留下任何行（含 FAILED 复活）");
+    assertTrue(store.chunks("ops", 0).isEmpty(), "索引期间被删的文档不得留下孤儿片段");
+    assertTrue(retrieve("磁盘告警", 5, "ops").isEmpty(), "已删文档内容不得被检索命中");
+  }
+
+  @Test
+  void vectorRecallFailureDegradesWithReason() {
+    indexReady();
+    // embedder bean 在、embed 调用才失败（embedding API 宕机）：必须标注降级，不能静默吞成纯关键词结果
+    embedderRef.set(
+        () ->
+            new TextEmbedder() {
+              @Override
+              public float[] embed(String text) {
+                throw new IllegalStateException("embedding API 503");
+              }
+
+              @Override
+              public String modelId() {
+                return "test/v1";
+              }
+
+              @Override
+              public int dimensions() {
+                return 16;
+              }
+            });
+
+    List<KnowledgeHit> hits = retrieve("磁盘告警", 5, "ops");
+
+    assertFalse(hits.isEmpty(), "关键词路应继续服务");
+    assertTrue(hits.stream().allMatch(KnowledgeHit::degraded), "向量路失败必须逐条标注降级（FR-013）");
+    assertTrue(String.valueOf(hits.get(0).payload().get("degraded_reason")).contains("关键词"));
+  }
+
+  @Test
   void capabilitiesAreHonestAboutAdminPresence() {
     // 行为契约 7：能力声明与 admin() 有无一致（规避「契约谎言」）
     assertTrue(backend.capabilities().importDocs());

--- a/oryxos-knowledge/src/test/java/io/oryxos/knowledge/watch/KnowledgeWatcherTest.java
+++ b/oryxos-knowledge/src/test/java/io/oryxos/knowledge/watch/KnowledgeWatcherTest.java
@@ -116,6 +116,23 @@ class KnowledgeWatcherTest {
     assertTrue(store.allDocuments("ops").isEmpty());
   }
 
+  @Test
+  @DisplayName("库内新建嵌套子目录 → 递归补挂监听（WatchService 非递归，不补挂则嵌套文档改动永不投递）")
+  void nestedDirectoryCreateIsWatchedRecursively() throws IOException {
+    Path kb = knowledgeBase("ops", "运维手册");
+    Path nested = Files.createDirectories(kb.resolve("sub").resolve("deeper"));
+    java.nio.file.WatchService watchService = kbRoot.getFileSystem().newWatchService();
+    try {
+      watcher.dispatch(
+          watchService, kb, nested.getParent(), java.nio.file.StandardWatchEventKinds.ENTRY_CREATE);
+
+      assertTrue(watcher.watching(nested.getParent()), "新建子目录必须补挂监听");
+      assertTrue(watcher.watching(nested), "子目录自带的更深层目录也必须补挂");
+    } finally {
+      watchService.close();
+    }
+  }
+
   private Path knowledgeBase(String name, String description) throws IOException {
     Path dir = Files.createDirectories(kbRoot.resolve(name));
     Files.writeString(


### PR DESCRIPTION
## 动机

Review 发现知识库索引生命周期四处缺口，都发生在「后台段与外部并发交互」的接缝上：

1. **TOCTOU 孤儿片段（违反 SC-006）**：`indexDocument` 只在开头检查一次文档存在，随后 embed 是秒级 HTTP 调用——窗口内文档被删（watcher `removeBase` / API `deleteDocument`）后，`saveChunks` 照常落库。而检索取数 `findByKbNameAndGeneration` 不 join documents 表，孤儿片段继续被召回，已删除文档的内容泄露给检索结果。更糟的是失败分支的 `saveDocument(FAILED)` 会把已删行**复活**。
2. **importDocument 未串行化**：`rebuild`/`reconcile` 都是 synchronized，唯独它不是。并发导入（watcher 对账 + Web/CLI 手动）同时通过 id 检查进入 `indexNow`，`deleteChunksOf`+`saveChunks` 交错后同文档片段翻倍；若双方 existing==null，后到 insert 撞 `UNIQUE(kb_name,rel_path,generation)` 直接 500。
3. **向量路运行期失败静默**：`vectorRecall` 里 embed 抛异常被 catch 成 `List.of()`——无日志、不设 degradedReason，调用方拿到 degraded=false 的纯关键词结果。「bean 在、embed 才失败」（embedding API 宕机）恰是最常见的降级场景；`MemoryRecallEngine` 同类失败是 WARN + 尾行标注，口径不一致。
4. **Watcher 非递归监听**：启动只为根目录和一层库目录挂 WatchKey，`WatchService` 本身是浅的——`kb/sub/doc.md` 的 MODIFY 永不投递；但索引侧 `listSupportedFiles` 是递归 `Files.walk`，嵌套文档会被索引、改了却 stale 到重启。原注释「天然覆盖嵌套子目录文档」不成立。

## 改动（3 生产文件 + 2 测试文件，+150/-17）

- `KnowledgeIndexService`：
  - `indexNow` 落片段前复检文档行仍在（按 id 比对），不在则抛「放弃落库」；
  - `indexDocument` 失败分支只在行还在时落 FAILED，已删文档不复活；
  - `importDocument` 补 synchronized（与 rebuild/reconcile 同款，可重入，对账内调用无死锁）。
- `LocalKnowledgeBackend`：`vectorRecall` 的 embed 失败不再静默吞——上抛由 `retrieveOne` 统一 WARN + 逐条标注 `degraded_reason`（「向量检索失败（原因），已降级为关键词检索」）。
- `KnowledgeWatcher`：库目录树递归补挂（`Files.walk` + NOFOLLOW，目录软链不跟随，与索引侧口径一致）；根目录新增库目录、库内新建子目录两条事件路径都走 `watchTreeQuietly`；修正类注释与 dispatch 注释的旧口径。

## 测试（3 新用例）

- `deleteDuringIndexingLeavesNoOrphanChunks`：确定性构造 TOCTOU——embedder 在 embed 进行中删除文档（后台任务捕获为 Runnable，时序可控）；断言不留行、不留片段、检索不命中。
- `vectorRecallFailureDegradesWithReason`：embed 抛 503 → 关键词路照常命中 + 逐条 degraded + reason 含「关键词」。
- `nestedDirectoryCreateIsWatchedRecursively`：dispatch 新建子目录事件 → 两层嵌套都注册监听（包级探针 `watching(Path)`）。

## 本地验证（Windows）

- `oryxos-knowledge`：Tests run: 35, Failures: 0, Errors: 0, Skipped: 8（skip 均为 #310 探针的软链用例）
- spotless / checkstyle / PMD 门禁全过