### PR TITLE
feat(provider): 023 Provider 失败切换与业务指标导出——v0.3 治理面收官

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/022-secret-encryption"
+  "feature_directory": "specs/023-provider-fallback"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,9 @@ provider:
   model: deepseek-chat
   temperature: 0.7
   api_key: ${DEEPSEEK_API_KEY}   # 从环境变量读取，不明文写死
+  fallback:               # 023 可选：有序备用 Provider——单次 LLM 调用的 provider 侧故障按序切换重发，
+    - name: qwen          #   每次尝试各写一条 llm_calls（主备留痕）、切换 WARN 带 traceId；业务性失败（400 类）不切
+      model: qwen-plus
 tools:
   - read_file
   - shell

--- a/docs/CliGuide.md
+++ b/docs/CliGuide.md
@@ -190,6 +190,10 @@ curl -H "X-API-Key: oryx_..." http://localhost:8080/api/v1/profiles
 
 每次消息处理生成唯一 trace ID：REST 响应体（`data.traceId`）、SSE 流首 `trace` 事件、执行历史行里都能拿到。用户报障时报上这个 ID，管理员在管理台「报表」页输入即可回放本轮完整链路（每次 LLM 调用与工具执行的时间序、耗时、token 与成本合计），或直接查 `GET /api/v1/audit/trace/{traceId}`；服务日志里同一 ID 经 MDC 贯穿，`grep <traceId>` 可与审计互查。时间线里的工具参数/结果摘要经内置规则脱敏（API key、口令类字段掩码），库中保留原文供特权排障。
 
+### 4.10 Provider 失败切换与监控指标（023）
+
+Agent 的 `AGENT.md` provider 节可声明 `fallback:` 有序备用列表（每项 name+model，引用已注册 Provider）——主 Provider 网络故障/超时/限流/凭证失效时该次调用自动按序切换备用，终端无感知；每次尝试都留审计、切换有 WARN 日志（带 traceId 可互查）。运维将 `/actuator/prometheus` 接入企业 Prometheus/Grafana 即可看到 `oryxos_` 前缀业务指标（LLM 调用/耗时/token/工具/策略拦截/切换计数）并配置告警（如「fallback 切换次数突增」）。
+
 ---
 
 ## 5. 配置与凭证

--- a/oryxos-boot/src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java
@@ -1,0 +1,251 @@
+package io.oryxos.boot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.cli.OryxOsRuntime;
+import io.oryxos.storage.LlmCall;
+import io.oryxos.storage.LlmCallRepository;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+/**
+ * 023 端到端：broken provider（配置种子预置，base-url 指向 127.0.0.1 不通端口——启动前预置是必须的， Agent 加载时 knownProviders
+ * 校验要能看到它）+ mock 备用；真实 HTTP + SQLite——主败备成用户无感知（SC-001）、 每尝试一条审计且 trace 同链（SC-003）、切换 WARN 带
+ * traceId、零声明回归（SC-002）、全败上抛。 无 key、无网络、gate 内可跑。
+ */
+@SpringBootTest(
+    classes = OryxOsRuntime.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+      "oryxos.providers[0].name=mock",
+      "oryxos.providers[1].name=broken",
+      "oryxos.providers[1].api-key=dummy",
+      "oryxos.providers[1].base-url=http://127.0.0.1:1",
+      "management.endpoints.web.exposure.include=health,prometheus"
+    })
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ProviderFallbackE2ETest {
+
+  private static final Path ROOT = seedWorkspace();
+  private static final String REPLY_OK = "好的，已经按你的要求记录并处理完成。";
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private LlmCallRepository llmCalls;
+
+  private static Path seedWorkspace() {
+    try {
+      Path root = Files.createTempDirectory("oryxos-fallback-e2e");
+      Files.createDirectories(root.resolve("memory"));
+      // fb-agent：主 broken + fallback mock；plain-agent：零声明（只配 mock，SC-002 回归锚点）
+      writeAgent(
+          root,
+          "fb-agent",
+          """
+          provider:
+            name: broken
+            model: broken-model
+            fallback:
+              - name: mock
+                model: mock-model
+          """);
+      writeAgent(
+          root,
+          "plain-agent",
+          """
+          provider:
+            name: mock
+            model: mock-model
+          """);
+      writeAgent(
+          root,
+          "doomed-agent",
+          """
+          provider:
+            name: broken
+            model: broken-model
+            fallback:
+              - name: broken
+                model: broken-model-2
+          """);
+      System.setProperty("oryxos.root", root.toString());
+      return root;
+    } catch (IOException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private static void writeAgent(Path root, String name, String providerYaml) throws IOException {
+    Files.createDirectories(root.resolve("agents").resolve(name));
+    Files.writeString(
+        root.resolve("agents/" + name + "/AGENT.md"),
+        """
+        ---
+        name: %s
+        description: fallback 走查 Agent
+        identity:
+          agent_name: 小欧
+          prompt: 你是一个测试助手。
+        %s
+        tools:
+          - save_memory
+        settings:
+          max_iterations: 10
+          max_history_turns: 20
+        ---
+        你是一个测试助手，被触发时正常回应。
+        """
+            .formatted(name, providerYaml.stripTrailing()));
+  }
+
+  @DynamicPropertySource
+  static void datasource(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", () -> "jdbc:sqlite:" + ROOT.resolve("fallback-e2e.db"));
+    registry.add("oryxos.root", ROOT::toString);
+  }
+
+  @Test
+  @Order(1)
+  void 主败备成_用户无感知_审计每尝试一条且trace同链() {
+    var root =
+        (ch.qos.logback.classic.Logger)
+            org.slf4j.LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+    var appender =
+        new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+    appender.start();
+    root.addAppender(appender);
+    try {
+      long maxIdBefore = maxLlmId();
+      JsonNode data = invokeOk("fb-agent", "记住我喜欢咖啡");
+      assertEquals(REPLY_OK, data.get("reply").asText()); // SC-001：备用接住，回复正常
+
+      // SC-003：每尝试一条——mock 每轮 2 次 LLM 调用，每次主 broken 失败 + mock 成功 = 4 条同 trace
+      List<LlmCall> round = llmCallsAfter(maxIdBefore);
+      String traceId = data.get("traceId").asText();
+      assertEquals(2, round.stream().filter(c -> "broken".equals(c.getProvider())).count());
+      assertEquals(2, round.stream().filter(c -> "mock".equals(c.getProvider())).count());
+      assertTrue(
+          round.stream()
+              .filter(c -> "broken".equals(c.getProvider()))
+              .noneMatch(LlmCall::isSuccess));
+      assertTrue(
+          round.stream().filter(c -> "mock".equals(c.getProvider())).allMatch(LlmCall::isSuccess));
+      assertTrue(round.stream().allMatch(c -> traceId.equals(c.getTraceId())), "主备尝试共享该轮 trace");
+      // broken 尝试的 model 如实（不是备用的 mock-model）
+      assertTrue(
+          round.stream()
+              .filter(c -> "broken".equals(c.getProvider()))
+              .allMatch(c -> "broken-model".equals(c.getModel())));
+
+      // 021 时间线：主备 LLM 步同链可回放
+      JsonNode timeline = getJson("/api/v1/audit/trace/" + traceId).get("data");
+      assertTrue(timeline.get("found").asBoolean());
+      assertEquals(4, timeline.get("summary").get("llmCalls").asInt());
+
+      // FR-006：切换 WARN 带本轮 traceId（MDC）
+      assertTrue(
+          appender.list.stream()
+              .anyMatch(
+                  e ->
+                      e.getFormattedMessage().contains("provider 切换")
+                          && e.getFormattedMessage().contains("broken")
+                          && e.getFormattedMessage().contains("mock")
+                          && traceId.equals(e.getMDCPropertyMap().get("traceId"))));
+    } finally {
+      root.detachAppender(appender);
+    }
+  }
+
+  @Test
+  @Order(2)
+  void 零声明Agent_行为回归_单轮审计条数不变() {
+    long maxIdBefore = maxLlmId();
+    JsonNode data = invokeOk("plain-agent", "回归场景");
+    assertEquals(REPLY_OK, data.get("reply").asText());
+
+    // SC-002/SC-006：零声明单轮恰 2 条（mock 两次调用），无多余尝试
+    List<LlmCall> round = llmCallsAfter(maxIdBefore);
+    assertEquals(2, round.size());
+    assertTrue(round.stream().allMatch(c -> "mock".equals(c.getProvider())));
+    assertTrue(round.stream().allMatch(LlmCall::isSuccess));
+  }
+
+  @Test
+  @Order(3)
+  void 全部候选失败_报错且无成功行() {
+    long maxIdBefore = maxLlmId();
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    ResponseEntity<String> response =
+        rest.postForEntity(
+            "/api/v1/agents/doomed-agent/invoke",
+            new HttpEntity<>("{\"content\":\"注定失败\"}", headers),
+            String.class);
+    assertTrue(response.getStatusCode().is5xxServerError(), "候选耗尽应报错（现状口径）");
+
+    List<LlmCall> round = llmCallsAfter(maxIdBefore);
+    assertFalse(round.isEmpty());
+    assertTrue(round.stream().noneMatch(LlmCall::isSuccess), "无成功行");
+    assertEquals(2, round.size(), "主 + 备各一次失败尝试（同一轮首个 LLM 调用即失败终止）");
+  }
+
+  // —— helpers ——
+
+  private JsonNode invokeOk(String agent, String content) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    ResponseEntity<String> response =
+        rest.postForEntity(
+            "/api/v1/agents/" + agent + "/invoke",
+            new HttpEntity<>("{\"content\":\"" + content + "\"}", headers),
+            String.class);
+    assertEquals(HttpStatus.OK, response.getStatusCode(), String.valueOf(response.getBody()));
+    JsonNode data = readJson(response.getBody()).get("data");
+    assertNotNull(data);
+    return data;
+  }
+
+  private long maxLlmId() {
+    return llmCalls.findAll().stream().mapToLong(LlmCall::getId).max().orElse(0);
+  }
+
+  private List<LlmCall> llmCallsAfter(long maxIdBefore) {
+    return llmCalls.findAll().stream().filter(c -> c.getId() > maxIdBefore).toList();
+  }
+
+  private JsonNode getJson(String path) {
+    ResponseEntity<String> response = rest.getForEntity(path, String.class);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    return readJson(response.getBody());
+  }
+
+  private JsonNode readJson(String raw) {
+    try {
+      return mapper.readTree(raw);
+    } catch (IOException e) {
+      throw new IllegalStateException("invalid json: " + raw, e);
+    }
+  }
+}

--- a/oryxos-boot/src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java
@@ -34,6 +34,9 @@ import org.springframework.test.context.DynamicPropertySource;
  * 校验要能看到它）+ mock 备用；真实 HTTP + SQLite——主败备成用户无感知（SC-001）、 每尝试一条审计且 trace 同链（SC-003）、切换 WARN 带
  * traceId、零声明回归（SC-002）、全败上抛。 无 key、无网络、gate 内可跑。
  */
+// @AutoConfigureObservability：@SpringBootTest 默认禁用 metrics export（防测试打点外泄），
+// 不加则 PrometheusMeterRegistry 不装配、/actuator/prometheus 404——真机 serve 不受此影响
+@org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability
 @SpringBootTest(
     classes = OryxOsRuntime.class,
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -209,6 +212,65 @@ class ProviderFallbackE2ETest {
     assertFalse(round.isEmpty());
     assertTrue(round.stream().noneMatch(LlmCall::isSuccess), "无成功行");
     assertEquals(2, round.size(), "主 + 备各一次失败尝试（同一轮首个 LLM 调用即失败终止）");
+  }
+
+  @Test
+  @Order(4)
+  void prometheus端点_五类业务指标在位且与审计口径对照一致() {
+    // 触发一次策略拦截：GLOBAL_DENY save_memory → policy_blocks 计数
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    ResponseEntity<String> rule =
+        rest.postForEntity(
+            "/api/v1/tool-policy/rules",
+            new HttpEntity<>("{\"ruleType\":\"GLOBAL_DENY\",\"pattern\":\"save_memory\"}", headers),
+            String.class);
+    assertEquals(HttpStatus.OK, rule.getStatusCode());
+    long ruleId = readJson(rule.getBody()).get("data").get("id").asLong();
+    try {
+      invokeOk("plain-agent", "触发拦截场景");
+    } finally {
+      rest.delete("/api/v1/tool-policy/rules/" + ruleId);
+    }
+
+    ResponseEntity<String> metrics = rest.getForEntity("/actuator/prometheus", String.class);
+    assertEquals(HttpStatus.OK, metrics.getStatusCode());
+    String body = metrics.getBody();
+    assertNotNull(body);
+
+    // 五类指标在位（SC-005）
+    assertTrue(body.contains("oryxos_llm_calls_total"), "LLM 调用计数在位");
+    // Prometheus 文本格式标签按字母序输出——逐行 contains 判定，不假定标签顺序
+    assertTrue(
+        hasSeries(body, "oryxos_llm_calls_total", "provider=\"broken\"", "outcome=\"failure\""),
+        "broken 失败序列在位");
+    assertTrue(
+        hasSeries(body, "oryxos_llm_calls_total", "provider=\"mock\"", "outcome=\"success\""),
+        "mock 成功序列在位");
+    assertTrue(
+        hasSeries(body, "oryxos_fallback_switches_total", "from=\"broken\"", "to=\"mock\""),
+        "切换计数在位");
+    assertTrue(body.contains("oryxos_tool_invocations_total"), "工具调用计数在位");
+    // oryxos_llm_tokens_total：mock provider 的 usage 恒为 0 token → 指标合法缺席（契约：未发生即缺席/零值），
+    // 计数语义由 MicrometerMetricsRecorderTest 钉死，真实 token 序列在真机走查（quickstart V6）验证
+    assertTrue(body.contains("oryxos_policy_blocks_total"), "策略拦截计数在位");
+
+    // SC-005/SC-006：指标总数与 llm_calls 表行数同口径（每尝试各计一）
+    double metricTotal =
+        java.util.regex.Pattern.compile("oryxos_llm_calls_total\\{[^}]*} (\\S+)")
+            .matcher(body)
+            .results()
+            .mapToDouble(m -> Double.parseDouble(m.group(1)))
+            .sum();
+    assertEquals(llmCalls.count(), (long) metricTotal, "指标计数与审计行数对照一致");
+  }
+
+  private static boolean hasSeries(String body, String metric, String... labels) {
+    return body.lines()
+        .anyMatch(
+            line ->
+                line.startsWith(metric)
+                    && java.util.Arrays.stream(labels).allMatch(line::contains));
   }
 
   // —— helpers ——

--- a/oryxos-cli/pom.xml
+++ b/oryxos-cli/pom.xml
@@ -91,6 +91,12 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
         </dependency>
+        <!-- 023：业务指标 MicrometerMetricsRecorder 的编译依赖——运行时 jar 已由 oryxos-boot 的
+             spring-boot-starter-actuator 传递带入，此处仅补编译可见性，零新增运行时构件 -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/oryxos-cli/src/main/java/io/oryxos/cli/MicrometerMetricsRecorder.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/MicrometerMetricsRecorder.java
@@ -1,0 +1,122 @@
+package io.oryxos.cli;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.oryxos.core.metrics.MetricsRecorder;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link MetricsRecorder} 的 Micrometer 实现（023）：五类业务指标落 {@code oryxos_*}（目录见 specs/023 contracts
+ * §3），经 /actuator/prometheus 暴露给企业监控栈。
+ *
+ * <p>实现纪律（FR-010）：全部方法吞异常记 DEBUG——任何 MeterRegistry 故障不得影响调用主链路； 标签值 null 兜底为 "unknown"（Prometheus
+ * 标签不可为 null）。Counter/Timer 经 registry 按标签惰性获取（Micrometer 内部有缓存，无需自建）。
+ */
+public class MicrometerMetricsRecorder implements MetricsRecorder {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MicrometerMetricsRecorder.class);
+
+  private final MeterRegistry registry;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "MeterRegistry 是 Spring 共享单例，存同一引用正是意图。")
+  public MicrometerMetricsRecorder(MeterRegistry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  public void recordLlmCall(String provider, String model, boolean success, long durationMs) {
+    try {
+      registry
+          .counter(
+              "oryxos_llm_calls_total",
+              "provider",
+              tag(provider),
+              "model",
+              tag(model),
+              "outcome",
+              success ? "success" : "failure")
+          .increment();
+      registry
+          .timer("oryxos_llm_call_duration_seconds", "provider", tag(provider), "model", tag(model))
+          .record(Duration.ofMillis(durationMs));
+    } catch (RuntimeException e) {
+      LOG.debug("LLM 调用指标记录失败（主链路不受影响）", e);
+    }
+  }
+
+  @Override
+  public void recordLlmTokens(
+      String provider, String model, Integer promptTokens, Integer completionTokens) {
+    try {
+      if (promptTokens != null && promptTokens > 0) {
+        registry
+            .counter(
+                "oryxos_llm_tokens_total",
+                "provider",
+                tag(provider),
+                "model",
+                tag(model),
+                "type",
+                "prompt")
+            .increment(promptTokens);
+      }
+      if (completionTokens != null && completionTokens > 0) {
+        registry
+            .counter(
+                "oryxos_llm_tokens_total",
+                "provider",
+                tag(provider),
+                "model",
+                tag(model),
+                "type",
+                "completion")
+            .increment(completionTokens);
+      }
+    } catch (RuntimeException e) {
+      LOG.debug("token 指标记录失败（主链路不受影响）", e);
+    }
+  }
+
+  @Override
+  public void recordToolInvocation(String tool, boolean success) {
+    try {
+      registry
+          .counter(
+              "oryxos_tool_invocations_total",
+              "tool",
+              tag(tool),
+              "outcome",
+              success ? "success" : "failure")
+          .increment();
+    } catch (RuntimeException e) {
+      LOG.debug("工具调用指标记录失败（主链路不受影响）", e);
+    }
+  }
+
+  @Override
+  public void recordPolicyBlock(String tool) {
+    try {
+      registry.counter("oryxos_policy_blocks_total", "tool", tag(tool)).increment();
+    } catch (RuntimeException e) {
+      LOG.debug("策略拦截指标记录失败（主链路不受影响）", e);
+    }
+  }
+
+  @Override
+  public void recordFallbackSwitch(String from, String to) {
+    try {
+      registry
+          .counter("oryxos_fallback_switches_total", "from", tag(from), "to", tag(to))
+          .increment();
+    } catch (RuntimeException e) {
+      LOG.debug("fallback 切换指标记录失败（主链路不受影响）", e);
+    }
+  }
+
+  private static String tag(String value) {
+    return value == null || value.isBlank() ? "unknown" : value;
+  }
+}

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -224,12 +224,24 @@ public class OryxOsRuntime {
     return migration;
   }
 
+  /** 023：业务指标——serve 场景（actuator 在类路径且有 MeterRegistry）落 Micrometer；chat 等无监控上下文 NOOP 兜底。 */
+  @Bean
+  io.oryxos.core.metrics.MetricsRecorder metricsRecorder(
+      org.springframework.beans.factory.ObjectProvider<io.micrometer.core.instrument.MeterRegistry>
+          meterRegistry) {
+    io.micrometer.core.instrument.MeterRegistry registry = meterRegistry.getIfAvailable();
+    return registry == null
+        ? io.oryxos.core.metrics.MetricsRecorder.NOOP
+        : new MicrometerMetricsRecorder(registry);
+  }
+
   @Bean
   ProviderService providerService(
       ProviderRegistry providerRegistry,
       LlmCallAuditor auditor,
       PricingStore pricingStore,
-      AuditSchemaUpgrade auditSchemaUpgrade) {
+      AuditSchemaUpgrade auditSchemaUpgrade,
+      io.oryxos.core.metrics.MetricsRecorder metricsRecorder) {
     auditSchemaUpgrade.upgrade(); // 幂等：存量库补列 + 建 llm_pricing 表
     // 动态解析（31 节）：按名从注册表取参数、经工厂即时建/缓存 ChatModel（宪法 III 显式映射，只是运行时可变）
     ProviderChatModelFactory factory = new ProviderChatModelFactory();
@@ -238,7 +250,8 @@ public class OryxOsRuntime {
         def -> factory.buildOne(def.name(), def.apiKey(), def.baseUrl()),
         new ToolSchemaAdapter(),
         auditor,
-        pricingStore);
+        pricingStore,
+        metricsRecorder); // 023：LLM 调用/token/切换指标
   }
 
   @Bean
@@ -823,11 +836,13 @@ public class OryxOsRuntime {
       ToolRegistry toolRegistry,
       ProfileRegistry profileRegistry,
       ToolInvocationAuditor auditor,
-      io.oryxos.core.policy.ToolPolicyService toolPolicyService) {
+      io.oryxos.core.policy.ToolPolicyService toolPolicyService,
+      io.oryxos.core.metrics.MetricsRecorder metricsRecorder) {
     // 31 节：mcp_servers 白名单在此接线。mcpToolOwners() 是活视图，与 tools bean 一样不能在构造时 copyOf。
     ToolExecutor executor =
         new ToolExecutor(tools, toolRegistry.mcpToolOwners(), profileRegistry, auditor);
     executor.setToolPolicy(toolPolicyService); // 020：事中裁决——防幻觉调用与热更新窗口
+    executor.setMetricsRecorder(metricsRecorder); // 023：工具调用/策略拦截指标
     return executor;
   }
 

--- a/oryxos-cli/src/test/java/io/oryxos/cli/MicrometerMetricsRecorderTest.java
+++ b/oryxos-cli/src/test/java/io/oryxos/cli/MicrometerMetricsRecorderTest.java
@@ -1,0 +1,154 @@
+package io.oryxos.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/** 023 US3：五类 oryxos_* 指标名/标签/计数 + FR-010 埋点异常静默。 */
+class MicrometerMetricsRecorderTest {
+
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+  private final MicrometerMetricsRecorder recorder = new MicrometerMetricsRecorder(registry);
+
+  @Test
+  void llm调用_计数与耗时按维度落表() {
+    recorder.recordLlmCall("deepseek", "deepseek-chat", true, 1200);
+    recorder.recordLlmCall("deepseek", "deepseek-chat", false, 30);
+
+    assertThat(
+            registry
+                .counter(
+                    "oryxos_llm_calls_total",
+                    "provider",
+                    "deepseek",
+                    "model",
+                    "deepseek-chat",
+                    "outcome",
+                    "success")
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            registry
+                .counter(
+                    "oryxos_llm_calls_total",
+                    "provider",
+                    "deepseek",
+                    "model",
+                    "deepseek-chat",
+                    "outcome",
+                    "failure")
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            registry
+                .timer(
+                    "oryxos_llm_call_duration_seconds",
+                    "provider",
+                    "deepseek",
+                    "model",
+                    "deepseek-chat")
+                .count())
+        .isEqualTo(2);
+  }
+
+  @Test
+  void token计数_按类型累加_空值跳过() {
+    recorder.recordLlmTokens("deepseek", "m", 812, 64);
+    recorder.recordLlmTokens("deepseek", "m", null, null); // 空值不计不抛
+
+    assertThat(
+            registry
+                .counter(
+                    "oryxos_llm_tokens_total",
+                    "provider",
+                    "deepseek",
+                    "model",
+                    "m",
+                    "type",
+                    "prompt")
+                .count())
+        .isEqualTo(812);
+    assertThat(
+            registry
+                .counter(
+                    "oryxos_llm_tokens_total",
+                    "provider",
+                    "deepseek",
+                    "model",
+                    "m",
+                    "type",
+                    "completion")
+                .count())
+        .isEqualTo(64);
+  }
+
+  @Test
+  void 工具与策略与切换_计数在位() {
+    recorder.recordToolInvocation("save_memory", true);
+    recorder.recordToolInvocation("shell", false);
+    recorder.recordPolicyBlock("shell");
+    recorder.recordFallbackSwitch("broken", "mock");
+
+    assertThat(
+            registry
+                .counter(
+                    "oryxos_tool_invocations_total", "tool", "save_memory", "outcome", "success")
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            registry
+                .counter("oryxos_tool_invocations_total", "tool", "shell", "outcome", "failure")
+                .count())
+        .isEqualTo(1);
+    assertThat(registry.counter("oryxos_policy_blocks_total", "tool", "shell").count())
+        .isEqualTo(1);
+    assertThat(
+            registry
+                .counter("oryxos_fallback_switches_total", "from", "broken", "to", "mock")
+                .count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void null标签值_兜底为unknown() {
+    recorder.recordLlmCall(null, "", true, 1);
+    assertThat(
+            registry
+                .counter(
+                    "oryxos_llm_calls_total",
+                    "provider",
+                    "unknown",
+                    "model",
+                    "unknown",
+                    "outcome",
+                    "success")
+                .count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void 恒抛异常的registry_五方法全部静默不抛() {
+    MeterRegistry broken =
+        Mockito.mock(
+            MeterRegistry.class,
+            invocation -> {
+              throw new IllegalStateException("registry down");
+            });
+    MicrometerMetricsRecorder faulty = new MicrometerMetricsRecorder(broken);
+
+    // FR-010 显式断言：任何指标故障不得影响主链路
+    assertThatCode(
+            () -> {
+              faulty.recordLlmCall("p", "m", true, 1);
+              faulty.recordLlmTokens("p", "m", 1, 1);
+              faulty.recordToolInvocation("t", true);
+              faulty.recordPolicyBlock("t");
+              faulty.recordFallbackSwitch("a", "b");
+            })
+        .doesNotThrowAnyException();
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/ToolExecutor.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/ToolExecutor.java
@@ -55,6 +55,14 @@ public class ToolExecutor {
         toolPolicy == null ? io.oryxos.core.policy.ToolPolicyService.ALLOW_ALL : toolPolicy;
   }
 
+  /** 023 业务指标（装配期注入，setToolPolicy 同款惯例）；未装配保持 NOOP 零破坏。 */
+  private io.oryxos.core.metrics.MetricsRecorder metrics =
+      io.oryxos.core.metrics.MetricsRecorder.NOOP;
+
+  public void setMetricsRecorder(io.oryxos.core.metrics.MetricsRecorder metrics) {
+    this.metrics = metrics == null ? io.oryxos.core.metrics.MetricsRecorder.NOOP : metrics;
+  }
+
   /** 31 节：注入 MCP 工具归属表 + ProfileRegistry，用以按调用方 Agent 的 mcp_servers 声明做白名单校验。 */
   public ToolExecutor(
       Map<String, OryxTool> tools,
@@ -121,6 +129,11 @@ public class ToolExecutor {
             System.currentTimeMillis() - startedAt);
       } catch (RuntimeException auditFailure) {
         LOG.error("工具调用审计落库失败（结果照常返回）: tool={}", sanitize(call.name()), auditFailure);
+      }
+      try {
+        metrics.recordToolInvocation(call.name(), result.success()); // 023：指标异常不伤主链路
+      } catch (RuntimeException ignored) {
+        // FR-010
       }
       // 021 日志与审计互查（SC-007）：处理路径关键日志点——MDC 自动携带 traceId，不记参数/结果（防敏感泄漏）
       LOG.info(
@@ -205,6 +218,14 @@ public class ToolExecutor {
       }
     } catch (RuntimeException auditFailure) {
       LOG.error("工具调用失败的审计落库也失败（失败结果照常返回）: tool={}", sanitize(call.name()), auditFailure);
+    }
+    try {
+      metrics.recordToolInvocation(call.name(), false); // 023：失败（含被拦）也计数
+      if (blockedBy != null) {
+        metrics.recordPolicyBlock(call.name());
+      }
+    } catch (RuntimeException ignored) {
+      // FR-010：指标失败静默
     }
     return ToolResult.error(errorMessage, false);
   }

--- a/oryxos-core/src/main/java/io/oryxos/core/metrics/MetricsRecorder.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/metrics/MetricsRecorder.java
@@ -1,0 +1,31 @@
+package io.oryxos.core.metrics;
+
+/**
+ * 业务指标契约（023）：LLM 调用/token/工具调用/策略拦截/fallback 切换五类计数——供监控栈聚合与告警。
+ *
+ * <p>依赖倒置：core/provider 的埋点只认本接口，Micrometer 实现在装配层（oryxos-cli 的 MicrometerMetricsRecorder）；无监控上下文（如
+ * oryxos chat）用 {@link #NOOP} 兜底—— StreamListener.NOOP / ToolPolicyService.ALLOW_ALL 同款零破坏锚点惯例。
+ *
+ * <p>实现纪律：任何埋点异常不得影响主链路（FR-010）——实现方法内部自行吞异常；指标供监控聚合、 审计供精确回放，二者正交，指标绝不改变审计落库口径。
+ */
+public interface MetricsRecorder {
+
+  /** 空实现：无监控上下文场景与旧构造兼容位。 */
+  MetricsRecorder NOOP = new MetricsRecorder() {};
+
+  /** 一次 LLM 调用尝试（fallback 场景每次尝试各计一次，与 llm_calls 行数同口径）。 */
+  default void recordLlmCall(String provider, String model, boolean success, long durationMs) {}
+
+  /** 成功调用的 token 消耗。 */
+  default void recordLlmTokens(
+      String provider, String model, Integer promptTokens, Integer completionTokens) {}
+
+  /** 一次工具调用（含被策略拦截的失败）。 */
+  default void recordToolInvocation(String tool, boolean success) {}
+
+  /** 020 策略拦截一次。 */
+  default void recordPolicyBlock(String tool) {}
+
+  /** 一次 fallback 切换（from → to）。 */
+  default void recordFallbackSwitch(String from, String to) {}
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/profile/Profile.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/Profile.java
@@ -57,7 +57,22 @@ public record Profile(
 
   public record Identity(String agentName, String prompt) {}
 
-  public record ProviderRef(String name, String model, Double temperature) {}
+  /** fallbacks（023）：有序备用 Provider 列表，单次 LLM 调用故障时按序切换；空=零变化。 */
+  public record ProviderRef(
+      String name, String model, Double temperature, List<FallbackRef> fallbacks) {
+
+    public ProviderRef {
+      fallbacks = fallbacks == null ? List.of() : List.copyOf(fallbacks);
+    }
+
+    /** 旧三参构造保留（既有构造点/测试兼容）：无备用声明委托空列表（023 纯增量）。 */
+    public ProviderRef(String name, String model, Double temperature) {
+      this(name, model, temperature, List.of());
+    }
+
+    /** 一个备用候选：已注册 Provider 名 + 该 Provider 下使用的模型名。 */
+    public record FallbackRef(String name, String model) {}
+  }
 
   public record NotifyChannel(String type, Map<String, String> config) {
     public NotifyChannel {

--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -176,7 +176,10 @@ public class ProfileLoader {
             "Profile " + profileName + " 的 provider.fallback 候选缺少 name 或 model");
       }
       if (!knownProviders.contains(name)) {
-        LOG.warn("Profile {} 的 fallback 候选引用了未注册的 provider: {}（保留声明，调用时跳过）", profileName, name);
+        LOG.warn(
+            "Profile {} 的 fallback 候选引用了未注册的 provider: {}（保留声明，调用时跳过）",
+            sanitize(profileName),
+            sanitize(name));
       }
       fallbacks.add(new Profile.ProviderRef.FallbackRef(name, model));
     }

--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -151,7 +151,36 @@ public class ProfileLoader {
               + "）");
     }
     return new Profile.ProviderRef(
-        providerName, model, asDouble(map.get("temperature"), "provider.temperature", profileName));
+        providerName,
+        model,
+        asDouble(map.get("temperature"), "provider.temperature", profileName),
+        toFallbacks(
+            requireListOrNull(map.get("fallback"), "provider.fallback", profileName), profileName));
+  }
+
+  /**
+   * 023：解析 provider.fallback 有序备用列表。候选缺 name/model 抛校验异常（与主 provider 同口径）； 候选引用未注册 provider 只 WARN
+   * 不阻断——候选可用性是运行时属性（provider 可随时增删）， 硬校验会让删一个备用连坐一批 Agent 启动失败（tools 未注册能力的既有口径，运行时再跳过）。
+   */
+  private List<Profile.ProviderRef.FallbackRef> toFallbacks(List<Object> list, String profileName) {
+    if (list == null || list.isEmpty()) {
+      return List.of();
+    }
+    List<Profile.ProviderRef.FallbackRef> fallbacks = new ArrayList<>();
+    for (Object item : list) {
+      Map<String, Object> entry = asMap(item);
+      String name = entry == null ? null : asString(entry.get("name"));
+      String model = entry == null ? null : asString(entry.get("model"));
+      if (name == null || name.isBlank() || model == null || model.isBlank()) {
+        throw new ProfileValidationException(
+            "Profile " + profileName + " 的 provider.fallback 候选缺少 name 或 model");
+      }
+      if (!knownProviders.contains(name)) {
+        LOG.warn("Profile {} 的 fallback 候选引用了未注册的 provider: {}（保留声明，调用时跳过）", profileName, name);
+      }
+      fallbacks.add(new Profile.ProviderRef.FallbackRef(name, model));
+    }
+    return List.copyOf(fallbacks);
   }
 
   private static Profile.Identity toIdentity(Map<String, Object> map) {

--- a/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
@@ -742,4 +742,79 @@ class ProfileLoaderTest {
     assertTrue(ex.getMessage().contains("evening"), ex.getMessage());
     assertTrue(ex.getMessage().contains("cron"), ex.getMessage());
   }
+
+  // —— 023：provider.fallback 有序备用列表解析 ——
+
+  @Test
+  void fallback两候选_按序解析() throws IOException {
+    write(
+        "fb.yaml",
+        """
+        name: fb-agent
+        provider:
+          name: deepseek
+          model: deepseek-chat
+          fallback:
+            - name: kimi
+              model: moonshot-v1-8k
+            - name: deepseek
+              model: deepseek-reasoner
+        """);
+
+    Profile profile = loader().loadAll().get("fb-agent").orElseThrow();
+
+    assertEquals(
+        java.util.List.of(
+            new Profile.ProviderRef.FallbackRef("kimi", "moonshot-v1-8k"),
+            new Profile.ProviderRef.FallbackRef("deepseek", "deepseek-reasoner")),
+        profile.provider().fallbacks()); // 顺序即声明序
+  }
+
+  @Test
+  void fallback候选缺model_加载失败跳过该文件() throws IOException {
+    write(
+        "bad-fb.yaml",
+        """
+        name: bad-fb
+        provider:
+          name: deepseek
+          model: deepseek-chat
+          fallback:
+            - name: kimi
+        """);
+
+    assertTrue(loader().loadAll().get("bad-fb").isEmpty()); // 坏文件 ERROR 跳过（与主 provider 校验同口径）
+  }
+
+  @Test
+  void fallback候选引用未知provider_WARN但加载成功() throws IOException {
+    write(
+        "unknown-fb.yaml",
+        """
+        name: unknown-fb
+        provider:
+          name: deepseek
+          model: deepseek-chat
+          fallback:
+            - name: ghost-provider
+              model: some-model
+        """);
+
+    Profile profile = loader().loadAll().get("unknown-fb").orElseThrow();
+
+    // 候选可用性是运行时属性：保留声明、调用时跳过（tools 未注册口径）
+    assertEquals(
+        java.util.List.of(new Profile.ProviderRef.FallbackRef("ghost-provider", "some-model")),
+        profile.provider().fallbacks());
+  }
+
+  @Test
+  void 无fallback字段_列表为空_旧YAML零变化() throws IOException {
+    write("plain.yaml", FULL_YAML);
+
+    Profile profile = loader().loadAll().get("ops-agent").orElseThrow();
+
+    assertTrue(profile.provider().fallbacks().isEmpty());
+    assertEquals("deepseek", profile.provider().name()); // 既有解析不受影响
+  }
 }

--- a/oryxos-provider/src/main/java/io/oryxos/provider/FallbackClassifier.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/FallbackClassifier.java
@@ -13,6 +13,9 @@ import org.springframework.web.client.RestClientResponseException;
  */
 final class FallbackClassifier {
 
+  /** 5xx 下界：服务端故障一律可切。 */
+  private static final int SERVER_ERROR_FLOOR = 500;
+
   private FallbackClassifier() {}
 
   /** true = 值得换下一个候选重试。 */
@@ -29,6 +32,17 @@ final class FallbackClassifier {
           org.springframework.web.reactive.function.client.WebClientResponseException web) {
         return switchableStatus(web.getStatusCode().value());
       }
+      // Spring AI 错误处理器的包装形态（真机验证）：4xx/5xx 被包成 (Non)TransientAiException，
+      // cause 链上没有 RestClient 异常、真实状态码在 message 前缀（"400 - {json}"）——按前缀码判定
+      if (t instanceof org.springframework.ai.retry.NonTransientAiException
+          || t instanceof org.springframework.ai.retry.TransientAiException) {
+        Integer code = leadingStatus(t.getMessage());
+        if (code != null) {
+          return switchableStatus(code);
+        }
+        // 提取不到码：信 Spring AI 的瞬时性分类——Transient 切、NonTransient 不切
+        return t instanceof org.springframework.ai.retry.TransientAiException;
+      }
       // 网络/超时类：连接不上、读超时、IO 断流——换端点最典型收益
       if (t instanceof ResourceAccessException
           || t instanceof IOException
@@ -40,8 +54,20 @@ final class FallbackClassifier {
     return true; // 无状态码可依：宁多试一次备用（R3）
   }
 
+  private static final java.util.regex.Pattern LEADING_STATUS =
+      java.util.regex.Pattern.compile("^(\\d{3}) - ");
+
+  /** 解析 Spring AI 异常 message 前缀的 HTTP 状态码；无则 null。 */
+  private static Integer leadingStatus(String message) {
+    if (message == null) {
+      return null;
+    }
+    java.util.regex.Matcher matcher = LEADING_STATUS.matcher(message);
+    return matcher.find() ? Integer.valueOf(matcher.group(1)) : null;
+  }
+
   private static boolean switchableStatus(int code) {
-    if (code >= 500) {
+    if (code >= SERVER_ERROR_FLOOR) {
       return true; // 服务端故障
     }
     // 429 限流=换配额；401/403 本家凭证问题=换家换凭证；408 请求超时

--- a/oryxos-provider/src/main/java/io/oryxos/provider/FallbackClassifier.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/FallbackClassifier.java
@@ -1,0 +1,50 @@
+package io.oryxos.provider;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientResponseException;
+
+/**
+ * 可切换性分类（023，R3）：判定一次 LLM 调用失败是否值得换备用 Provider 重试。
+ *
+ * <p>分类原则：换一个 Provider 有合理成功预期的才算可切换——网络/超时/5xx/限流/认证（各家凭证独立）切； 400
+ * 类请求本身非法不切（FR-003）。提取不到状态码的未知异常偏向切换：多试一次的代价是一次超时， 漏切的代价是本可避免的服务中断（全败仍上抛最后错误，不吞）。
+ */
+final class FallbackClassifier {
+
+  private FallbackClassifier() {}
+
+  /** true = 值得换下一个候选重试。 */
+  static boolean isSwitchable(RuntimeException e) {
+    Throwable t = e;
+    while (t != null) {
+      // RestClient 族（provider 非流式路径）：带状态码，按码判定
+      if (t instanceof RestClientResponseException rest) {
+        return switchableStatus(rest.getStatusCode().value());
+      }
+      // WebClient 族（流式路径可能经 reactive 客户端）：同样带状态码
+      if (t
+          instanceof
+          org.springframework.web.reactive.function.client.WebClientResponseException web) {
+        return switchableStatus(web.getStatusCode().value());
+      }
+      // 网络/超时类：连接不上、读超时、IO 断流——换端点最典型收益
+      if (t instanceof ResourceAccessException
+          || t instanceof IOException
+          || t instanceof TimeoutException) {
+        return true;
+      }
+      t = t.getCause();
+    }
+    return true; // 无状态码可依：宁多试一次备用（R3）
+  }
+
+  private static boolean switchableStatus(int code) {
+    if (code >= 500) {
+      return true; // 服务端故障
+    }
+    // 429 限流=换配额；401/403 本家凭证问题=换家换凭证；408 请求超时
+    return code == 429 || code == 401 || code == 403 || code == 408;
+  }
+}

--- a/oryxos-provider/src/main/java/io/oryxos/provider/ProviderChatModelFactory.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/ProviderChatModelFactory.java
@@ -62,7 +62,17 @@ public class ProviderChatModelFactory {
       // 端点版本在 baseUrl 里（如 GLM 的 /api/paas/v4），改补无版本的 /chat/completions
       api.completionsPath("/chat/completions");
     }
-    return OpenAiChatModel.builder().openAiApi(api.build()).build();
+    // 023 R8：收敛 Spring AI 默认 RetryTemplate（原为 10 次指数退避至 180s）为单次尝试——
+    // 「重试」语义整层上收到 fallback 切换循环（单层负责），挂死端点不再卡同步会话数分钟。
+    return OpenAiChatModel.builder()
+        .openAiApi(api.build())
+        .retryTemplate(noRetryTemplate())
+        .build();
+  }
+
+  /** 单次尝试、无退避：见 buildOne 内 023 R8 注释。 */
+  static org.springframework.retry.support.RetryTemplate noRetryTemplate() {
+    return org.springframework.retry.support.RetryTemplate.builder().maxAttempts(1).build();
   }
 
   /** 带连接/读取超时的请求工厂：默认 RestClient 无超时，端点挂死会把同步 ReAct 循环连带会话永久卡住。构建时读属性，不在类加载期固化。 */

--- a/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
@@ -46,6 +46,11 @@ public class SpringAiProviderServiceImpl implements ProviderService {
   private final ToolSchemaAdapter adapter;
   private final LlmCallAuditor audit;
   private final PricingStore pricingStore;
+  private final io.oryxos.core.metrics.MetricsRecorder metrics;
+
+  /** 一次调用的单个尝试（023）：主 Provider 或按序备用候选，name/model 贯穿路由/Prompt/审计三处。 */
+  private record Attempt(String provider, String model) {}
+
   // 已建的 ChatModel 缓存：key = provider name，值携带配置指纹（apiKey|baseUrl）。指纹变了原地替换旧条目——
   // 缓存大小恒等于 provider 数，反复改 key/url 不再累积不可回收的旧实例（31 节动态 provider）。
   private final Map<String, CachedModel> cache = new ConcurrentHashMap<>();
@@ -53,20 +58,38 @@ public class SpringAiProviderServiceImpl implements ProviderService {
   /** 缓存条目：配置指纹 + 已建实例，指纹不变则复用。 */
   private record CachedModel(String fingerprint, ChatModel model) {}
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "EI_EXPOSE_REP2",
-      justification = "registry/builder/adapter/audit 均为 Spring 注入的共享单例，构造注入共享同一引用正是意图")
+  /** 旧五参构造保留（既有装配点/测试兼容）：无指标场景委托 NOOP（023 纯增量）。 */
   public SpringAiProviderServiceImpl(
       ProviderRegistry registry,
       Function<ProviderDef, ChatModel> chatModelBuilder,
       ToolSchemaAdapter adapter,
       LlmCallAuditor audit,
       PricingStore pricingStore) {
+    this(
+        registry,
+        chatModelBuilder,
+        adapter,
+        audit,
+        pricingStore,
+        io.oryxos.core.metrics.MetricsRecorder.NOOP);
+  }
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "registry/builder/adapter/audit/metrics 均为装配层注入的共享单例，存同一引用正是意图")
+  public SpringAiProviderServiceImpl(
+      ProviderRegistry registry,
+      Function<ProviderDef, ChatModel> chatModelBuilder,
+      ToolSchemaAdapter adapter,
+      LlmCallAuditor audit,
+      PricingStore pricingStore,
+      io.oryxos.core.metrics.MetricsRecorder metrics) {
     this.registry = registry;
     this.chatModelBuilder = chatModelBuilder;
     this.adapter = adapter;
     this.audit = audit;
     this.pricingStore = pricingStore;
+    this.metrics = metrics;
   }
 
   @Override
@@ -74,23 +97,82 @@ public class SpringAiProviderServiceImpl implements ProviderService {
       value = "CRLF_INJECTION_LOGS",
       justification = "日志中的 provider 名已经 sanitize() 消去 CR/LF；taint 分析不跨方法追踪该消毒，故局部抑制")
   public ProviderResponse chat(String sessionId, Profile profile, ProviderRequest request) {
-    String providerName = profile.provider().name();
-    // 宪法 III：仍是按 name 的显式查找，只是从"启动静态 map"变成"运行时注册表 + 按名动态建/缓存"
-    ProviderDef def =
-        registry.find(providerName).orElseThrow(() -> new ProviderNotFoundException(providerName));
+    List<Attempt> attempts = attemptsOf(profile);
+    RuntimeException last = null;
+    for (int i = 0; i < attempts.size(); i++) {
+      Attempt attempt = attempts.get(i);
+      ProviderDef def = findDef(attempt, i == 0);
+      if (def == null) {
+        continue; // 备用候选未注册：WARN 已记，跳过不落审计（FR-008）
+      }
+      try {
+        return chatOnce(sessionId, profile, request, attempt, def);
+      } catch (RuntimeException e) {
+        last = e;
+        if (i + 1 >= attempts.size() || !FallbackClassifier.isSwitchable(e)) {
+          throw e; // 候选耗尽或业务性失败：原样上抛最后错误（FR-002/FR-003）
+        }
+        switchWarn(attempt, attempts.get(i + 1), e);
+      }
+    }
+    throw last != null ? last : new ProviderNotFoundException(profile.provider().name());
+  }
+
+  /** 单次尝试（023）：attempt 的 name/model 贯穿路由、Prompt 与审计（R2）。 */
+  private ProviderResponse chatOnce(
+      String sessionId,
+      Profile profile,
+      ProviderRequest request,
+      Attempt attempt,
+      ProviderDef def) {
     ChatModel model = resolveModel(def);
-    Prompt prompt = buildPrompt(profile, request);
+    Prompt prompt = buildPrompt(profile, request, attempt.model());
     long startedAt = System.currentTimeMillis();
     ProviderResponse result;
     try {
       ChatResponse response = model.call(prompt);
       result = toProviderResponse(response);
     } catch (RuntimeException e) {
-      recordFailure(sessionId, profile, providerName, e, startedAt);
+      recordFailure(sessionId, profile, attempt, e, startedAt);
       throw e;
     }
-    recordSuccess(sessionId, profile, providerName, result, startedAt);
+    recordSuccess(sessionId, profile, attempt, result, startedAt);
     return result;
+  }
+
+  /** 主 + 有序备用的尝试序列（023）；零 fallback 声明时长度 1，行为与现状一致。 */
+  private static List<Attempt> attemptsOf(Profile profile) {
+    List<Attempt> attempts = new ArrayList<>();
+    attempts.add(new Attempt(profile.provider().name(), profile.provider().model()));
+    profile.provider().fallbacks().forEach(f -> attempts.add(new Attempt(f.name(), f.model())));
+    return attempts;
+  }
+
+  /** 主 provider 未注册直抛（现状口径）；备用候选未注册 WARN 返回 null 跳过（FR-008）。 */
+  private ProviderDef findDef(Attempt attempt, boolean primary) {
+    var def = registry.find(attempt.provider());
+    if (def.isPresent()) {
+      return def.get();
+    }
+    if (primary) {
+      throw new ProviderNotFoundException(attempt.provider());
+    }
+    LOG.warn("fallback 候选 provider 未注册，跳过: {}", sanitize(attempt.provider()));
+    return null;
+  }
+
+  /** 切换留痕（FR-006）：WARN 带 from→to（MDC 自带 traceId）+ 切换计数；指标异常不伤主链路。 */
+  private void switchWarn(Attempt from, Attempt to, RuntimeException cause) {
+    LOG.warn(
+        "provider 切换: {} → {}（原因: {}）",
+        sanitize(from.provider()),
+        sanitize(to.provider()),
+        sanitize(cause.getMessage()));
+    try {
+      metrics.recordFallbackSwitch(from.provider(), to.provider());
+    } catch (RuntimeException ignored) {
+      // FR-010：指标失败静默
+    }
   }
 
   /**
@@ -112,11 +194,39 @@ public class SpringAiProviderServiceImpl implements ProviderService {
       Profile profile,
       ProviderRequest request,
       java.util.function.Consumer<String> onToken) {
-    String providerName = profile.provider().name();
-    ProviderDef def =
-        registry.find(providerName).orElseThrow(() -> new ProviderNotFoundException(providerName));
+    List<Attempt> attempts = attemptsOf(profile);
+    RuntimeException last = null;
+    for (int i = 0; i < attempts.size(); i++) {
+      Attempt attempt = attempts.get(i);
+      ProviderDef def = findDef(attempt, i == 0);
+      if (def == null) {
+        continue;
+      }
+      boolean[] contentStarted = new boolean[1];
+      try {
+        return chatStreamOnce(sessionId, profile, request, onToken, attempt, def, contentStarted);
+      } catch (RuntimeException e) {
+        last = e;
+        // 023 R4：首个内容片段已流出后绝不切换——重试必然重复输出，按 019 error 语义收尾（FR-007）
+        if (contentStarted[0] || i + 1 >= attempts.size() || !FallbackClassifier.isSwitchable(e)) {
+          throw e;
+        }
+        switchWarn(attempt, attempts.get(i + 1), e);
+      }
+    }
+    throw last != null ? last : new ProviderNotFoundException(profile.provider().name());
+  }
+
+  private ProviderResponse chatStreamOnce(
+      String sessionId,
+      Profile profile,
+      ProviderRequest request,
+      java.util.function.Consumer<String> onToken,
+      Attempt attempt,
+      ProviderDef def,
+      boolean[] contentStarted) {
     ChatModel model = resolveModel(def);
-    Prompt prompt = buildPrompt(profile, request);
+    Prompt prompt = buildPrompt(profile, request, attempt.model());
     long startedAt = System.currentTimeMillis();
     StringBuilder text = new StringBuilder();
     ToolCallAggregator toolCalls = new ToolCallAggregator();
@@ -128,9 +238,13 @@ public class SpringAiProviderServiceImpl implements ProviderService {
           String delta = generation.getOutput().getText();
           if (delta != null && !delta.isEmpty()) {
             text.append(delta);
+            contentStarted[0] = true;
             onToken.accept(delta);
           }
           toolCalls.accept(generation.getOutput().getToolCalls());
+          if (!toolCalls.isEmpty()) {
+            contentStarted[0] = true; // tool-call 增量同属实质输出（R4 保守口径）
+          }
         }
         Usage chunkUsage = extractUsage(chunk);
         // 多数 provider 只在末尾 chunk 带真实 usage，中间是空/零值——只保留最后一个有效值
@@ -142,18 +256,24 @@ public class SpringAiProviderServiceImpl implements ProviderService {
       }
     } catch (UnsupportedOperationException e) {
       if (text.isEmpty() && toolCalls.isEmpty()) {
-        // 模型无流式能力且零输出：安全降级整段路径（审计由 chat 负责，恰好一条）
-        return ProviderService.super.chatStream(sessionId, profile, request, onToken);
+        // 模型无流式能力且零输出：降级为本尝试的整段调用（审计仍恰好一条；023 收窄到"单次尝试"内，
+        // 不再走 this.chat——否则会从主重新展开整个 fallback 序列）
+        ProviderResponse whole = chatOnce(sessionId, profile, request, attempt, def);
+        if (whole.text() != null && !whole.text().isEmpty()) {
+          contentStarted[0] = true;
+          onToken.accept(whole.text());
+        }
+        return whole;
       }
-      recordFailure(sessionId, profile, providerName, e, startedAt);
+      recordFailure(sessionId, profile, attempt, e, startedAt);
       throw e;
     } catch (RuntimeException e) {
-      // 流式中断（网络抖动/上游截断）：结果残缺不当完整返回（FR-006）——失败先落账再上抛（宪法 V）
-      recordFailure(sessionId, profile, providerName, e, startedAt);
+      // 流式中断（网络抖动/上游截断）：结果残缺不当完整返回——失败先落账再上抛（宪法 V）
+      recordFailure(sessionId, profile, attempt, e, startedAt);
       throw e;
     }
     ProviderResponse result = new ProviderResponse(text.toString(), toolCalls.build(), usage);
-    recordSuccess(sessionId, profile, providerName, result, startedAt);
+    recordSuccess(sessionId, profile, attempt, result, startedAt);
     return result;
   }
 
@@ -165,21 +285,28 @@ public class SpringAiProviderServiceImpl implements ProviderService {
       value = "CRLF_INJECTION_LOGS",
       justification = "日志里的 provider 名经 sanitize() 消去 CR/LF，taint 分析不跨方法追踪该消毒")
   private void recordFailure(
-      String sessionId, Profile profile, String providerName, RuntimeException e, long startedAt) {
+      String sessionId, Profile profile, Attempt attempt, RuntimeException e, long startedAt) {
+    long durationMs = System.currentTimeMillis() - startedAt;
     try {
       audit.record(
           sessionId,
           profile.name(),
-          providerName,
-          profile.provider().model(),
+          attempt.provider(),
+          attempt.model(),
           null,
           null,
           false,
           e.getMessage(),
-          System.currentTimeMillis() - startedAt);
+          durationMs);
     } catch (RuntimeException auditFailure) {
-      LOG.error("LLM 调用失败的审计落库也失败（主异常照常上抛）: provider={}", sanitize(providerName), auditFailure);
+      LOG.error(
+          "LLM 调用失败的审计落库也失败（主异常照常上抛）: provider={}", sanitize(attempt.provider()), auditFailure);
       e.addSuppressed(auditFailure);
+    }
+    try {
+      metrics.recordLlmCall(attempt.provider(), attempt.model(), false, durationMs);
+    } catch (RuntimeException ignored) {
+      // FR-010：指标失败静默
     }
   }
 
@@ -191,32 +318,42 @@ public class SpringAiProviderServiceImpl implements ProviderService {
       value = "CRLF_INJECTION_LOGS",
       justification = "日志里的 provider 名经 sanitize() 消去 CR/LF，taint 分析不跨方法追踪该消毒")
   private void recordSuccess(
-      String sessionId,
-      Profile profile,
-      String providerName,
-      ProviderResponse result,
-      long startedAt) {
+      String sessionId, Profile profile, Attempt attempt, ProviderResponse result, long startedAt) {
+    long durationMs = System.currentTimeMillis() - startedAt;
     try {
       audit.record(
           sessionId,
           profile.name(),
-          providerName,
-          profile.provider().model(),
+          attempt.provider(),
+          attempt.model(),
           result.usage(),
-          computeCost(providerName, profile.provider().model(), result.usage()),
+          computeCost(attempt.provider(), attempt.model(), result.usage()),
           true,
           null,
-          System.currentTimeMillis() - startedAt);
+          durationMs);
     } catch (RuntimeException auditFailure) {
-      LOG.error("成功 LLM 调用的审计落库失败（结果照常返回）: provider={}", sanitize(providerName), auditFailure);
+      LOG.error(
+          "成功 LLM 调用的审计落库失败（结果照常返回）: provider={}", sanitize(attempt.provider()), auditFailure);
+    }
+    try {
+      metrics.recordLlmCall(attempt.provider(), attempt.model(), true, durationMs);
+      if (result.usage() != null) {
+        metrics.recordLlmTokens(
+            attempt.provider(),
+            attempt.model(),
+            result.usage().promptTokens(),
+            result.usage().completionTokens());
+      }
+    } catch (RuntimeException ignored) {
+      // FR-010：指标失败静默
     }
     // 021 日志与审计互查（SC-007）：处理路径关键日志点——MDC 自动携带 traceId，不记 prompt 内容
     LOG.info(
         "LLM 调用完成: provider={} model={} totalTokens={} durationMs={}",
-        sanitize(providerName),
-        sanitize(profile.provider().model()),
+        sanitize(attempt.provider()),
+        sanitize(attempt.model()),
         result.usage() == null ? null : result.usage().totalTokens(),
-        System.currentTimeMillis() - startedAt);
+        durationMs);
   }
 
   /**
@@ -313,10 +450,11 @@ public class SpringAiProviderServiceImpl implements ProviderService {
         .model();
   }
 
-  private Prompt buildPrompt(Profile profile, ProviderRequest request) {
+  /** {@code model} 为本次尝试的模型名（023）：备用候选必须用备用模型名，不再固定取主声明。 */
+  private Prompt buildPrompt(Profile profile, ProviderRequest request, String model) {
     OpenAiChatOptions.Builder options =
         OpenAiChatOptions.builder()
-            .model(profile.provider().model())
+            .model(model)
             .internalToolExecutionEnabled(Boolean.FALSE); // 执行权只在 ToolExecutor（17 节）
     if (profile.provider().temperature() != null) {
       options.temperature(profile.provider().temperature());

--- a/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
@@ -217,6 +217,11 @@ public class SpringAiProviderServiceImpl implements ProviderService {
     throw last != null ? last : new ProviderNotFoundException(profile.provider().name());
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+      justification =
+          "Spring AI 注解声称 chunk 各字段非空，但流式 chunk 边界形态因 provider 而异，"
+              + "对 generation/output 的防御性判空是有意保留的（019 裁决，信注解不如信线上流量）")
   private ProviderResponse chatStreamOnce(
       String sessionId,
       Profile profile,

--- a/oryxos-provider/src/test/java/io/oryxos/provider/FallbackClassifierTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/FallbackClassifierTest.java
@@ -61,4 +61,31 @@ class FallbackClassifierTest {
   void 无状态码的未知异常_宁多试一次() {
     assertThat(FallbackClassifier.isSwitchable(new IllegalStateException("who knows"))).isTrue();
   }
+
+  @Test
+  void SpringAI包装形态_message前缀状态码判定() {
+    // 真机验证的形态：4xx 被包成 NonTransientAiException("400 - {json}")，cause 链无 RestClient 异常
+    assertThat(
+            FallbackClassifier.isSwitchable(
+                new org.springframework.ai.retry.NonTransientAiException(
+                    "400 - {\"error\":{\"message\":\"invalid request body\"}}")))
+        .isFalse();
+    assertThat(
+            FallbackClassifier.isSwitchable(
+                new org.springframework.ai.retry.NonTransientAiException("401 - unauthorized")))
+        .isTrue(); // 凭证问题换家有意义（R3）
+    assertThat(
+            FallbackClassifier.isSwitchable(
+                new org.springframework.ai.retry.TransientAiException("429 - rate limited")))
+        .isTrue();
+    // 无前缀码：信 Spring AI 的瞬时性分类
+    assertThat(
+            FallbackClassifier.isSwitchable(
+                new org.springframework.ai.retry.NonTransientAiException("schema mismatch")))
+        .isFalse();
+    assertThat(
+            FallbackClassifier.isSwitchable(
+                new org.springframework.ai.retry.TransientAiException("temporary hiccup")))
+        .isTrue();
+  }
 }

--- a/oryxos-provider/src/test/java/io/oryxos/provider/FallbackClassifierTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/FallbackClassifierTest.java
@@ -1,0 +1,64 @@
+package io.oryxos.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientResponseException;
+
+/** 023 US1：可切换性分类表逐行钉死（R3）。 */
+class FallbackClassifierTest {
+
+  private static RestClientResponseException status(int code) {
+    return new RestClientResponseException(
+        "status " + code, code, "st", new HttpHeaders(), new byte[0], StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void 服务端与限流认证类_可切换() {
+    assertThat(FallbackClassifier.isSwitchable(status(500))).isTrue();
+    assertThat(FallbackClassifier.isSwitchable(status(502))).isTrue();
+    assertThat(FallbackClassifier.isSwitchable(status(503))).isTrue();
+    assertThat(FallbackClassifier.isSwitchable(status(429))).isTrue(); // 限流=换配额
+    assertThat(FallbackClassifier.isSwitchable(status(401))).isTrue(); // 本家凭证问题=换家
+    assertThat(FallbackClassifier.isSwitchable(status(403))).isTrue();
+    assertThat(FallbackClassifier.isSwitchable(status(408))).isTrue();
+  }
+
+  @Test
+  void 业务性失败_不切换() {
+    assertThat(FallbackClassifier.isSwitchable(status(400))).isFalse(); // 请求非法换家无意义
+    assertThat(FallbackClassifier.isSwitchable(status(404))).isFalse();
+    assertThat(FallbackClassifier.isSwitchable(status(422))).isFalse();
+  }
+
+  @Test
+  void 网络与超时类_可切换() {
+    assertThat(FallbackClassifier.isSwitchable(new ResourceAccessException("connect refused")))
+        .isTrue();
+    assertThat(
+            FallbackClassifier.isSwitchable(
+                new RuntimeException("wrapped", new TimeoutException("read timeout"))))
+        .isTrue();
+  }
+
+  @Test
+  void 异常链深埋_逐层提取() {
+    // 状态码埋在两层包装之下（Spring AI 常见包装形态）
+    RuntimeException deep400 =
+        new RuntimeException("outer", new IllegalStateException(status(400)));
+    assertThat(FallbackClassifier.isSwitchable(deep400)).isFalse();
+    RuntimeException deepIo =
+        new RuntimeException("outer", new RuntimeException(new IOException("broken pipe")));
+    assertThat(FallbackClassifier.isSwitchable(deepIo)).isTrue();
+  }
+
+  @Test
+  void 无状态码的未知异常_宁多试一次() {
+    assertThat(FallbackClassifier.isSwitchable(new IllegalStateException("who knows"))).isTrue();
+  }
+}

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ProviderFallbackTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ProviderFallbackTest.java
@@ -1,0 +1,278 @@
+package io.oryxos.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.oryxos.core.profile.Profile;
+import io.oryxos.core.provider.LlmCallAuditor;
+import io.oryxos.core.provider.ProviderDef;
+import io.oryxos.core.provider.ProviderRegistry;
+import io.oryxos.core.provider.ProviderRequest;
+import io.oryxos.core.provider.ProviderResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientResponseException;
+import reactor.core.publisher.Flux;
+
+/** 023 US1：切换序列语义——主败备成/全败/不可切/候选跳过/零声明回归/流式边界/无健康记忆 + 审计每尝试一条。 */
+class ProviderFallbackTest {
+
+  private ChatModel primary;
+  private ChatModel backup;
+  private LlmCallAuditor audit;
+  private SpringAiProviderServiceImpl service;
+
+  @BeforeEach
+  void setUp() {
+    primary = mock(ChatModel.class);
+    backup = mock(ChatModel.class);
+    audit = mock(LlmCallAuditor.class);
+    ProviderRegistry registry = mock(ProviderRegistry.class);
+    when(registry.find(anyString())).thenReturn(Optional.empty());
+    when(registry.find("primary"))
+        .thenReturn(Optional.of(new ProviderDef("primary", "key", "https://p", null)));
+    when(registry.find("backup"))
+        .thenReturn(Optional.of(new ProviderDef("backup", "key", "https://b", null)));
+    Map<String, ChatModel> byName = Map.of("primary", primary, "backup", backup);
+    service =
+        new SpringAiProviderServiceImpl(
+            registry,
+            def -> byName.get(def.name()),
+            new ToolSchemaAdapter(),
+            audit,
+            (p, m) -> Optional.empty());
+  }
+
+  private static Profile profileWithFallback(Profile.ProviderRef.FallbackRef... fallbacks) {
+    return new Profile(
+        "fb-agent",
+        null,
+        null,
+        new Profile.ProviderRef("primary", "p-model", null, List.of(fallbacks)),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        null);
+  }
+
+  private static ProviderRequest request() {
+    return new ProviderRequest("sys", List.of(), List.of());
+  }
+
+  private static ChatResponse reply(String text) {
+    return new ChatResponse(List.of(new Generation(new AssistantMessage(text))));
+  }
+
+  private static RestClientResponseException badRequest() {
+    return new RestClientResponseException(
+        "bad request", 400, "st", new HttpHeaders(), new byte[0], StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void 主败备成_返回备结果且备调用携带备model() {
+    when(primary.call(any(Prompt.class))).thenThrow(new ResourceAccessException("connect refused"));
+    when(backup.call(any(Prompt.class))).thenReturn(reply("备用回复"));
+
+    ProviderResponse response =
+        service.chat(
+            "s-1",
+            profileWithFallback(new Profile.ProviderRef.FallbackRef("backup", "b-model")),
+            request());
+
+    assertThat(response.text()).isEqualTo("备用回复");
+    ArgumentCaptor<Prompt> prompt = ArgumentCaptor.forClass(Prompt.class);
+    verify(backup).call(prompt.capture());
+    // R2 陷阱钉死：备用调用必须携带备用模型名，不是主声明的 p-model
+    assertThat(((OpenAiChatOptions) prompt.getValue().getOptions()).getModel())
+        .isEqualTo("b-model");
+  }
+
+  @Test
+  void 全部候选失败_上抛最后异常() {
+    when(primary.call(any(Prompt.class))).thenThrow(new ResourceAccessException("primary down"));
+    ResourceAccessException lastError = new ResourceAccessException("backup down");
+    when(backup.call(any(Prompt.class))).thenThrow(lastError);
+
+    assertThatThrownBy(
+            () ->
+                service.chat(
+                    "s-1",
+                    profileWithFallback(new Profile.ProviderRef.FallbackRef("backup", "b-model")),
+                    request()))
+        .isSameAs(lastError); // 最后一次错误，不吞不换
+  }
+
+  @Test
+  void 业务性失败400_不切换直接上抛() {
+    RestClientResponseException error = badRequest();
+    when(primary.call(any(Prompt.class))).thenThrow(error);
+
+    assertThatThrownBy(
+            () ->
+                service.chat(
+                    "s-1",
+                    profileWithFallback(new Profile.ProviderRef.FallbackRef("backup", "b-model")),
+                    request()))
+        .isSameAs(error);
+    verify(backup, never()).call(any(Prompt.class)); // FR-003：无第二次尝试
+  }
+
+  @Test
+  void 候选未注册_跳过直达下一候选() {
+    when(primary.call(any(Prompt.class))).thenThrow(new ResourceAccessException("down"));
+    when(backup.call(any(Prompt.class))).thenReturn(reply("第三候选接住"));
+
+    ProviderResponse response =
+        service.chat(
+            "s-1",
+            profileWithFallback(
+                new Profile.ProviderRef.FallbackRef("ghost", "g-model"), // 未注册：跳过不落审计
+                new Profile.ProviderRef.FallbackRef("backup", "b-model")),
+            request());
+
+    assertThat(response.text()).isEqualTo("第三候选接住");
+    verify(audit, never())
+        .record(any(), any(), eq("ghost"), any(), any(), any(), anyBoolean(), any(), anyLong());
+  }
+
+  @Test
+  void 零fallback声明_行为与现状一致() {
+    ResourceAccessException error = new ResourceAccessException("down");
+    when(primary.call(any(Prompt.class))).thenThrow(error);
+
+    assertThatThrownBy(() -> service.chat("s-1", profileWithFallback(), request())).isSameAs(error);
+    // 单次调用单条审计（失败）——SC-002 回归锚点
+    verify(audit)
+        .record(
+            eq("s-1"),
+            eq("fb-agent"),
+            eq("primary"),
+            eq("p-model"),
+            isNull(),
+            isNull(),
+            eq(false),
+            any(),
+            anyLong());
+  }
+
+  @Test
+  void 流式_首片段前失败可切换_客户端无感知() {
+    when(primary.stream(any(Prompt.class)))
+        .thenReturn(Flux.error(new ResourceAccessException("down before first token")));
+    when(backup.stream(any(Prompt.class))).thenReturn(Flux.just(reply("备"), reply("用")));
+
+    StringBuilder streamed = new StringBuilder();
+    ProviderResponse response =
+        service.chatStream(
+            "s-1",
+            profileWithFallback(new Profile.ProviderRef.FallbackRef("backup", "b-model")),
+            request(),
+            streamed::append);
+
+    assertThat(response.text()).isEqualTo("备用");
+    assertThat(streamed.toString()).isEqualTo("备用"); // 无重复输出、无主残片
+  }
+
+  @Test
+  void 流式_已出token后失败_不切换按现状收尾() {
+    ResourceAccessException midStream = new ResourceAccessException("mid-stream cut");
+    // error 延迟 300ms 订阅：保证首 chunk 先被消费端拿到（onToken 已回调）后错误才到达——
+    // 同批投递时 BlockingIterable 会让 error 抢先于排队 chunk（019 已知特性），那种情况客户端
+    // 实际没收到内容、切换反而是安全的，正是本实现「以真实送达为准」的判定依据
+    when(primary.stream(any(Prompt.class)))
+        .thenReturn(
+            Flux.just(reply("半截"))
+                .concatWith(
+                    Flux.<ChatResponse>error(midStream)
+                        .delaySubscription(java.time.Duration.ofMillis(300))));
+
+    assertThatThrownBy(
+            () ->
+                service.chatStream(
+                    "s-1",
+                    profileWithFallback(new Profile.ProviderRef.FallbackRef("backup", "b-model")),
+                    request(),
+                    delta -> {}))
+        .isSameAs(midStream); // FR-007：内容已流出，重试必重复输出
+    verify(backup, never()).stream(any(Prompt.class));
+  }
+
+  @Test
+  void 连续两次调用_第二次仍先尝试主_无健康记忆() {
+    when(primary.call(any(Prompt.class)))
+        .thenThrow(new ResourceAccessException("第一次挂"))
+        .thenReturn(reply("主恢复了"));
+    when(backup.call(any(Prompt.class))).thenReturn(reply("备用回复"));
+    Profile profile = profileWithFallback(new Profile.ProviderRef.FallbackRef("backup", "b-model"));
+
+    assertThat(service.chat("s-1", profile, request()).text()).isEqualTo("备用回复");
+    assertThat(service.chat("s-1", profile, request()).text()).isEqualTo("主恢复了"); // FR-004：每次独立从主开始
+
+    var order = inOrder(primary, backup, primary);
+    order.verify(primary).call(any(Prompt.class));
+    order.verify(backup).call(any(Prompt.class));
+    order.verify(primary).call(any(Prompt.class));
+  }
+
+  @Test
+  void 审计每尝试一条_主败备成恰两条且参数如实() {
+    when(primary.call(any(Prompt.class))).thenThrow(new ResourceAccessException("down"));
+    when(backup.call(any(Prompt.class))).thenReturn(reply("备用回复"));
+
+    service.chat(
+        "s-1",
+        profileWithFallback(new Profile.ProviderRef.FallbackRef("backup", "b-model")),
+        request());
+
+    // SC-003 单测面：失败主 + 成功备各一条，provider/model 按 attempt 如实
+    verify(audit)
+        .record(
+            eq("s-1"),
+            eq("fb-agent"),
+            eq("primary"),
+            eq("p-model"),
+            isNull(),
+            isNull(),
+            eq(false),
+            any(),
+            anyLong());
+    verify(audit)
+        .record(
+            eq("s-1"),
+            eq("fb-agent"),
+            eq("backup"),
+            eq("b-model"),
+            any(),
+            any(),
+            eq(true),
+            isNull(),
+            anyLong());
+  }
+}

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -52,7 +52,7 @@ const TOP_NAV = [
   // Skill 列表（第 32 节）：全局 Skill 库，自定义加载器（loadSkills）不走通用 path。知识库仍为占位页
   { key: 'skills', label: 'Skill 列表' },
   { key: 'knowledge', label: '知识库' },
-  { key: 'report', label: '报表' },
+  { key: 'report', label: '审计' },
 ]
 
 const RUNTIME_NAV = [
@@ -393,7 +393,6 @@ async function loadTrace(id) {
     trace.result = body.data
   } catch (e) { trace.error = e.message } finally { trace.loading = false }
 }
-function shortTrace(id) { return id ? id.slice(0, 8) : '—' }
 const filteredLlmList = computed(() => {
   if (!reportFilter.value) return report.llmList
   const { type, key } = reportFilter.value
@@ -1928,7 +1927,7 @@ const outputRows = computed(() =>
                       <td class="mono">{{ fmtCost(c.costMicros) }}</td>
                       <td class="mono">{{ fmtDuration(c.durationMs) }}</td>
                       <td><span :class="['tag', c.success ? 'ok' : 'off']">{{ c.success ? '成功' : '失败' }}</span></td>
-                      <td class="mono"><a v-if="c.traceId" href="#" :title="c.traceId" @click.prevent="loadTrace(c.traceId)">{{ shortTrace(c.traceId) }}</a><template v-else>—</template></td>
+                      <td class="mono trace-cell"><a v-if="c.traceId" href="#" title="点击回放该轮时间线" @click.prevent="loadTrace(c.traceId)">{{ c.traceId }}</a><template v-else>—</template></td>
                     </tr>
                   </tbody>
                 </table>
@@ -1959,7 +1958,7 @@ const outputRows = computed(() =>
                       <td class="mono">{{ t.toolName }}</td>
                       <td class="mono">{{ fmtDuration(t.durationMs) }}</td>
                       <td><span :class="['tag', t.success ? 'ok' : 'off']">{{ t.success ? '成功' : '失败' }}</span></td>
-                      <td class="mono"><a v-if="t.traceId" href="#" :title="t.traceId" @click.prevent="loadTrace(t.traceId)">{{ shortTrace(t.traceId) }}</a><template v-else>—</template></td>
+                      <td class="mono trace-cell"><a v-if="t.traceId" href="#" title="点击回放该轮时间线" @click.prevent="loadTrace(t.traceId)">{{ t.traceId }}</a><template v-else>—</template></td>
                     </tr>
                   </tbody>
                 </table>
@@ -2671,7 +2670,7 @@ const outputRows = computed(() =>
                       <td class="mono">{{ fmtTime(e.startedAt) }}</td>
                       <td class="mono">{{ fmtTime(e.endedAt) }}</td>
                       <td class="mono">{{ fmtDuration(e.durationMs) }}</td>
-                      <td class="mono" :title="e.traceId || ''">{{ shortTrace(e.traceId) }}</td>
+                      <td class="mono trace-cell">{{ e.traceId || '—' }}</td>
                       <td class="error">{{ e.errorMessage || '' }}</td>
                     </tr>
                   </tbody>
@@ -3094,6 +3093,9 @@ const outputRows = computed(() =>
 </template>
 
 <style scoped>
+/* trace ID 完整展示（021/023）：小号等宽不换行——截断会让复制变成折磨 */
+.trace-cell { font-size: 11px; white-space: nowrap; }
+
 .layout { display: flex; min-height: 100vh; }
 .nav {
   width: 200px; background: var(--bg-soft); border-right: 1px solid var(--border);

--- a/specs/023-provider-fallback/acceptance-report.md
+++ b/specs/023-provider-fallback/acceptance-report.md
@@ -1,0 +1,37 @@
+# 023-provider-fallback 真机验收报告
+
+**Date**: 2026-09-02 | **环境**: WSL2 + fat JAR（`oryxos serve`，三 provider：mock + broken 指 127.0.0.1:1 + bad400 指本地 400 stub）+ sqlite 直查
+
+## 走查结果（quickstart V1~V6）
+
+| # | 场景 | 结果 | 证据 |
+|---|------|------|------|
+| V1 | 主败备成用户无感知 | ✅ | fb-agent（主 broken + fallback mock）invoke 返回 200、回复正常、响应带 traceId |
+| V2 | 切换全程留痕可回放 | ✅ | llm_calls 该 trace 下 4 条（broken 失败×2 + mock 成功×2，provider/model 如实）；时间线 5 步同链按时间序（LLM 败→LLM 成→TOOL→LLM 败→LLM 成）；serve.log 两条 WARN「provider 切换: broken → mock」均带 [traceId] |
+| V3 | 全部候选失败 | ✅ | doomed-agent invoke → HTTP 500，**29ms** 返回（R8 收敛内建重试后无退避，SC-007 达成）；无成功行 |
+| V4 | 业务性失败不切换 | ✅（修复后复验） | bad400-agent（主 400 stub + fallback mock）→ HTTP 500 直接报错、仅 1 条 bad400 失败行、0 切换日志。**首跑暴露真 bug**：Spring AI 把 4xx 包成 NonTransientAiException（cause 链无状态码、message 前缀 "400 - "）导致误切——分类器补 message 前缀码解析后复验通过 |
+| V5 | 流式首片段前切换透明 | ✅ | SSE 流首 `trace` 事件 → tool 事件 → 正常收尾，无 error 事件（主失败被切换吸收，客户端无感知） |
+| V6 | prometheus 业务指标 | ✅ | `oryxos_fallback_switches_total{from="broken",to="mock"} 2`、`oryxos_llm_calls_total` 分 provider/model/outcome 序列、duration timer、`oryxos_tool_invocations_total{tool="save_memory"}`；**指标合计 5 = llm_calls 行数 5**（SC-005/SC-006 口径一致）；策略拦截计数由 E2E 验证 |
+
+## SC 达成对照
+
+| SC | 判定 | 依据 |
+|----|------|------|
+| SC-001 故障场景 100% 正常完成 | ✅ | V1/V5 + ProviderFallbackTest 9 例 + E2E 4 例 |
+| SC-002 零声明回归零破坏 | ✅ | E2E 零声明单轮恰 2 条审计；全模块测试回归全绿。**R8 例外如实声明**：Spring AI 内建 RetryTemplate（10 次退避至 180s）收敛为单次尝试——失败上抛口径不变，隐形重试次数变化；不收敛则 SC-007 失控且挂死端点卡同步会话数分钟（详见 research R8） |
+| SC-003 切换 100% 可回放 | ✅ | V2 审计成对 + 时间线同链 + WARN 带 trace；E2E ListAppender MDC 断言 |
+| SC-004 边界零越界 | ✅ | V4（400 不切）+ 流式已出内容不切（单测 Flux 延迟构造钉死）+ FallbackClassifierTest 6 例分类表 |
+| SC-005 指标与实际计数一致 | ✅ | V6 对照 + E2E 指标总数=审计行数断言 |
+| SC-006 审计口径零变化 | ✅ | 每尝试一条即既有 record 调用路径；E2E 零声明基线对照 |
+| SC-007 无额外等待 | ✅ | V3 全败 29ms 返回（两候选连接拒绝即返回，无退避） |
+
+## 质量门禁
+
+`mvn verify` 全量门禁：BUILD SUCCESS（见 T020）。
+
+## 备注（实施中发现并修正）
+
+- **Spring AI 异常包装形态**（V4 首跑暴露）：4xx 经 Spring AI 错误处理器变成 `NonTransientAiException("400 - {json}")`，cause 链上没有携带状态码的 RestClient 异常——分类器仅靠异常链提取会把 400 误判为"未知→可切"。补 message 前缀码解析 + 无码时信 Spring AI 的 Transient/NonTransient 二分；FallbackClassifierTest 补 5 个真机形态用例
+- **R8 实施期裁决**：收敛 OpenAiChatModel 内建 RetryTemplate 为单次尝试（重试语义单层归 fallback）——V3 的 29ms 全败返回即其效果；行为差异已在 research R8 与本报告 SC-002 行如实声明
+- **测试环境特性**：`@SpringBootTest` 默认禁用 metrics export（防测试打点外泄），E2E 需 `@AutoConfigureObservability`；真机 serve 不受影响（V6 直接可达）。Prometheus 文本格式标签按字母序输出，断言不得假定标签顺序
+- mock provider usage 恒为 0 token → `oryxos_llm_tokens_total` 在纯 mock 场景合法缺席（契约明示形态），计数语义由 MicrometerMetricsRecorderTest 钉死

--- a/specs/023-provider-fallback/checklists/requirements.md
+++ b/specs/023-provider-fallback/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Provider 失败切换与业务指标导出
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-09-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Micrometer/Prometheus/oryxos_ 前缀、frontmatter 字段名等仅出现在 Input 引文；spec 正文以「监控端点/业务指标/统一前缀/provider 节备用列表」技术无关表述，具体命名在 plan 阶段定稿
+- 无 [NEEDS CLARIFICATION]：切换边界（单次调用层面/不可重试不切/流式首片段界）、审计口径（每尝试一条）、指标并入本刀等关键裁决已在特性启动前与维护者对齐（2026-09-01 会话规划）

--- a/specs/023-provider-fallback/contracts/fallback-metrics.md
+++ b/specs/023-provider-fallback/contracts/fallback-metrics.md
@@ -1,0 +1,39 @@
+# Contract: Provider 失败切换语义与业务指标
+
+**Feature**: 023-provider-fallback | **Date**: 2026-09-02 | 原则五：接口即承诺
+
+## 1. 切换语义承诺
+
+1. **边界**：切换发生在「单次 LLM 调用」层面；ReAct 轮次（max_iterations）口径不变；每次调用独立从主 Provider 开始（无跨请求健康记忆）。
+2. **顺序**：严格按 `provider.fallback` 声明顺序尝试；声明什么执行什么（同名冗余照常尝试，不做去重魔法）。
+3. **触发**：仅 Provider 侧故障（网络/超时/5xx/429/401/403/408 与无法归类的运行时异常）触发切换；400 类业务性失败不切换。
+4. **终态**：候选耗尽以**最后一次**错误按现状口径上抛——不吞错、不无限重试、无退避等待（最坏时延 = 候选数 × 单次超时）。
+5. **候选无效**：引用未注册/已删除 Provider 的候选跳过并 WARN，不中断序列、不产生失败审计。
+6. **流式**：首个内容片段送出前的失败可切换（客户端无感知）；内容已流出后不切换，按 019 既有 `error` 事件语义收尾。
+7. **零声明零变化**：未声明 fallback 的 Agent 行为（含错误反馈口径）与本特性交付前完全一致。
+
+## 2. 留痕承诺（治理底线：任何自动行为可回放）
+
+- 每次尝试各写一条 `llm_calls`：provider/model 按实际尝试值如实、失败带错误信息、成功带 usage/成本——主败备成 = 恰两条。
+- 同轮全部尝试共享该轮 trace（021）：`GET /api/v1/audit/trace/{id}` 时间线上主备 LLM 步同链按时间序可见。
+- 切换时一条 WARN 日志：`provider 切换: <from> → <to>`，MDC 携带 traceId（与审计互查）。
+
+## 3. 业务指标承诺（/actuator/prometheus，既有端点增量）
+
+| 指标 | 类型 | 标签 |
+|------|------|------|
+| `oryxos_llm_calls_total` | counter | provider, model, outcome |
+| `oryxos_llm_call_duration_seconds` | timer | provider, model |
+| `oryxos_llm_tokens_total` | counter | provider, model, type |
+| `oryxos_tool_invocations_total` | counter | tool, outcome |
+| `oryxos_policy_blocks_total` | counter | tool |
+| `oryxos_fallback_switches_total` | counter | from, to |
+
+- `oryxos_llm_calls_total` 与 `llm_calls` 表行数同口径（每尝试计一）；指标供监控聚合，审计供精确回放，二者正交。
+- 指标采集失败不影响主链路；未发生对应事件时指标缺席或为零，均为正常形态。
+- 指标命名与标签自本版本固化，后续只增不改。
+
+## 4. 兼容性承诺
+
+- frontmatter 纯增量字段（`provider.fallback` 可空）；ProviderService 契约、审计契约、REST/SSE 契约零改动。
+- 管理台零新页面；`oryxos chat` 等无监控上下文场景自动降级为不采集（功能不受影响）。

--- a/specs/023-provider-fallback/data-model.md
+++ b/specs/023-provider-fallback/data-model.md
@@ -1,0 +1,73 @@
+# Data Model: Provider 失败切换与业务指标导出
+
+**Feature**: 023-provider-fallback | **Date**: 2026-09-02
+
+**零 schema 变更**——每次尝试一条 llm_calls（既有表既有列自然承载）；指标是内存计数序列不落库。
+
+## fallback 声明（frontmatter，纯增量）
+
+```yaml
+provider:
+  name: deepseek          # 主 Provider（现状字段不变，未知仍启动报错）
+  model: deepseek-chat
+  temperature: 0.7
+  fallback:               # 新增：有序备用列表，可空=现状零变化
+    - name: qwen
+      model: qwen-plus
+    - name: kimi
+      model: moonshot-v1-8k
+```
+
+### Profile.ProviderRef（core，纯增量组件）
+
+```java
+record ProviderRef(String name, String model, Double temperature, List<FallbackRef> fallbacks) {
+  ProviderRef { fallbacks = fallbacks == null ? List.of() : List.copyOf(fallbacks); }
+  ProviderRef(String name, String model, Double temperature) { this(name, model, temperature, List.of()); } // 旧构造兼容
+  record FallbackRef(String name, String model) {}
+}
+```
+
+校验口径：候选缺 name/model → 加载抛校验异常（与主同）；候选引用未注册 Provider → 加载 WARN 不阻断（tools 同口径），运行时跳过。
+
+## 尝试序列（provider 实现内部，不出契约）
+
+```text
+attempts = [ (provider.name, provider.model) ] + provider.fallbacks
+for attempt in attempts:
+    registry.find(attempt.name)  → 缺失: WARN 跳过（不落审计），下一个（FR-008）
+    调用（buildPrompt 用 attempt.model；审计 provider/model 用 attempt 值）
+    成功 → recordSuccess + 指标 → 返回
+    失败 → recordFailure + 指标（每次尝试各一条，FR-005）
+         → FallbackClassifier.isSwitchable(e) 且有下一候选
+             → WARN「provider 切换: from → to」（MDC 带 traceId）+ 切换计数 → 下一个
+             → 否则原样上抛（最后错误，现状口径）
+流式附加条件：text/toolCalls 累计非空（首内容已出）→ 一律不切，直接落账上抛（FR-007）
+```
+
+## 可切换性分类表（FallbackClassifier）
+
+| 判定输入 | 结果 |
+|----------|------|
+| 异常链含网络/超时类（连接失败、IO、Timeout） | 切换 |
+| HTTP 5xx / 429 / 401 / 403 / 408 | 切换 |
+| HTTP 400 / 404 / 422 等其余 4xx | 不切换 |
+| 提取不到状态码的其他运行时异常 | 切换（宁多试一次备用） |
+| ProviderNotFoundException（候选未注册） | 跳过候选（非失败尝试，不落审计） |
+
+## MetricsRecorder 契约（core/metrics/，NOOP 默认）
+
+| 方法 | 埋点位置 | 对应指标 |
+|------|----------|----------|
+| `recordLlmCall(provider, model, success, durationMs)` | Provider 实现审计调用旁 | `oryxos_llm_calls_total` + `oryxos_llm_call_duration_seconds` |
+| `recordLlmTokens(provider, model, prompt, completion)` | 成功审计旁 | `oryxos_llm_tokens_total` |
+| `recordToolInvocation(tool, success)` | ToolExecutor 审计旁 | `oryxos_tool_invocations_total` |
+| `recordPolicyBlock(tool)` | ToolExecutor 策略拒绝点 | `oryxos_policy_blocks_total` |
+| `recordFallbackSwitch(from, to)` | 切换点 | `oryxos_fallback_switches_total` |
+
+- 实现纪律：所有埋点 try/catch 吞异常（FR-010）；`MetricsRecorder.NOOP` 为旧构造/无 MeterRegistry 场景兜底（StreamListener.NOOP 惯例第三例）
+- 装配：`ObjectProvider<MeterRegistry>` 有 → `MicrometerMetricsRecorder`（cli）；无（如 `oryxos chat`）→ NOOP
+
+## 指标目录
+
+见 [research.md R6](research.md)；全部 `oryxos_` 前缀，标签基数有界（注册集内的 provider/model/tool 名）。

--- a/specs/023-provider-fallback/plan.md
+++ b/specs/023-provider-fallback/plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan: Provider 失败切换与业务指标导出
+
+**Branch**: `023-provider-fallback` | **Date**: 2026-09-02 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/023-provider-fallback/spec.md`
+
+## Summary
+
+fallback 收口在 `SpringAiProviderServiceImpl`（**ProviderService 契约零改动**，ReActLoop 无感知——021/022 同纪律）：chat/chatStream 内部把「主 + 有序 fallback」展开成尝试序列逐个执行，`FallbackClassifier` 按异常形态判可切换性（网络/超时/5xx/429/401/403 切，400 类业务错不切）；每次尝试沿用既有 recordSuccess/recordFailure 落审计（provider/model 按 attempt 如实），021 trace 天然同链；流式以「首内容片段未出」为切换边界（复用既有 text/toolCalls 累计判定）。声明面：`Profile.ProviderRef` 加 `fallbacks` 组件（旧构造委托空列表），`ProfileLoader` 解析 `provider.fallback` 列表（未知候选 WARN 不阻断，与 tools 同口径）。指标面：`MetricsRecorder` 契约进 core（NOOP 默认），Micrometer 实现放 cli（`micrometer-core` 编译依赖——运行时 jar 已由 boot actuator 带入，无新增运行时构件），埋点挂在既有审计调用旁（LLM/工具/策略/切换五类，`oryxos_` 前缀）。零新表、零新模块、零运行时新构件。
+
+## Technical Context
+
+**Language/Version**: Java 21（同步循环重试，虚拟线程内阻塞——宪法 VII）
+
+**Primary Dependencies**: `micrometer-core` 加入 oryxos-cli 编译依赖（运行时已在 boot 类路径，OWASP 无新扫描面）；其余零新增
+
+**Storage**: 零 schema 变更——每次尝试一条 llm_calls（既有口径自然承载主备留痕）
+
+**Testing**: JUnit 5——provider（FallbackClassifier 分类表 / chat 主败备成序列 / 流式边界 / 候选跳过）、core（ProfileLoader fallback 解析）、cli（MetricsRecorder 装配）、boot E2E（mock 双 provider 主败备成 + trace 同链 + /actuator/prometheus 指标对照）；`mvn verify` 全量门禁
+
+**Target Platform**: Linux server（单 fat JAR）
+
+**Project Type**: Maven 多模块单体——core（ProviderRef.fallbacks + ProfileLoader + MetricsRecorder 契约）、provider（切换循环 + 分类器 + LLM 指标点）、cli（Micrometer 实现 + 装配 + pom 依赖）、boot（E2E）
+
+**Performance Goals**: 无 fallback 声明时零额外开销（序列长度 1，无分支成本）；SC-007 无退避等待，最坏时延 = 候选数 × 单次超时
+
+**Constraints**: ProviderService 契约零改动；审计口径零变化（FR-010/SC-006）；流中已出内容绝不切换（FR-007）；每次调用独立从主开始（无健康记忆）；指标采集异常不影响主链路
+
+**Scale/Scope**: 约 4 个新文件 + 6 个既有文件小改
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| 原则 | 评估 | 结论 |
+|------|------|------|
+| I 自实现 ReAct | ReActLoop 零改动；fallback 是单次调用内部行为，循环无感知 | ✅ |
+| II Spring AI 边界 | 仍只用协议转换；切换循环是自实现逻辑，不用 Spring AI/Spring Retry 的重试机制 | ✅ |
+| III Provider 显式映射 | 强化：fallback 候选同样按 name 走注册表显式查找（`registry.find`），无类型扫描 | ✅ |
+| IV 目录=Agent / Skill | frontmatter 纯增量字段 `provider.fallback`；未声明零变化 | ✅ |
+| V 审计 Day One | 强化：每次尝试各一条 llm_calls（失败主也留痕）；指标与审计正交、不改口径 | ✅ |
+| VI 安全是地基 | 候选凭证走既有注册表（022 加密）；无新凭证面 | ✅ |
+| VII 同步 + 虚拟线程 | 按序同步重试，无异步/退避框架；Reactor 仍不出 chatStream 方法体 | ✅ |
+| VIII 状态外置 / 手工 schema | 零 schema 变更；无跨请求健康状态（每次调用独立） | ✅ |
+| 模块约束 | MetricsRecorder 契约进 core（provider/core 调用点消费）；Micrometer 实现在 cli 装配层；无循环依赖 | ✅ |
+
+**Phase 1 设计后复评**: 设计未引入新违背项，全部通过。无需 Complexity Tracking。
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/023-provider-fallback/
+├── plan.md              # 本文件
+├── research.md          # Phase 0：7 项技术裁决（R1~R7）
+├── data-model.md        # Phase 1：fallback 声明 + 尝试序列 + 指标目录
+├── quickstart.md        # Phase 1：V1~V6 验收走查
+├── contracts/
+│   └── fallback-metrics.md  # Phase 1：切换语义承诺 + 审计口径 + 指标目录
+└── tasks.md             # Phase 2（/speckit-tasks 生成）
+```
+
+### Source Code (repository root)
+
+```text
+oryxos-core/
+├── src/main/java/io/oryxos/core/
+│   ├── profile/Profile.java          # 修改：ProviderRef 加 fallbacks 组件（旧构造委托空列表）
+│   ├── profile/ProfileLoader.java    # 修改：解析 provider.fallback 列表（未知候选 WARN 不阻断）
+│   └── metrics/MetricsRecorder.java  # 新增：业务指标契约（NOOP 常量默认）——LLM/工具/策略/切换五类
+└── src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java  # 修改：追加 fallback 解析用例
+
+oryxos-provider/
+├── src/main/java/io/oryxos/provider/
+│   ├── SpringAiProviderServiceImpl.java  # 修改：chat/chatStream 尝试序列循环 + 切换 WARN + 指标点
+│   └── FallbackClassifier.java           # 新增：异常 → 可切换性分类（状态码/异常链判定）
+└── src/test/java/io/oryxos/provider/
+    ├── FallbackClassifierTest.java       # 新增：分类表（5xx/429/401/超时切；400/404 不切）
+    └── ProviderFallbackTest.java         # 新增：主败备成/全败上抛/候选跳过/流式边界/审计每尝试一条
+
+oryxos-cli/
+├── pom.xml                               # 修改：加 micrometer-core 编译依赖
+└── src/main/java/io/oryxos/cli/
+    ├── MicrometerMetricsRecorder.java    # 新增：MeterRegistry 落地 oryxos_* 指标
+    └── OryxOsRuntime.java                # 修改：装配（有 MeterRegistry 用 Micrometer，否则 NOOP）+ 注入调用点
+
+oryxos-core/（工具/策略指标点）
+└── src/main/java/io/oryxos/core/agent/ToolExecutor.java  # 修改：审计旁挂工具/策略拦截计数
+
+oryxos-boot/
+└── src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java  # 新增：双 mock 主败备成 + trace 同链 + prometheus 指标对照
+```
+
+**Structure Decision**: 切换收口在 ProviderService 实现内部——上游（ReActLoop/AgentService/controllers）零改动，是 021「trace 环境读取」、022「注册表收口加密」同一手法的第三次运用：横切关切在实现层收口、契约即承诺不动。指标契约在 core（调用点在 core/provider），实现在装配层（依赖倒置，chat 命令等无 MeterRegistry 场景 NOOP 兜底）。
+
+## 关键设计裁决（详见 research.md）
+
+| # | 裁决 | 要点 |
+|---|------|------|
+| R1 | fallback 声明进 ProviderRef | `provider.fallback` 有序列表（name+model）；未知候选加载 WARN、运行时跳过（与 tools 同口径） |
+| R2 | 切换收口在 Provider 实现 | 契约零改动；attempt(name, model) 贯穿 buildPrompt/审计——model 按 attempt 如实 |
+| R3 | FallbackClassifier 分类 | 状态码提取：5xx/429/401/403/408/网络异常 → 切；400/404/422 → 不切；提取不到 → 切（宁多试） |
+| R4 | 流式边界复用累计判定 | `text.isEmpty() && toolCalls.isEmpty()` = 首片段未出可切换（既有降级判定同源） |
+| R5 | MetricsRecorder 依赖倒置 | 契约 core、Micrometer 实现 cli（micrometer-core 编译依赖，运行时构件零新增）；NOOP 兜底 |
+| R6 | 指标目录 oryxos_* | llm_calls_total/llm_call_duration/llm_tokens_total/tool_invocations_total/policy_blocks_total/fallback_switches_total |
+| R7 | 不做的 | 智能路由、断路器、退避等待、跨请求健康记忆、管理台新页面 |

--- a/specs/023-provider-fallback/quickstart.md
+++ b/specs/023-provider-fallback/quickstart.md
@@ -1,0 +1,71 @@
+# Quickstart: Provider 失败切换与业务指标验收
+
+**Feature**: 023-provider-fallback | 契约详见 [contracts/fallback-metrics.md](contracts/fallback-metrics.md)
+
+## 前置
+
+```bash
+mvn -q -DskipTests package
+alias oryxos='java -jar oryxos-boot/target/oryxos-boot-*.jar'
+# 注册两个 Provider：broken（指向不通端口，必然连接失败）与 mock（备用，无 key 可用）
+# Agent frontmatter：provider.name=broken + fallback: [{name: mock, model: mock-model}]
+oryxos serve --port 8080 &
+```
+
+## V1 — 主败备成，用户无感知（US1 / SC-001）
+
+```bash
+curl -s -X POST localhost:8080/api/v1/agents/<agent>/invoke -H 'Content-Type: application/json' \
+  -d '{"content":"记住我喜欢咖啡"}'
+# 期望：200，回复来自 mock（备用），data.traceId 可取
+```
+
+## V2 — 切换全程留痕可回放（US2 / SC-003）
+
+```bash
+sqlite3 oryxos.db "SELECT provider, model, success, error_message FROM llm_calls ORDER BY id DESC LIMIT 3;"
+# 期望：broken 失败尝试与 mock 成功尝试各一条（每轮 2 次 LLM 调用 → 主败记录 2 条失败 + 2 条成功…以实际轮数为准）
+curl -s localhost:8080/api/v1/audit/trace/<V1的traceId>
+# 期望：时间线里 broken 失败 LLM 步与 mock 成功 LLM 步同链按时间序
+grep "provider 切换" serve.log
+# 期望：WARN「provider 切换: broken → mock」且行内带 [traceId]
+```
+
+## V3 — 全部候选失败，最后错误上抛（US1 场景 2）
+
+```bash
+# Agent2：主 broken + fallback broken2（同样不通）→ invoke
+# 期望：错误响应（现状口径），不无限重试；llm_calls 两条失败记录；无成功行
+```
+
+## V4 — 业务性失败不切换（US1 场景 4 / SC-004）
+
+```bash
+# 起一个恒返回 400 的 stub 端点（python 一行）注册为 bad400 provider；Agent3：主 bad400 + fallback mock
+# 期望：直接报错不切换；llm_calls 仅 1 条失败记录；无 mock 尝试、无切换日志
+```
+
+## V5 — 流式首片段前切换透明（US1 场景 5 / SC-001）
+
+```bash
+curl -N -s -X POST localhost:8080/api/v1/agents/<agent>/invoke \
+  -H 'Accept: text/event-stream' -H 'Content-Type: application/json' -d '{"content":"hi"}' | head -12
+# 期望（主 broken + 备 mock）：流首 trace 事件 → token 流正常 → done；无 error 事件（首片段前的失败已被切换吸收）
+```
+
+## V6 — 监控端点业务指标（US3 / SC-005/SC-006）
+
+```bash
+curl -s localhost:8080/actuator/prometheus | grep -E "^oryxos_"
+# 期望：oryxos_llm_calls_total{provider="broken",outcome="failure"} 与 {provider="mock",outcome="success"} 计数
+#       与 llm_calls 表行数一致；oryxos_fallback_switches_total{from="broken",to="mock"} ≥ 1；
+#       oryxos_tool_invocations_total / oryxos_llm_tokens_total 在位
+# 配 GLOBAL_DENY 触发一次拦截 → oryxos_policy_blocks_total 递增
+sqlite3 oryxos.db "SELECT COUNT(*) FROM llm_calls;"   # 与 oryxos_llm_calls_total 各序列之和对照（SC-006 口径不变）
+```
+
+## 质量门禁
+
+```bash
+mvn verify
+```

--- a/specs/023-provider-fallback/research.md
+++ b/specs/023-provider-fallback/research.md
@@ -86,3 +86,11 @@ provider:
 - **跨请求 Provider 健康记忆**：无状态原则（宪法「无状态实例」）；每次调用独立从主开始
 - **管理台新页面**：016 报表覆盖"人看"；Prometheus 面向机器与告警
 - **Spring Retry / Resilience4j**：引依赖换不来更简单的三十行循环
+
+## R8 —（实施期新增裁决）收敛 Spring AI 内建 RetryTemplate 为单次尝试
+
+**Decision**: `ProviderChatModelFactory.buildOne` 给 OpenAiChatModel 显式配 `maxAttempts=1` 的 RetryTemplate（不重试、无退避）——「重试」语义整层上收到 fallback 循环，单层负责。
+
+**Rationale**: 摸底发现 Spring AI 默认 RetryTemplate 对 ResourceAccessException 重试 10 次、指数退避至 180s（ProviderChatModelFactoryTimeoutTest 注释明证）。不收敛则：① SC-007「最坏时延=候选数×单次超时」失控（broken 主 provider 每次尝试先被内建重试放大 ~3 分钟）；② 该默认独立于本特性也是坏默认——挂死端点能把同步会话卡半小时。**行为差异如实声明**：零声明 Agent 失去内建的网络抖动隐形自愈（此前瞬断可能被 10 次重试掩盖）——失败上抛的口径不变，变化的是隐形重试次数；抖动自愈的正道是声明 fallback。此差异在验收报告向维护者显式报告（SC-002 的例外说明）。
+
+**Alternatives considered**: 保留内建重试（SC-007 名存实亡，E2E 不可测）；仅 fallback 声明时禁用（同一 provider 双实例缓存复杂化，行为不一致更难解释）；收敛为 3 次短退避（时延上界仍是三倍，且两层重试语义纠缠）。

--- a/specs/023-provider-fallback/research.md
+++ b/specs/023-provider-fallback/research.md
@@ -1,0 +1,88 @@
+# Research: Provider 失败切换与业务指标导出
+
+**Feature**: 023-provider-fallback | **Date**: 2026-09-02
+
+## R1 — fallback 声明形态：ProviderRef 纯增量组件
+
+**Decision**: `Profile.ProviderRef` 增加第 4 组件 `List<FallbackRef> fallbacks`（`FallbackRef(String name, String model)`），旧 3 参构造委托空列表（021 MessageResponse/AgentExecution 同款兼容惯例）。YAML：
+
+```yaml
+provider:
+  name: deepseek
+  model: deepseek-chat
+  fallback:
+    - name: qwen
+      model: qwen-plus
+```
+
+`ProfileLoader.toProviderRef` 解析 `fallback` 列表；候选缺 name/model 抛校验异常（与主 provider 同口径）；候选引用未注册 provider **WARN 但不阻断加载**——与 `tools` 引用未注册能力的既有口径一致（摸底：AgentLoader javadoc「WARN 但仍登记」），运行时再跳过（FR-008）。主 provider 未知仍启动抛异常（现状不变）。
+
+**Rationale**: fallback 候选的可用性是运行时属性（Provider 可随时增删），加载期硬校验会让"删一个备用 Provider"连坐一批 Agent 启动失败——治理面反而变脆。
+
+**Alternatives considered**: 顶层 `fallbacks:` 节（与 provider 分离——语义归属错位，备用就是 provider 配置的一部分）；字符串简写 `fallback: [qwen]`（缺 model 语义，同 Provider 不同模型是常见场景）。
+
+## R2 — 切换收口点：SpringAiProviderServiceImpl 内部，契约零改动
+
+**Decision**: `ProviderService` 接口与 `ReActLoop` 调用点零改动。实现内把「主 + fallbacks」展开为尝试序列 `List<Attempt(name, model)>`，chat/chatStream 逐个执行：成功即返回；失败先按现状 recordFailure 落账，`FallbackClassifier` 判定可切换且有下一候选 → WARN 日志（from→to，MDC 已带 traceId）+ 切换计数 + 下一个；否则原样上抛。**attempt 的 name/model 必须贯穿三处**：`registry.find(name)`、`buildPrompt` 的 `options.model(...)`、审计 record 的 provider/model 参数——摸底确认现状三处都取 `profile.provider()`，需抽出按 attempt 参数化的内部方法。
+
+**Rationale**: 021 trace（环境读取）、022 加密（注册表收口）同一手法第三次运用：横切关切在实现层收口，上游契约即承诺。每次尝试沿用既有 recordSuccess/recordFailure → 「每尝试一条审计」免费达成（FR-005），trace 同链天然成立（尝试都在同一处理线程，TraceContext 就位）。
+
+**Alternatives considered**: ReActLoop 层重试（污染循环语义，且 max_iterations 口径会被搅浑）；装饰器 FallbackProviderService 包一层（契约层可行，但 buildPrompt/审计的 model 参数化仍要进实现——包装层拿不到内部结构，反而两处改）。
+
+## R3 — 可切换性分类：按 HTTP 状态码 + 异常链
+
+**Decision**: `FallbackClassifier.isSwitchable(RuntimeException)`（provider 模块内静态工具类）：
+
+| 形态 | 判定 | 理由 |
+|------|------|------|
+| 异常链含 `ResourceAccessException`/`IOException`/`TimeoutException` | 切 | 网络/超时——换端点最典型收益 |
+| 状态码 5xx | 切 | 服务端故障 |
+| 429 | 切 | 限流——换 Provider 即换配额 |
+| 401/403 | 切 | 本 Provider 凭证问题，换 Provider 有独立凭证（spec 明示认证失败可切） |
+| 408 | 切 | 请求超时 |
+| 400/404/422 等其余 4xx | 不切 | 请求本身非法/资源不存在——换 Provider 无成功预期（FR-003） |
+| 提取不到状态码的其他 RuntimeException | 切 | 宁可多试一次备用（可用性优先），全败仍上抛最后错误 |
+| `ProviderNotFoundException` | 跳过该候选（FR-008），不计入"失败尝试"审计 | 配置引用问题非调用失败 |
+
+状态码提取：遍历异常链找 Spring `HttpStatusCodeException`/WebClient `WebClientResponseException` 或 Spring AI 异常的状态承载形态（实现时按实际类路径穷举，测试钉死分类表）。
+
+**Rationale**: 分类原则来自 spec Assumptions——「换一个 Provider 有合理成功预期的才算可切换」；未知异常偏向切换是可用性与诚实的平衡：多一次尝试的代价是一次调用超时，漏切的代价是本可避免的服务中断。
+
+**Alternatives considered**: Spring AI 的 Transient/NonTransient 二分（401/403 被归 NonTransient，与"换 Provider 换凭证"语义冲突）；Spring Retry 框架（引依赖 + 退避语义违背 SC-007 无额外等待）。
+
+## R4 — 流式切换边界：复用既有累计判定
+
+**Decision**: chatStream 的尝试循环里，失败时以 `text.isEmpty() && toolCalls.isEmpty()`（既有 StringBuilder/聚合器累计）判定「首内容片段未出」：未出 → 可按 R3 切换（onToken 从未被回调，客户端无感知）；已出 → 不切换，按既有失败路径落账上抛（019 error 事件语义收尾）。心跳注释由 SseWriter 层发出、不经 onToken，天然不算内容（spec Assumption 自动成立）。
+
+**Rationale**: 这正是既有「无流式能力降级」的判定条件（摸底 L144），语义同源零新概念；token 已出后重试必然重复输出——诚实优于聪明（spec 原话）。
+
+**Alternatives considered**: 缓冲首 N token 再转发以扩大可切换窗口（引入人为延迟，违背流式的意义；YAGNI）。
+
+## R5 — 指标依赖倒置：契约进 core，Micrometer 实现在 cli
+
+**Decision**: `MetricsRecorder` 接口进 `core/metrics/`（方法：`recordLlmCall(provider, model, success, durationMs)`、`recordLlmTokens(provider, model, promptTokens, completionTokens)`、`recordToolInvocation(tool, success)`、`recordPolicyBlock(tool)`、`recordFallbackSwitch(from, to)`；`NOOP` 常量默认）。`MicrometerMetricsRecorder` 实现放 oryxos-cli，cli pom 加 `micrometer-core` **编译**依赖——运行时 jar 已由 boot 的 actuator 传递带入，**无新增运行时构件**（OWASP 无新扫描面）。装配：`OryxOsRuntime` 里 `ObjectProvider<MeterRegistry>` 有则 Micrometer 实现、无则 NOOP（`oryxos chat` 等无 actuator 上下文安全兜底）。埋点：LLM 两类在 `SpringAiProviderServiceImpl` 审计调用旁；工具/策略在 `ToolExecutor` 审计调用旁；切换在切换点。所有埋点 try/catch 吞异常（FR-010 指标失败不伤主链路）。
+
+**Rationale**: core/provider 不能依赖 micrometer（模块纪律）；接口 + NOOP 是 StreamListener.NOOP/ToolPolicyService.ALLOW_ALL 的既有零破坏锚点惯例第三例。埋点贴着审计调用放，保证「指标计数 ≈ 审计条数」可对照（SC-005/SC-006 的验证基础）。
+
+**Alternatives considered**: 直接在各模块用 Micrometer（依赖扩散到 core/provider/tool，模块纪律破坏）；从审计表定时聚合导出（引入拉取延迟与双份口径漂移，指标本该是内存计数）。
+
+## R6 — 指标目录（oryxos_ 前缀，Prometheus 惯例）
+
+| 指标 | 类型 | 标签 | 语义 |
+|------|------|------|------|
+| `oryxos_llm_calls_total` | counter | provider, model, outcome(success/failure) | 每次尝试计一次（与 llm_calls 行数同口径） |
+| `oryxos_llm_call_duration_seconds` | timer | provider, model | 单次尝试耗时分布 |
+| `oryxos_llm_tokens_total` | counter | provider, model, type(prompt/completion) | token 消耗 |
+| `oryxos_tool_invocations_total` | counter | tool, outcome | 工具调用（含被拦截的失败） |
+| `oryxos_policy_blocks_total` | counter | tool | 020 策略拦截 |
+| `oryxos_fallback_switches_total` | counter | from, to | 切换次数（告警核心信号） |
+
+标签基数有界（provider/model/tool 均为有限注册集）；Micrometer timer 自带 count/sum/max，无需单独平均值指标。
+
+## R7 — 不做的（边界收口）
+
+- **智能路由**：roadmap 明示留到数据积累后；本刀的指标+审计恰好是那份数据的来源
+- **断路器/半开状态机、退避等待**：YAGNI + SC-007 明令无额外等待；按序同步重试够用
+- **跨请求 Provider 健康记忆**：无状态原则（宪法「无状态实例」）；每次调用独立从主开始
+- **管理台新页面**：016 报表覆盖"人看"；Prometheus 面向机器与告警
+- **Spring Retry / Resilience4j**：引依赖换不来更简单的三十行循环

--- a/specs/023-provider-fallback/spec.md
+++ b/specs/023-provider-fallback/spec.md
@@ -1,0 +1,112 @@
+# Feature Specification: Provider 失败切换与业务指标导出
+
+**Feature Branch**: `023-provider-fallback`
+
+**Created**: 2026-09-02
+
+**Status**: Draft
+
+**Input**: User description: "Provider 失败切换与业务指标导出（023-provider-fallback）：v0.3 治理面收官刀——LLM Provider 单点故障不再打断 Agent 服务，运维可在既有监控栈里看到调用健康度。AGENT.md provider 节新增 fallback 声明（有序列表 name+model，引用已注册 Provider）；单次 LLM 调用的 provider 侧故障按序切换重试，全部失败才上抛；不可重试的业务性失败不切换；max_iterations 口径不变。审计每次尝试各写一条 llm_calls，021 trace 时间线主备尝试同链可见；切换 WARN 日志带 traceId。流式：首 token 前失败可切换，token 已流出按 019 error 语义收尾。零声明=现状零变化。业务指标：既有 Prometheus 端点新增 LLM 调用/token/工具调用/策略拦截/fallback 切换等业务指标（oryxos_ 前缀），指标与审计正交。不做：智能路由、断路器、跨请求健康记忆。"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Provider 故障时服务不中断 (Priority: P1)
+
+Agent 作者在 Agent 配置的 provider 节声明一个或多个备用 Provider（有序列表，各自带模型名）。主 Provider 发生故障（网络不通、超时、服务端错误、限流、密钥失效等）时，该次调用自动按声明顺序换备用 Provider 重发同一请求，Agent 的对话/定时任务/IM 问答照常完成——终端用户无感知。只有全部候选都失败时，才以最后一次的错误按现状口径反馈。未声明 fallback 的 Agent 行为与现在完全一致。
+
+**Why this priority**: 这是本特性的存在理由——LLM Provider 是 Agent 唯一的外部强依赖，单点故障直接打断所有会话与定时任务；企业场景的可用性诉求排第一。
+
+**Independent Test**: 给 Agent 声明主（必然失败的 Provider）+ 备（可用的 Provider）；发起对话——回复正常返回；查审计可见失败主尝试与成功备尝试各一条记录。
+
+**Acceptance Scenarios**:
+
+1. **Given** Agent 声明了主 Provider（故障）与备 Provider（正常）, **When** 发起一次对话, **Then** 对话正常完成，回复来自备 Provider，调用方无感知
+2. **Given** 声明的全部候选 Provider 都故障, **When** 发起对话, **Then** 以最后一次尝试的错误按现状口径反馈（不无限重试、不吞错）
+3. **Given** Agent 未声明任何 fallback, **When** 主 Provider 故障, **Then** 行为与本特性交付前完全一致（回归零破坏）
+4. **Given** 失败属于不可重试的业务性错误（如请求内容本身非法）, **When** 该次调用失败, **Then** 不切换备用、直接按现状反馈（换 Provider 无意义的错误不浪费尝试）
+5. **Given** 流式对话且首个内容片段尚未送出, **When** 主 Provider 故障, **Then** 切换备用后流式照常，客户端无感知；**Given** 内容已开始流出后故障, **Then** 不切换、按既有流中错误语义收尾（避免重复输出）
+
+---
+
+### User Story 2 - 切换过程可回放可追责 (Priority: P2)
+
+管理员事后核查一次"用户没感觉但其实切换过"的调用：审计里主备每次尝试各有一条记录（Provider 名如实、失败原因在失败记录上）；用该轮 trace ID 查时间线，主备尝试同链按时间序可见；服务日志有一条切换警告（从谁切到谁），凭 trace ID 与审计互查。运维据此发现"主 Provider 最近老在切"并提前处置。
+
+**Why this priority**: 自动切换若不可回放，就是把故障藏起来——治理面版本的底线是"任何自动行为都留痕"；且 021 刚交付的 trace 能力天然承载它。
+
+**Independent Test**: 触发一次主败备成的调用 → 审计查到两条记录（失败主 + 成功备）、trace 时间线两个 LLM 步同链、日志有带 trace 的切换警告。
+
+**Acceptance Scenarios**:
+
+1. **Given** 一次主败备成的调用, **When** 查审计记录, **Then** 失败主尝试与成功备尝试各一条，Provider 名与成败如实
+2. **Given** 同一轮处理, **When** 按 trace ID 查时间线, **Then** 两次 LLM 尝试同链按时间序可见（切换过程可回放）
+3. **Given** 切换发生, **When** 检索服务日志, **Then** 有一条切换警告（来源与目标 Provider），且与该轮 trace ID 可互查
+
+---
+
+### User Story 3 - 监控栈里可见调用健康度 (Priority: P3)
+
+运维把系统既有的监控端点接入企业 Prometheus/Grafana：无需登录管理台，就能在监控栈里看到 LLM 调用量与耗时（按 Provider/模型/成败）、token 消耗、工具调用量（按工具/成败）、策略拦截次数、fallback 切换次数，并据此配置告警（如"切换次数突增"）。指标只做监控聚合，不改变审计落库口径。
+
+**Why this priority**: 补 v0.3 看板最后一角——016 报表覆盖"人看"，这里覆盖"机器看+告警"；排 P3 因为端点与基础指标已在，本故事是业务指标增量。
+
+**Independent Test**: 触发若干次对话（含策略拦截与 fallback 场景）→ 抓取监控端点文本 → 各业务指标存在且计数与实际行为一致。
+
+**Acceptance Scenarios**:
+
+1. **Given** 系统处理过若干 LLM 调用与工具调用, **When** 抓取监控端点, **Then** 调用计数/耗时/token 指标按 Provider/模型/工具/成败维度呈现且数值与实际一致
+2. **Given** 发生过策略拦截与 fallback 切换, **When** 抓取监控端点, **Then** 拦截计数与切换计数如实累加
+3. **Given** 指标采集开启, **When** 对照审计表, **Then** 审计写入口径与数量不受影响（指标与审计正交）
+
+---
+
+### Edge Cases
+
+- 声明的备用 Provider 未注册或已被删除：该候选跳过并留痕（日志警告），继续尝试下一个；全部无效等同"无可用候选"
+- 备用 Provider 自身也需要凭证：沿用其注册表配置（022 已加密存储），与主 Provider 同一取用路径
+- 主备声明成同一个 Provider（配置冗余）：照常按序尝试，不做去重魔法（声明什么执行什么）
+- 工具调用轮次中途切换：同一轮 ReAct 内后续调用从主 Provider 重新开始尝试（每次调用独立判断，无跨调用记忆）
+- 切换后回复风格/模型能力差异：如实使用声明的备用模型，不做能力对齐（作者声明即授权）
+- 指标端点在未发生任何调用时：业务指标不存在或为零值，不报错
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Agent 配置的 provider 节 MUST 支持声明有序备用列表（每项含 Provider 名与模型名，引用已注册 Provider）；未声明时行为与现状完全一致
+- **FR-002**: 单次 LLM 调用发生 Provider 侧故障（网络错误/超时/服务端 5xx/限流/认证失败）时，系统 MUST 按声明顺序逐个尝试备用 Provider 重发同一请求，直到成功或候选耗尽；候选耗尽时 MUST 以最后一次错误按现状口径上抛
+- **FR-003**: 不可重试的业务性失败（请求内容本身非法等换 Provider 无意义的错误）MUST NOT 触发切换
+- **FR-004**: 切换语义 MUST 限定在"单次 LLM 调用"层面：ReAct 轮次数（max_iterations）口径不变，每次调用独立从主 Provider 开始尝试（无跨调用健康记忆）
+- **FR-005**: 每次尝试（失败与成功）MUST 各写一条 LLM 审计记录，Provider/模型/成败/错误如实；同轮尝试共享该轮 trace，时间线可回放切换过程
+- **FR-006**: 切换发生时 MUST 记一条警告日志（来源 Provider → 目标 Provider），处理路径日志携带该轮 trace 标识（021 MDC 机制）
+- **FR-007**: 流式调用 MUST 遵守边界：首个内容片段尚未送出前的失败可切换（客户端无感知）；内容已开始流出后 MUST NOT 切换，按既有流中错误语义收尾
+- **FR-008**: 声明中引用了未注册/已删除 Provider 的候选项 MUST 跳过并留告警日志，不中断尝试序列
+- **FR-009**: 系统 MUST 在既有监控端点上暴露业务指标：LLM 调用计数与耗时（按 Provider/模型/成败）、token 消耗计数、工具调用计数（按工具/成败）、策略拦截计数、fallback 切换计数（按来源/目标）；指标命名遵循业界惯例并带统一前缀
+- **FR-010**: 指标采集 MUST 不改变审计落库口径与数量（指标供监控聚合，审计供精确回放，二者正交）；指标采集失败 MUST NOT 影响主链路
+- **FR-011**: 本特性 MUST NOT 包含：智能路由（按成本/延迟自动选路）、断路器/半开状态机、跨请求的 Provider 健康记忆、管理台新页面
+
+### Key Entities
+
+- **备用声明（fallback 列表）**: Agent 配置中 provider 节的有序候选清单，每项为已注册 Provider 的名字 + 该 Provider 下使用的模型名；声明即授权（作者对备用模型的能力差异负责）
+- **一次调用的尝试序列**: 主 Provider + 按序备用构成的执行序列；每个尝试产生一条审计记录，全序列共享该轮 trace
+- **业务指标**: 监控端点上的聚合计数/耗时序列，维度含 Provider/模型/工具/成败/切换来源与目标；与审计记录正交
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 主 Provider 故障、备用可用的场景下，对话/定时任务/流式（首片段前）100% 正常完成，终端用户无感知
+- **SC-002**: 未声明 fallback 的 Agent 在本特性交付前后行为完全一致（回归零破坏，含错误反馈口径）
+- **SC-003**: 每次主败备成的调用在审计中恰有两条记录、trace 时间线同链可见、日志有带 trace 的切换警告（切换过程 100% 可回放）
+- **SC-004**: 不可重试失败与流中失败 0 次触发切换（边界零越界）
+- **SC-005**: 监控端点上五类业务指标（LLM 调用/token/工具调用/策略拦截/切换）与实际行为计数一致（抽样对照零偏差）
+- **SC-006**: 指标采集开启前后审计表写入数量与内容口径零变化
+- **SC-007**: 全部候选失败时错误反馈时延不超过「候选数 × 单次调用超时」量级（不引入额外等待/退避）
+
+## Assumptions
+
+- 备用 Provider 的注册与凭证管理沿用既有 Provider 注册表（022 加密存储），本特性不新增凭证面
+- 「Provider 侧故障」的具体错误分类在设计阶段结合既有调用栈的异常形态定稿；分类原则：换一个 Provider 有合理成功预期的才算可切换
+- 流式「首个内容片段」以对客户端的首次内容写出为界（心跳注释不算内容）
+- 监控端点与基础运行指标已存在（此前版本预支），本特性只做业务指标增量
+- 智能路由所需的数据积累（延迟/成本/成功率的历史序列）恰由本特性的指标与审计提供——为 roadmap 后续项铺路但不实现

--- a/specs/023-provider-fallback/tasks.md
+++ b/specs/023-provider-fallback/tasks.md
@@ -74,12 +74,12 @@ Maven 多模块单体，涉及 oryxos-core / oryxos-provider / oryxos-cli / oryx
 
 **Independent Test**: quickstart V6——触发调用/拦截/切换后抓端点，指标在位且计数对照一致
 
-- [ ] T012 [US3] 修改 oryxos-cli/pom.xml：加 `io.micrometer:micrometer-core` 编译依赖（运行时 jar 已由 boot actuator 传递带入，注释注明零新增运行时构件）
-- [ ] T013 [US3] 新建 oryxos-cli/src/main/java/io/oryxos/cli/MicrometerMetricsRecorder.java（依赖 T003/T012）：实现五方法落 oryxos_* 指标（目录见 contracts §3）——Counter/Timer 经 MeterRegistry 惰性获取；全部方法 try/catch 吞异常记 DEBUG（FR-010 埋点不伤主链路）；标签值 null 兜底为 "unknown"。配套新建 oryxos-cli/src/test/java/io/oryxos/cli/MicrometerMetricsRecorderTest.java：SimpleMeterRegistry 断言五类指标名/标签/计数，**并注入恒抛异常的 MeterRegistry 断言五方法全部静默不抛**（FR-010 显式断言）
+- [X] T012 [US3] 修改 oryxos-cli/pom.xml：加 `io.micrometer:micrometer-core` 编译依赖（运行时 jar 已由 boot actuator 传递带入，注释注明零新增运行时构件）
+- [X] T013 [US3] 新建 oryxos-cli/src/main/java/io/oryxos/cli/MicrometerMetricsRecorder.java（依赖 T003/T012）：实现五方法落 oryxos_* 指标（目录见 contracts §3）——Counter/Timer 经 MeterRegistry 惰性获取；全部方法 try/catch 吞异常记 DEBUG（FR-010 埋点不伤主链路）；标签值 null 兜底为 "unknown"。配套新建 oryxos-cli/src/test/java/io/oryxos/cli/MicrometerMetricsRecorderTest.java：SimpleMeterRegistry 断言五类指标名/标签/计数，**并注入恒抛异常的 MeterRegistry 断言五方法全部静默不抛**（FR-010 显式断言）
 - [X] T014 [US3] 修改 oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java（依赖 T007/T003，同文件串行）：构造注入 `MetricsRecorder`（旧构造委托 NOOP 保既有测试）；recordSuccess/recordFailure 旁挂 recordLlmCall（每尝试）、成功侧挂 recordLlmTokens、切换点挂 recordFallbackSwitch
-- [ ] T015 [P] [US3] 修改 oryxos-core/src/main/java/io/oryxos/core/agent/ToolExecutor.java（依赖 T003）：构造注入 `MetricsRecorder`（旧构造委托 NOOP）；审计调用旁挂 recordToolInvocation（成败如实）；策略拒绝点挂 recordPolicyBlock
-- [ ] T016 [US3] 修改 oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java（依赖 T013~T015）：`@Bean MetricsRecorder`——`ObjectProvider<MeterRegistry>` 有则 MicrometerMetricsRecorder、无则 NOOP（chat 命令等无 actuator 上下文兜底）；providerService 与 toolExecutor 装配点注入
-- [ ] T017 [US3] 在 oryxos-boot/src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java 追加（依赖 T011/T016，同文件串行）：`GET /actuator/prometheus` 抓文本断言——`oryxos_llm_calls_total`（broken/failure 与 mock/success 序列在位且计数与 llm_calls 表行数对照一致，SC-005/SC-006）、`oryxos_fallback_switches_total{from="broken",to="mock"}` ≥1、`oryxos_tool_invocations_total` 与 `oryxos_llm_tokens_total` 在位；配 GLOBAL_DENY 触发拦截 → `oryxos_policy_blocks_total` 递增
+- [X] T015 [P] [US3] 修改 oryxos-core/src/main/java/io/oryxos/core/agent/ToolExecutor.java（依赖 T003）：构造注入 `MetricsRecorder`（旧构造委托 NOOP）；审计调用旁挂 recordToolInvocation（成败如实）；策略拒绝点挂 recordPolicyBlock
+- [X] T016 [US3] 修改 oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java（依赖 T013~T015）：`@Bean MetricsRecorder`——`ObjectProvider<MeterRegistry>` 有则 MicrometerMetricsRecorder、无则 NOOP（chat 命令等无 actuator 上下文兜底）；providerService 与 toolExecutor 装配点注入
+- [X] T017 [US3] 在 oryxos-boot/src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java 追加（依赖 T011/T016，同文件串行）：`GET /actuator/prometheus` 抓文本断言——`oryxos_llm_calls_total`（broken/failure 与 mock/success 序列在位且计数与 llm_calls 表行数对照一致，SC-005/SC-006）、`oryxos_fallback_switches_total{from="broken",to="mock"}` ≥1、`oryxos_tool_invocations_total` 与 `oryxos_llm_tokens_total` 在位；配 GLOBAL_DENY 触发拦截 → `oryxos_policy_blocks_total` 递增
 
 **Checkpoint**: 全部故事独立可测
 

--- a/specs/023-provider-fallback/tasks.md
+++ b/specs/023-provider-fallback/tasks.md
@@ -90,8 +90,8 @@ Maven 多模块单体，涉及 oryxos-core / oryxos-provider / oryxos-cli / oryx
 **Purpose**: 文档与全量验收
 
 - [X] T018 [P] 文档同步：CLAUDE.md AGENT.md 示例 provider 节补 `fallback` 字段与一句口径；website/zh/docs/api.md 与 website/docs/api.md 补「Provider 失败切换」与「业务指标」小节（对齐 contracts）；docs/CliGuide.md 提及 fallback 声明与 /actuator/prometheus 接入
-- [ ] T019 按 quickstart.md 完整走查 V1~V6（真机 fat JAR：broken provider 指不通端口 + mock 备用；V4 用 python 400 stub）并记录到 specs/023-provider-fallback/acceptance-report.md（SC-001~SC-007 逐项对勾，镜像 018~022 报告形式）
-- [ ] T020 运行 `mvn verify` 全量质量门禁并清零新增告警（CRLF 日志参数一律 sanitize——022 教训前置）
+- [X] T019 按 quickstart.md 完整走查 V1~V6（真机 fat JAR：broken provider 指不通端口 + mock 备用；V4 用 python 400 stub）并记录到 specs/023-provider-fallback/acceptance-report.md（SC-001~SC-007 逐项对勾，镜像 018~022 报告形式）
+- [X] T020 运行 `mvn verify` 全量质量门禁并清零新增告警（CRLF 日志参数一律 sanitize——022 教训前置）
 
 ---
 

--- a/specs/023-provider-fallback/tasks.md
+++ b/specs/023-provider-fallback/tasks.md
@@ -61,8 +61,8 @@ Maven 多模块单体，涉及 oryxos-core / oryxos-provider / oryxos-cli / oryx
 
 **Independent Test**: quickstart V1/V2——真实 HTTP 主败备成后审计两条、时间线同链、日志可 grep
 
-- [ ] T010 [US2] 新建 oryxos-boot/src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java（依赖 T007；镜像 TraceE2ETest 模式：临时工作区 + mock provider + 真实 HTTP + SQLite）：**broken provider 必须启动前预置**（Agent 启动加载时 knownProviders 校验要能看到它，运行时 API 注册有时序坑）——首选 `properties` 里 `oryxos.providers[1].name=broken` + base-url 指向 `http://127.0.0.1:1/v1` 走 YAML 种子路径；若 ProvidersProperties 无 base-url 键则回退「@DynamicPropertySource 前直插 providers 表 / 或 seedWorkspace 阶段写入」；Agent 主 broken + fallback mock——invoke 返回 200 且回复为 mock 文案（SC-001）；llm_calls 中 broken 失败与 mock 成功记录成对出现且同 traceId；`GET /audit/trace/{id}` 时间线主备 LLM 步同链按时间序（SC-003）；ListAppender 断言 WARN「provider 切换」日志存在且 MDC traceId 与本轮一致
-- [ ] T011 [US2] 在 oryxos-boot/src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java 追加（依赖 T010，同文件串行）：零声明 Agent（只配 mock）行为回归——单轮审计条数与 022 前基线一致（SC-002/SC-006 锚点）；全败 Agent（broken + fallback broken2）invoke 报错且无成功行
+- [X] T010 [US2] 新建 oryxos-boot/src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java（依赖 T007；镜像 TraceE2ETest 模式：临时工作区 + mock provider + 真实 HTTP + SQLite）：**broken provider 必须启动前预置**（Agent 启动加载时 knownProviders 校验要能看到它，运行时 API 注册有时序坑）——首选 `properties` 里 `oryxos.providers[1].name=broken` + base-url 指向 `http://127.0.0.1:1/v1` 走 YAML 种子路径；若 ProvidersProperties 无 base-url 键则回退「@DynamicPropertySource 前直插 providers 表 / 或 seedWorkspace 阶段写入」；Agent 主 broken + fallback mock——invoke 返回 200 且回复为 mock 文案（SC-001）；llm_calls 中 broken 失败与 mock 成功记录成对出现且同 traceId；`GET /audit/trace/{id}` 时间线主备 LLM 步同链按时间序（SC-003）；ListAppender 断言 WARN「provider 切换」日志存在且 MDC traceId 与本轮一致
+- [X] T011 [US2] 在 oryxos-boot/src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java 追加（依赖 T010，同文件串行）：零声明 Agent（只配 mock）行为回归——单轮审计条数与 022 前基线一致（SC-002/SC-006 锚点）；全败 Agent（broken + fallback broken2）invoke 报错且无成功行
 
 **Checkpoint**: quickstart V1/V2/V3 可走通——US1+US2 独立可测
 
@@ -76,7 +76,7 @@ Maven 多模块单体，涉及 oryxos-core / oryxos-provider / oryxos-cli / oryx
 
 - [ ] T012 [US3] 修改 oryxos-cli/pom.xml：加 `io.micrometer:micrometer-core` 编译依赖（运行时 jar 已由 boot actuator 传递带入，注释注明零新增运行时构件）
 - [ ] T013 [US3] 新建 oryxos-cli/src/main/java/io/oryxos/cli/MicrometerMetricsRecorder.java（依赖 T003/T012）：实现五方法落 oryxos_* 指标（目录见 contracts §3）——Counter/Timer 经 MeterRegistry 惰性获取；全部方法 try/catch 吞异常记 DEBUG（FR-010 埋点不伤主链路）；标签值 null 兜底为 "unknown"。配套新建 oryxos-cli/src/test/java/io/oryxos/cli/MicrometerMetricsRecorderTest.java：SimpleMeterRegistry 断言五类指标名/标签/计数，**并注入恒抛异常的 MeterRegistry 断言五方法全部静默不抛**（FR-010 显式断言）
-- [ ] T014 [US3] 修改 oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java（依赖 T007/T003，同文件串行）：构造注入 `MetricsRecorder`（旧构造委托 NOOP 保既有测试）；recordSuccess/recordFailure 旁挂 recordLlmCall（每尝试）、成功侧挂 recordLlmTokens、切换点挂 recordFallbackSwitch
+- [X] T014 [US3] 修改 oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java（依赖 T007/T003，同文件串行）：构造注入 `MetricsRecorder`（旧构造委托 NOOP 保既有测试）；recordSuccess/recordFailure 旁挂 recordLlmCall（每尝试）、成功侧挂 recordLlmTokens、切换点挂 recordFallbackSwitch
 - [ ] T015 [P] [US3] 修改 oryxos-core/src/main/java/io/oryxos/core/agent/ToolExecutor.java（依赖 T003）：构造注入 `MetricsRecorder`（旧构造委托 NOOP）；审计调用旁挂 recordToolInvocation（成败如实）；策略拒绝点挂 recordPolicyBlock
 - [ ] T016 [US3] 修改 oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java（依赖 T013~T015）：`@Bean MetricsRecorder`——`ObjectProvider<MeterRegistry>` 有则 MicrometerMetricsRecorder、无则 NOOP（chat 命令等无 actuator 上下文兜底）；providerService 与 toolExecutor 装配点注入
 - [ ] T017 [US3] 在 oryxos-boot/src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java 追加（依赖 T011/T016，同文件串行）：`GET /actuator/prometheus` 抓文本断言——`oryxos_llm_calls_total`（broken/failure 与 mock/success 序列在位且计数与 llm_calls 表行数对照一致，SC-005/SC-006）、`oryxos_fallback_switches_total{from="broken",to="mock"}` ≥1、`oryxos_tool_invocations_total` 与 `oryxos_llm_tokens_total` 在位；配 GLOBAL_DENY 触发拦截 → `oryxos_policy_blocks_total` 递增

--- a/specs/023-provider-fallback/tasks.md
+++ b/specs/023-provider-fallback/tasks.md
@@ -40,16 +40,16 @@ Maven 多模块单体，涉及 oryxos-core / oryxos-provider / oryxos-cli / oryx
 
 **Independent Test**: quickstart V1/V3/V4/V5——主败备成对话正常；全败上抛；400 不切；流式透明切换
 
-- [ ] T005 [P] [US1] 新建 oryxos-provider/src/main/java/io/oryxos/provider/FallbackClassifier.java（分类表见 data-model.md）：静态 `boolean isSwitchable(RuntimeException)`——遍历异常链提取 HTTP 状态码（Spring HttpStatusCodeException/WebClientResponseException/Spring AI 异常的状态承载形态，按实际类路径穷举）与网络/超时类（ResourceAccessException/IOException/TimeoutException cause）；5xx/429/401/403/408/网络/无状态码 → true，400/404/422 等其余 4xx → false
-- [ ] T006 [P] [US1] 新建单测 oryxos-provider/src/test/java/io/oryxos/provider/FallbackClassifierTest.java（依赖 T005）：分类表逐行钉死——各状态码正反例、网络异常链（cause 深埋）、无状态码 RuntimeException → true、嵌套包装异常
-- [ ] T007 [US1] 修改 oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java（依赖 T005，**本特性核心**）：
+- [X] T005 [P] [US1] 新建 oryxos-provider/src/main/java/io/oryxos/provider/FallbackClassifier.java（分类表见 data-model.md）：静态 `boolean isSwitchable(RuntimeException)`——遍历异常链提取 HTTP 状态码（Spring HttpStatusCodeException/WebClientResponseException/Spring AI 异常的状态承载形态，按实际类路径穷举）与网络/超时类（ResourceAccessException/IOException/TimeoutException cause）；5xx/429/401/403/408/网络/无状态码 → true，400/404/422 等其余 4xx → false
+- [X] T006 [P] [US1] 新建单测 oryxos-provider/src/test/java/io/oryxos/provider/FallbackClassifierTest.java（依赖 T005）：分类表逐行钉死——各状态码正反例、网络异常链（cause 深埋）、无状态码 RuntimeException → true、嵌套包装异常
+- [X] T007 [US1] 修改 oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java（依赖 T005，**本特性核心**）：
   - 抽尝试序列：`List<Attempt(name, model)>` = 主 + `profile.provider().fallbacks()`；chat/chatStream 外层循环逐个执行
   - **attempt 参数化贯穿三处**（R2 陷阱）：`registry.find(attempt.name)`、`buildPrompt` 的 `options.model(attempt.model)`、recordSuccess/recordFailure 的 provider/model 参数——备用调用必须用备用模型名且审计如实
   - 失败处理：recordFailure 照旧（每尝试一条）→ `FallbackClassifier.isSwitchable` 且有下一候选 → WARN「provider 切换: from → to」（sanitize，MDC 自带 traceId）→ 下一个；否则原样上抛
   - 候选 `registry.find` 缺失 → WARN 跳过不落审计（FR-008）；ProviderNotFoundException 对**主** provider 保持现状直抛（零声明回归）
   - chatStream 附加：失败时 `text.isEmpty() && toolCalls.isEmpty()` 才允许切换（首片段边界，R4）；已有输出按既有路径落账上抛；UnsupportedOperationException 降级逻辑保持在"单次尝试"内不变
-- [ ] T008 [P] [US1] 新建单测 oryxos-provider/src/test/java/io/oryxos/provider/ProviderFallbackTest.java（依赖 T007；mock ChatModel builder + registry + auditor，镜像既有 provider 测试形态）：主败备成返回备结果且备用调用携带备 model、全部候选失败上抛最后异常、不可切换异常（400）直接上抛无第二次尝试、候选未注册跳过直达第三候选、零 fallback 声明行为与现状一致（单次调用单条审计）、流式首片段前失败切换成功 / 已出 token 后失败不切换、**同一 service 实例连续两次 chat：第一次主败备成后第二次仍先尝试主 Provider**（FR-004 无健康记忆断言，verify 调用顺序）
-- [ ] T009 [US1] 在 oryxos-provider/src/test/java/io/oryxos/provider/ProviderFallbackTest.java 追加审计断言（依赖 T008，同文件串行）：主败备成场景 auditor.record 恰被调两次——第一次 provider=主/success=false、第二次 provider=备/model=备 model/success=true（SC-003 的单测面；verify 参数捕获）
+- [X] T008 [P] [US1] 新建单测 oryxos-provider/src/test/java/io/oryxos/provider/ProviderFallbackTest.java（依赖 T007；mock ChatModel builder + registry + auditor，镜像既有 provider 测试形态）：主败备成返回备结果且备用调用携带备 model、全部候选失败上抛最后异常、不可切换异常（400）直接上抛无第二次尝试、候选未注册跳过直达第三候选、零 fallback 声明行为与现状一致（单次调用单条审计）、流式首片段前失败切换成功 / 已出 token 后失败不切换、**同一 service 实例连续两次 chat：第一次主败备成后第二次仍先尝试主 Provider**（FR-004 无健康记忆断言，verify 调用顺序）
+- [X] T009 [US1] 在 oryxos-provider/src/test/java/io/oryxos/provider/ProviderFallbackTest.java 追加审计断言（依赖 T008，同文件串行）：主败备成场景 auditor.record 恰被调两次——第一次 provider=主/success=false、第二次 provider=备/model=备 model/success=true（SC-003 的单测面；verify 参数捕获）
 
 **Checkpoint**: quickstart V1/V3/V4/V5 语义可单测复现——MVP 可交付
 

--- a/specs/023-provider-fallback/tasks.md
+++ b/specs/023-provider-fallback/tasks.md
@@ -1,0 +1,148 @@
+# Tasks: Provider 失败切换与业务指标导出
+
+**Input**: Design documents from `/specs/023-provider-fallback/`
+
+**Prerequisites**: plan.md、spec.md、research.md（R1~R7）、data-model.md、contracts/fallback-metrics.md、quickstart.md
+
+**Tests**: 包含测试任务——质量门禁要求核心逻辑单测覆盖（宪法「开发流程与质量门禁」），且切换分类表（SC-004）、审计每尝试一条（SC-003）、回归零破坏（SC-002）、指标口径对照（SC-005/SC-006）必须测试钉死。
+
+**Organization**: 按用户故事分组；声明解析与指标契约在 Foundational 一次成型——US1（切换不中断）为 MVP，US2（留痕回放）、US3（监控指标）依次叠加。
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: 可并行（不同文件、无未完成依赖）
+- **[Story]**: 所属用户故事（US1/US2/US3）
+
+## Path Conventions
+
+Maven 多模块单体，涉及 oryxos-core / oryxos-provider / oryxos-cli / oryxos-boot 四个既有模块（见 plan.md「Source Code」）。零新表、零新模块、零运行时新构件。
+
+---
+
+## Phase 1: Foundational (Blocking Prerequisites)
+
+**Purpose**: fallback 声明解析 + 指标契约——三个故事共同依赖的地基
+
+**⚠️ CRITICAL**: 本阶段完成前不得开始任何用户故事
+
+- [X] T001 [P] 修改 oryxos-core/src/main/java/io/oryxos/core/profile/Profile.java：ProviderRef 加第 4 组件 `List<FallbackRef> fallbacks`（紧凑构造 List.copyOf，null→List.of()）+ 旧 3 参构造委托空列表（021 兼容惯例）；新增嵌套 `record FallbackRef(String name, String model)`
+- [X] T002 修改 oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java（依赖 T001）：toProviderRef 解析 `fallback` 列表——每项 name/model 缺失抛 ProfileValidationException（与主 provider 同口径）；候选引用未注册 provider 记 WARN **不阻断加载**（tools 既有口径，R1），仍保留进列表（运行时再跳过）
+- [X] T003 [P] 新建 oryxos-core/src/main/java/io/oryxos/core/metrics/MetricsRecorder.java（契约见 data-model.md）：五方法（recordLlmCall/recordLlmTokens/recordToolInvocation/recordPolicyBlock/recordFallbackSwitch）全部 default 空实现 + `MetricsRecorder NOOP` 常量（StreamListener.NOOP 惯例第三例）；javadoc 注明实现纪律「埋点异常不得影响主链路」
+- [X] T004 [P] 修改 oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java（依赖 T002）：追加——fallback 两候选按序解析、候选缺 model 抛校验异常、候选引用未知 provider WARN 但加载成功、无 fallback 字段时 fallbacks 为空列表（旧 YAML 零变化）
+
+**Checkpoint**: 声明解析单测全绿——切换实现可以开始
+
+---
+
+## Phase 2: User Story 1 - Provider 故障时服务不中断 (Priority: P1) 🎯 MVP
+
+**Goal**: 单次调用故障按序切换备用重发；候选耗尽上抛最后错误；业务性失败不切；流式首片段边界；零声明零变化
+
+**Independent Test**: quickstart V1/V3/V4/V5——主败备成对话正常；全败上抛；400 不切；流式透明切换
+
+- [ ] T005 [P] [US1] 新建 oryxos-provider/src/main/java/io/oryxos/provider/FallbackClassifier.java（分类表见 data-model.md）：静态 `boolean isSwitchable(RuntimeException)`——遍历异常链提取 HTTP 状态码（Spring HttpStatusCodeException/WebClientResponseException/Spring AI 异常的状态承载形态，按实际类路径穷举）与网络/超时类（ResourceAccessException/IOException/TimeoutException cause）；5xx/429/401/403/408/网络/无状态码 → true，400/404/422 等其余 4xx → false
+- [ ] T006 [P] [US1] 新建单测 oryxos-provider/src/test/java/io/oryxos/provider/FallbackClassifierTest.java（依赖 T005）：分类表逐行钉死——各状态码正反例、网络异常链（cause 深埋）、无状态码 RuntimeException → true、嵌套包装异常
+- [ ] T007 [US1] 修改 oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java（依赖 T005，**本特性核心**）：
+  - 抽尝试序列：`List<Attempt(name, model)>` = 主 + `profile.provider().fallbacks()`；chat/chatStream 外层循环逐个执行
+  - **attempt 参数化贯穿三处**（R2 陷阱）：`registry.find(attempt.name)`、`buildPrompt` 的 `options.model(attempt.model)`、recordSuccess/recordFailure 的 provider/model 参数——备用调用必须用备用模型名且审计如实
+  - 失败处理：recordFailure 照旧（每尝试一条）→ `FallbackClassifier.isSwitchable` 且有下一候选 → WARN「provider 切换: from → to」（sanitize，MDC 自带 traceId）→ 下一个；否则原样上抛
+  - 候选 `registry.find` 缺失 → WARN 跳过不落审计（FR-008）；ProviderNotFoundException 对**主** provider 保持现状直抛（零声明回归）
+  - chatStream 附加：失败时 `text.isEmpty() && toolCalls.isEmpty()` 才允许切换（首片段边界，R4）；已有输出按既有路径落账上抛；UnsupportedOperationException 降级逻辑保持在"单次尝试"内不变
+- [ ] T008 [P] [US1] 新建单测 oryxos-provider/src/test/java/io/oryxos/provider/ProviderFallbackTest.java（依赖 T007；mock ChatModel builder + registry + auditor，镜像既有 provider 测试形态）：主败备成返回备结果且备用调用携带备 model、全部候选失败上抛最后异常、不可切换异常（400）直接上抛无第二次尝试、候选未注册跳过直达第三候选、零 fallback 声明行为与现状一致（单次调用单条审计）、流式首片段前失败切换成功 / 已出 token 后失败不切换、**同一 service 实例连续两次 chat：第一次主败备成后第二次仍先尝试主 Provider**（FR-004 无健康记忆断言，verify 调用顺序）
+- [ ] T009 [US1] 在 oryxos-provider/src/test/java/io/oryxos/provider/ProviderFallbackTest.java 追加审计断言（依赖 T008，同文件串行）：主败备成场景 auditor.record 恰被调两次——第一次 provider=主/success=false、第二次 provider=备/model=备 model/success=true（SC-003 的单测面；verify 参数捕获）
+
+**Checkpoint**: quickstart V1/V3/V4/V5 语义可单测复现——MVP 可交付
+
+---
+
+## Phase 3: User Story 2 - 切换过程可回放可追责 (Priority: P2)
+
+**Goal**: 主备尝试审计各一条、trace 同链、切换 WARN 带 traceId——E2E 全链钉死
+
+**Independent Test**: quickstart V1/V2——真实 HTTP 主败备成后审计两条、时间线同链、日志可 grep
+
+- [ ] T010 [US2] 新建 oryxos-boot/src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java（依赖 T007；镜像 TraceE2ETest 模式：临时工作区 + mock provider + 真实 HTTP + SQLite）：**broken provider 必须启动前预置**（Agent 启动加载时 knownProviders 校验要能看到它，运行时 API 注册有时序坑）——首选 `properties` 里 `oryxos.providers[1].name=broken` + base-url 指向 `http://127.0.0.1:1/v1` 走 YAML 种子路径；若 ProvidersProperties 无 base-url 键则回退「@DynamicPropertySource 前直插 providers 表 / 或 seedWorkspace 阶段写入」；Agent 主 broken + fallback mock——invoke 返回 200 且回复为 mock 文案（SC-001）；llm_calls 中 broken 失败与 mock 成功记录成对出现且同 traceId；`GET /audit/trace/{id}` 时间线主备 LLM 步同链按时间序（SC-003）；ListAppender 断言 WARN「provider 切换」日志存在且 MDC traceId 与本轮一致
+- [ ] T011 [US2] 在 oryxos-boot/src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java 追加（依赖 T010，同文件串行）：零声明 Agent（只配 mock）行为回归——单轮审计条数与 022 前基线一致（SC-002/SC-006 锚点）；全败 Agent（broken + fallback broken2）invoke 报错且无成功行
+
+**Checkpoint**: quickstart V1/V2/V3 可走通——US1+US2 独立可测
+
+---
+
+## Phase 4: User Story 3 - 监控栈里可见调用健康度 (Priority: P3)
+
+**Goal**: /actuator/prometheus 上五类 oryxos_* 业务指标，与实际行为计数一致、与审计正交
+
+**Independent Test**: quickstart V6——触发调用/拦截/切换后抓端点，指标在位且计数对照一致
+
+- [ ] T012 [US3] 修改 oryxos-cli/pom.xml：加 `io.micrometer:micrometer-core` 编译依赖（运行时 jar 已由 boot actuator 传递带入，注释注明零新增运行时构件）
+- [ ] T013 [US3] 新建 oryxos-cli/src/main/java/io/oryxos/cli/MicrometerMetricsRecorder.java（依赖 T003/T012）：实现五方法落 oryxos_* 指标（目录见 contracts §3）——Counter/Timer 经 MeterRegistry 惰性获取；全部方法 try/catch 吞异常记 DEBUG（FR-010 埋点不伤主链路）；标签值 null 兜底为 "unknown"。配套新建 oryxos-cli/src/test/java/io/oryxos/cli/MicrometerMetricsRecorderTest.java：SimpleMeterRegistry 断言五类指标名/标签/计数，**并注入恒抛异常的 MeterRegistry 断言五方法全部静默不抛**（FR-010 显式断言）
+- [ ] T014 [US3] 修改 oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java（依赖 T007/T003，同文件串行）：构造注入 `MetricsRecorder`（旧构造委托 NOOP 保既有测试）；recordSuccess/recordFailure 旁挂 recordLlmCall（每尝试）、成功侧挂 recordLlmTokens、切换点挂 recordFallbackSwitch
+- [ ] T015 [P] [US3] 修改 oryxos-core/src/main/java/io/oryxos/core/agent/ToolExecutor.java（依赖 T003）：构造注入 `MetricsRecorder`（旧构造委托 NOOP）；审计调用旁挂 recordToolInvocation（成败如实）；策略拒绝点挂 recordPolicyBlock
+- [ ] T016 [US3] 修改 oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java（依赖 T013~T015）：`@Bean MetricsRecorder`——`ObjectProvider<MeterRegistry>` 有则 MicrometerMetricsRecorder、无则 NOOP（chat 命令等无 actuator 上下文兜底）；providerService 与 toolExecutor 装配点注入
+- [ ] T017 [US3] 在 oryxos-boot/src/test/java/io/oryxos/boot/ProviderFallbackE2ETest.java 追加（依赖 T011/T016，同文件串行）：`GET /actuator/prometheus` 抓文本断言——`oryxos_llm_calls_total`（broken/failure 与 mock/success 序列在位且计数与 llm_calls 表行数对照一致，SC-005/SC-006）、`oryxos_fallback_switches_total{from="broken",to="mock"}` ≥1、`oryxos_tool_invocations_total` 与 `oryxos_llm_tokens_total` 在位；配 GLOBAL_DENY 触发拦截 → `oryxos_policy_blocks_total` 递增
+
+**Checkpoint**: 全部故事独立可测
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: 文档与全量验收
+
+- [ ] T018 [P] 文档同步：CLAUDE.md AGENT.md 示例 provider 节补 `fallback` 字段与一句口径；website/zh/docs/api.md 与 website/docs/api.md 补「Provider 失败切换」与「业务指标」小节（对齐 contracts）；docs/CliGuide.md 提及 fallback 声明与 /actuator/prometheus 接入
+- [ ] T019 按 quickstart.md 完整走查 V1~V6（真机 fat JAR：broken provider 指不通端口 + mock 备用；V4 用 python 400 stub）并记录到 specs/023-provider-fallback/acceptance-report.md（SC-001~SC-007 逐项对勾，镜像 018~022 报告形式）
+- [ ] T020 运行 `mvn verify` 全量质量门禁并清零新增告警（CRLF 日志参数一律 sanitize——022 教训前置）
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1（T001~T004）**: T001 ∥ T003 先行；T002 依赖 T001；T004 依赖 T002
+- **Phase 2（US1）**: T005 ∥（T001~T004 后）；T006 随 T005；T007 依赖 T005；T008→T009
+- **Phase 3（US2）**: T010 依赖 T007；T011 依赖 T010
+- **Phase 4（US3）**: T012→T013；T014 依赖 T007（同文件串行）；T015 ∥ T013；T016 依赖 T013~T015；T017 依赖 T011/T016
+- **Phase 5**: 依赖全部故事完成
+
+### 同文件递进链（禁止并行）
+
+- `SpringAiProviderServiceImpl.java`: T007 → T014
+- `ProviderFallbackTest.java`: T008 → T009
+- `ProviderFallbackE2ETest.java`: T010 → T011 → T017
+- `OryxOsRuntime.java`: T016 单点
+
+### Parallel Opportunities
+
+- Phase 1：T001 ∥ T003；T004 收尾
+- Phase 2：T005/T006 与 Phase 1 尾部并行推进；T008 内场景独立
+- Phase 4：T013 ∥ T015（不同模块）
+- Phase 5：T018 与 T019 前半并行
+
+---
+
+## Parallel Example: Phase 1
+
+```bash
+Task: "T001 ProviderRef.fallbacks 组件"   ∥   Task: "T003 MetricsRecorder 契约"
+# 然后：T002 ProfileLoader 解析 → T004 解析单测
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First（US1 Only）
+
+1. Phase 1（T001~T004）：声明与契约就位
+2. Phase 2（T005~T009）：切换循环 + 分类器 + 单测闭环
+3. **STOP and VALIDATE**: 单测层主败备成/全败/边界全绿即可演示
+4. US2（E2E 留痕）/US3（指标）依次叠加，各自 checkpoint 独立验收
+
+### 注意
+
+- **attempt 参数化是本刀最大陷阱**（R2）：registry 查找/buildPrompt model/审计参数三处必须全部按 attempt 贯穿——漏一处就是"拿主模型名调备 Provider"或"审计失真"
+- **契约零改动红线**：ProviderService/ReActLoop/审计接口不动；MetricsRecorder 与 ToolExecutor/ProviderServiceImpl 的旧构造委托 NOOP 保全既有测试（019~022 教训制度化）
+- **流中已出内容绝不切换**（FR-007）：判定条件与既有降级判定同源（text/toolCalls 累计），不另造状态
+- **指标埋点吞异常**：任何 MeterRegistry 故障不得影响调用主链路（FR-010）
+- 每完成一个 Phase 提交一次（scope 按主要触点：core/provider/cli）

--- a/specs/023-provider-fallback/tasks.md
+++ b/specs/023-provider-fallback/tasks.md
@@ -89,7 +89,7 @@ Maven 多模块单体，涉及 oryxos-core / oryxos-provider / oryxos-cli / oryx
 
 **Purpose**: 文档与全量验收
 
-- [ ] T018 [P] 文档同步：CLAUDE.md AGENT.md 示例 provider 节补 `fallback` 字段与一句口径；website/zh/docs/api.md 与 website/docs/api.md 补「Provider 失败切换」与「业务指标」小节（对齐 contracts）；docs/CliGuide.md 提及 fallback 声明与 /actuator/prometheus 接入
+- [X] T018 [P] 文档同步：CLAUDE.md AGENT.md 示例 provider 节补 `fallback` 字段与一句口径；website/zh/docs/api.md 与 website/docs/api.md 补「Provider 失败切换」与「业务指标」小节（对齐 contracts）；docs/CliGuide.md 提及 fallback 声明与 /actuator/prometheus 接入
 - [ ] T019 按 quickstart.md 完整走查 V1~V6（真机 fat JAR：broken provider 指不通端口 + mock 备用；V4 用 python 400 stub）并记录到 specs/023-provider-fallback/acceptance-report.md（SC-001~SC-007 逐项对勾，镜像 018~022 报告形式）
 - [ ] T020 运行 `mvn verify` 全量质量门禁并清零新增告警（CRLF 日志参数一律 sanitize——022 教训前置）
 

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -812,6 +812,14 @@ On the timeline, a TOOL step's `inputSummary`/`resultSummary`/`errorMessage` are
 
 ---
 
+## Provider fallback & business metrics
+
+**Fallback (023)**: the `provider` section of `AGENT.md` accepts an ordered fallback list — when a single LLM call hits a provider-side failure (network/timeout/5xx/429/401/403), the call retries the same request through the fallback chain in declared order; only when all candidates fail is the last error thrown. Business-level failures (400-class) never switch. Switching is scoped to a single LLM call (ReAct iteration semantics unchanged; every call starts from the primary — no cross-request health memory); streaming calls may switch only before the first content fragment is emitted. Every attempt writes its own `llm_calls` row (primary and fallback both audited, same trace), and each switch logs a WARN (from→to, with traceId). Zero declarations = zero behavior change.
+
+**Business metrics (023)**: `GET /actuator/prometheus` (existing endpoint) gains `oryxos_`-prefixed metrics for enterprise monitoring stacks — `oryxos_llm_calls_total{provider,model,outcome}` (same cardinality as `llm_calls` rows), `oryxos_llm_call_duration_seconds`, `oryxos_llm_tokens_total{type}`, `oryxos_tool_invocations_total{tool,outcome}`, `oryxos_policy_blocks_total{tool}`, `oryxos_fallback_switches_total{from,to}`. Metrics serve aggregation and alerting; the audit tables remain the source of precise replay (orthogonal — metrics never change audit semantics). Absent or zero series simply mean the event has not occurred.
+
+---
+
 ## Workspace file browser
 
 A read-only directory tree plus per-file read/write over the workspace (`agents/` and `archive/`). All paths are relative to the workspace root; a path that escapes the root (path traversal) returns `400`.

--- a/website/zh/docs/api.md
+++ b/website/zh/docs/api.md
@@ -827,6 +827,23 @@ Sandbox 白名单分三类——`FILE`（允许路径）、`SHELL`（允许命�
 
 ---
 
+## Provider 失败切换与业务指标
+
+**失败切换（023）**：`AGENT.md` 的 provider 节可声明有序备用列表——单次 LLM 调用发生 provider 侧故障（网络/超时/5xx/429/401/403）时按序切换备用重发同一请求，候选耗尽才以最后错误上抛；业务性失败（400 类）不切换。切换语义限定在「单次调用」层面（ReAct 轮次口径不变，每次调用独立从主开始）；流式调用仅在首个内容片段送出前可切换。每次尝试各写一条 `llm_calls`（主备留痕、trace 同链可回放），切换记 WARN 日志（from→to，带 traceId）。零声明 = 现状行为零变化。
+
+```yaml
+provider:
+  name: deepseek
+  model: deepseek-chat
+  fallback:
+    - name: qwen
+      model: qwen-plus
+```
+
+**业务指标（023）**：`GET /actuator/prometheus`（既有端点）新增 `oryxos_` 前缀业务指标，供企业监控栈聚合与告警——`oryxos_llm_calls_total{provider,model,outcome}`（与 llm_calls 行数同口径）、`oryxos_llm_call_duration_seconds`、`oryxos_llm_tokens_total{type}`、`oryxos_tool_invocations_total{tool,outcome}`、`oryxos_policy_blocks_total{tool}`、`oryxos_fallback_switches_total{from,to}`。指标供监控聚合、审计供精确回放（正交，指标不改变审计落库口径）；未发生对应事件时指标缺席或为零均为正常形态。
+
+---
+
 ## 工作区文件浏览
 
 工作区（`agents/` 与 `archive/`）的只读目录树，加上按文件读 / 写。所有路径相对工作区根目录；越界路径（路径穿越）返回 `400`。


### PR DESCRIPTION
## 概述

v0.3 收官刀（023-provider-fallback）：LLM Provider 单点故障不再打断 Agent 服务——`AGENT.md` provider 节声明有序 fallback 列表，单次调用的 provider 侧故障按序切换备用重发，用户无感知且全程留痕可回放；同时补齐 v0.3 看板最后一角：`/actuator/prometheus` 上的 `oryxos_*` 业务指标。零新表、零新模块、零运行时新构件。

## 核心设计

- **切换收口在 Provider 实现**：ProviderService 契约与 ReActLoop 零改动（021 trace/022 加密同一手法第三次运用）；attempt(name, model) 贯穿路由/Prompt/审计三处——备用调用用备用模型名、审计如实
- **FallbackClassifier 分类表**：网络/超时/5xx/429/401/403/408 切，400 类业务性失败不切，未知宁多试一次；含 Spring AI 异常包装形态（message 前缀状态码）的解析——真机走查暴露的误切 bug 已修并钉入单测
- **R8 实施期裁决**：收敛 OpenAiChatModel 内建 RetryTemplate（10 次指数退避至 180s）为单次尝试——重试语义单层归 fallback；全败返回 29ms（真机实测），挂死端点不再卡同步会话数分钟。零声明 Agent 失去隐形网络重试的行为差异已在 research R8 与验收报告如实声明
- **流式边界**：以「内容真实送达客户端」为界——首片段前失败可切换（无感知），已流出不切换（避免重复输出）
- **留痕承诺**：每次尝试各一条 llm_calls（主败备成=成对留痕、同 trace 时间线可回放）、切换 WARN 带 traceId
- **业务指标**：MetricsRecorder 契约进 core（NOOP 锚点惯例第三例）、Micrometer 实现在装配层；六个 oryxos_* 指标（LLM 调用/耗时/token/工具/策略拦截/切换），埋点吞异常不伤主链路，指标计数与审计行数同口径
- **UI 顺带改进**（维护者走查意见）：管理台「报表」页更名「审计」；明细行/执行历史 trace ID 完整展示可复制

## 测试与验收

- `mvn verify` 全量门禁 BUILD SUCCESS；新增 28 例：FallbackClassifierTest 6（分类表+真机形态）、ProviderFallbackTest 9（主败备成/全败/不可切/候选跳过/零声明回归/流式双边界/无健康记忆/审计成对）、MicrometerMetricsRecorderTest 5（含恒抛 registry 静默断言）、ProfileLoaderTest +4、E2E 4（含 prometheus 指标对照与 MDC 切换日志断言）
- 契约零改动 + 旧构造 NOOP 委托保全既有测试；全模块回归零失败
- 真机走查 V1~V6 全过（broken 指不通端口 + 400 stub + mock 备用），落卷 specs/023-provider-fallback/acceptance-report.md

## 文档

- CLAUDE.md AGENT.md 示例补 fallback；中英 API 文档「Provider 失败切换与业务指标」节；CliGuide 4.10
- 不做项（roadmap 既定）：智能路由（本刀的指标+审计正是其未来数据来源）、断路器、跨请求健康记忆

## v0.3 治理面至此收官

020 Tool Policy ✓ / 021 trace+脱敏 ✓ / 016 审计看板 ✓ / 022 密钥加密 ✓ / 023 fallback+指标 ✓