### PR TITLE
fix(notify): feishu format=markdown uses interactive lark_md

### DIFF
--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/FeishuNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/FeishuNotifyAdapter.java
@@ -15,9 +15,9 @@ import javax.crypto.spec.SecretKeySpec;
  *
  * <p>二者协议相同、仅域名不同（open.feishu.cn / open.larksuite.com），URL 来自配置故一个实现覆盖两者。
  *
- * <p>默认 body：{@code {"msg_type":"text","content":{"text":"..."}}}。 {@code
- * config.format=post}/{@code markdown} 时发官方富文本 post（把 content 整段放入 text 节点）。 {@code
- * format=interactive}/{@code card} 时发简易互动卡片（header + lark_md 正文）。
+ * <p>默认 body：{@code {"msg_type":"text","content":{"text":"..."}}}。 {@code config.format=post}
+ * 时发官方富文本 post（把 content 整段放入 text 节点）。 {@code format=markdown} 时发互动卡片 {@code lark_md} 以渲染
+ * Markdown。 {@code format=interactive}/{@code card} 时发简易互动卡片（header + lark_md 正文）。
  *
  * <p>签名校验为可选项：config 含 {@code secret} 时按官方算法把 {@code timestamp}+{@code sign} 写入 JSON 体（秒级时间戳；
  * 与钉钉「拼到 URL」不同）。
@@ -52,8 +52,10 @@ public class FeishuNotifyAdapter implements NotifyChannelAdapter {
     }
     String format = resolveFormat(target.config());
     Map<String, Object> body;
-    if (FORMAT_POST.equals(format) || FORMAT_MARKDOWN.equals(format)) {
+    if (FORMAT_POST.equals(format)) {
       body = buildPostBody(target.config(), content);
+    } else if (FORMAT_MARKDOWN.equals(format)) {
+      body = buildInteractiveBody(target.config(), content);
     } else if (FORMAT_INTERACTIVE.equals(format) || FORMAT_CARD.equals(format)) {
       body = buildInteractiveBody(target.config(), content);
     } else if (FORMAT_TEXT.equals(format)) {

--- a/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
@@ -148,16 +148,20 @@ class VendorNotifyAdapterTest {
   }
 
   @Test
-  @DisplayName("飞书：format=markdown 走 post 富文本（与企微同参）")
-  void feishuMarkdownAliasUsesPostBody() throws IOException {
+  @DisplayName("飞书：format=markdown 发互动卡片 lark_md（可渲染 Markdown）")
+  void feishuMarkdownAliasUsesInteractiveLarkMd() throws IOException {
     new FeishuNotifyAdapter(poster)
         .send(
             new NotifyTarget("feishu", Map.of("url", url(), "format", "markdown")),
             "## 告警\nCPU 90%");
 
     JsonNode body = lastBody();
-    assertEquals("post", body.get("msg_type").asText());
-    assertEquals("告警", body.get("content").get("post").get("zh_cn").get("title").asText());
+    assertEquals("interactive", body.get("msg_type").asText());
+    assertEquals(
+        "lark_md", body.get("card").get("elements").get(0).get("text").get("tag").asText());
+    assertEquals(
+        "## 告警\nCPU 90%",
+        body.get("card").get("elements").get(0).get("text").get("content").asText());
   }
 
   @Test


### PR DESCRIPTION
Closes #367

- format=post still sends post rich text
- format=markdown now sends interactive card with lark_md for proper Markdown rendering

Made with [Cursor](https://cursor.com)