### PR TITLE
feat(sandbox): 024 Phase1+2——执行后端契约与纯函数组件（T001~T008）

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/agent/ToolInvocationAuditor.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/ToolInvocationAuditor.java
@@ -34,4 +34,33 @@ public interface ToolInvocationAuditor {
     record(
         sessionId, profileName, toolName, inputJson, resultJson, success, errorMessage, durationMs);
   }
+
+  /**
+   * 带执行后端标识的写入（024）：{@code executionBackend} 记录执行位置（"local"/"docker"）， {@code containerId} 记录
+   * docker 档容器 ID（local 档 null）——供审计按后端筛选与容器溯源（FR-008）。
+   * 默认实现丢弃后端信息委托上一级签名（旧实现/测试桩零破坏）；要落列的实现方（JPA）须覆写本方法。
+   */
+  default void record(
+      String sessionId,
+      String profileName,
+      String toolName,
+      String inputJson,
+      String resultJson,
+      boolean success,
+      String errorMessage,
+      String blockedBy,
+      String executionBackend,
+      String containerId,
+      long durationMs) {
+    record(
+        sessionId,
+        profileName,
+        toolName,
+        inputJson,
+        resultJson,
+        success,
+        errorMessage,
+        blockedBy,
+        durationMs);
+  }
 }

--- a/oryxos-storage/src/main/java/io/oryxos/storage/AuditSchemaUpgrade.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/AuditSchemaUpgrade.java
@@ -23,6 +23,8 @@ public final class AuditSchemaUpgrade {
   private static final String PROFILE_NAME_COLUMN = "profile_name";
   private static final String BLOCKED_BY_COLUMN = "blocked_by";
   private static final String TRACE_ID_COLUMN = "trace_id";
+  private static final String EXECUTION_BACKEND_COLUMN = "execution_backend";
+  private static final String CONTAINER_ID_COLUMN = "container_id";
 
   /** 021：trace_id 落到审计三表（llm_calls / tool_invocations / agent_executions）。 */
   private static final String[] TRACE_TABLES = {
@@ -79,6 +81,14 @@ public final class AuditSchemaUpgrade {
     if (!columns.contains(BLOCKED_BY_COLUMN)) {
       execute(connection, "ALTER TABLE tool_invocations ADD COLUMN blocked_by VARCHAR(16)");
       log.info("tool_invocations 已补 blocked_by 列（020 策略拒绝标记）");
+    }
+    if (!columns.contains(EXECUTION_BACKEND_COLUMN)) {
+      execute(connection, "ALTER TABLE tool_invocations ADD COLUMN execution_backend VARCHAR(8)");
+      log.info("tool_invocations 已补 execution_backend 列（024 执行后端标识）");
+    }
+    if (!columns.contains(CONTAINER_ID_COLUMN)) {
+      execute(connection, "ALTER TABLE tool_invocations ADD COLUMN container_id VARCHAR(64)");
+      log.info("tool_invocations 已补 container_id 列（024 容器执行溯源）");
     }
   }
 

--- a/oryxos-storage/src/main/java/io/oryxos/storage/JpaToolInvocationAuditor.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/JpaToolInvocationAuditor.java
@@ -53,6 +53,37 @@ public class JpaToolInvocationAuditor implements ToolInvocationAuditor {
       String errorMessage,
       String blockedBy,
       long durationMs) {
+    record(
+        sessionId,
+        profileName,
+        toolName,
+        inputJson,
+        resultJson,
+        success,
+        errorMessage,
+        blockedBy,
+        null,
+        null,
+        durationMs);
+  }
+
+  /**
+   * 真实写入（024 起为最下层实现）：executionBackend 缺省归一化为 {@code "local"}——FR-008「新调用恒写值」： 旧签名路径写
+   * local（语义本就为真），历史行保持 NULL（≡ local，D4 查询层兼容）。
+   */
+  @Override
+  public void record(
+      String sessionId,
+      String profileName,
+      String toolName,
+      String inputJson,
+      String resultJson,
+      boolean success,
+      String errorMessage,
+      String blockedBy,
+      String executionBackend,
+      String containerId,
+      long durationMs) {
     try {
       ToolInvocation record = new ToolInvocation();
       record.setSessionId(sessionId);
@@ -63,6 +94,8 @@ public class JpaToolInvocationAuditor implements ToolInvocationAuditor {
       record.setSuccess(success);
       record.setErrorMessage(errorMessage);
       record.setBlockedBy(blockedBy);
+      record.setExecutionBackend(executionBackend == null ? "local" : executionBackend);
+      record.setContainerId(containerId);
       // 021：trace 走环境读取而非参数传递——Auditor 接口零改动（R2 红线），未开启上下文时为 null
       record.setTraceId(TraceContext.current());
       record.setDurationMs(durationMs);

--- a/oryxos-storage/src/main/java/io/oryxos/storage/ToolInvocation.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/ToolInvocation.java
@@ -47,6 +47,14 @@ public class ToolInvocation {
   @Column(name = "blocked_by")
   private String blockedBy;
 
+  /** 执行后端标识（024）：'local' / 'docker'；历史行为 null（≡ local，查询层兼容，D4）。 */
+  @Column(name = "execution_backend")
+  private String executionBackend;
+
+  /** docker 档容器 ID（024，容器执行溯源）；local 档与历史行为为 null。 */
+  @Column(name = "container_id")
+  private String containerId;
+
   @Column(name = "duration_ms", nullable = false)
   private long durationMs;
 
@@ -138,6 +146,22 @@ public class ToolInvocation {
 
   public void setBlockedBy(String blockedBy) {
     this.blockedBy = blockedBy;
+  }
+
+  public String getExecutionBackend() {
+    return executionBackend;
+  }
+
+  public void setExecutionBackend(String executionBackend) {
+    this.executionBackend = executionBackend;
+  }
+
+  public String getContainerId() {
+    return containerId;
+  }
+
+  public void setContainerId(String containerId) {
+    this.containerId = containerId;
   }
 
   public String getTraceId() {

--- a/oryxos-storage/src/main/resources/schema.sql
+++ b/oryxos-storage/src/main/resources/schema.sql
@@ -32,11 +32,14 @@ CREATE TABLE IF NOT EXISTS tool_invocations (
     success BOOLEAN NOT NULL,
     error_message TEXT,
     blocked_by VARCHAR(16),
+    execution_backend VARCHAR(8),
+    container_id VARCHAR(64),
     duration_ms INTEGER NOT NULL,
     created_at TIMESTAMP NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_tool_invocations_session ON tool_invocations (session_id);
 -- idx_tool_invocations_profile (profile_name) / idx_tool_invocations_trace (trace_id) 由 AuditSchemaUpgrade 创建（同上）。
+-- execution_backend / container_id（024 容器级执行隔离）：local 档恒写 backend、docker 档另记容器 ID；历史行 NULL ≡ local（查询层兼容）。
 
 -- sessions：会话元数据 + JSON 序列化的对话历史（18 节）
 -- session_id 由 SessionManager 按 channel:user:profile 唯一拼接（全库唯一拼接点，H4④）

--- a/oryxos-storage/src/test/java/io/oryxos/storage/AuditSchemaUpgradeTest.java
+++ b/oryxos-storage/src/test/java/io/oryxos/storage/AuditSchemaUpgradeTest.java
@@ -33,7 +33,7 @@ class AuditSchemaUpgradeTest {
       assertThat(columns(connection, "llm_calls"))
           .contains("cost_micros", "profile_name", "trace_id");
       assertThat(columns(connection, "tool_invocations"))
-          .contains("profile_name", "blocked_by", "trace_id");
+          .contains("profile_name", "blocked_by", "trace_id", "execution_backend", "container_id");
       assertThat(columns(connection, "agent_executions")).contains("trace_id");
     }
     assertThat(indexNames(dataSource, "llm_calls"))

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/ShellTools.java
@@ -1,6 +1,8 @@
 package io.oryxos.tool.builtin;
 
 import io.oryxos.tool.sandbox.ActionType;
+import io.oryxos.tool.sandbox.LocalProcessStarter;
+import io.oryxos.tool.sandbox.ProcessStarter;
 import io.oryxos.tool.sandbox.Sandbox;
 import io.oryxos.tool.sandbox.SandboxAction;
 import java.io.IOException;
@@ -47,7 +49,7 @@ public class ShellTools {
   }
 
   ShellTools(Sandbox sandbox, Duration timeout) {
-    this(sandbox, timeout, ShellTools::startProcess, Charset.defaultCharset());
+    this(sandbox, timeout, new LocalProcessStarter(), Charset.defaultCharset());
   }
 
   ShellTools(Sandbox sandbox, Duration timeout, ProcessStarter processStarter) {
@@ -104,17 +106,6 @@ public class ShellTools {
     }
   }
 
-  /**
-   * 默认 ProcessStarter：命名方法而非 lambda，让 SuppressFBWarnings 能落在告警位置上（lambda 编译成 synthetic
-   * 方法，构造器上的注解盖不住）。
-   */
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "COMMAND_INJECTION",
-      justification = "以 argv 直接执行、不经 shell 解释；可执行文件在 shell() 启动前经 Sandbox 精确白名单校验")
-  private static Process startProcess(List<String> command) throws IOException {
-    return new ProcessBuilder(command).start();
-  }
-
   private static String requireExecutable(String executable) {
     if (executable == null || executable.isBlank()) {
       throw new IllegalArgumentException("可执行文件不能为空");
@@ -134,11 +125,6 @@ public class ShellTools {
       }
     }
     return List.copyOf(command);
-  }
-
-  @FunctionalInterface
-  interface ProcessStarter {
-    Process start(List<String> command) throws IOException;
   }
 
   /** 先递归杀命令派生的子孙进程，再杀命令本身（只 destroyForcibly 主进程会留孤儿继续执行）。 */

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/CidfileProcessWrapper.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/CidfileProcessWrapper.java
@@ -22,6 +22,9 @@ import org.slf4j.LoggerFactory;
 public final class CidfileProcessWrapper extends Process {
   private static final Logger LOG = LoggerFactory.getLogger(CidfileProcessWrapper.class);
 
+  /** docker kill 子进程的等待上限（秒）——超时强杀 kill 进程并报错。 */
+  private static final int KILL_TIMEOUT_SECONDS = 5;
+
   /** 容器终止执行器：生产实现跑 {@code docker kill <id>}，单测注入记录桩。 */
   @FunctionalInterface
   public interface ContainerKiller {
@@ -38,12 +41,26 @@ public final class CidfileProcessWrapper extends Process {
     this.killer = Objects.requireNonNull(killer, "killer 不能为空");
   }
 
-  /** 生产用 killer：起 {@code docker kill} 子进程并短暂等待（退出码忽略——容器已不存在也算达成）。 */
+  /**
+   * 生产用 killer：起 {@code docker kill} 子进程并短暂等待（退出码忽略——容器已不存在也算达成）。 命名类而非 lambda：lambda 编译成 synthetic
+   * 方法，方法上的注解盖不住 SpotBugs 告警 （ShellTools.startProcess 同款教训）。
+   */
   public static ContainerKiller dockerCliKiller() {
-    return containerId -> {
+    return new DockerCliKiller();
+  }
+
+  private static final class DockerCliKiller implements ContainerKiller {
+
+    @Override
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+        value = "COMMAND_INJECTION",
+        justification =
+            "containerId 取自本进程创建的 --cidfile（docker daemon 写入的十六进制 ID），非用户输入；"
+                + "以 argv 形式传给 docker CLI、不经 shell 解释（LocalProcessStarter 同款先例）")
+    public void kill(String containerId) throws IOException {
       Process kill = new ProcessBuilder("docker", "kill", containerId).start();
       try {
-        if (!kill.waitFor(5, TimeUnit.SECONDS)) {
+        if (!kill.waitFor(KILL_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
           kill.destroyForcibly();
           throw new IOException("docker kill 超时未返回: " + containerId);
         }
@@ -52,7 +69,7 @@ public final class CidfileProcessWrapper extends Process {
         kill.destroyForcibly();
         throw new IOException("docker kill 被中断: " + containerId, e);
       }
-    };
+    }
   }
 
   @Override
@@ -74,7 +91,8 @@ public final class CidfileProcessWrapper extends Process {
       } catch (IOException | RuntimeException e) {
         // 容器大概率已自行退出（No such container）；kill 失败不阻断 CLI 清理（FR-011 语义在启动层，
         // 此处是清理路径，宁吞勿漏杀 CLI）
-        LOG.warn("docker kill 容器 {} 未成功（按已退出处理）: {}", containerId, e.getMessage());
+        LOG.warn(
+            "docker kill 容器 {} 未成功（按已退出处理）: {}", sanitize(containerId), sanitize(e.getMessage()));
       }
     }
     cliKill.accept(cli);
@@ -88,7 +106,8 @@ public final class CidfileProcessWrapper extends Process {
       String id = Files.readString(cidFile).trim();
       return id.isEmpty() ? null : id;
     } catch (IOException e) {
-      LOG.warn("读取 cidfile {} 失败（按无容器处理）: {}", cidFile, e.getMessage());
+      LOG.warn(
+          "读取 cidfile {} 失败（按无容器处理）: {}", sanitize(cidFile.toString()), sanitize(e.getMessage()));
       return null;
     }
   }
@@ -132,5 +151,10 @@ public final class CidfileProcessWrapper extends Process {
   @Override
   public ProcessHandle toHandle() {
     return cli.toHandle();
+  }
+
+  /** cidfile 内容与异常消息进日志前的净化（防日志伪造，JpaToolInvocationAuditor 同款）。 */
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
   }
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/CidfileProcessWrapper.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/CidfileProcessWrapper.java
@@ -1,0 +1,136 @@
+package io.oryxos.tool.sandbox;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * docker CLI 进程的 destroy 联动包装（024 FR-006）：杀掉 docker CLI 及其进程树<b>够不到容器</b>—— 容器由 daemon 派生，与 CLI
+ * 无父子关系。本包装在 destroy/destroyForcibly 时先按 {@code --cidfile} 回读容器 ID 并执行 {@code docker
+ * kill}（终止真实执行本体，ProcessStarter 契约），再终止 CLI 进程。
+ *
+ * <p>竞态兜底（plan 风险 1）：容器极快退出或 cidfile 尚未写入时读不到 ID——只杀 CLI； {@code docker kill} 失败（容器已不存在）按成功处理，不阻断
+ * CLI 清理。
+ */
+public final class CidfileProcessWrapper extends Process {
+  private static final Logger LOG = LoggerFactory.getLogger(CidfileProcessWrapper.class);
+
+  /** 容器终止执行器：生产实现跑 {@code docker kill <id>}，单测注入记录桩。 */
+  @FunctionalInterface
+  public interface ContainerKiller {
+    void kill(String containerId) throws IOException;
+  }
+
+  private final Process cli;
+  private final Path cidFile;
+  private final ContainerKiller killer;
+
+  public CidfileProcessWrapper(Process cli, Path cidFile, ContainerKiller killer) {
+    this.cli = Objects.requireNonNull(cli, "cli 不能为空");
+    this.cidFile = Objects.requireNonNull(cidFile, "cidFile 不能为空");
+    this.killer = Objects.requireNonNull(killer, "killer 不能为空");
+  }
+
+  /** 生产用 killer：起 {@code docker kill} 子进程并短暂等待（退出码忽略——容器已不存在也算达成）。 */
+  public static ContainerKiller dockerCliKiller() {
+    return containerId -> {
+      Process kill = new ProcessBuilder("docker", "kill", containerId).start();
+      try {
+        if (!kill.waitFor(5, TimeUnit.SECONDS)) {
+          kill.destroyForcibly();
+          throw new IOException("docker kill 超时未返回: " + containerId);
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        kill.destroyForcibly();
+        throw new IOException("docker kill 被中断: " + containerId, e);
+      }
+    };
+  }
+
+  @Override
+  public void destroy() {
+    killContainerThen(Process::destroy);
+  }
+
+  @Override
+  public Process destroyForcibly() {
+    killContainerThen(Process::destroyForcibly);
+    return this;
+  }
+
+  private void killContainerThen(Consumer<Process> cliKill) {
+    String containerId = readContainerId();
+    if (containerId != null) {
+      try {
+        killer.kill(containerId);
+      } catch (IOException | RuntimeException e) {
+        // 容器大概率已自行退出（No such container）；kill 失败不阻断 CLI 清理（FR-011 语义在启动层，
+        // 此处是清理路径，宁吞勿漏杀 CLI）
+        LOG.warn("docker kill 容器 {} 未成功（按已退出处理）: {}", containerId, e.getMessage());
+      }
+    }
+    cliKill.accept(cli);
+  }
+
+  private String readContainerId() {
+    try {
+      if (!Files.exists(cidFile)) {
+        return null; // 竞态兜底：容器未及创建即被终止，或早已退出
+      }
+      String id = Files.readString(cidFile).trim();
+      return id.isEmpty() ? null : id;
+    } catch (IOException e) {
+      LOG.warn("读取 cidfile {} 失败（按无容器处理）: {}", cidFile, e.getMessage());
+      return null;
+    }
+  }
+
+  // ---- 以下全部委托 CLI 进程：流 / 等待 / 句柄（descendants/children 经 toHandle 生效于 CLI 树）----
+  @Override
+  public OutputStream getOutputStream() {
+    return cli.getOutputStream();
+  }
+
+  @Override
+  public InputStream getInputStream() {
+    return cli.getInputStream();
+  }
+
+  @Override
+  public InputStream getErrorStream() {
+    return cli.getErrorStream();
+  }
+
+  @Override
+  public int waitFor() throws InterruptedException {
+    return cli.waitFor();
+  }
+
+  @Override
+  public boolean waitFor(long timeout, TimeUnit unit) throws InterruptedException {
+    return cli.waitFor(timeout, unit);
+  }
+
+  @Override
+  public int exitValue() {
+    return cli.exitValue();
+  }
+
+  @Override
+  public boolean isAlive() {
+    return cli.isAlive();
+  }
+
+  @Override
+  public ProcessHandle toHandle() {
+    return cli.toHandle();
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/DockerRunSpec.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/DockerRunSpec.java
@@ -1,0 +1,68 @@
+package io.oryxos.tool.sandbox;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * docker 档命令构造（024 FR-002/FR-004，纯函数——参数顺序与安全默认值在此钉死并由单测锁死）。
+ *
+ * <p>产物形态：{@code docker run --rm --cidfile <f> -v <root>:/workspace --network <n> --memory <m>
+ * --cpus <c> --read-only --tmpfs /tmp --user <u> <image> <cmd…>}——工作区读写挂载 （RQ-4）、默认安全参数全在场（RQ-5：断网
+ * / 限额 / rootfs 只读 + tmpfs / 非 root）。 命令内的工作区绝对路径经 {@link WorkspacePathMapper} 翻译为 {@code
+ * /workspace/...}（FR-003）。
+ */
+public final class DockerRunSpec {
+
+  private DockerRunSpec() {}
+
+  /**
+   * 构造完整的 docker run argv。
+   *
+   * @param props 执行后端配置（镜像必填——启动校验把关，此处不重复校验仅要求非空）
+   * @param mapper 工作区路径翻译器（宿主根来自 {@code mapper.workspaceRoot()}）
+   * @param cidFile 容器 ID 回写文件路径（{@code --cidfile}，超时联动 docker kill 的依据，FR-006）
+   * @param command argv 形式的命令（argv[0] 为可执行文件），工作区路径参数被翻译
+   */
+  public static List<String> build(
+      ExecutionBackendProperties props,
+      WorkspacePathMapper mapper,
+      Path cidFile,
+      List<String> command) {
+    Objects.requireNonNull(props, "props 不能为空");
+    Objects.requireNonNull(mapper, "mapper 不能为空");
+    Objects.requireNonNull(cidFile, "cidFile 不能为空");
+    if (command == null || command.isEmpty()) {
+      throw new IllegalArgumentException("command 不能为空");
+    }
+    if (props.image() == null || props.image().isBlank()) {
+      throw new IllegalArgumentException("docker 档必须配置执行镜像（oryxos.sandbox.execution.image）");
+    }
+
+    List<String> argv = new ArrayList<>();
+    argv.add("docker");
+    argv.add("run");
+    argv.add("--rm"); // 短命容器（RQ-2）：正常退出即销毁，无残留
+    argv.add("--cidfile");
+    argv.add(cidFile.toString());
+    argv.add("-v");
+    argv.add(mapper.workspaceRoot() + ":" + WorkspacePathMapper.CONTAINER_ROOT); // 读写挂载（RQ-4）
+    argv.add("--network");
+    argv.add(props.network()); // 默认 none（RQ-5）：容器内出网需显式打开
+    argv.add("--memory");
+    argv.add(props.memory());
+    argv.add("--cpus");
+    argv.add(props.cpus());
+    argv.add("--read-only"); // 容器自身 rootfs 只读（工作区挂载不受影响，见 spec FR-014 澄清）
+    argv.add("--tmpfs");
+    argv.add("/tmp"); // 命令的临时写空间（rootfs 只读的配套）
+    argv.add("--user");
+    argv.add(props.user()); // 非 root 执行（默认 nobody）
+    argv.add(props.image());
+    for (String arg : command) {
+      argv.add(mapper.toContainer(arg)); // 工作区路径翻译，非工作区直通
+    }
+    return List.copyOf(argv);
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/ExecutionBackendProperties.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/ExecutionBackendProperties.java
@@ -1,0 +1,43 @@
+package io.oryxos.tool.sandbox;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 执行后端配置（键 {@code oryxos.sandbox.execution.*}，024 容器级执行隔离）。
+ *
+ * <p>术语约定（spec）：execution 词根专指执行位置抽象，与白名单沙箱（{@code file.*}/{@code shell.*}/{@code http.*}）相区分。默认
+ * local 档零行为变化（SC-001 锚点）；docker 档必填 {@code image} 的校验由启动检查把关（FR-005，fail loud），本类只做 null/空白归一化默认值。
+ */
+@ConfigurationProperties(prefix = "oryxos.sandbox.execution")
+public record ExecutionBackendProperties(
+    String backend, String image, String memory, String cpus, String network, String user) {
+
+  /** 默认档：local——不配即现状，行为零变化。 */
+  public static final String DEFAULT_BACKEND = "local";
+
+  /** 默认资源限额与安全参数（RQ-5：安全优先而非性能优先）。 */
+  public static final String DEFAULT_MEMORY = "512m";
+
+  public static final String DEFAULT_CPUS = "1.0";
+  public static final String DEFAULT_NETWORK = "none";
+  public static final String DEFAULT_USER = "65534:65534";
+  public static final String DOCKER_BACKEND = "docker";
+
+  public ExecutionBackendProperties {
+    backend = normalize(backend, DEFAULT_BACKEND);
+    image = normalize(image, "");
+    memory = normalize(memory, DEFAULT_MEMORY);
+    cpus = normalize(cpus, DEFAULT_CPUS);
+    network = normalize(network, DEFAULT_NETWORK);
+    user = normalize(user, DEFAULT_USER);
+  }
+
+  /** docker 档判断的唯一权威口径（装配与启动校验共用，避免字符串散落）。 */
+  public boolean isDocker() {
+    return DOCKER_BACKEND.equals(backend);
+  }
+
+  private static String normalize(String value, String fallback) {
+    return value == null || value.isBlank() ? fallback : value.trim();
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/LocalProcessStarter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/LocalProcessStarter.java
@@ -1,0 +1,21 @@
+package io.oryxos.tool.sandbox;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * local 档执行后端（024 默认档）：{@link ProcessBuilder} 直接派生本地进程——自 ShellTools 默认实现逐字节搬运，行为零变化（SC-001）。docker
+ * 档见 DockerProcessStarter（Phase 3）。
+ */
+public final class LocalProcessStarter implements ProcessStarter {
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "COMMAND_INJECTION",
+      justification =
+          "以 argv 直接执行、不经 shell 解释；可执行文件在 ShellTools.shell() 启动前经 Sandbox"
+              + " 精确白名单校验（自 ShellTools.startProcess 原样搬运，含注解）")
+  @Override
+  public Process start(List<String> command) throws IOException {
+    return new ProcessBuilder(command).start();
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/ProcessStarter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/ProcessStarter.java
@@ -1,0 +1,32 @@
+package io.oryxos.tool.sandbox;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * 进程启动契约（024 容器级执行隔离，自 ShellTools 包级接缝升格，形状不变）。
+ *
+ * <p><b>destroy 语义契约（FR-006 的根基）</b>：实现返回的 {@link Process}，其 {@code destroy()/destroyForcibly()}
+ * MUST 终止<b>真实执行本体</b>而非仅终止本地句柄——
+ *
+ * <ul>
+ *   <li>local 档：终止进程树（主进程 + 派生子孙）；
+ *   <li>docker 档：终止容器本体（如 {@code --cidfile} + destroy 联动 {@code docker kill}）—— docker CLI
+ *       与容器进程无父子关系（容器由 daemon 派生），杀 CLI 及其进程树够不到容器。
+ * </ul>
+ *
+ * <p>调用方（ShellTools 超时终止）依赖此条实现「命令挂死不拖死 ReAct 循环」。实现另需保证 {@code start} 抛出的 {@link IOException}
+ * 携带可区分失败原因的信息（CLI 缺失 / daemon 不可达 / 镜像缺失，FR-011 fail-loud 口径）。
+ */
+@FunctionalInterface
+public interface ProcessStarter {
+
+  /**
+   * 启动命令并返回进程句柄。
+   *
+   * @param command argv 形式的完整命令（argv[0] 为可执行文件），不经 shell 解释
+   * @return 进程句柄，destroy 语义见接口契约
+   * @throws IOException 启动失败（本地进程创建失败 / docker CLI 或 daemon 故障等）
+   */
+  Process start(List<String> command) throws IOException;
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WorkspacePathMapper.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WorkspacePathMapper.java
@@ -14,6 +14,18 @@ public final class WorkspacePathMapper {
   /** 容器内固定挂载点（RQ-4 裁决推荐：固定挂载点让翻译规则可预测、可测试）。 */
   public static final String CONTAINER_ROOT = "/workspace";
 
+  /** POSIX 绝对路径前缀。 */
+  private static final String POSIX_ROOT = "/";
+
+  /** Windows 盘符绝对路径（C:/ 或 C:\ 形态）。 */
+  private static final String WINDOWS_DRIVE = "^[A-Za-z]:[\\\\/].*";
+
+  /** 仅根（POSIX 的 "/"）不参与尾分隔符剥离。 */
+  private static final int ROOT_ONLY = 1;
+
+  /** 前缀剥离时的分隔符长度。 */
+  private static final int ROOT_SEPARATOR_LENGTH = 1;
+
   private final Path workspaceRoot;
 
   public WorkspacePathMapper(Path workspaceRoot) {
@@ -32,7 +44,7 @@ public final class WorkspacePathMapper {
 
   /** 该宿主路径是否落在工作区内（按路径组件比较，非字符串前缀）。 */
   public boolean isWorkspacePath(String hostPath) {
-    if (hostPath == null || !hostPath.startsWith("/") && !hostPath.matches("^[A-Za-z]:[\\\\/].*")) {
+    if (hostPath == null || !isAbsolute(hostPath)) {
       return false; // 相对路径与非绝对路径不属工作区判定
     }
     try {
@@ -40,6 +52,10 @@ public final class WorkspacePathMapper {
     } catch (IllegalArgumentException e) {
       return false;
     }
+  }
+
+  private static boolean isAbsolute(String path) {
+    return path.startsWith(POSIX_ROOT) || path.matches(WINDOWS_DRIVE);
   }
 
   /**
@@ -70,16 +86,16 @@ public final class WorkspacePathMapper {
       return null;
     }
     String normalized =
-        containerPath.endsWith("/") && containerPath.length() > 1
+        containerPath.endsWith(POSIX_ROOT) && containerPath.length() > ROOT_ONLY
             ? containerPath.substring(0, containerPath.length() - 1)
             : containerPath;
     if (CONTAINER_ROOT.equals(normalized)) {
       return workspaceRoot.toString();
     }
-    if (!normalized.startsWith(CONTAINER_ROOT + "/")) {
+    if (!normalized.startsWith(CONTAINER_ROOT + POSIX_ROOT)) {
       return containerPath;
     }
-    String relative = normalized.substring(CONTAINER_ROOT.length() + 1);
+    String relative = normalized.substring(CONTAINER_ROOT.length() + ROOT_SEPARATOR_LENGTH);
     return workspaceRoot.resolve(relative).toString();
   }
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WorkspacePathMapper.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/WorkspacePathMapper.java
@@ -1,0 +1,85 @@
+package io.oryxos.tool.sandbox;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * 工作区路径双向翻译（024 FR-003 / 设计决策 D6）：宿主 {@code ORYXOS_ROOT} 前缀 ↔ 容器内固定挂载点 {@code
+ * /workspace}。纯前缀字符串映射，不做 realpath 跟随（容器内路径无宿主 realpath 语义）；
+ * 非工作区路径与相对路径原样直通（不属翻译范围）。审计记录始终使用宿主原始路径（FR-003）。
+ */
+public final class WorkspacePathMapper {
+
+  /** 容器内固定挂载点（RQ-4 裁决推荐：固定挂载点让翻译规则可预测、可测试）。 */
+  public static final String CONTAINER_ROOT = "/workspace";
+
+  private final Path workspaceRoot;
+
+  public WorkspacePathMapper(Path workspaceRoot) {
+    Path normalized =
+        Objects.requireNonNull(workspaceRoot, "workspaceRoot 不能为空").toAbsolutePath().normalize();
+    if (!normalized.equals(workspaceRoot.normalize()) && !normalized.isAbsolute()) {
+      throw new IllegalArgumentException("workspaceRoot 必须能解析为绝对路径: " + workspaceRoot);
+    }
+    this.workspaceRoot = normalized;
+  }
+
+  /** 宿主工作区根（绝对、已归一化）——挂载参数 {@code -v <root>:/workspace} 的宿主侧来源。 */
+  public Path workspaceRoot() {
+    return workspaceRoot;
+  }
+
+  /** 该宿主路径是否落在工作区内（按路径组件比较，非字符串前缀）。 */
+  public boolean isWorkspacePath(String hostPath) {
+    if (hostPath == null || !hostPath.startsWith("/") && !hostPath.matches("^[A-Za-z]:[\\\\/].*")) {
+      return false; // 相对路径与非绝对路径不属工作区判定
+    }
+    try {
+      return Path.of(hostPath).normalize().startsWith(workspaceRoot);
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  /**
+   * 宿主绝对路径 → 容器内路径（{@code /workspace/<相对部分>}）。非工作区路径原样返回（直通）。 尾分隔符归一：工作区根本身 → {@code
+   * /workspace}；子路径斜杠统一。
+   */
+  public String toContainer(String hostPath) {
+    if (!isWorkspacePath(hostPath)) {
+      return hostPath;
+    }
+    Path relative = workspaceRoot.relativize(Path.of(hostPath).normalize());
+    if (relative.toString().isEmpty()) {
+      return CONTAINER_ROOT;
+    }
+    StringJoiner joiner = new StringJoiner("/", CONTAINER_ROOT + "/", "");
+    for (Path part : relative) {
+      joiner.add(part.toString());
+    }
+    return joiner.toString();
+  }
+
+  /**
+   * 容器内路径 → 宿主路径字符串。仅翻译 {@code /workspace} 前缀（含本体）；其余原样返回—— 容器自有路径（如 {@code
+   * /tmp}）不属于工作区，保持容器视角原样（模型输出反译场景见 FR-003）。
+   */
+  public String toHost(String containerPath) {
+    if (containerPath == null) {
+      return null;
+    }
+    String normalized =
+        containerPath.endsWith("/") && containerPath.length() > 1
+            ? containerPath.substring(0, containerPath.length() - 1)
+            : containerPath;
+    if (CONTAINER_ROOT.equals(normalized)) {
+      return workspaceRoot.toString();
+    }
+    if (!normalized.startsWith(CONTAINER_ROOT + "/")) {
+      return containerPath;
+    }
+    String relative = normalized.substring(CONTAINER_ROOT.length() + 1);
+    return workspaceRoot.resolve(relative).toString();
+  }
+}

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/CidfileProcessWrapperTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/CidfileProcessWrapperTest.java
@@ -1,0 +1,167 @@
+package io.oryxos.tool.sandbox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * 024 T007：destroy 联动 docker kill 的四个分支——有 ID 则 kill、无 ID 只杀 CLI、kill 抛异常不阻断 CLI
+ * 清理、流与等待委托。FR-006（超时必须终止容器本体）的机制核心。
+ */
+class CidfileProcessWrapperTest {
+
+  @TempDir Path tempDir;
+
+  /** 记录型 killer：可断言调用并可注入故障。 */
+  private static final class RecordingKiller implements CidfileProcessWrapper.ContainerKiller {
+    final List<String> killed = new ArrayList<>();
+    boolean fail;
+
+    @Override
+    public void kill(String containerId) throws IOException {
+      if (fail) {
+        throw new IOException("No such container: " + containerId);
+      }
+      killed.add(containerId);
+    }
+  }
+
+  /** 最小 CLI 假进程：只记录 destroy/destroyForcibly，其余桩实现。 */
+  private static final class FakeCliProcess extends Process {
+    boolean destroyed;
+    boolean forciblyDestroyed;
+
+    @Override
+    public OutputStream getOutputStream() {
+      return OutputStream.nullOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public int waitFor() {
+      return 0;
+    }
+
+    @Override
+    public boolean waitFor(long timeout, TimeUnit unit) {
+      return true;
+    }
+
+    @Override
+    public int exitValue() {
+      return 0;
+    }
+
+    @Override
+    public void destroy() {
+      destroyed = true;
+    }
+
+    @Override
+    public Process destroyForcibly() {
+      forciblyDestroyed = true;
+      return this;
+    }
+  }
+
+  @Test
+  @DisplayName("destroy_有容器ID_先docker_kILL再杀CLI")
+  void destroyKillsContainerThenCli() throws IOException {
+    Path cidFile = tempDir.resolve("cid");
+    Files.writeString(cidFile, "abc123def\n");
+    RecordingKiller killer = new RecordingKiller();
+    FakeCliProcess cli = new FakeCliProcess();
+
+    new CidfileProcessWrapper(cli, cidFile, killer).destroy();
+
+    assertEquals(List.of("abc123def"), killer.killed);
+    assertTrue(cli.destroyed);
+    assertFalse(cli.forciblyDestroyed);
+  }
+
+  @Test
+  @DisplayName("destroyForcibly_有容器ID_同样联动kill")
+  void destroyForciblyKillsContainerThenCli() throws IOException {
+    Path cidFile = tempDir.resolve("cid");
+    Files.writeString(cidFile, "abc123def");
+    RecordingKiller killer = new RecordingKiller();
+    FakeCliProcess cli = new FakeCliProcess();
+
+    new CidfileProcessWrapper(cli, cidFile, killer).destroyForcibly();
+
+    assertEquals(List.of("abc123def"), killer.killed);
+    assertTrue(cli.forciblyDestroyed);
+  }
+
+  @Test
+  @DisplayName("cidfile缺失_竞态兜底_只杀CLI不调kill")
+  void missingCidfileFallsBackToCliOnly() {
+    Path cidFile = tempDir.resolve("never-written");
+    RecordingKiller killer = new RecordingKiller();
+    FakeCliProcess cli = new FakeCliProcess();
+
+    new CidfileProcessWrapper(cli, cidFile, killer).destroyForcibly();
+
+    assertTrue(killer.killed.isEmpty());
+    assertTrue(cli.forciblyDestroyed);
+  }
+
+  @Test
+  @DisplayName("cidfile空白_等价缺失")
+  void blankCidfileTreatedAsMissing() throws IOException {
+    Path cidFile = tempDir.resolve("cid");
+    Files.writeString(cidFile, "   ");
+    RecordingKiller killer = new RecordingKiller();
+
+    new CidfileProcessWrapper(new FakeCliProcess(), cidFile, killer).destroy();
+
+    assertTrue(killer.killed.isEmpty());
+  }
+
+  @Test
+  @DisplayName("docker_kill抛异常_不阻断CLI清理")
+  void killerFailureStillKillsCli() throws IOException {
+    Path cidFile = tempDir.resolve("cid");
+    Files.writeString(cidFile, "abc123def");
+    RecordingKiller killer = new RecordingKiller();
+    killer.fail = true;
+    FakeCliProcess cli = new FakeCliProcess();
+
+    new CidfileProcessWrapper(cli, cidFile, killer).destroyForcibly();
+
+    assertTrue(cli.forciblyDestroyed);
+  }
+
+  @Test
+  @DisplayName("流与等待委托CLI进程")
+  void delegatesStreamsAndWaiting() throws Exception {
+    FakeCliProcess cli = new FakeCliProcess();
+    CidfileProcessWrapper wrapper =
+        new CidfileProcessWrapper(cli, tempDir.resolve("cid"), new RecordingKiller());
+
+    assertTrue(wrapper.waitFor(1, TimeUnit.SECONDS));
+    assertEquals(0, wrapper.exitValue());
+    assertFalse(wrapper.isAlive()); // FakeCliProcess 未覆写 isAlive，默认 false
+  }
+}

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/DockerRunSpecTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/DockerRunSpecTest.java
@@ -1,0 +1,117 @@
+package io.oryxos.tool.sandbox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** 024 T006：docker argv 构造钉死——参数顺序、默认安全参数全在场（SC-005 的第一道防线）、 自定义覆写、工作区路径翻译、必填校验 fail loud。 */
+class DockerRunSpecTest {
+
+  @TempDir Path tempDir;
+
+  private WorkspacePathMapper mapper() {
+    return new WorkspacePathMapper(tempDir.resolve(".oryxos"));
+  }
+
+  private ExecutionBackendProperties props() {
+    return new ExecutionBackendProperties(null, "python:3.12-alpine", null, null, null, null);
+  }
+
+  @Test
+  @DisplayName("默认参数_完整argv顺序与安全参数钉死")
+  void defaultArgvPinned() {
+    // cidfile 以 Path.toString() 进 argv（随宿主平台分隔符），期望值同源构造保持平台中立
+    Path cidFile = Path.of("/tmp", "cid");
+    List<String> argv =
+        DockerRunSpec.build(props(), mapper(), cidFile, List.of("python3", "main.py"));
+
+    assertEquals(
+        List.of(
+            "docker",
+            "run",
+            "--rm",
+            "--cidfile",
+            cidFile.toString(),
+            "-v",
+            mapper().workspaceRoot() + ":/workspace",
+            "--network",
+            "none",
+            "--memory",
+            "512m",
+            "--cpus",
+            "1.0",
+            "--read-only",
+            "--tmpfs",
+            "/tmp",
+            "--user",
+            "65534:65534",
+            "python:3.12-alpine",
+            "python3",
+            "main.py"),
+        argv);
+  }
+
+  @Test
+  @DisplayName("自定义覆写_网络限额镜像生效_未覆写项保持默认")
+  void overridesTakeEffect() {
+    ExecutionBackendProperties props =
+        new ExecutionBackendProperties(
+            "docker", "alpine:3.20", "1g", "2.0", "default", "1000:1000");
+    List<String> argv =
+        DockerRunSpec.build(props, mapper(), Path.of("/tmp/cid"), List.of("sh", "-c", "ls"));
+
+    assertTrue(argv.contains("--network"));
+    assertEquals(argv.get(argv.indexOf("--network") + 1), "default");
+    assertEquals(argv.get(argv.indexOf("--memory") + 1), "1g");
+    assertEquals(argv.get(argv.indexOf("--cpus") + 1), "2.0");
+    assertEquals(argv.get(argv.indexOf("--user") + 1), "1000:1000");
+    assertEquals("alpine:3.20", argv.get(argv.indexOf("--user") + 2));
+  }
+
+  @Test
+  @DisplayName("工作区路径参数_翻译为_/workspace")
+  void workspaceArgsTranslated() {
+    WorkspacePathMapper mapper = mapper();
+    String script = mapper.workspaceRoot().resolve("scripts").resolve("run.py").toString();
+    List<String> argv =
+        DockerRunSpec.build(props(), mapper, Path.of("/tmp/cid"), List.of("python3", script));
+
+    assertTrue(argv.contains("/workspace/scripts/run.py"));
+    assertTrue(!argv.contains(script)); // 宿主路径不得漏进容器参数
+  }
+
+  @Test
+  @DisplayName("非工作区路径_直通不翻译")
+  void nonWorkspaceArgsPassThrough() {
+    List<String> argv =
+        DockerRunSpec.build(props(), mapper(), Path.of("/tmp/cid"), List.of("ls", "/etc"));
+
+    assertTrue(argv.contains("/etc"));
+  }
+
+  @Test
+  @DisplayName("镜像未配_fail_loud")
+  void missingImageFailsLoud() {
+    ExecutionBackendProperties noImage =
+        new ExecutionBackendProperties("docker", null, null, null, null, null);
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> DockerRunSpec.build(noImage, mapper(), Path.of("/tmp/cid"), List.of("ls")));
+    assertTrue(e.getMessage().contains("oryxos.sandbox.execution.image"));
+  }
+
+  @Test
+  @DisplayName("空命令_fail_loud")
+  void emptyCommandFailsLoud() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DockerRunSpec.build(props(), mapper(), Path.of("/tmp/cid"), List.of()));
+  }
+}

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/ExecutionBackendPropertiesTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/ExecutionBackendPropertiesTest.java
@@ -1,0 +1,78 @@
+package io.oryxos.tool.sandbox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 024 T002：执行后端配置绑定与默认值钉死（SC-001 锚点——默认 local 档的一切默认值在此锁死， 后续任何「顺手改默认」都会被本测试拦截）。模式镜像
+ * SandboxDefaultsConfigTest。
+ */
+class ExecutionBackendPropertiesTest {
+
+  private final ApplicationContextRunner runner =
+      new ApplicationContextRunner().withUserConfiguration(PropertiesConfiguration.class);
+
+  @Test
+  @DisplayName("默认_local档_512m_1.0CPU_断网_非root_image空")
+  void defaults_localAndSafeLimits() {
+    runner.run(
+        context -> {
+          ExecutionBackendProperties props = context.getBean(ExecutionBackendProperties.class);
+          assertEquals("local", props.backend());
+          assertEquals("", props.image());
+          assertEquals("512m", props.memory());
+          assertEquals("1.0", props.cpus());
+          assertEquals("none", props.network());
+          assertEquals("65534:65534", props.user());
+          assertFalse(props.isDocker());
+        });
+  }
+
+  @Test
+  @DisplayName("yml覆盖_docker档_自定义镜像与限额生效")
+  void override_dockerWithCustomLimits() {
+    runner
+        .withPropertyValues(
+            "oryxos.sandbox.execution.backend=docker",
+            "oryxos.sandbox.execution.image=python:3.12-alpine",
+            "oryxos.sandbox.execution.memory=1g",
+            "oryxos.sandbox.execution.cpus=2.0")
+        .run(
+            context -> {
+              ExecutionBackendProperties props = context.getBean(ExecutionBackendProperties.class);
+              assertEquals("docker", props.backend());
+              assertEquals("python:3.12-alpine", props.image());
+              assertEquals("1g", props.memory());
+              assertEquals("2.0", props.cpus());
+              // 未覆盖的项回落默认（安全参数不因部分配置而丢失）
+              assertEquals("none", props.network());
+              assertEquals("65534:65534", props.user());
+              assertTrue(props.isDocker());
+            });
+  }
+
+  @Test
+  @DisplayName("空白值归一化_blank网络回落none而非null")
+  void blankValuesNormalizedToDefaults() {
+    runner
+        .withPropertyValues(
+            "oryxos.sandbox.execution.backend= ", "oryxos.sandbox.execution.network=")
+        .run(
+            context -> {
+              ExecutionBackendProperties props = context.getBean(ExecutionBackendProperties.class);
+              assertEquals("local", props.backend());
+              assertEquals("none", props.network());
+            });
+  }
+
+  @Configuration
+  @EnableConfigurationProperties(ExecutionBackendProperties.class)
+  static class PropertiesConfiguration {}
+}

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WorkspacePathMapperTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/WorkspacePathMapperTest.java
@@ -1,0 +1,84 @@
+package io.oryxos.tool.sandbox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * 024 T005：工作区路径双向翻译。跨平台注意：宿主侧期望值用 {@code workspaceRoot.resolve(...)} 构造 （随平台分隔符），容器侧恒为 {@code
+ * /}——翻译规则本身钉死（RQ-4 固定挂载点）。
+ */
+class WorkspacePathMapperTest {
+
+  @TempDir Path tempDir;
+
+  private WorkspacePathMapper mapper() {
+    return new WorkspacePathMapper(tempDir.resolve(".oryxos"));
+  }
+
+  @Test
+  @DisplayName("双向翻译_工作区子路径_host↔/workspace")
+  void bidirectionalSubPath() {
+    WorkspacePathMapper mapper = mapper();
+    Path hostFile = mapper.workspaceRoot().resolve("agents").resolve("ops").resolve("script.py");
+    String containerPath = mapper.toContainer(hostFile.toString());
+
+    assertEquals("/workspace/agents/ops/script.py", containerPath);
+    assertEquals(hostFile.toString(), mapper.toHost(containerPath));
+  }
+
+  @Test
+  @DisplayName("工作区根本体_往返为_/workspace")
+  void workspaceRootItself() {
+    WorkspacePathMapper mapper = mapper();
+    assertEquals("/workspace", mapper.toContainer(mapper.workspaceRoot().toString()));
+    assertEquals(mapper.workspaceRoot().toString(), mapper.toHost("/workspace"));
+  }
+
+  @Test
+  @DisplayName("非工作区绝对路径_直通不翻译")
+  void nonWorkspaceAbsolutePathPassesThrough() {
+    WorkspacePathMapper mapper = mapper();
+    assertEquals("/etc/os-release", mapper.toContainer("/etc/os-release"));
+    assertEquals("/etc/os-release", mapper.toHost("/etc/os-release"));
+    assertFalse(mapper.isWorkspacePath("/etc/os-release"));
+  }
+
+  @Test
+  @DisplayName("相对路径_直通不翻译")
+  void relativePathPassesThrough() {
+    WorkspacePathMapper mapper = mapper();
+    assertEquals("script.py", mapper.toContainer("script.py"));
+    assertEquals("agents/ops", mapper.toHost("agents/ops"));
+    assertFalse(mapper.isWorkspacePath("script.py"));
+  }
+
+  @Test
+  @DisplayName("容器自有路径_/tmp_不反译")
+  void containerOwnPathNotReverseTranslated() {
+    WorkspacePathMapper mapper = mapper();
+    assertEquals("/tmp/out.txt", mapper.toHost("/tmp/out.txt"));
+  }
+
+  @Test
+  @DisplayName("尾分隔符归一")
+  void trailingSeparatorNormalized() {
+    WorkspacePathMapper mapper = mapper();
+    assertEquals(mapper.workspaceRoot().toString(), mapper.toHost("/workspace/"));
+  }
+
+  @Test
+  @DisplayName("isWorkspacePath_组件级前缀匹配")
+  void isWorkspacePathComponentWise() {
+    WorkspacePathMapper mapper = mapper();
+    assertTrue(mapper.isWorkspacePath(mapper.workspaceRoot().resolve("agents").toString()));
+    // 字符串前缀相似但组件不同的目录不算工作区（/opt/x.oryxos 不是 /opt/x/.oryxos）
+    Path sibling = mapper.workspaceRoot().getParent().resolve(".oryxos-backup");
+    assertFalse(mapper.isWorkspacePath(sibling.toString()));
+  }
+}


### PR DESCRIPTION
#362（spec/plan/tasks）的实施 PR，本批交付 **Phase 1+2（T001~T008）**——执行后端契约与纯函数组件层。Phase 3（docker 档装配/启动校验/契约测试）将在本 PR 续接提交（单 PR 长大，017/020 惯例）。

## 本批内容（17 文件 +934 行，11 个新文件全带单测）

**Phase 1 Setup**
- T001 `tool_invocations` 幂等 ALTER 加 `execution_backend`/`container_id`（镜像 020 `blocked_by` 模式），schema.sql 新装库同步
- T002 `ExecutionBackendProperties`（`oryxos.sandbox.execution.*`，默认 local/512m/1.0/none/非root）+ 默认值钉死测试

**Phase 2 Foundational（全部纯函数/可 mock，不依赖 docker daemon）**
- T003 `ProcessStarter` 升格公开契约——**destroy 语义写进 Javadoc**（MUST 终止真实执行本体，FR-006 的根基）
- T004 `LocalProcessStarter`：默认实现逐字节搬运；**ShellToolsTest 零修改通过（SC-001 锚点）**
- T005 `WorkspacePathMapper`：`ORYXOS_ROOT` ↔ `/workspace` 双向翻译（纯前缀映射，D6）
- T006 `DockerRunSpec`：docker argv 纯函数，参数顺序与安全默认值单测钉死（--rm/--cidfile/读写挂载/network=none/memory/cpus/read-only+tmpfs/非root）
- T007 `CidfileProcessWrapper`：destroy/destroyForcibly 联动 `docker kill`（杀 CLI 够不到容器——容器由 daemon 派生）；竞态兜底与 kill 失败两分支有测试
- T008 `ToolInvocationAuditor` 加 backend/containerId 重载（default 委托，020 模式）；JPA 落列缺省归一 `local`（FR-008 新调用恒写值，历史行 NULL≡local）

## 验证

- 单测：oryxos-tool 260 + oryxos-storage 90 全绿，**既有测试零修改**
- 质量门禁本地全绿：spotless / checkstyle 0 违规 / PMD 5 处已修 / SpotBugs 3 处已修（命令注入按 LocalProcessStarter 先例 Suppress+命名类，日志 CRLF 净化）
- 已知无关红点：`MasterKeyResolverTest`（022）Windows 平台必挂——stash 实证与本特性无关，Linux CI 不受影响，建议单独小修复

## 与 022 的执行顺序说明

本分支基于含 022 的 main（1e3509d），无交叠文件。
