### PR TITLE
fix(web): mask credential echo in MCP and notify-channel views

### DIFF
--- a/oryxos-web/src/main/java/io/oryxos/web/controller/McpApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/McpApiController.java
@@ -5,6 +5,7 @@ import io.oryxos.core.mcp.McpCatalogEntry;
 import io.oryxos.core.mcp.McpServerAdmin;
 import io.oryxos.core.mcp.McpServerConfig;
 import io.oryxos.web.common.ApiResponse;
+import io.oryxos.web.controller.dto.CredentialMasks;
 import io.oryxos.web.controller.dto.EnableMcpCatalogRequest;
 import io.oryxos.web.controller.dto.McpCatalogView;
 import io.oryxos.web.controller.dto.McpServerStatusView;
@@ -85,12 +86,16 @@ public class McpApiController {
   @PutMapping("/{name}")
   public ApiResponse<McpServerView> update(
       @PathVariable String name, @RequestBody McpServerView req) {
-    if (admin.list().stream().noneMatch(c -> c.name().equals(name))) {
-      throw new ResourceNotFoundException("MCP server 不存在: " + name); // → 404
-    }
+    McpServerConfig existing =
+        admin.list().stream()
+            .filter(c -> c.name().equals(name))
+            .findFirst()
+            .orElseThrow(() -> new ResourceNotFoundException("MCP server 不存在: " + name)); // → 404
+    // 视图回显的是掩码值；提交掩码 = 未修改，保留原凭证——否则打码值会覆盖真实 token（Provider 同款口径）
+    Map<String, String> env = CredentialMasks.mergeUnchanged(existing.env(), req.env());
+    Map<String, String> headers = CredentialMasks.mergeUnchanged(existing.headers(), req.headers());
     McpServerConfig config =
-        new McpServerConfig(
-            name, req.transport(), req.command(), req.env(), req.url(), req.headers());
+        new McpServerConfig(name, req.transport(), req.command(), env, req.url(), headers);
     return ApiResponse.ok(McpServerView.from(admin.update(name, config)));
   }
 

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/NotifyChannelApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/NotifyChannelApiController.java
@@ -5,6 +5,7 @@ import io.oryxos.core.notify.NotifyChannelDef;
 import io.oryxos.core.notify.NotifyChannelRegistry;
 import io.oryxos.web.common.ApiResponse;
 import io.oryxos.web.controller.dto.CreateNotifyChannelRequest;
+import io.oryxos.web.controller.dto.CredentialMasks;
 import io.oryxos.web.controller.dto.NotifyChannelView;
 import io.oryxos.web.controller.dto.UpdateNotifyChannelRequest;
 import io.oryxos.web.error.ResourceNotFoundException;
@@ -90,6 +91,10 @@ public class NotifyChannelApiController {
     // 022：前端编辑表单回填的是敏感项掩码；提交掩码原样或留空 = 未修改，保留原值——否则打码值会覆盖真实凭证
     Map<String, String> config = keepUnchangedSecrets(existing.config(), req.config());
     String url = normalizeUrl(req.type(), req.url());
+    // webhook URL 同口径：提交值等于原 URL 的掩码 = 未修改，保留原 URL
+    if (CredentialMasks.maskWebhookUrl(existing.url()).equals(url)) {
+      url = existing.url();
+    }
     validate(req.type(), url, config);
     NotifyChannelDef saved =
         registry.save(new NotifyChannelDef(name, req.type(), url, req.description(), config));

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/CredentialMasks.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/CredentialMasks.java
@@ -1,0 +1,82 @@
+package io.oryxos.web.controller.dto;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * 凭证回显掩码工具（FR-012 口径的补齐）：webhook URL 与配置里的敏感值只回显掩码，杜绝明文经 {@code /api/v1/**} 泄露。
+ *
+ * <p>掩码全部确定性且幂等（mask(mask(x)) == mask(x)）——这是 {@code mergeUnchanged}「提交掩码 = 未修改」判定的基础， 与 {@code
+ * ProviderView.mask} / {@code ProviderApiController} 的既有范式一致。
+ */
+public final class CredentialMasks {
+
+  /** 敏感配置键：password/secret/token/authorization/api-key/pwd（大小写不敏感，子串命中即掩码）。 */
+  private static final Pattern SENSITIVE_KEY =
+      Pattern.compile("(?i).*(password|secret|token|authorization|api[-_]?key|pwd).*");
+
+  private CredentialMasks() {}
+
+  /** 单值掩码：复用 ProviderView.mask 的口径（留末 4 位，幂等）。 */
+  public static String maskValue(String value) {
+    return ProviderView.mask(value);
+  }
+
+  /** Map 中敏感键的值打码；非敏感键原样。返回新 Map，入参不变。 */
+  public static Map<String, String> maskSensitiveValues(Map<String, String> values) {
+    if (values == null || values.isEmpty()) {
+      return Map.of();
+    }
+    Map<String, String> masked = new LinkedHashMap<>(values);
+    masked.replaceAll(
+        (key, value) -> SENSITIVE_KEY.matcher(key).matches() ? maskValue(value) : value);
+    return masked;
+  }
+
+  /**
+   * webhook URL 掩码：URL 本身就是凭证（拿到即可推送）。query 整体打码（钉钉 access_token / 企微 key 在 query）； 多段 path
+   * 的末段打码（飞书 hook id 在末段）；单段 path 与 scheme+host 保留，便于辨认渠道端点。幂等。
+   */
+  public static String maskWebhookUrl(String url) {
+    if (url == null || url.isBlank()) {
+      return "";
+    }
+    String working = url;
+    String query = "";
+    int q = working.indexOf('?');
+    if (q >= 0) {
+      query = "?****";
+      working = working.substring(0, q);
+    }
+    int schemeEnd = working.indexOf("://");
+    int pathStart = schemeEnd >= 0 ? working.indexOf('/', schemeEnd + 3) : -1;
+    if (pathStart >= 0) {
+      int lastSlash = working.lastIndexOf('/');
+      if (lastSlash > pathStart) {
+        working = working.substring(0, lastSlash + 1) + "****";
+      }
+    }
+    return working + query;
+  }
+
+  /** update 路径的「未修改」归并：敏感键提交值等于既有值的掩码 → 视为前端原样回填，保留既有明文； 其余按提交值。非敏感键直接透传。 */
+  public static Map<String, String> mergeUnchanged(
+      Map<String, String> existing, Map<String, String> submitted) {
+    if (submitted == null) {
+      return Map.of();
+    }
+    if (existing == null || existing.isEmpty()) {
+      return Map.copyOf(submitted);
+    }
+    Map<String, String> merged = new LinkedHashMap<>();
+    submitted.forEach(
+        (key, value) -> {
+          String old = existing.get(key);
+          boolean unchanged =
+              old != null && SENSITIVE_KEY.matcher(key).matches() && maskValue(old).equals(value);
+          merged.put(key, unchanged ? old : value);
+        });
+    return merged;
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/McpServerView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/McpServerView.java
@@ -3,7 +3,10 @@ package io.oryxos.web.controller.dto;
 import io.oryxos.core.mcp.McpServerConfig;
 import java.util.Map;
 
-/** MCP server 视图（列表/详情返回）：env/headers 里的 {@code ${ENV}} 占位符原样回显，不解析成明文。 */
+/**
+ * MCP server 视图（列表/详情返回）：env/headers 里的 {@code ${ENV}} 占位符原样回显不解析； 字面量凭证值（catalog 启用时写入的 token
+ * 等）只回显掩码——凭证明文永不回显（FR-012 口径）。
+ */
 public record McpServerView(
     String name,
     String transport,
@@ -18,7 +21,13 @@ public record McpServerView(
   }
 
   public static McpServerView from(McpServerConfig c) {
-    return new McpServerView(c.name(), c.transport(), c.command(), c.env(), c.url(), c.headers());
+    return new McpServerView(
+        c.name(),
+        c.transport(),
+        c.command(),
+        CredentialMasks.maskSensitiveValues(c.env()),
+        c.url(),
+        CredentialMasks.maskSensitiveValues(c.headers()));
   }
 
   public McpServerConfig toConfig() {

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/NotifyChannelView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/NotifyChannelView.java
@@ -10,6 +10,9 @@ import java.util.Map;
  *
  * <p>022：config 敏感项（{@link SensitiveConfigKeys} 名录）只回显掩码——口径与 {@link ProviderView#mask} 一致（确定性 +
  * 幂等），杜绝明文经查询接口泄露；掩码值被前端原样提交时由 controller 识别为"未修改"，保留原值。
+ *
+ * <p>webhook URL 本身也是凭证（拿到即可推送）：query 整体打码（钉钉 access_token / 企微 key 在 query）、 多段 path 末段打码（飞书 hook
+ * id 在末段），scheme+host 与单段 path 保留以辨认端点。
  */
 public record NotifyChannelView(
     String name, String type, String url, String description, Map<String, String> config) {
@@ -21,7 +24,11 @@ public record NotifyChannelView(
 
   public static NotifyChannelView from(NotifyChannelDef d) {
     return new NotifyChannelView(
-        d.name(), d.type(), d.url(), d.description(), maskConfig(d.config()));
+        d.name(),
+        d.type(),
+        CredentialMasks.maskWebhookUrl(d.url()),
+        d.description(),
+        maskConfig(d.config()));
   }
 
   /**

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/McpApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/McpApiControllerTest.java
@@ -1,0 +1,128 @@
+package io.oryxos.web.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.oryxos.core.mcp.McpServerAdmin;
+import io.oryxos.core.mcp.McpServerConfig;
+import io.oryxos.web.GlobalExceptionHandler;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/** mcp-servers 端点切片：凭证回显掩码（FR-012）与「提交掩码 = 未修改」归并。 */
+class McpApiControllerTest {
+
+  private McpServerAdmin admin;
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setUp() {
+    admin = mock(McpServerAdmin.class);
+    mvc =
+        MockMvcBuilders.standaloneSetup(new McpApiController(admin))
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+  }
+
+  @Test
+  @DisplayName("list 回显掩码_env/headers 里的字面量凭证不明文泄露（FR-012）")
+  void list_masksLiteralCredentials() throws Exception {
+    when(admin.list())
+        .thenReturn(
+            List.of(
+                new McpServerConfig(
+                    "github",
+                    "http",
+                    null,
+                    Map.of(),
+                    "https://api.githubcopilot.com/mcp/",
+                    Map.of("Authorization", "Bearer ghp_secret123456"))));
+
+    mvc.perform(get("/api/v1/mcp-servers"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].headers.Authorization").value("****3456"));
+  }
+
+  @Test
+  @DisplayName("update 回传掩码 env 值_视为未修改_保留原 token")
+  void update_maskedEnvValue_keepsOriginal() throws Exception {
+    McpServerConfig existing =
+        new McpServerConfig(
+            "gh",
+            "stdio",
+            "npx -y server",
+            Map.of("GITHUB_TOKEN", "ghp_token1234"),
+            null,
+            Map.of());
+    when(admin.list()).thenReturn(List.of(existing));
+    when(admin.update(eq("gh"), any())).thenAnswer(invocation -> invocation.getArgument(1));
+
+    mvc.perform(
+            put("/api/v1/mcp-servers/gh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"transport\":\"stdio\",\"command\":\"npx -y server\","
+                        + "\"env\":{\"GITHUB_TOKEN\":\"****1234\"},\"headers\":{}}"))
+        .andExpect(status().isOk());
+
+    ArgumentCaptor<McpServerConfig> captor = ArgumentCaptor.forClass(McpServerConfig.class);
+    verify(admin).update(eq("gh"), captor.capture());
+    Assertions.assertEquals(
+        "ghp_token1234", captor.getValue().env().get("GITHUB_TOKEN"), "掩码回填不得覆盖真实 token");
+  }
+
+  @Test
+  @DisplayName("update 新值（非掩码）_照常覆盖")
+  void update_newValue_overwrites() throws Exception {
+    McpServerConfig existing =
+        new McpServerConfig(
+            "gh",
+            "stdio",
+            "npx -y server",
+            Map.of("GITHUB_TOKEN", "ghp_token1234"),
+            null,
+            Map.of());
+    when(admin.list()).thenReturn(List.of(existing));
+    when(admin.update(eq("gh"), any())).thenAnswer(invocation -> invocation.getArgument(1));
+
+    mvc.perform(
+            put("/api/v1/mcp-servers/gh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"transport\":\"stdio\",\"command\":\"npx -y server\","
+                        + "\"env\":{\"GITHUB_TOKEN\":\"ghp_newtoken99\"},\"headers\":{}}"))
+        .andExpect(status().isOk());
+
+    ArgumentCaptor<McpServerConfig> captor = ArgumentCaptor.forClass(McpServerConfig.class);
+    verify(admin).update(eq("gh"), captor.capture());
+    Assertions.assertEquals("ghp_newtoken99", captor.getValue().env().get("GITHUB_TOKEN"));
+  }
+
+  @Test
+  @DisplayName("update 不存在_返回404")
+  void update_unknown_returns404() throws Exception {
+    when(admin.list()).thenReturn(List.of());
+
+    mvc.perform(
+            put("/api/v1/mcp-servers/ghost")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"transport\":\"stdio\",\"command\":\"x\"}"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value(404));
+  }
+}

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/NotifyChannelApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/NotifyChannelApiControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import io.oryxos.core.notify.NotifyChannelDef;
 import io.oryxos.core.notify.NotifyChannelRegistry;
 import io.oryxos.web.GlobalExceptionHandler;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -201,5 +202,59 @@ class NotifyChannelApiControllerTest {
         .containsEntry("password", "p@ss-secret");
     org.assertj.core.api.Assertions.assertThat(captor.getAllValues().get(1).config())
         .containsEntry("password", "new-pass-9");
+  }
+
+  // —— webhook URL 掩码（URL 本身即凭证，拿到即可推送）——
+
+  @Test
+  @DisplayName("list 回显掩码_webhook URL 不明文泄露（access_token/key 在 query，hook id 在 path 末段）")
+  void list_masksWebhookUrl() throws Exception {
+    when(registry.list())
+        .thenReturn(
+            List.of(
+                new NotifyChannelDef(
+                    "dt",
+                    "dingtalk",
+                    "https://oapi.dingtalk.com/robot/send?access_token=abcd1234efgh",
+                    null,
+                    java.util.Map.of("host", "smtp.corp.com"))));
+
+    mvc.perform(get("/api/v1/notify-channels"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].url").value("https://oapi.dingtalk.com/robot/****?****"));
+  }
+
+  @Test
+  @DisplayName("update 回传掩码 url_视为未修改_保留原 webhook；非敏感字段照常更新")
+  void update_maskedUrl_keepsOriginal() throws Exception {
+    NotifyChannelDef existing =
+        new NotifyChannelDef(
+            "dt",
+            "dingtalk",
+            "https://oapi.dingtalk.com/robot/send?access_token=abcd1234efgh",
+            "旧描述",
+            java.util.Map.of());
+    when(registry.find("dt")).thenReturn(Optional.of(existing));
+    when(registry.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    mvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put(
+                    "/api/v1/notify-channels/dt")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"type\":\"dingtalk\","
+                        + "\"url\":\"https://oapi.dingtalk.com/robot/****?****\","
+                        + "\"description\":\"新描述\"}"))
+        .andExpect(status().isOk());
+
+    org.mockito.ArgumentCaptor<NotifyChannelDef> captor =
+        org.mockito.ArgumentCaptor.forClass(NotifyChannelDef.class);
+    verify(registry).save(captor.capture());
+    NotifyChannelDef saved = captor.getValue();
+    org.junit.jupiter.api.Assertions.assertEquals(
+        "https://oapi.dingtalk.com/robot/send?access_token=abcd1234efgh",
+        saved.url(),
+        "掩码 url 不得覆盖真实 webhook");
+    org.junit.jupiter.api.Assertions.assertEquals("新描述", saved.description(), "非敏感字段照常更新");
   }
 }


### PR DESCRIPTION
## 动机

凭证明文回显有两处漏网，与已确立的掩码口径（`ChannelApiController` 的 appSecret 掩码 FR-012、`ProviderView.mask`「杜绝明文经 /api/v1/** 泄露」）不一致：

1. **MCP server**：`enableFromCatalog` 把用户提交的 token 拼成字面量 `Authorization: Bearer <token>` / env 值落盘，`McpServerView.from` 原样回显——POST 响应与后续 `GET /api/v1/mcp-servers` 都带明文。`McpServerView` 注释声称「只回显 ${ENV} 占位符」，但 catalog 路径写入的是字面量。
2. **通知渠道**：`NotifyChannelView` 原样回显 webhook URL（钉钉/企微的 token 在 query、飞书 hook id 在 path 末段——URL 本身就是凭证，拿到即可推送）和整个 config map（email 渠道含 password）。

## 改动（5 生产文件 + 2 测试文件，+306/-13）

新增 `dto/CredentialMasks` 工具（复用 `ProviderView.mask` 单值口径，全部掩码确定性 + 幂等）：

- `maskWebhookUrl`：query 整体打码 + 多段 path 末段打码，scheme+host 与单段 path 保留以辨认端点；
- `maskSensitiveValues`：Map 中键名命中 password/secret/token/authorization/api-key/pwd 的值打码；
- `mergeUnchanged`：update 路径「提交掩码 = 未修改」归并，掩码回填保留既有明文（ProviderApiController 同款范式），非敏感键直接透传。

接入点：

- `McpServerView.from` / `NotifyChannelView.from` 掩码回显；
- `McpApiController.update`：env/headers 经 `mergeUnchanged` 归并后再落库；
- `NotifyChannelApiController.update`：config 归并 + URL 掩码比对（`exists` 改 `find` 取既有值），非敏感字段（description 等）照常更新。

## 测试（6 新用例）

- NotifyChannel：list 掩码钉死（URL → `…/robot/****?****`，password → `****t-pw`，host 明文透传）；update 掩码回填保留原凭证、description 照常更新。
- MCP（新测试类）：list 掩码 Authorization 头；update 掩码 env 保留原 token；新值照常覆盖；不存在 404。

## 已知遗留（PR 外 follow-up）

`enableFromCatalog` 仍把字面量 token 落盘到 `mcp_servers.yaml`——MCP 连接路径目前不解析 `${ENV}` 占位（`McpClientService.connectStdio/connectHttp` 直接透传），改成语义占位需要在连接时补解析，属另一处行为变更，建议单开 PR 讨论。本 PR 堵住的是「经 API 明文读出」这条泄露路径。

## 本地验证（Windows）

- `oryxos-web`：Tests run: 220, Failures: 0, Errors: 0, Skipped: 12（skip 均为 #310 探针的软链用例）；`McpApiControllerTest` 4/4、`NotifyChannelApiControllerTest` 7/7 实跑通过
- spotless / checkstyle / PMD 门禁全过