### PR TITLE
chore(ci): suppress Spring Framework 6.2.19 OWASP CVEs pending Boot 4

### DIFF
--- a/config/dependency-check-suppressions.xml
+++ b/config/dependency-check-suppressions.xml
@@ -9,4 +9,21 @@
         <packageUrl regex="true">^pkg:maven/io\.oryxos/oryxos-core@.*$</packageUrl>
         <cve>CVE-2023-39022</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Spring Boot 3.5.16 pins Spring Framework 6.2.19. OSS fix requires Spring Framework 7.0.9
+        (Boot 4); 6.2.20 is enterprise-only per https://spring.io/security/cve-2026-59313
+
+        CVE-2026-59313 / CVE-2026-59283 / CVE-2026-59314 affect SSE in Spring MVC functional web
+        (RouterFunction, ServerResponse.sse). OryxOS uses conventional @RestController only; no
+        matching usage in the codebase. Spring rates CVE-2026-59313 LOW.
+
+        Remove this suppression when upgrading to Spring Boot 4 / Spring Framework 7.0.9+.
+        See oryx-labs/oryxos#371.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/.*@6\.2\.19$</packageUrl>
+        <cve>CVE-2026-59313</cve>
+        <cve>CVE-2026-59283</cve>
+        <cve>CVE-2026-59314</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Closes #371

## Summary

Add documented OWASP suppressions for Spring Framework 6.2.19 CVEs that block CI (ailBuildOnCVSS=8) while Boot 3.5.x has no OSS patch.

## Suppressed CVEs

- CVE-2026-59313, CVE-2026-59283, CVE-2026-59314 on org.springframework:*@6.2.19

## Justification

- Boot 3.5.16 is latest 3.5.x; OSS fix requires Boot 4 / Spring Framework 7.0.9
- CVE-2026-59313 requires SSE functional web; OryxOS has no such usage
- Spring rates CVE-2026-59313 LOW: https://spring.io/security/cve-2026-59313

## Test plan

- [ ] CI OWASP Dependency-Check passes
- [ ] CI Build & quality gate still passes
- [ ] Unblocks #364, #368, #369, #370 after merge + re-run checks

Made with [Cursor](https://cursor.com)