### PR TITLE
fix(channel-dingtalk): picture inbound uses downloadCode not picURL

### DIFF
--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizer.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizer.java
@@ -72,10 +72,7 @@ public class DingTalkEventNormalizer {
       }
       content = content.strip();
     } else if (MSG_PICTURE.equals(msgtype)) {
-      String picUrl = body.path("content").path("picURL").asText(null);
-      if (picUrl != null && !picUrl.isBlank()) {
-        attachments.add(InboundAttachment.imageUrl(picUrl));
-      }
+      extractPictureAttachment(body.path("content")).ifPresent(attachments::add);
     }
     return Optional.of(
         new InboundMessage(
@@ -89,6 +86,26 @@ public class DingTalkEventNormalizer {
             textual,
             group,
             attachments));
+  }
+
+  private static Optional<InboundAttachment> extractPictureAttachment(JsonNode content) {
+    if (content == null || content.isMissingNode()) {
+      return Optional.empty();
+    }
+    String picUrl = content.path("picURL").asText(null);
+    if (picUrl != null && !picUrl.isBlank()) {
+      return Optional.of(InboundAttachment.imageUrl(picUrl));
+    }
+    // 官方 Stream 图片：content.downloadCode / pictureDownloadCode（无直链 URL）
+    String downloadCode = content.path("downloadCode").asText(null);
+    if (downloadCode != null && !downloadCode.isBlank()) {
+      return Optional.of(InboundAttachment.imageReference(downloadCode));
+    }
+    String pictureDownloadCode = content.path("pictureDownloadCode").asText(null);
+    if (pictureDownloadCode != null && !pictureDownloadCode.isBlank()) {
+      return Optional.of(InboundAttachment.imageReference(pictureDownloadCode));
+    }
+    return Optional.empty();
   }
 
   private static String text(JsonNode node, String field) {

--- a/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizerTest.java
+++ b/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkEventNormalizerTest.java
@@ -72,7 +72,27 @@ class DingTalkEventNormalizerTest {
   }
 
   @Test
-  @DisplayName("非文本仍构造消息但 textual=false；图片带附件")
+  @DisplayName("picture + downloadCode（官方 Stream 格式）→ 图片附件")
+  void pictureWithDownloadCode() {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgId", "m3b");
+    body.put("conversationType", "1");
+    body.put("conversationId", "conv-p2p");
+    body.put("senderId", "u1");
+    body.put("msgtype", "picture");
+    body.putObject("content")
+        .put("pictureDownloadCode", "pWjA****ks=")
+        .put("downloadCode", "mIof****JE0E");
+
+    InboundMessage msg = normalizer.normalize(body).orElseThrow();
+    assertFalse(msg.textual());
+    assertTrue(msg.processable());
+    assertEquals(1, msg.attachments().size());
+    assertEquals("mIof****JE0E", msg.attachments().get(0).reference());
+  }
+
+  @Test
+  @DisplayName("非文本仍构造消息但 textual=false；图片带 picURL 附件")
   void nonText() {
     ObjectNode body = mapper.createObjectNode();
     body.put("msgId", "m3");


### PR DESCRIPTION
Closes #373

## Summary

DingTalk Stream official picture messages use \content.downloadCode\ / \pictureDownloadCode\, not \picURL\. After #364 merge, real-device picture messages still hit B7 (unsupported type reply).

## Fix

- Map official picture payload to \InboundAttachment.imageReference(downloadCode)\
- Keep \picURL\ fallback for test/legacy payloads

## Test plan

- [x] \DingTalkEventNormalizerTest\ (downloadCode + picURL)
- [x] Real device: DingTalk private chat picture no longer returns B7 reply

Made with [Cursor](https://cursor.com)