### PR TITLE
fix(channel-dingtalk): immediate reconnect on server disconnect rotation

### DIFF
--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkChannelAdapter.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkChannelAdapter.java
@@ -45,6 +45,7 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
   private final AtomicReference<DingTalkStreamClient> streamRef = new AtomicReference<>();
   private volatile DingTalkMessageSender sender;
   private volatile DingTalkEventNormalizer normalizer;
+  private volatile DingTalkDisconnectKind lastDisconnectKind = DingTalkDisconnectKind.ABRUPT;
   private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
   private volatile String lastError;
   private volatile boolean running;
@@ -172,18 +173,26 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
     }
   }
 
-  private void handleDisconnected() {
+  private void handleDisconnected(DingTalkDisconnectKind kind) {
     boolean shouldReconnect;
     synchronized (this) {
       if (!running || state == ChannelStatus.State.ERROR) {
         return;
+      }
+      lastDisconnectKind = kind == null ? DingTalkDisconnectKind.ABRUPT : kind;
+      if (lastDisconnectKind == DingTalkDisconnectKind.GRACEFUL) {
+        reconnectAttempt = 0;
       }
       streamRef.set(null);
       state = ChannelStatus.State.DISCONNECTED;
       shouldReconnect = true;
     }
     if (shouldReconnect) {
-      LOG.warn("钉钉渠道 {} Stream 断开，将自动重连", sanitize(config.name()));
+      if (lastDisconnectKind == DingTalkDisconnectKind.GRACEFUL) {
+        LOG.info("钉钉渠道 {} Stream 服务端轮换断开，立即重连", sanitize(config.name()));
+      } else {
+        LOG.warn("钉钉渠道 {} Stream 断开，将自动重连", sanitize(config.name()));
+      }
       scheduleReconnect();
     }
   }
@@ -193,7 +202,10 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
       if (!running || reconnectFuture != null) {
         return;
       }
-      long delayMs = reconnectDelayMs(reconnectAttempt);
+      long delayMs =
+          lastDisconnectKind == DingTalkDisconnectKind.GRACEFUL
+              ? 0L
+              : reconnectDelayMs(reconnectAttempt);
       reconnectFuture =
           reconnectScheduler().schedule(this::attemptReconnect, delayMs, TimeUnit.MILLISECONDS);
     }

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkDisconnectKind.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkDisconnectKind.java
@@ -1,0 +1,9 @@
+package io.oryxos.channel.dingtalk;
+
+/** 钉钉 Stream 断线原因：服务端轮换 disconnect 与异常/对端关闭。 */
+enum DingTalkDisconnectKind {
+  /** 服务端 SYSTEM disconnect 帧（计划内轮换，应立即重连）。 */
+  GRACEFUL,
+  /** onClose / onError 等非计划断线。 */
+  ABRUPT
+}

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkStreamClient.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkStreamClient.java
@@ -46,7 +46,7 @@ final class DingTalkStreamClient implements WebSocket.Listener {
   private final String clientSecret;
   private final OutboundGuard guard;
   private final Consumer<JsonNode> onBotMessage;
-  private final Runnable onDisconnected;
+  private final Consumer<DingTalkDisconnectKind> onDisconnected;
 
   private final AtomicReference<WebSocket> socket = new AtomicReference<>();
   private final AtomicBoolean connected = new AtomicBoolean(false);
@@ -54,22 +54,25 @@ final class DingTalkStreamClient implements WebSocket.Listener {
   private final StringBuilder textBuf = new StringBuilder();
   private final CountDownLatch openLatch = new CountDownLatch(1);
   private volatile String openError;
+  private volatile long connectedAtMillis;
+  private final AtomicBoolean disconnectNotified = new AtomicBoolean(false);
 
   DingTalkStreamClient(
       String clientId,
       String clientSecret,
       OutboundGuard guard,
       Consumer<JsonNode> onBotMessage,
-      Runnable onDisconnected) {
+      Consumer<DingTalkDisconnectKind> onDisconnected) {
     this.clientId = Objects.requireNonNull(clientId);
     this.clientSecret = Objects.requireNonNull(clientSecret);
     this.guard = Objects.requireNonNull(guard);
     this.onBotMessage = Objects.requireNonNull(onBotMessage);
-    this.onDisconnected = onDisconnected == null ? () -> {} : onDisconnected;
+    this.onDisconnected = onDisconnected == null ? kind -> {} : onDisconnected;
   }
 
   void connect(Duration timeout) throws Exception {
     closed.set(false);
+    disconnectNotified.set(false);
     guard.check(API_BASE_URL);
     URI wsUri = openWebSocketUri();
     HttpClient client = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
@@ -112,6 +115,8 @@ final class DingTalkStreamClient implements WebSocket.Listener {
   @Override
   public void onOpen(WebSocket webSocket) {
     connected.set(true);
+    connectedAtMillis = System.currentTimeMillis();
+    disconnectNotified.set(false);
     openLatch.countDown();
     webSocket.request(1);
   }
@@ -136,8 +141,7 @@ final class DingTalkStreamClient implements WebSocket.Listener {
 
   @Override
   public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
-    markDisconnected();
-    onDisconnected.run();
+    notifyDisconnected(DingTalkDisconnectKind.ABRUPT, "close " + statusCode + " " + reason);
     return null;
   }
 
@@ -148,8 +152,7 @@ final class DingTalkStreamClient implements WebSocket.Listener {
       openError = error == null ? "unknown" : error.getMessage();
       openLatch.countDown();
     }
-    markDisconnected();
-    onDisconnected.run();
+    notifyDisconnected(DingTalkDisconnectKind.ABRUPT, error == null ? null : error.getMessage());
   }
 
   void dispatchFrameForTest(String raw, WebSocket webSocket) {
@@ -189,9 +192,11 @@ final class DingTalkStreamClient implements WebSocket.Listener {
       return;
     }
     if (TOPIC_DISCONNECT.equals(topic)) {
-      LOG.info("钉钉 Stream 服务端请求断开: {}", sanitize(dataRaw));
+      long uptimeMs = connectedAtMillis > 0 ? System.currentTimeMillis() - connectedAtMillis : -1L;
+      LOG.info("钉钉 Stream 服务端请求断开（uptime={}ms）: {}", uptimeMs, sanitize(dataRaw));
       closeQuietly();
-      onDisconnected.run();
+      notifyDisconnected(DingTalkDisconnectKind.GRACEFUL, dataRaw);
+      return;
     }
   }
 
@@ -269,6 +274,14 @@ final class DingTalkStreamClient implements WebSocket.Listener {
     closed.set(true);
     connected.set(false);
     openLatch.countDown();
+  }
+
+  private void notifyDisconnected(DingTalkDisconnectKind kind, String detail) {
+    if (!disconnectNotified.compareAndSet(false, true)) {
+      return;
+    }
+    markDisconnected();
+    onDisconnected.accept(kind);
   }
 
   private static String extractOpaque(String dataRaw) {

--- a/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkStreamClientTest.java
+++ b/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkStreamClientTest.java
@@ -2,7 +2,6 @@ package io.oryxos.channel.dingtalk;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -32,7 +31,7 @@ class DingTalkStreamClientTest {
     AtomicReference<String> ack = new AtomicReference<>();
     WebSocket ws = mockWebSocket(ack);
     DingTalkStreamClient client =
-        new DingTalkStreamClient("id", "secret", url -> {}, messages::add, () -> {});
+        new DingTalkStreamClient("id", "secret", url -> {}, messages::add, k -> {});
     String frame =
         """
         {
@@ -59,7 +58,7 @@ class DingTalkStreamClientTest {
     AtomicReference<String> ack = new AtomicReference<>();
     WebSocket ws = mockWebSocket(ack);
     DingTalkStreamClient client =
-        new DingTalkStreamClient("id", "secret", url -> {}, node -> {}, () -> {});
+        new DingTalkStreamClient("id", "secret", url -> {}, node -> {}, k -> {});
     String frame =
         """
         {
@@ -80,12 +79,11 @@ class DingTalkStreamClientTest {
   @Test
   @DisplayName("disconnect 帧主动 closeQuietly 并通知上层")
   void disconnectTopicClosesSocketAndNotifies() throws Exception {
-    AtomicBoolean disconnected = new AtomicBoolean(false);
+    AtomicReference<DingTalkDisconnectKind> kind = new AtomicReference<>();
     WebSocket ws = mock(WebSocket.class);
     when(ws.sendClose(anyInt(), anyString())).thenReturn(CompletableFuture.completedFuture(ws));
     DingTalkStreamClient client =
-        new DingTalkStreamClient(
-            "id", "secret", url -> {}, node -> {}, () -> disconnected.set(true));
+        new DingTalkStreamClient("id", "secret", url -> {}, node -> {}, kind::set);
     seedOpenClient(client, ws);
 
     String frame =
@@ -102,7 +100,7 @@ class DingTalkStreamClientTest {
     client.dispatchFrameForTest(frame, ws);
 
     assertFalse(client.isConnected());
-    assertTrue(disconnected.get());
+    assertEquals(DingTalkDisconnectKind.GRACEFUL, kind.get());
     verify(ws).sendClose(WebSocket.NORMAL_CLOSURE, "bye");
   }
 


### PR DESCRIPTION
Closes #365

- Add DingTalkDisconnectKind (GRACEFUL vs ABRUPT)
- Server disconnect rotation reconnects immediately (delayMs=0)
- Deduplicate disconnect notifications in stream client

Made with [Cursor](https://cursor.com)