### PR TITLE
fix(core,web): reserve knowledge/ namespace, map spring client errors to 400, stream skill imports with bound

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
@@ -800,7 +800,12 @@ public class AgentLifecycleService {
     if (relative.isAbsolute() || relative.startsWith(PARENT_PATH_SEGMENT)) {
       return true;
     }
-    return relative.getNameCount() > 0 && "skills".equals(relative.getName(0).toString());
+    // skills/ 与 knowledge/ 都是「只许受控软链」的绑定保留目录，草稿不得产出普通文件占位
+    if (relative.getNameCount() > 0) {
+      String first = relative.getName(0).toString();
+      return "skills".equals(first) || "knowledge".equals(first);
+    }
+    return false;
   }
 
   /**

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentStore.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentStore.java
@@ -30,6 +30,9 @@ public class AgentStore {
 
   private static final String SKILLS_NAMESPACE = "skills";
 
+  /** 知识库绑定视图目录：与 skills/ 同为「只许受控软链」的绑定事实来源，禁止写普通文件。 */
+  private static final String KNOWLEDGE_NAMESPACE = "knowledge";
+
   private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9_-]+");
   private static final String AGENT_FILE = "AGENT.md";
 
@@ -226,9 +229,15 @@ public class AgentStore {
       throw new IllegalArgumentException("非法文件路径: " + relativePath);
     }
     Path relative = dir.relativize(target);
-    if (relative.getNameCount() > 0
-        && SKILLS_NAMESPACE.equalsIgnoreCase(relative.getName(0).toString())) {
-      throw new IllegalArgumentException("skills/ 是 Agent Skill 绑定保留目录，禁止写普通文件");
+    if (relative.getNameCount() > 0) {
+      String first = relative.getName(0).toString();
+      if (SKILLS_NAMESPACE.equalsIgnoreCase(first)) {
+        throw new IllegalArgumentException("skills/ 是 Agent Skill 绑定保留目录，禁止写普通文件");
+      }
+      if (KNOWLEDGE_NAMESPACE.equalsIgnoreCase(first)) {
+        // 普通文件会被 KnowledgeBindingService 判 INVALID_TARGET 并卡死 replaceBindings 整体替换
+        throw new IllegalArgumentException("knowledge/ 是 Agent 知识库绑定保留目录，禁止写普通文件");
+      }
     }
     requireSafe(target);
     if (isNonRegularTarget(target)) {

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentStoreTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentStoreTest.java
@@ -107,6 +107,17 @@ class AgentStoreTest {
   }
 
   @Test
+  @DisplayName("write/writeAll 拒绝占用 knowledge 保留命名空间（与 skills/ 同口径）")
+  void writesRejectReservedKnowledgeNamespace() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store.writeAll("demo", Map.of("knowledge/ops.md", "copy")));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store.writeAll("demo", Map.of("knowledge/ops/README.md", "copy")));
+  }
+
+  @Test
   @DisplayName("writeAll 全量预校验失败时已存在文件保持原样")
   void writeAllValidationFailureIsAtomic() throws IOException {
     Path agent = store.write("demo", "old");

--- a/oryxos-web/src/main/java/io/oryxos/web/GlobalExceptionHandler.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/GlobalExceptionHandler.java
@@ -45,6 +45,20 @@ public class GlobalExceptionHandler {
         .body(ApiResponse.error(HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
   }
 
+  /** 400 — Spring MVC 层的客户端错误：请求体缺失/JSON 语法错、参数类型不匹配、缺必填参数。 */
+  @ExceptionHandler({
+    org.springframework.http.converter.HttpMessageNotReadableException.class,
+    org.springframework.web.bind.MissingServletRequestParameterException.class,
+    org.springframework.web.method.annotation.MethodArgumentTypeMismatchException.class
+  })
+  public ResponseEntity<ApiResponse<Void>> handleClientError(Exception ex) {
+    // 这类异常此前落进 catch-all 变成 500 + ERROR 堆栈——客户端错误不应污染服务端告警
+    LOG.warn("Client error: {}", sanitize(ex.getMessage()));
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+        .body(ApiResponse.error(HttpStatus.BAD_REQUEST.value(), "Bad request"));
+  }
+
   /** 404 — no handler or static resource matched the request. */
   @ExceptionHandler(NoResourceFoundException.class)
   public ResponseEntity<ApiResponse<Void>> handleNotFound(NoResourceFoundException ex) {

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/SkillApiController.java
@@ -14,7 +14,9 @@ import io.oryxos.web.controller.dto.SkillView;
 import io.oryxos.web.controller.dto.UpdateSkillRequest;
 import io.oryxos.web.error.ResourceNotFoundException;
 import io.oryxos.web.skill.GithubFolderFetcher;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.IDN;
 import java.net.InetAddress;
@@ -162,9 +164,9 @@ public class SkillApiController {
       guardPublicHost(uri); // 每跳都校验（防重定向绕过）
       HttpRequest request =
           HttpRequest.newBuilder(uri).timeout(Duration.ofSeconds(10)).GET().build();
-      HttpResponse<String> resp;
+      HttpResponse<InputStream> resp;
       try {
-        resp = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        resp = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
       } catch (IOException e) {
         throw new UncheckedIOException("拉取 URL 失败: " + uri, e);
       } catch (InterruptedException e) {
@@ -173,12 +175,14 @@ public class SkillApiController {
       }
       int status = resp.statusCode();
       if (status / 100 == 2) {
-        String body = resp.body();
-        if (body != null && body.length() > MAX_SKILL_BYTES) {
-          throw new IllegalArgumentException("SKILL.md 过大（>512KB），拒绝导入");
+        // 有界流式读：超限即断——ofString 会把整个 body 缓冲进内存，512KB 上限挡不住 GB 级响应的 OOM
+        try (InputStream in = resp.body()) {
+          return readBoundedUtf8(in, MAX_SKILL_BYTES);
+        } catch (IOException e) {
+          throw new UncheckedIOException("读取响应体失败: " + uri, e);
         }
-        return body;
       }
+      closeQuietly(resp.body()); // 3xx/错误路径不消费 body，主动关流释放连接
       if (status / 100 == 3) {
         String location = resp.headers().firstValue("location").orElse(null);
         if (location == null || location.isBlank()) {
@@ -190,6 +194,30 @@ public class SkillApiController {
       throw new IllegalArgumentException("拉取失败，HTTP " + status + ": " + uri);
     }
     throw new IllegalArgumentException("重定向次数过多，拒绝导入");
+  }
+
+  /** 有界读取响应体并按 UTF-8 解码：超过 maxBytes 即拒绝（不多占内存）；截断点落在多字节字符上会由解码器落替换符。包私有供单测。 */
+  static String readBoundedUtf8(InputStream in, long maxBytes) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    byte[] buffer = new byte[8192];
+    long total = 0;
+    int n;
+    while ((n = in.read(buffer)) != -1) {
+      total += n;
+      if (total > maxBytes) {
+        throw new IllegalArgumentException("SKILL.md 过大（>512KB），拒绝导入");
+      }
+      out.write(buffer, 0, n);
+    }
+    return out.toString(StandardCharsets.UTF_8);
+  }
+
+  private static void closeQuietly(InputStream in) {
+    try {
+      in.close();
+    } catch (IOException ignored) {
+      // 释放连接的兜底路径，异常无意义
+    }
   }
 
   /**

--- a/oryxos-web/src/main/java/io/oryxos/web/skill/GithubFolderFetcher.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/skill/GithubFolderFetcher.java
@@ -108,7 +108,8 @@ public class GithubFolderFetcher {
         continue;
       }
       String content = httpGet.apply(URI.create(downloadUrl));
-      totalBytes[0] += content.length();
+      // 按 UTF-8 字节数累计（content.length() 是字符数，中文场景低估内存占用）
+      totalBytes[0] += content.getBytes(StandardCharsets.UTF_8).length;
       if (totalBytes[0] > MAX_TOTAL_BYTES) {
         throw new IllegalArgumentException("目录总大小超过上限（5MB），拒绝导入");
       }

--- a/oryxos-web/src/test/java/io/oryxos/web/GlobalExceptionHandlerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/GlobalExceptionHandlerTest.java
@@ -92,6 +92,25 @@ class GlobalExceptionHandlerTest {
         .andExpect(content().string(not(containsString("jdbc:sqlite")))); // 连接串一个字不漏
   }
 
+  @Test
+  @DisplayName("请求体JSON语法错/缺失_映射400而非500（Spring MVC 客户端错误不再落 catch-all）")
+  void malformedJson_maps400() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.post("/throw/echo")
+                .contentType("application/json")
+                .content("{bad json"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(400));
+  }
+
+  @Test
+  @DisplayName("参数类型不匹配_映射400而非500")
+  void typeMismatch_maps400() throws Exception {
+    mvc.perform(MockMvcRequestBuilders.get("/throw/typed").param("limit", "abc"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(400));
+  }
+
   /** 内联 dummy：每个路径抛一种异常，交给真 GlobalExceptionHandler 翻译。 */
   @RestController
   static class ThrowingController {
@@ -128,6 +147,17 @@ class GlobalExceptionHandlerTest {
     @GetMapping("/throw/internal")
     void internal() {
       throw new RuntimeException("jdbc:sqlite:/data/oryxos.db connect failed");
+    }
+
+    @org.springframework.web.bind.annotation.PostMapping("/throw/echo")
+    String echo(
+        @org.springframework.web.bind.annotation.RequestBody java.util.Map<String, String> body) {
+      return "ok";
+    }
+
+    @GetMapping("/throw/typed")
+    String typed(@org.springframework.web.bind.annotation.RequestParam int limit) {
+      return "ok";
     }
   }
 }

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/SkillApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/SkillApiControllerTest.java
@@ -44,6 +44,29 @@ class SkillApiControllerTest {
   }
 
   @Test
+  @DisplayName("readBoundedUtf8 超限即拒（流式上限，不再先全量缓冲）")
+  void readBoundedRejectsOversizedStream() throws Exception {
+    byte[] big = new byte[600 * 1024];
+    java.util.Arrays.fill(big, (byte) 'a');
+
+    IllegalArgumentException ex =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                SkillApiController.readBoundedUtf8(
+                    new java.io.ByteArrayInputStream(big), 512L * 1024));
+    org.junit.jupiter.api.Assertions.assertTrue(ex.getMessage().contains("过大"));
+
+    // 上限内照常解码
+    String small =
+        SkillApiController.readBoundedUtf8(
+            new java.io.ByteArrayInputStream(
+                "内容".getBytes(java.nio.charset.StandardCharsets.UTF_8)),
+            1024);
+    org.junit.jupiter.api.Assertions.assertEquals("内容", small);
+  }
+
+  @Test
   @DisplayName("create → list/get 能取到")
   void create_thenListAndGet() throws Exception {
     mvc.perform(


### PR DESCRIPTION
## 动机

Review 收尾的三处中危缺口：

1. **`knowledge/` 未列保留目录**：`AgentStore.writableTarget` 只拦 `skills/` 首段，但 014 起 `agents/<agent>/knowledge/` 同样是「只许受控软链」的绑定事实来源。经 `POST /agents/{name}/files` 可往其中写普通文件——该文件每轮 prompt 被 `KnowledgeBindingService.inspectEntry` 判 INVALID_TARGET 并 WARN，且 `replaceBindings` 遇任何 issue 直接抛「修复后才能整体替换」——该 Agent 的知识库绑定管理被永久锁死，只能手工上盘清理。作者模型草稿路径 `isIllegalGeneratedPath` 同款遗漏（`===FILE: knowledge/x===` 可通过校验被保存）。
2. **Spring MVC 客户端错误落成 500**：`HttpMessageNotReadableException`（请求体缺失/JSON 语法错）、`MethodArgumentTypeMismatchException`（`limit=abc`）、`MissingServletRequestParameterException` 全被 catch-all 拦截成 500 + ERROR 级全堆栈——4xx 客户端错误污染服务端告警且语义错误。
3. **Skill 导入大小上限在缓冲之后才检查**：`SkillApiController.fetch` 用 `BodyHandlers.ofString` 把整个响应读成 String 后才判 512KB——上限挡不住 GB 级响应的 OOM；`GithubFolderFetcher` 总量累计用 `content.length()`（字符数，中文场景低估内存）。

## 改动（5 生产文件 + 3 测试文件，+132/-11）

- `AgentStore`：`writableTarget` 补 `knowledge` 首段拦截（与 skills 同款、大小写不敏感），报错文案点名原因（普通文件会卡死 replaceBindings）。
- `AgentLifecycleService.isIllegalGeneratedPath`：补 `knowledge` 首段，草稿不得产出绑定保留目录的普通文件。
- `GlobalExceptionHandler`：新增三类 MVC 客户端错误 → 400 + WARN + 统一信封（响应体不回显内部细节，沿用 500 的统一话术风格）。
- `SkillApiController.fetch`：改 `ofInputStream` + 有界流式读（`readBoundedUtf8`，超 512KB 即断，不多占内存）；3xx/错误路径主动关流释放连接。
- `GithubFolderFetcher`：总量按 UTF-8 字节数累计（单文件已由 fetch 的流式上限兜底）。

## 测试（4 新用例）

- `writesRejectReservedKnowledgeNamespace`：`knowledge/x` 单层与嵌套路径均拒绝（Windows 可跑，无软链依赖）。
- `malformedJson_maps400` / `typeMismatch_maps400`：坏 JSON 与 `limit=abc` 映射 400。
- `readBoundedRejectsOversizedStream`：600KB 流在 512KB 上限处拒绝，上限内正常解码。

## 本地验证（Windows）

- `oryxos-core` / `oryxos-web` 全模块 0 failure / 0 error（web 217 run / 12 skip 均为 #310 探针用例）；`GlobalExceptionHandlerTest` 8/8、`SkillApiControllerTest` 9/9、`AgentStoreTest` 9/9 实跑
- spotless / checkstyle / PMD 门禁全过