### PR TITLE
fix(channel): parse channels.yaml enabled yes/on/1 correctly

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/channel/ChannelConfigLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/ChannelConfigLoader.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -101,8 +102,7 @@ public class ChannelConfigLoader {
               asString(entry.get("app_id")),
               asString(entry.get("app_secret")),
               asString(entry.get("agent")),
-              entry.get("enabled") == null
-                  || Boolean.parseBoolean(String.valueOf(entry.get("enabled"))));
+              asEnabled(entry.get("enabled"), asString(entry.get("name"))));
       config.validateShape();
       if (!seen.add(config.name())) {
         throw new IllegalArgumentException("channels.yaml 渠道名重复: " + config.name());
@@ -166,6 +166,42 @@ public class ChannelConfigLoader {
     }
     matcher.appendTail(sb);
     return sb.toString();
+  }
+
+  /**
+   * {@code enabled} 缺省 true；接受 YAML 布尔、常见字符串/数字真值。{@code Boolean.parseBoolean("yes")} 恒为
+   * false，会静默关断渠道。
+   */
+  private static boolean asEnabled(Object value, String channelName) {
+    if (value == null) {
+      return true;
+    }
+    if (value instanceof Boolean enabled) {
+      return enabled;
+    }
+    if (value instanceof Number number) {
+      int n = number.intValue();
+      if (n == 1) {
+        return true;
+      }
+      if (n == 0) {
+        return false;
+      }
+      throw invalidEnabled(channelName, value);
+    }
+    if (value instanceof String text) {
+      return switch (text.trim().toLowerCase(Locale.ROOT)) {
+        case "true", "yes", "on", "1" -> true;
+        case "false", "no", "off", "0" -> false;
+        default -> throw invalidEnabled(channelName, text);
+      };
+    }
+    throw invalidEnabled(channelName, value);
+  }
+
+  private static IllegalArgumentException invalidEnabled(String channelName, Object value) {
+    String who = channelName == null || channelName.isBlank() ? "渠道" : "渠道 " + channelName;
+    return new IllegalArgumentException(who + " 的 enabled 必须是布尔值: " + value);
   }
 
   private static String asString(Object value) {

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/ChannelConfigLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/ChannelConfigLoader.java
@@ -172,6 +172,10 @@ public class ChannelConfigLoader {
    * {@code enabled} 缺省 true；接受 YAML 布尔、常见字符串/数字真值。{@code Boolean.parseBoolean("yes")} 恒为
    * false，会静默关断渠道。
    */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification =
+          "enabled truthy tokens are ASCII (true/yes/on/1); Locale.ROOT lowercasing is the correct case-fold.")
   private static boolean asEnabled(Object value, String channelName) {
     if (value == null) {
       return true;

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/ChannelConfigLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/ChannelConfigLoaderTest.java
@@ -147,6 +147,54 @@ class ChannelConfigLoaderTest {
   }
 
   @Test
+  @DisplayName("enabled 接受 yes/on/1 等常见真值，非法值 fail-loud")
+  void enabledCoercion() throws Exception {
+    write(
+        """
+        channels:
+          - name: quoted-yes
+            type: feishu
+            app_id: a
+            app_secret: b
+            agent: x
+            enabled: "yes"
+          - name: quoted-on
+            type: feishu
+            app_id: a
+            app_secret: b
+            agent: x
+            enabled: "on"
+          - name: numeric-one
+            type: feishu
+            app_id: a
+            app_secret: b
+            agent: x
+            enabled: 1
+        """);
+    List<ChannelConfig> configs = new ChannelConfigLoader(configFile()).loadRaw();
+    assertEquals(3, configs.size());
+    assertTrue(configs.get(0).enabled());
+    assertTrue(configs.get(1).enabled());
+    assertTrue(configs.get(2).enabled());
+
+    write(
+        """
+        channels:
+          - name: bad-enabled
+            type: feishu
+            app_id: a
+            app_secret: b
+            agent: x
+            enabled: maybe
+        """);
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class, () -> new ChannelConfigLoader(configFile()).loadRaw());
+    assertTrue(e.getMessage().contains("bad-enabled"));
+    assertTrue(e.getMessage().contains("enabled"));
+  }
+
+  @Test
   @DisplayName("YAML 1.1 布尔词 yes/on 不得被 String.valueOf 改成 true（须加引号）")
   void rejectsYamlBooleanWordsAsStringFields() throws Exception {
     write(


### PR DESCRIPTION
Closes #375

## Summary

- Replace `Boolean.parseBoolean(String.valueOf(enabled))` with explicit coercion for YAML/common truthy values
- `enabled: "yes"` / `"on"` / `1` → enabled (no longer silently disabled)
- Invalid `enabled` values fail loud with channel name in the error

## Test plan

- [x] `ChannelConfigLoaderTest.enabledCoercion` (yes/on/1 + invalid value)
- [x] Existing `disabledEntry` / string-field yes/on rejection regressions
