### PR TITLE
feat(channel): inbound image attachments + media enricher (feishu/wecom/dingtalk)

### DIFF
--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizer.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizer.java
@@ -2,7 +2,10 @@ package io.oryxos.channel.dingtalk;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -22,6 +25,7 @@ public class DingTalkEventNormalizer {
   private static final String CONVERSATION_SINGLE = "1";
   private static final String CONVERSATION_GROUP = "2";
   private static final String MSG_TEXT = "text";
+  private static final String MSG_PICTURE = "picture";
   private static final String FIELD_IN_AT_LIST = "isInAtList";
   private static final Pattern LEADING_AT = Pattern.compile("^@\\S+\\s*");
 
@@ -60,12 +64,18 @@ public class DingTalkEventNormalizer {
     String msgtype = text(body, "msgtype");
     boolean textual = MSG_TEXT.equals(msgtype);
     String content = "";
+    List<InboundAttachment> attachments = new ArrayList<>();
     if (textual) {
       content = body.path("text").path("content").asText("");
       if (group) {
         content = LEADING_AT.matcher(content).replaceFirst("");
       }
       content = content.strip();
+    } else if (MSG_PICTURE.equals(msgtype)) {
+      String picUrl = body.path("content").path("picURL").asText(null);
+      if (picUrl != null && !picUrl.isBlank()) {
+        attachments.add(InboundAttachment.imageUrl(picUrl));
+      }
     }
     return Optional.of(
         new InboundMessage(
@@ -77,7 +87,8 @@ public class DingTalkEventNormalizer {
             conversationId,
             content,
             textual,
-            group));
+            group,
+            attachments));
   }
 
   private static String text(JsonNode node, String field) {

--- a/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkChannelContractTest.java
+++ b/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkChannelContractTest.java
@@ -30,6 +30,11 @@ class DingTalkChannelContractTest extends InboundMessageServiceContractTestBase 
 
   @Override
   protected InboundMessage nonTextualMessage(String messageId) {
+    return normalizer.normalize(body(messageId, "1", "audio", null, false)).orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage imageMessage(String messageId) {
     return normalizer.normalize(body(messageId, "1", "picture", null, false)).orElseThrow();
   }
 

--- a/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizerTest.java
+++ b/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizerTest.java
@@ -72,7 +72,7 @@ class DingTalkEventNormalizerTest {
   }
 
   @Test
-  @DisplayName("非文本仍构造消息但 textual=false")
+  @DisplayName("非文本仍构造消息但 textual=false；图片带附件")
   void nonText() {
     ObjectNode body = mapper.createObjectNode();
     body.put("msgId", "m3");
@@ -85,6 +85,8 @@ class DingTalkEventNormalizerTest {
     InboundMessage msg = normalizer.normalize(body).orElseThrow();
     assertFalse(msg.textual());
     assertEquals("", msg.content());
+    assertEquals(1, msg.attachments().size());
+    assertEquals("https://x", msg.attachments().get(0).url());
   }
 
   @Test

--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuEventNormalizer.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuEventNormalizer.java
@@ -7,7 +7,9 @@ import com.lark.oapi.service.im.v1.model.EventMessage;
 import com.lark.oapi.service.im.v1.model.MentionEvent;
 import com.lark.oapi.service.im.v1.model.P2MessageReceiveV1;
 import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
+import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +30,7 @@ public class FeishuEventNormalizer {
   private static final String CHANNEL_TYPE = "feishu";
   private static final String CHAT_TYPE_P2P = "p2p";
   private static final String MSG_TYPE_TEXT = "text";
+  private static final String MSG_TYPE_IMAGE = "image";
   private static final String MENTIONED_TYPE_BOT = "bot";
 
   private final String channelName;
@@ -61,6 +64,7 @@ public class FeishuEventNormalizer {
     boolean textual = MSG_TYPE_TEXT.equals(message.getMessageType());
     String content =
         textual ? stripMentions(extractText(message.getContent()), message.getMentions()) : "";
+    List<InboundAttachment> attachments = extractAttachments(message);
     return Optional.of(
         new InboundMessage(
             CHANNEL_TYPE,
@@ -71,7 +75,37 @@ public class FeishuEventNormalizer {
             message.getChatId(),
             content,
             textual,
-            mentionedBot));
+            mentionedBot,
+            attachments));
+  }
+
+  private List<InboundAttachment> extractAttachments(EventMessage message) {
+    if (!MSG_TYPE_IMAGE.equals(message.getMessageType())) {
+      return List.of();
+    }
+    String imageKey = extractImageKey(message.getContent());
+    if (imageKey == null || imageKey.isBlank()) {
+      return List.of();
+    }
+    return List.of(InboundAttachment.imageReference(imageKey));
+  }
+
+  /** 图片消息 content 是 JSON：{"image_key":"img_xxx"}。 */
+  static String extractImageKey(String contentJson) {
+    if (contentJson == null || contentJson.isBlank()) {
+      return null;
+    }
+    try {
+      JsonElement root = JsonParser.parseString(contentJson);
+      if (!root.isJsonObject()) {
+        return null;
+      }
+      JsonElement key = root.getAsJsonObject().get("image_key");
+      return key == null || key.isJsonNull() ? null : key.getAsString();
+    } catch (RuntimeException e) {
+      LOG.warn("飞书图片消息 content 解析失败，按无附件处理");
+      return null;
+    }
   }
 
   /** mention 列表中是否 @ 了本机器人（open_id 比对；bot open_id 缺失时按 mentioned_type 降级）。 */

--- a/oryxos-channel-feishu/src/test/java/io/oryxos/channel/feishu/FeishuChannelContractTest.java
+++ b/oryxos-channel-feishu/src/test/java/io/oryxos/channel/feishu/FeishuChannelContractTest.java
@@ -50,6 +50,11 @@ class FeishuChannelContractTest extends InboundMessageServiceContractTestBase {
 
   @Override
   protected InboundMessage nonTextualMessage(String messageId) {
+    return normalizer.normalize(event(messageId, "p2p", "audio", "{}", null)).orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage imageMessage(String messageId) {
     return normalizer
         .normalize(event(messageId, "p2p", "image", "{\"image_key\":\"img\"}", null))
         .orElseThrow();

--- a/oryxos-channel-feishu/src/test/java/io/oryxos/channel/feishu/FeishuEventNormalizerTest.java
+++ b/oryxos-channel-feishu/src/test/java/io/oryxos/channel/feishu/FeishuEventNormalizerTest.java
@@ -76,13 +76,15 @@ class FeishuEventNormalizerTest {
   }
 
   @Test
-  @DisplayName("私聊图片：textual=false，内容为空（FR-009 能力说明由编排回复）")
+  @DisplayName("私聊图片：textual=false，附带 image_key 附件")
   void p2pImage() {
     Optional<InboundMessage> out =
         normalizer.normalize(event("p2p", "image", "{\"image_key\":\"img_x\"}"));
     assertTrue(out.isPresent());
     assertFalse(out.get().textual());
     assertEquals("", out.get().content());
+    assertEquals(1, out.get().attachments().size());
+    assertEquals("img_x", out.get().attachments().get(0).reference());
   }
 
   @Test

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComEventNormalizer.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComEventNormalizer.java
@@ -2,7 +2,10 @@ package io.oryxos.channel.wecom;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -22,6 +25,7 @@ public class WeComEventNormalizer {
   private static final String CHAT_SINGLE = "single";
   private static final String CHAT_GROUP = "group";
   private static final String MSG_TEXT = "text";
+  private static final String MSG_IMAGE = "image";
   private static final Pattern LEADING_AT = Pattern.compile("^@\\S+\\s*");
 
   private final String channelName;
@@ -56,12 +60,18 @@ public class WeComEventNormalizer {
     String msgtype = text(body, "msgtype");
     boolean textual = MSG_TEXT.equals(msgtype);
     String content = "";
+    List<InboundAttachment> attachments = new ArrayList<>();
     if (textual) {
       content = body.path("text").path("content").asText("");
       if (group) {
         content = LEADING_AT.matcher(content).replaceFirst("");
       }
       content = content.strip();
+    } else if (MSG_IMAGE.equals(msgtype)) {
+      String imageUrl = body.path("image").path("url").asText(null);
+      if (imageUrl != null && !imageUrl.isBlank()) {
+        attachments.add(InboundAttachment.imageUrl(imageUrl));
+      }
     }
     return Optional.of(
         new InboundMessage(
@@ -73,7 +83,8 @@ public class WeComEventNormalizer {
             chatId,
             content,
             textual,
-            group));
+            group,
+            attachments));
   }
 
   /** 会话类型：1 单聊 / 2 群聊；未知返回 0（发送时让平台兼容解析）。 */

--- a/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComChannelContractTest.java
+++ b/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComChannelContractTest.java
@@ -30,6 +30,11 @@ class WeComChannelContractTest extends InboundMessageServiceContractTestBase {
 
   @Override
   protected InboundMessage nonTextualMessage(String messageId) {
+    return normalizer.normalize(body(messageId, "single", "voice", null, null)).orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage imageMessage(String messageId) {
     return normalizer.normalize(body(messageId, "single", "image", null, null)).orElseThrow();
   }
 

--- a/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComEventNormalizerTest.java
+++ b/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComEventNormalizerTest.java
@@ -67,6 +67,8 @@ class WeComEventNormalizerTest {
     InboundMessage msg = normalizer.normalize(body).orElseThrow();
     assertFalse(msg.textual());
     assertEquals("", msg.content());
+    assertEquals(1, msg.attachments().size());
+    assertEquals("https://x", msg.attachments().get(0).url());
   }
 
   @Test

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -916,6 +916,7 @@ public class OryxOsRuntime {
         profileRegistry,
         agentExecutionService,
         messageDeduplicator,
+        new io.oryxos.core.channel.DefaultInboundMediaEnricher(),
         java.time.Duration.ofSeconds(15)); // 「处理中」提示阈值（Edge Case：先行告知）
   }
 

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/DefaultInboundMediaEnricher.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/DefaultInboundMediaEnricher.java
@@ -1,0 +1,29 @@
+package io.oryxos.core.channel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** 默认入站媒体富化：文本直传；图片转为带链接/资源 id 的说明，供 Agent 或 vision 模型继续处理。 */
+public final class DefaultInboundMediaEnricher implements InboundMediaEnricher {
+
+  private static final String IMAGE_WITH_URL = "[用户发送了一张图片]\n图片链接: ";
+  private static final String IMAGE_WITH_REF = "[用户发送了一张图片]\n图片资源: ";
+
+  @Override
+  public String toAgentInput(InboundMessage message) {
+    List<String> parts = new ArrayList<>();
+    if (message.content() != null && !message.content().isBlank()) {
+      parts.add(message.content().strip());
+    }
+    for (InboundAttachment attachment : message.attachments()) {
+      if (InboundAttachment.TYPE_IMAGE.equals(attachment.type())) {
+        if (attachment.url() != null && !attachment.url().isBlank()) {
+          parts.add(IMAGE_WITH_URL + attachment.url().strip());
+        } else if (attachment.reference() != null && !attachment.reference().isBlank()) {
+          parts.add(IMAGE_WITH_REF + attachment.reference().strip());
+        }
+      }
+    }
+    return String.join("\n\n", parts).strip();
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundAttachment.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundAttachment.java
@@ -1,0 +1,34 @@
+package io.oryxos.core.channel;
+
+/**
+ * 入站媒体附件（图片等），由渠道 normalizer 从平台事件提取。
+ *
+ * @param type 媒体类型，见 {@link #TYPE_IMAGE}
+ * @param url 可直接访问的 URL（企微/钉钉图片）；飞书可能为空
+ * @param reference 平台资源标识（如飞书 {@code image_key}），供后续解析
+ */
+public record InboundAttachment(String type, String url, String reference) {
+
+  public static final String TYPE_IMAGE = "image";
+
+  public InboundAttachment {
+    requireNonBlank(type, "type");
+    if ((url == null || url.isBlank()) && (reference == null || reference.isBlank())) {
+      throw new IllegalArgumentException("url 与 reference 至少提供一个");
+    }
+  }
+
+  public static InboundAttachment imageUrl(String url) {
+    return new InboundAttachment(TYPE_IMAGE, url, null);
+  }
+
+  public static InboundAttachment imageReference(String reference) {
+    return new InboundAttachment(TYPE_IMAGE, null, reference);
+  }
+
+  private static void requireNonBlank(String value, String field) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(field + " 不能为空");
+    }
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundAttachment.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundAttachment.java
@@ -13,8 +13,10 @@ public record InboundAttachment(String type, String url, String reference) {
 
   public InboundAttachment {
     requireNonBlank(type, "type");
-    if ((url == null || url.isBlank()) && (reference == null || reference.isBlank())) {
-      throw new IllegalArgumentException("url 与 reference 至少提供一个");
+    if (isBlank(url)) {
+      if (isBlank(reference)) {
+        throw new IllegalArgumentException("url 与 reference 至少提供一个");
+      }
     }
   }
 
@@ -26,8 +28,12 @@ public record InboundAttachment(String type, String url, String reference) {
     return new InboundAttachment(TYPE_IMAGE, null, reference);
   }
 
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
+  }
+
   private static void requireNonBlank(String value, String field) {
-    if (value == null || value.isBlank()) {
+    if (isBlank(value)) {
       throw new IllegalArgumentException(field + " 不能为空");
     }
   }

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaEnricher.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaEnricher.java
@@ -1,0 +1,7 @@
+package io.oryxos.core.channel;
+
+/** 将归一化入站消息（含图片附件）转为 Agent 可消费的文本输入。 */
+public interface InboundMediaEnricher {
+
+  String toAgentInput(InboundMessage message);
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessage.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessage.java
@@ -1,5 +1,7 @@
 package io.oryxos.core.channel;
 
+import java.util.List;
+
 /**
  * 归一化入站消息：平台事件经渠道适配器归一化后的唯一入站模型，编排服务只认它、不认平台原始事件（017 FR-010）。
  *
@@ -13,8 +15,9 @@ package io.oryxos.core.channel;
  * @param userId 提问者标识（飞书 open_id）；私聊会话三元组的 user 位
  * @param chatId 回复目标（私聊 = 用户会话，群聊 = 群）
  * @param content 纯文本正文；群聊已剥离 @ 机器人片段、其余 mention 已替换为人名；非文本时为空串
- * @param textual 是否文本消息；false 触发「仅支持文本」能力说明回复（FR-009）
+ * @param textual 是否文本消息；false 且无附件时触发「仅支持文本」能力说明回复（FR-009）
  * @param mentionedBot 群聊是否 @ 了本机器人；进入编排的群消息恒为 true
+ * @param attachments 图片等媒体附件（可为空）
  */
 public record InboundMessage(
     String channelType,
@@ -25,7 +28,8 @@ public record InboundMessage(
     String chatId,
     String content,
     boolean textual,
-    boolean mentionedBot) {
+    boolean mentionedBot,
+    List<InboundAttachment> attachments) {
 
   public InboundMessage {
     requireNonBlank(channelType, "channelType");
@@ -39,6 +43,14 @@ public record InboundMessage(
     if (content == null) {
       content = "";
     }
+    if (attachments == null) {
+      attachments = List.of();
+    }
+  }
+
+  /** 文本或含可处理附件（如图片）时进入 Agent 编排。 */
+  public boolean processable() {
+    return textual || !attachments.isEmpty();
   }
 
   private static void requireNonBlank(String value, String field) {

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessage.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessage.java
@@ -45,6 +45,8 @@ public record InboundMessage(
     }
     if (attachments == null) {
       attachments = List.of();
+    } else {
+      attachments = List.copyOf(attachments);
     }
   }
 

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
@@ -38,6 +38,7 @@ public class InboundMessageService {
   private final ProfileRegistry profileRegistry;
   private final AgentExecutionService executionService;
   private final MessageDeduplicator deduplicator;
+  private final InboundMediaEnricher mediaEnricher;
   private final Duration processingNoticeDelay;
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
@@ -49,12 +50,14 @@ public class InboundMessageService {
       ProfileRegistry profileRegistry,
       AgentExecutionService executionService,
       MessageDeduplicator deduplicator,
+      InboundMediaEnricher mediaEnricher,
       Duration processingNoticeDelay) {
     this.agentService = agentService;
     this.sessionManager = sessionManager;
     this.profileRegistry = profileRegistry;
     this.executionService = executionService;
     this.deduplicator = deduplicator;
+    this.mediaEnricher = mediaEnricher == null ? new DefaultInboundMediaEnricher() : mediaEnricher;
     this.processingNoticeDelay = processingNoticeDelay;
   }
 
@@ -72,8 +75,9 @@ public class InboundMessageService {
     }
     // B4：群聊回复引用原消息使问答可对应；私聊直发
     String replyTo = msg.chatKind() == ChatKind.GROUP ? msg.messageId() : null;
-    // B7：非文本消息回能力说明，不进推理、不落执行记录
-    if (!msg.textual()) {
+    // B7：不可处理的消息（非文本且无附件）回能力说明，不进推理、不落执行记录
+    String agentInput = mediaEnricher.toAgentInput(msg);
+    if (!msg.processable() || agentInput.isBlank()) {
       safeReply(replyVia, msg.chatId(), UNSUPPORTED_TYPE_REPLY, replyTo);
       return;
     }
@@ -98,8 +102,7 @@ public class InboundMessageService {
       Session session = sessionManager.getOrCreate(msg.channelType(), msg.userId(), agent);
       sessionId = session.sessionId();
       inference =
-          () ->
-              replyVia.sendReply(msg.chatId(), agentService.process(session, msg.content()), null);
+          () -> replyVia.sendReply(msg.chatId(), agentService.process(session, agentInput), null);
     } else {
       // B3：群聊每次 @ 为独立无状态问答，不落 sessions 表；渠道前缀让审计可辨（B10）
       sessionId = msg.channelType() + "-group:" + UUID.randomUUID();
@@ -107,7 +110,7 @@ public class InboundMessageService {
           () ->
               replyVia.sendReply(
                   msg.chatId(),
-                  agentService.processStateless(agent, msg.content(), sessionId),
+                  agentService.processStateless(agent, agentInput, sessionId),
                   replyTo);
     }
     CountDownLatch done = new CountDownLatch(1);

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/DefaultInboundMediaEnricherTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/DefaultInboundMediaEnricherTest.java
@@ -1,0 +1,60 @@
+package io.oryxos.core.channel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DefaultInboundMediaEnricherTest {
+
+  private final DefaultInboundMediaEnricher enricher = new DefaultInboundMediaEnricher();
+
+  @Test
+  @DisplayName("文本消息原样传递")
+  void textOnly() {
+    InboundMessage msg =
+        new InboundMessage(
+            "feishu", "ops-feishu", "m1", ChatKind.P2P, "u1", "c1", "你好", true, false, List.of());
+    assertEquals("你好", enricher.toAgentInput(msg));
+  }
+
+  @Test
+  @DisplayName("图片 URL 附件转为 Agent 可消费说明")
+  void imageUrlAttachment() {
+    InboundMessage msg =
+        new InboundMessage(
+            "wecom",
+            "ops-wecom",
+            "m2",
+            ChatKind.P2P,
+            "u1",
+            "c1",
+            "",
+            false,
+            false,
+            List.of(InboundAttachment.imageUrl("https://example/img.png")));
+    String input = enricher.toAgentInput(msg);
+    assertTrue(input.contains("https://example/img.png"));
+    assertTrue(input.contains("图片"));
+  }
+
+  @Test
+  @DisplayName("飞书 image_key 作为资源引用传递")
+  void imageReferenceAttachment() {
+    InboundMessage msg =
+        new InboundMessage(
+            "feishu",
+            "ops-feishu",
+            "m3",
+            ChatKind.P2P,
+            "u1",
+            "c1",
+            "",
+            false,
+            false,
+            List.of(InboundAttachment.imageReference("img_abc")));
+    assertTrue(enricher.toAgentInput(msg).contains("img_abc"));
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceContractTestBase.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceContractTestBase.java
@@ -59,8 +59,11 @@ public abstract class InboundMessageServiceContractTestBase {
   /** 构造一条群聊 @ 机器人文本消息。 */
   protected abstract InboundMessage groupMessage(String messageId, String content);
 
-  /** 构造一条私聊非文本消息。 */
+  /** 构造一条私聊非文本且不可处理的消息（无附件）。 */
   protected abstract InboundMessage nonTextualMessage(String messageId);
+
+  /** 构造一条私聊图片消息（含附件，应进入编排）。 */
+  protected abstract InboundMessage imageMessage(String messageId);
 
   @BeforeEach
   void contractSetUp() {
@@ -76,6 +79,7 @@ public abstract class InboundMessageServiceContractTestBase {
             profileRegistry,
             executionService,
             new MessageDeduplicator(),
+            null,
             Duration.ofSeconds(30));
     when(profileRegistry.get(AGENT)).thenReturn(Optional.of(mock(Profile.class)));
     doAnswer(
@@ -179,13 +183,26 @@ public abstract class InboundMessageServiceContractTestBase {
   }
 
   @Test
-  @DisplayName("B7: 非文本消息回能力说明，不触发推理")
+  @DisplayName("B7: 不可处理非文本消息回能力说明，不触发推理")
   void b7NonTextualNotice() {
     service.onMessage(nonTextualMessage("img-1"), replyChannel);
 
     assertEquals(InboundMessageService.UNSUPPORTED_TYPE_REPLY, replyChannel.sent().get(0).text());
     verifyNoInteractions(agentService);
     verify(executionService, never()).triggerAsync(anyString(), anyString(), any(), any());
+  }
+
+  @Test
+  @DisplayName("B7b: 图片附件消息进入编排")
+  void b7ImageAttachmentProcessed() {
+    InboundMessage img = imageMessage("img-2");
+    Session session = stubSession(img.userId());
+    when(agentService.process(eq(session), anyString())).thenReturn("看到了图片");
+
+    service.onMessage(img, replyChannel);
+
+    verify(agentService).process(eq(session), anyString());
+    assertEquals("看到了图片", replyChannel.sent().get(0).text());
   }
 
   @Test

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceTest.java
@@ -55,6 +55,7 @@ class InboundMessageServiceTest {
             profileRegistry,
             executionService,
             new MessageDeduplicator(),
+            null,
             Duration.ofMillis(120));
     when(profileRegistry.get(AGENT)).thenReturn(Optional.of(mock(Profile.class)));
     // 默认：triggerAsync 同步执行 work（吞掉 work 异常，模拟真实实现里的记录失败不上抛）
@@ -73,12 +74,30 @@ class InboundMessageServiceTest {
 
   private InboundMessage p2p(String messageId, String content) {
     return new InboundMessage(
-        "stub", "stub-chan", messageId, ChatKind.P2P, "user-1", "chat-p2p", content, true, false);
+        "stub",
+        "stub-chan",
+        messageId,
+        ChatKind.P2P,
+        "user-1",
+        "chat-p2p",
+        content,
+        true,
+        false,
+        java.util.List.of());
   }
 
   private InboundMessage group(String messageId, String content) {
     return new InboundMessage(
-        "stub", "stub-chan", messageId, ChatKind.GROUP, "user-1", "chat-grp", content, true, true);
+        "stub",
+        "stub-chan",
+        messageId,
+        ChatKind.GROUP,
+        "user-1",
+        "chat-grp",
+        content,
+        true,
+        true,
+        java.util.List.of());
   }
 
   @Test
@@ -141,11 +160,20 @@ class InboundMessageServiceTest {
   }
 
   @Test
-  @DisplayName("B7: 非文本消息回能力说明，不触发推理与执行记录")
+  @DisplayName("B7: 不可处理非文本消息回能力说明，不触发推理与执行记录")
   void nonTextualGetsCapabilityNotice() {
     InboundMessage img =
         new InboundMessage(
-            "stub", "stub-chan", "m-5", ChatKind.P2P, "user-1", "chat-p2p", "", false, false);
+            "stub",
+            "stub-chan",
+            "m-5",
+            ChatKind.P2P,
+            "user-1",
+            "chat-p2p",
+            "",
+            false,
+            false,
+            java.util.List.of());
 
     service.onMessage(img, adapter);
 
@@ -153,6 +181,31 @@ class InboundMessageServiceTest {
     assertEquals(InboundMessageService.UNSUPPORTED_TYPE_REPLY, adapter.sent().get(0).text());
     verifyNoInteractions(agentService);
     verify(executionService, never()).triggerAsync(anyString(), anyString(), any(), any());
+  }
+
+  @Test
+  @DisplayName("B7b: 图片附件消息进入 Agent 编排")
+  void imageAttachmentProcessed() {
+    InboundMessage img =
+        new InboundMessage(
+            "stub",
+            "stub-chan",
+            "m-5b",
+            ChatKind.P2P,
+            "user-1",
+            "chat-p2p",
+            "",
+            false,
+            false,
+            java.util.List.of(InboundAttachment.imageUrl("https://example/img.png")));
+    Session session = new Session("stub:user-1:" + AGENT, AGENT);
+    when(sessionManager.getOrCreate("stub", "user-1", AGENT)).thenReturn(session);
+    when(agentService.process(eq(session), anyString())).thenReturn("图片已收到");
+
+    service.onMessage(img, adapter);
+
+    verify(agentService).process(eq(session), anyString());
+    assertEquals("图片已收到", adapter.sent().get(0).text());
   }
 
   @Test

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/StubInboundContractTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/StubInboundContractTest.java
@@ -1,5 +1,7 @@
 package io.oryxos.core.channel;
 
+import java.util.List;
+
 /**
  * 契约测试集·桩档（017 T024 / SC-007）：直接构造归一化消息——证明第二个入站渠道只需产出 {@link InboundMessage} 即可零 core 修改跑通全部契约行为。
  */
@@ -21,7 +23,8 @@ class StubInboundContractTest extends InboundMessageServiceContractTestBase {
         "chat-p2p",
         content,
         true,
-        false);
+        false,
+        List.of());
   }
 
   @Override
@@ -35,7 +38,8 @@ class StubInboundContractTest extends InboundMessageServiceContractTestBase {
         "chat-grp",
         content,
         true,
-        true);
+        true,
+        List.of());
   }
 
   @Override
@@ -49,6 +53,22 @@ class StubInboundContractTest extends InboundMessageServiceContractTestBase {
         "chat-p2p",
         "",
         false,
-        false);
+        false,
+        List.of());
+  }
+
+  @Override
+  protected InboundMessage imageMessage(String messageId) {
+    return new InboundMessage(
+        channelType(),
+        "contract-chan",
+        messageId,
+        ChatKind.P2P,
+        "user-1",
+        "chat-p2p",
+        "",
+        false,
+        false,
+        List.of(InboundAttachment.imageUrl("https://example/img.png")));
   }
 }


### PR DESCRIPTION
Closes #363

## Summary

- Extend `InboundMessage` with `attachments` and `processable()` so image-only inbound messages can enter Agent orchestration.
- Add `InboundAttachment`, `InboundMediaEnricher`, and `DefaultInboundMediaEnricher` (URL / image_key → agent-readable text).
- Extract image metadata in feishu / wecom / dingtalk normalizers.
- `InboundMessageService` B7: still reject unsupported non-text; B7b: image attachments proceed to Agent via enricher.
- Wire `DefaultInboundMediaEnricher` in `OryxOsRuntime`.

## Out of scope

- Feishu image_key → temporary URL resolution
- HTTP download / Vision / OCR

## Test plan

- [x] `DefaultInboundMediaEnricherTest`
- [x] `InboundMessageServiceTest` B7 + B7b
- [x] Contract tests (stub / feishu / wecom / dingtalk)
- [x] Normalizer tests for image attachments
- [ ] Manual: send an image in at least one IM private chat