### PR TITLE
fix(channel): wecom fail-loud errcode receipts and lock-free reconnect, cli chat survives per-turn errors

### DIFF
--- a/oryxos-channel-cli/src/main/java/io/oryxos/channel/cli/CliChannel.java
+++ b/oryxos-channel-cli/src/main/java/io/oryxos/channel/cli/CliChannel.java
@@ -50,11 +50,19 @@ public class CliChannel {
         continue;
       }
       TypewriterListener listener = new TypewriterListener(out);
-      String reply = agentService.process(session, line, listener);
-      if (listener.printedAny()) {
-        out.println(); // 打字机流结束补换行
-      } else {
-        out.println(reply); // 无任何 token 流出（如迭代耗尽占位文本）时回落整段输出
+      try {
+        String reply = agentService.process(session, line, listener);
+        if (listener.printedAny()) {
+          out.println(); // 打字机流结束补换行
+        } else {
+          out.println(reply); // 无任何 token 流出（如迭代耗尽占位文本）时回落整段输出
+        }
+      } catch (RuntimeException e) {
+        // 一轮出错（provider 400/超时等）不终结整个终端会话——对齐飞书/企微事件 handler 的保活口径
+        if (listener.printedAny()) {
+          out.println();
+        }
+        out.printf("[本轮出错: %s]%n", e.getMessage());
       }
     }
   }

--- a/oryxos-channel-cli/src/test/java/io/oryxos/channel/cli/CliChannelTest.java
+++ b/oryxos-channel-cli/src/test/java/io/oryxos/channel/cli/CliChannelTest.java
@@ -1,0 +1,52 @@
+package io.oryxos.channel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.oryxos.core.agent.AgentService;
+import io.oryxos.core.session.Session;
+import io.oryxos.core.session.SessionManager;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** CliChannel 循环健壮性：单轮异常（provider 400/超时等）不终结整个终端会话。 */
+class CliChannelTest {
+
+  @Test
+  @DisplayName("一轮 process 抛异常_打印原因并继续下一轮（对齐飞书/企微 handler 保活口径）")
+  void processFailureDoesNotEndSession() {
+    AgentService agentService = mock(AgentService.class);
+    SessionManager sessionManager = mock(SessionManager.class);
+    Session session = mock(Session.class);
+    when(sessionManager.getOrCreate("cli", "u", "p")).thenReturn(session);
+    when(agentService.process(eq(session), eq("第一轮"), any()))
+        .thenThrow(new IllegalStateException("provider 400"));
+    when(agentService.process(eq(session), eq("第二轮"), any())).thenReturn("正常回复");
+
+    InputStream oldIn = System.in;
+    PrintStream oldOut = System.out;
+    ByteArrayOutputStream captured = new ByteArrayOutputStream();
+    try {
+      System.setIn(new ByteArrayInputStream("第一轮\n第二轮\n/quit\n".getBytes(StandardCharsets.UTF_8)));
+      System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+
+      new CliChannel(agentService, sessionManager).run("p", "u");
+    } finally {
+      System.setIn(oldIn);
+      System.setOut(oldOut);
+    }
+
+    String output = captured.toString(StandardCharsets.UTF_8);
+    assertThat(output).contains("[本轮出错: provider 400]"); // 失败轮有可读提示
+    assertThat(output).contains("正常回复"); // 会话未被终结，后续轮照常
+    assertThat(output).contains("再见。"); // 循环活到 /quit
+  }
+}

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
@@ -98,7 +98,7 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
     reconnectAttempt = 0;
     cancelReconnectLocked();
     try {
-      connectLocked();
+      wsRef.set(connect());
       state = ChannelStatus.State.CONNECTED;
       lastError = null;
       LOG.info("企微渠道 {} 长连接已建立（Agent: {}）", sanitize(config.name()), sanitize(config.agent()));
@@ -151,7 +151,7 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
     return Math.min(RECONNECT_BASE_MS * (1L << capped), RECONNECT_MAX_MS);
   }
 
-  private void connectLocked() throws Exception {
+  private WeComWsClient connect() throws Exception {
     normalizer = new WeComEventNormalizer(config.name());
     WeComWsClient client =
         new WeComWsClient(
@@ -164,7 +164,7 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
         new WeComMessageSender(
             client::sendJson, guard, OUTBOUND_URL, WeComMessageSender.DEFAULT_CHUNK_SIZE);
     client.connectAndSubscribe(START_TIMEOUT);
-    wsRef.set(client);
+    return client;
   }
 
   private void handleDisconnected() {
@@ -200,13 +200,14 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
       if (!running) {
         return;
       }
-      try {
-        connectLocked();
-        reconnectAttempt = 0;
-        state = ChannelStatus.State.CONNECTED;
-        lastError = null;
-        LOG.info("企微渠道 {} 长连接已恢复", sanitize(config.name()));
-      } catch (Exception e) {
+    }
+    // 建连放锁外：connectAndSubscribe 最坏阻塞 ~40s（连接 20s + 订阅 20s），
+    // 锁内执行会把 stop() / 管理端停用渠道卡到建连结束
+    WeComWsClient client;
+    try {
+      client = connect();
+    } catch (Exception e) {
+      synchronized (this) {
         reconnectAttempt++;
         lastError = "长连接重连失败: " + sanitize(e.getMessage());
         LOG.warn(
@@ -214,8 +215,21 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
             sanitize(config.name()),
             reconnectAttempt,
             sanitize(lastError));
-        scheduleReconnect();
       }
+      scheduleReconnect();
+      return;
+    }
+    synchronized (this) {
+      if (!running) {
+        // 建连期间被 stop：新连接就地关闭，不交字段（防幽灵连接）
+        client.closeQuietly();
+        return;
+      }
+      wsRef.set(client);
+      reconnectAttempt = 0;
+      state = ChannelStatus.State.CONNECTED;
+      lastError = null;
+      LOG.info("企微渠道 {} 长连接已恢复", sanitize(config.name()));
     }
   }
 

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComWsClient.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComWsClient.java
@@ -52,6 +52,10 @@ final class WeComWsClient implements WebSocket.Listener {
   private final StringBuilder textBuf = new StringBuilder();
   private final CountDownLatch subscribeLatch = new CountDownLatch(1);
   private volatile String subscribeError;
+
+  /** 承载 WebSocket 的 HttpClient：持有 selector 线程，连接生命周期内必须存活、关闭时必须释放。 */
+  private volatile HttpClient httpClient;
+
   private ScheduledExecutorService heartbeat;
   private ScheduledFuture<?> heartbeatTask;
 
@@ -71,12 +75,26 @@ final class WeComWsClient implements WebSocket.Listener {
   void connectAndSubscribe(Duration timeout) throws Exception {
     closed.set(false);
     HttpClient client = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    httpClient = client;
     CompletableFuture<WebSocket> future =
         client
             .newWebSocketBuilder()
             .connectTimeout(CONNECT_TIMEOUT)
             .buildAsync(URI.create(wsUrl), this);
-    WebSocket ws = future.get(timeout.toSeconds(), TimeUnit.SECONDS);
+    WebSocket ws;
+    try {
+      ws = future.get(timeout.toSeconds(), TimeUnit.SECONDS);
+    } catch (java.util.concurrent.TimeoutException e) {
+      // 不取消的话迟到连接会变幽灵：onOpen 照发订阅且可能成功，但无人持有引用、永远收不到 close
+      future.cancel(true);
+      closeQuietly();
+      throw e;
+    } catch (InterruptedException e) {
+      future.cancel(true);
+      closeQuietly();
+      Thread.currentThread().interrupt();
+      throw e;
+    }
     socket.set(ws);
     if (!subscribeLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
       closeQuietly();
@@ -120,6 +138,11 @@ final class WeComWsClient implements WebSocket.Listener {
       } catch (RuntimeException ignored) {
         // ignore
       }
+    }
+    HttpClient client = httpClient;
+    httpClient = null;
+    if (client != null) {
+      client.shutdownNow(); // 释放 selector 线程；不关会泄漏到 GC（重连风暴下累积）
     }
   }
 
@@ -226,7 +249,17 @@ final class WeComWsClient implements WebSocket.Listener {
     if (CMD_PONG.equals(cmd)) {
       return true;
     }
-    return cmd.isBlank() && root.has(FIELD_ERRCODE);
+    if (cmd.isBlank() && root.has(FIELD_ERRCODE)) {
+      int code = root.path(FIELD_ERRCODE).asInt(ERRCODE_OK);
+      if (code != ERRCODE_OK) {
+        // 无 cmd 带 errcode 的帧是平台对 fire-and-forget 发送（aibot_send_msg）的失败回执——
+        // 静默吞掉会让「回复没发出去」零痕迹（对齐 dingtalk #342 的 fail-loud 口径）
+        LOG.warn(
+            "企微平台回执错误 errcode={} errmsg={}", code, sanitize(root.path(FIELD_ERRMSG).asText("")));
+      }
+      return true;
+    }
+    return false;
   }
 
   private void startHeartbeat() {

--- a/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComWsClientTest.java
+++ b/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComWsClientTest.java
@@ -2,10 +2,17 @@ package io.oryxos.channel.wecom;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.net.http.WebSocket;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 class WeComWsClientTest {
 
@@ -31,5 +38,56 @@ class WeComWsClientTest {
 
     assertFalse(client.isSubscribed());
     assertTrue(disconnected.get());
+  }
+
+  @Test
+  @DisplayName("无 cmd 带 errcode≠0 的回执帧_WARN 落日志不静默（发送失败不能零痕迹）")
+  void errorReceiptFrameIsLoggedNotSwallowed() {
+    Logger logger = (Logger) LoggerFactory.getLogger(WeComWsClient.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      WeComWsClient client =
+          new WeComWsClient("bot", "secret", WeComWsClient.DEFAULT_WS_URL, node -> {}, () -> {});
+      WebSocket ws = mock(WebSocket.class);
+      client.onText(ws, "{\"errcode\":0}", true); // 先吃订阅成功回执，进入已订阅态
+      assertTrue(client.isSubscribed());
+
+      client.onText(ws, "{\"errcode\":14,\"errmsg\":\"bad req_id\"}", true); // 发送失败回执
+
+      assertTrue(
+          appender.list.stream()
+              .anyMatch(
+                  e ->
+                      e.getLevel() == Level.WARN
+                          && e.getFormattedMessage().contains("errcode=14")
+                          && e.getFormattedMessage().contains("bad req_id")),
+          "平台错误回执必须 WARN 落日志");
+    } finally {
+      logger.detachAppender(appender);
+    }
+  }
+
+  @Test
+  @DisplayName("无 cmd 且 errcode=0 的控制帧_仍静默忽略（心跳/一般回执不刷日志）")
+  void okControlFrameStaysSilent() {
+    Logger logger = (Logger) LoggerFactory.getLogger(WeComWsClient.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      WeComWsClient client =
+          new WeComWsClient("bot", "secret", WeComWsClient.DEFAULT_WS_URL, node -> {}, () -> {});
+      WebSocket ws = mock(WebSocket.class);
+      client.onText(ws, "{\"errcode\":0}", true); // 订阅回执
+      int afterSubscribe = appender.list.size();
+
+      client.onText(ws, "{\"errcode\":0}", true); // 已订阅后的一般 OK 控制帧
+
+      assertTrue(appender.list.size() == afterSubscribe, "errcode=0 控制帧不得产生日志（含订阅回执）");
+    } finally {
+      logger.detachAppender(appender);
+    }
   }
 }


### PR DESCRIPTION
## 动机

渠道层三处健壮性缺口（review 发现，均与已合并的 dingtalk #342/#344 或飞书/企微 handler 既有口径不一致）：

1. **企微发送失败回执被静默吞**：`WeComWsClient.isIgnorableControlFrame` 把「无 cmd + 带 errcode」的帧一律 return——`aibot_send_msg` 是 fire-and-forget，平台对发送失败的回执正是这种帧。回复发送失败后用户收不到回答、日志无任何记录。这是 dingtalk #342「fail loud on errcode」在 wecom 的同款 fail-silent。
2. **企微重连把阻塞建连放在 synchronized 内**：`attemptReconnect` 整个 `connectAndSubscribe`（最坏 20s 连接超时 + 20s 订阅等待）在锁里执行，期间 `stop()`（同为 synchronized）拿不到锁——进程关停/管理端停用渠道被重连中的企微渠道卡住最长 ~40s。
3. **企微建连超时后 future 未取消**：`future.get(timeout)` 抛 TimeoutException 时不 cancel——迟到连接 `onOpen` 照发订阅且可能成功，但无人持有引用，成为永远收不到 close 的幽灵连接；另外每次建连新建 `HttpClient` 且从不关闭，重连风暴下 selector 线程依赖 GC 回收。
4. **CLI chat 循环不捕异常**：`CliChannel.run()` 对 `agentService.process(...)` 无任何 catch——provider 400/超时等 RuntimeException 一路抛出，终结整个终端会话。飞书/企微的事件 handler 都显式 catch RuntimeException 保活渠道，CLI 是不一致的例外。

## 改动（3 生产文件 + 2 测试文件，+183/-18）

- `WeComWsClient`：
  - 无 cmd 且 errcode≠0 的回执帧 → WARN（errcode + errmsg，过 sanitize）；errcode=0 控制帧保持静默；
  - `future.get` 超时/中断 → `future.cancel(true)` + `closeQuietly()`，中断路径恢复 interrupt 标记；
  - `HttpClient` 提为实例字段，`closeQuietly()` 里 `shutdownNow()` 释放 selector 线程。
- `WeComChannelAdapter`：`connectLocked()` 拆为返回客户端的 `connect()`；`attemptReconnect` 锁内只做状态检查，建连放锁外，完成后锁内复检 `running`——建连期间被 stop 的新连接就地 `closeQuietly()`，不交字段。`start()` 路径语义不变（synchronized 内一次性建连）。
- `CliChannel`：循环内 catch RuntimeException，打印 `[本轮出错: …]` 后继续；已流出 token 时先补换行保持终端整洁。

## 测试（3 新用例）

- `errorReceiptFrameIsLoggedNotSwallowed`：ListAppender 钉死 errcode≠0 回执 WARN 落日志；`okControlFrameStaysSilent` 反向钉死 errcode=0 不刷日志。
- `processFailureDoesNotEndSession`：第一轮抛异常 → 打印原因、第二轮正常回复、`/quit` 正常退出。
- 重连锁外建连未加新用例：`connect()` 触网，锁行为需注入建连替身才能确定性验证，为锁结构调整加 seam 得不偿失；既有 `WeComChannelAdapterLifecycleTest`/`WeComChannelContractTest` 全绿。如评审认为值得加，请指出。

## 本地验证（Windows）

- `oryxos-channel-wecom`：23 run / 0 failure；`oryxos-channel-cli`：4 run / 0 failure
- spotless / checkstyle / PMD 门禁全过