### PR TITLE
feat(channel-feishu): resolve inbound image_key via message resource download

### DIFF
--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
@@ -44,6 +44,7 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
   private static final String BOT_INFO_PATH = "/open-apis/bot/v3/info";
   private static final String BOT_OPEN_ID_FIELD = "open_id";
   private static final String MEDIA_DIR_PREFIX = "oryxos-feishu-media-";
+  private static final String MEDIA_FALLBACK_DIR = "oryxos-feishu-media";
   private static final int HTTP_OK = 200;
   private static final long READY_TIMEOUT_MS = 15_000;
   private static final long READY_PROBE_TIMEOUT_MS = 50;
@@ -212,15 +213,19 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
 
   /** 入站图片落盘目录：进程临时目录下按渠道隔离；失败不阻断 start（解析器会降级保留 image_key）。 */
   private Path createMediaRoot() {
+    String channelSeg = FeishuInboundImageResolver.safeSegment(config.name());
     try {
-      return Files.createTempDirectory(MEDIA_DIR_PREFIX + sanitize(config.name()) + "-");
+      // 前缀必须是常量字面量：SpotBugs 视 createTempDirectory(userInput+…) 为 PATH_TRAVERSAL_IN
+      Path root = Files.createTempDirectory(MEDIA_DIR_PREFIX);
+      Path channelDir = root.resolve(channelSeg);
+      Files.createDirectories(channelDir);
+      return channelDir;
     } catch (Exception e) {
       LOG.warn(
           "飞书渠道 {} 创建图片缓存目录失败（{}），入站图片将保留 image_key",
           sanitize(config.name()),
           sanitize(e.getMessage()));
-      return Path.of(
-          System.getProperty("java.io.tmpdir"), "oryxos-feishu-media", sanitize(config.name()));
+      return Path.of(System.getProperty("java.io.tmpdir"), MEDIA_FALLBACK_DIR, channelSeg);
     }
   }
 

--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
@@ -16,6 +16,8 @@ import io.oryxos.core.channel.InboundMessageService;
 import io.oryxos.core.channel.OutboundGuard;
 import io.oryxos.core.profile.ProfileRegistry;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +34,7 @@ import org.slf4j.LoggerFactory;
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
     justification =
-        "apiClient/normalizer/sender 在 start() 内初始化（长连接生命周期晚于构造）；事件回调只会在 start 成功后由 SDK 触发，sendReply 有显式空判，不存在未初始化解引用路径。")
+        "apiClient/normalizer/sender/imageResolver 在 start() 内初始化（长连接生命周期晚于构造）；事件回调只会在 start 成功后由 SDK 触发，sendReply 有显式空判，不存在未初始化解引用路径。")
 public class FeishuChannelAdapter implements InboundChannelAdapter {
 
   private static final Logger LOG = LoggerFactory.getLogger(FeishuChannelAdapter.class);
@@ -41,6 +43,7 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
   private static final String API_BASE_URL = "https://open.feishu.cn";
   private static final String BOT_INFO_PATH = "/open-apis/bot/v3/info";
   private static final String BOT_OPEN_ID_FIELD = "open_id";
+  private static final String MEDIA_DIR_PREFIX = "oryxos-feishu-media-";
   private static final int HTTP_OK = 200;
   private static final long READY_TIMEOUT_MS = 15_000;
   private static final long READY_PROBE_TIMEOUT_MS = 50;
@@ -54,6 +57,7 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
   private volatile com.lark.oapi.ws.Client wsClient;
   private volatile FeishuMessageSender sender;
   private volatile FeishuEventNormalizer normalizer;
+  private volatile FeishuInboundImageResolver imageResolver;
   private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
   private volatile String lastError;
 
@@ -101,6 +105,7 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
           new FeishuMessageSender(
               apiClient, guard, API_BASE_URL, FeishuMessageSender.DEFAULT_CHUNK_SIZE);
       normalizer = new FeishuEventNormalizer(config.name(), fetchBotOpenId());
+      imageResolver = new FeishuInboundImageResolver(apiClient, createMediaRoot(), config.name());
       EventDispatcher dispatcher =
           EventDispatcher.newBuilder("", "") // 长连接免验签：verificationToken/encryptKey 必须空串
               .onP2MessageReceiveV1(
@@ -190,13 +195,32 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
     active.send(chatId, text, replyToMessageId);
   }
 
-  /** 事件入口：归一化 → 编排；任何异常只留日志——抛出会触发平台重推循环（去重会拦但用户收不到回答）。 */
+  /** 事件入口：归一化 → 图片资源落地 → 编排；任何异常只留日志——抛出会触发平台重推循环（去重会拦但用户收不到回答）。 */
   private void handleEvent(P2MessageReceiveV1 event) {
     try {
       Optional<InboundMessage> msg = normalizer.normalize(event);
-      msg.ifPresent(m -> inboundMessageService.onMessage(m, this));
+      msg.ifPresent(
+          m -> {
+            FeishuInboundImageResolver resolver = imageResolver;
+            InboundMessage enriched = resolver == null ? m : resolver.resolve(m);
+            inboundMessageService.onMessage(enriched, this);
+          });
     } catch (RuntimeException e) {
       LOG.error("飞书渠道 {} 事件处理异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
+    }
+  }
+
+  /** 入站图片落盘目录：进程临时目录下按渠道隔离；失败不阻断 start（解析器会降级保留 image_key）。 */
+  private Path createMediaRoot() {
+    try {
+      return Files.createTempDirectory(MEDIA_DIR_PREFIX + sanitize(config.name()) + "-");
+    } catch (Exception e) {
+      LOG.warn(
+          "飞书渠道 {} 创建图片缓存目录失败（{}），入站图片将保留 image_key",
+          sanitize(config.name()),
+          sanitize(e.getMessage()));
+      return Path.of(
+          System.getProperty("java.io.tmpdir"), "oryxos-feishu-media", sanitize(config.name()));
     }
   }
 

--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuInboundImageResolver.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuInboundImageResolver.java
@@ -1,0 +1,161 @@
+package io.oryxos.channel.feishu;
+
+import com.lark.oapi.Client;
+import com.lark.oapi.service.im.v1.model.GetMessageResourceReq;
+import com.lark.oapi.service.im.v1.model.GetMessageResourceResp;
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMessage;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 飞书入站图片：官方无公开临时 URL，须用 message_id + image_key 调「获取消息中的资源文件」下载二进制。成功后把本地绝对路径写入 {@link
+ * InboundAttachment#url()}，enricher 即可与企微一样输出「图片链接」。
+ *
+ * <p>下载失败时保留原 {@code image_key} 引用（降级，不阻断编排）。
+ */
+final class FeishuInboundImageResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FeishuInboundImageResolver.class);
+
+  private static final String RESOURCE_TYPE_IMAGE = "image";
+  private static final int MAX_SEGMENT_LEN = 96;
+
+  private final Client client;
+  private final Path mediaRoot;
+  private final String channelName;
+
+  FeishuInboundImageResolver(Client client, Path mediaRoot, String channelName) {
+    this.client = client;
+    this.mediaRoot = mediaRoot;
+    this.channelName = channelName;
+  }
+
+  InboundMessage resolve(InboundMessage message) {
+    if (message.attachments().isEmpty()) {
+      return message;
+    }
+    List<InboundAttachment> resolved = new ArrayList<>(message.attachments().size());
+    boolean changed = false;
+    for (InboundAttachment attachment : message.attachments()) {
+      if (!needsDownload(attachment)) {
+        resolved.add(attachment);
+        continue;
+      }
+      InboundAttachment next = downloadOrKeep(message.messageId(), attachment);
+      changed |= next != attachment;
+      resolved.add(next);
+    }
+    if (!changed) {
+      return message;
+    }
+    return new InboundMessage(
+        message.channelType(),
+        message.channelName(),
+        message.messageId(),
+        message.chatKind(),
+        message.userId(),
+        message.chatId(),
+        message.content(),
+        message.textual(),
+        message.mentionedBot(),
+        resolved);
+  }
+
+  private static boolean needsDownload(InboundAttachment attachment) {
+    return InboundAttachment.TYPE_IMAGE.equals(attachment.type())
+        && (attachment.url() == null || attachment.url().isBlank())
+        && attachment.reference() != null
+        && !attachment.reference().isBlank();
+  }
+
+  private InboundAttachment downloadOrKeep(String messageId, InboundAttachment attachment) {
+    String imageKey = attachment.reference();
+    try {
+      GetMessageResourceResp resp =
+          client
+              .im()
+              .messageResource()
+              .get(
+                  GetMessageResourceReq.newBuilder()
+                      .messageId(messageId)
+                      .fileKey(imageKey)
+                      .type(RESOURCE_TYPE_IMAGE)
+                      .build());
+      if (resp == null || !resp.success() || resp.getData() == null) {
+        LOG.warn(
+            "飞书渠道 {} 下载图片失败（messageId={}, imageKey={}, code={}, msg={}），保留 image_key",
+            sanitize(channelName),
+            sanitize(messageId),
+            sanitize(imageKey),
+            resp == null ? -1 : resp.getCode(),
+            sanitize(resp == null ? null : resp.getMsg()));
+        return attachment;
+      }
+      Path file = writeToMediaRoot(messageId, imageKey, resp);
+      return new InboundAttachment(
+          InboundAttachment.TYPE_IMAGE, file.toAbsolutePath().toString(), imageKey);
+    } catch (Exception e) {
+      LOG.warn(
+          "飞书渠道 {} 下载图片异常（messageId={}, imageKey={}）：{}，保留 image_key",
+          sanitize(channelName),
+          sanitize(messageId),
+          sanitize(imageKey),
+          sanitize(e.getMessage()));
+      return attachment;
+    }
+  }
+
+  private Path writeToMediaRoot(String messageId, String imageKey, GetMessageResourceResp resp)
+      throws IOException {
+    String fileName = resp.getFileName();
+    String ext = extensionOf(fileName);
+    Path dir = mediaRoot.resolve(safeSegment(messageId));
+    Files.createDirectories(dir);
+    Path target = dir.resolve(safeSegment(imageKey) + ext);
+    try (OutputStream out = Files.newOutputStream(target)) {
+      resp.getData().writeTo(out);
+    }
+    return target;
+  }
+
+  private static String extensionOf(String fileName) {
+    if (fileName == null || fileName.isBlank()) {
+      return ".bin";
+    }
+    int dot = fileName.lastIndexOf('.');
+    if (dot < 0 || dot == fileName.length() - 1) {
+      return ".bin";
+    }
+    String ext = fileName.substring(dot).toLowerCase(Locale.ROOT);
+    if (!ext.matches("\\.[a-z0-9]{1,8}")) {
+      return ".bin";
+    }
+    return ext;
+  }
+
+  static String safeSegment(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return "x";
+    }
+    String cleaned = raw.replaceAll("[^a-zA-Z0-9._-]", "_");
+    if (cleaned.length() > MAX_SEGMENT_LEN) {
+      cleaned = cleaned.substring(0, MAX_SEGMENT_LEN);
+    }
+    if (cleaned.isBlank() || cleaned.chars().allMatch(ch -> ch == '_')) {
+      return "x";
+    }
+    return cleaned;
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuInboundImageResolver.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuInboundImageResolver.java
@@ -26,6 +26,10 @@ final class FeishuInboundImageResolver {
   private static final Logger LOG = LoggerFactory.getLogger(FeishuInboundImageResolver.class);
 
   private static final String RESOURCE_TYPE_IMAGE = "image";
+  private static final String DEFAULT_EXTENSION = ".bin";
+  private static final String FALLBACK_SEGMENT = "x";
+  private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
+  private static final char PATH_SAFE_REPLACEMENT = '_';
   private static final int MAX_SEGMENT_LEN = 96;
 
   private final Client client;
@@ -128,34 +132,36 @@ final class FeishuInboundImageResolver {
 
   private static String extensionOf(String fileName) {
     if (fileName == null || fileName.isBlank()) {
-      return ".bin";
+      return DEFAULT_EXTENSION;
     }
     int dot = fileName.lastIndexOf('.');
     if (dot < 0 || dot == fileName.length() - 1) {
-      return ".bin";
+      return DEFAULT_EXTENSION;
     }
     String ext = fileName.substring(dot).toLowerCase(Locale.ROOT);
-    if (!ext.matches("\\.[a-z0-9]{1,8}")) {
-      return ".bin";
+    if (!ext.matches(SAFE_EXTENSION_PATTERN)) {
+      return DEFAULT_EXTENSION;
     }
     return ext;
   }
 
   static String safeSegment(String raw) {
     if (raw == null || raw.isBlank()) {
-      return "x";
+      return FALLBACK_SEGMENT;
     }
-    String cleaned = raw.replaceAll("[^a-zA-Z0-9._-]", "_");
+    String cleaned = raw.replaceAll("[^a-zA-Z0-9._-]", String.valueOf(PATH_SAFE_REPLACEMENT));
     if (cleaned.length() > MAX_SEGMENT_LEN) {
       cleaned = cleaned.substring(0, MAX_SEGMENT_LEN);
     }
-    if (cleaned.isBlank() || cleaned.chars().allMatch(ch -> ch == '_')) {
-      return "x";
+    if (cleaned.isBlank() || cleaned.chars().allMatch(ch -> ch == PATH_SAFE_REPLACEMENT)) {
+      return FALLBACK_SEGMENT;
     }
     return cleaned;
   }
 
   private static String sanitize(String value) {
-    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+    return value == null
+        ? ""
+        : value.replace('\r', PATH_SAFE_REPLACEMENT).replace('\n', PATH_SAFE_REPLACEMENT);
   }
 }

--- a/oryxos-channel-feishu/src/test/java/io/oryxos/channel/feishu/FeishuInboundImageResolverTest.java
+++ b/oryxos-channel-feishu/src/test/java/io/oryxos/channel/feishu/FeishuInboundImageResolverTest.java
@@ -1,0 +1,104 @@
+package io.oryxos.channel.feishu;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.lark.oapi.Client;
+import com.lark.oapi.service.im.v1.model.GetMessageResourceResp;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMessage;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FeishuInboundImageResolverTest {
+
+  @TempDir Path mediaRoot;
+
+  @Test
+  @DisplayName("image_key 下载成功 → attachment.url 为本地绝对路径，保留 reference")
+  void downloadsImageKeyToLocalPath() throws Exception {
+    Client client = mock(Client.class, RETURNS_DEEP_STUBS);
+    GetMessageResourceResp resp = new GetMessageResourceResp();
+    resp.setCode(0);
+    resp.setMsg("ok");
+    resp.setFileName("shot.png");
+    ByteArrayOutputStream data = new ByteArrayOutputStream();
+    data.write("PNGDATA".getBytes(StandardCharsets.UTF_8));
+    resp.setData(data);
+    when(client.im().messageResource().get(any())).thenReturn(resp);
+
+    FeishuInboundImageResolver resolver =
+        new FeishuInboundImageResolver(client, mediaRoot, "ops-feishu");
+    InboundMessage input =
+        new InboundMessage(
+            "feishu",
+            "ops-feishu",
+            "om_msg_1",
+            ChatKind.P2P,
+            "ou_user",
+            "oc_chat",
+            "",
+            false,
+            false,
+            List.of(InboundAttachment.imageReference("img_v3_abc")));
+
+    InboundMessage out = resolver.resolve(input);
+
+    assertEquals(1, out.attachments().size());
+    InboundAttachment att = out.attachments().get(0);
+    assertEquals("img_v3_abc", att.reference());
+    assertTrue(att.url() != null && !att.url().isBlank());
+    assertTrue(Files.isRegularFile(Path.of(att.url())), att.url());
+    assertEquals("PNGDATA", Files.readString(Path.of(att.url())));
+    assertTrue(att.url().endsWith(".png") || att.url().endsWith(".PNG"), att.url());
+  }
+
+  @Test
+  @DisplayName("下载失败时保留原 image_key，不抛异常")
+  void downloadFailureKeepsReference() throws Exception {
+    Client client = mock(Client.class, RETURNS_DEEP_STUBS);
+    GetMessageResourceResp resp = new GetMessageResourceResp();
+    resp.setCode(234003);
+    resp.setMsg("File not in message");
+    when(client.im().messageResource().get(any())).thenReturn(resp);
+
+    FeishuInboundImageResolver resolver =
+        new FeishuInboundImageResolver(client, mediaRoot, "ops-feishu");
+    InboundMessage input =
+        new InboundMessage(
+            "feishu",
+            "ops-feishu",
+            "om_msg_2",
+            ChatKind.P2P,
+            "ou_user",
+            "oc_chat",
+            "",
+            false,
+            false,
+            List.of(InboundAttachment.imageReference("img_missing")));
+
+    InboundMessage out = resolver.resolve(input);
+    assertEquals("img_missing", out.attachments().get(0).reference());
+    assertTrue(out.attachments().get(0).url() == null || out.attachments().get(0).url().isBlank());
+  }
+
+  @Test
+  @DisplayName("路径段消毒：去掉路径分隔与非法字符")
+  void safeSegmentStripsPathTraversal() {
+    assertNotEquals("../evil", FeishuInboundImageResolver.safeSegment("../evil"));
+    assertTrue(FeishuInboundImageResolver.safeSegment("img/../x").contains("_"));
+    assertEquals("x", FeishuInboundImageResolver.safeSegment("???"));
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundAttachment.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundAttachment.java
@@ -4,8 +4,8 @@ package io.oryxos.core.channel;
  * 入站媒体附件（图片等），由渠道 normalizer 从平台事件提取。
  *
  * @param type 媒体类型，见 {@link #TYPE_IMAGE}
- * @param url 可直接访问的 URL（企微/钉钉图片）；飞书可能为空
- * @param reference 平台资源标识（如飞书 {@code image_key}），供后续解析
+ * @param url 可直接访问的路径或 URL（企微 COS / 飞书下载落地后的本地绝对路径）；可能为空
+ * @param reference 平台资源标识（如飞书 {@code image_key}），供下载或降级展示
  */
 public record InboundAttachment(String type, String url, String reference) {
 


### PR DESCRIPTION
Closes #381

## Summary

- Feishu IM images have no public temp URL; resolve `image_key` via official message-resource download
- Persist to a channel media cache and set `InboundAttachment.url` to the local absolute path (keep `image_key` as `reference`)
- Enricher then shows `图片链接:` like WeCom; download failures soft-fallback to `image_key`

## Test plan

- [x] `FeishuInboundImageResolverTest` (success / failure / path sanitization)
- [x] Existing `FeishuEventNormalizerTest`
- [ ] Optional real device: private-chat image → session `图片链接:` with local path
