### PR TITLE
fix(channel-wecom): preserve chatTypes mapping across reconnect

### DIFF
--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
@@ -1,6 +1,7 @@
 package io.oryxos.channel.wecom;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.oryxos.core.channel.ChannelConfig;
 import io.oryxos.core.channel.ChannelStatus;
 import io.oryxos.core.channel.InboundChannelAdapter;
@@ -15,6 +16,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +50,7 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
   private final OutboundGuard guard;
 
   private final AtomicReference<WeComWsClient> wsRef = new AtomicReference<>();
+  private final AtomicReference<Consumer<ObjectNode>> transportRef = new AtomicReference<>();
   private volatile WeComMessageSender sender;
   private volatile WeComEventNormalizer normalizer;
   private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
@@ -120,6 +123,9 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
     if (ws != null) {
       ws.closeQuietly();
     }
+    transportRef.set(null);
+    sender = null;
+    normalizer = null;
     state = ChannelStatus.State.DISCONNECTED;
   }
 
@@ -152,7 +158,7 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
   }
 
   private void connectLocked() throws Exception {
-    normalizer = new WeComEventNormalizer(config.name());
+    ensureOutboundStack();
     WeComWsClient client =
         new WeComWsClient(
             config.appId(),
@@ -160,11 +166,30 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
             WeComWsClient.DEFAULT_WS_URL,
             this::handleFrame,
             this::handleDisconnected);
-    sender =
-        new WeComMessageSender(
-            client::sendJson, guard, OUTBOUND_URL, WeComMessageSender.DEFAULT_CHUNK_SIZE);
+    transportRef.set(client::sendJson);
     client.connectAndSubscribe(START_TIMEOUT);
     wsRef.set(client);
+  }
+
+  /** 懒初始化出站组件；重连复用同一 {@link WeComMessageSender} 以保留 chatTypes 映射。 */
+  private void ensureOutboundStack() {
+    if (normalizer == null) {
+      normalizer = new WeComEventNormalizer(config.name());
+    }
+    if (sender == null) {
+      sender =
+          new WeComMessageSender(
+              frame -> {
+                Consumer<ObjectNode> transport = transportRef.get();
+                if (transport == null) {
+                  throw new IllegalStateException("企微长连接未建立，无法发送");
+                }
+                transport.accept(frame);
+              },
+              guard,
+              OUTBOUND_URL,
+              WeComMessageSender.DEFAULT_CHUNK_SIZE);
+    }
   }
 
   private void handleDisconnected() {

--- a/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComChannelAdapterLifecycleTest.java
+++ b/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComChannelAdapterLifecycleTest.java
@@ -1,8 +1,16 @@
 package io.oryxos.channel.wecom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
+import io.oryxos.core.channel.ChannelConfig;
+import io.oryxos.core.channel.InboundMessageService;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -21,5 +29,31 @@ class WeComChannelAdapterLifecycleTest {
   @DisplayName("重连退避：负 attempt 按 0 处理")
   void reconnectDelayClampsNegativeAttempt() {
     assertTrue(WeComChannelAdapter.reconnectDelayMs(-1) >= 2_000L);
+  }
+
+  @Test
+  @DisplayName("重连路径复用 MessageSender，chatTypes 映射不丢失")
+  void outboundStackReusedAcrossReconnectInit() throws Exception {
+    ChannelConfig config =
+        new ChannelConfig("ops-wecom", "wecom", "bot", "secret", "demo-agent", true);
+    WeComChannelAdapter adapter =
+        new WeComChannelAdapter(
+            config,
+            new ProfileRegistry(),
+            mock(InboundMessageService.class),
+            (OutboundGuard) url -> {});
+
+    Method ensure = WeComChannelAdapter.class.getDeclaredMethod("ensureOutboundStack");
+    ensure.setAccessible(true);
+    Field senderField = WeComChannelAdapter.class.getDeclaredField("sender");
+    senderField.setAccessible(true);
+
+    ensure.invoke(adapter);
+    WeComMessageSender first = (WeComMessageSender) senderField.get(adapter);
+    first.rememberChatType("chat-1", 1);
+
+    ensure.invoke(adapter);
+    WeComMessageSender second = (WeComMessageSender) senderField.get(adapter);
+    assertSame(first, second);
   }
 }


### PR DESCRIPTION
Closes #366

- Lazy-init sender/normalizer via ensureOutboundStack()
- Reconnect swaps WebSocket transport only, preserving chatTypes
- stop() clears sender for clean restart

Made with [Cursor](https://cursor.com)