### PR TITLE
feat(core/provider): pass inbound images as multimodal Media to LLM

### DIFF
--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuInboundImageResolver.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuInboundImageResolver.java
@@ -5,6 +5,7 @@ import com.lark.oapi.service.im.v1.model.GetMessageResourceReq;
 import com.lark.oapi.service.im.v1.model.GetMessageResourceResp;
 import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.session.ImageMime;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -126,6 +127,20 @@ final class FeishuInboundImageResolver {
     Path target = dir.resolve(safeSegment(imageKey) + ext);
     try (OutputStream out = Files.newOutputStream(target)) {
       resp.getData().writeTo(out);
+    }
+    // 飞书常不给后缀（落成 .bin）：用魔数改成正确扩展名，便于 MIME / vision
+    if (DEFAULT_EXTENSION.equals(ext)) {
+      String sniffed = ImageMime.probeFile(target);
+      String betterExt = ImageMime.extensionFor(sniffed);
+      if (!DEFAULT_EXTENSION.equals(betterExt) && !betterExt.equals(ext)) {
+        Path renamed = dir.resolve(safeSegment(imageKey) + betterExt);
+        try {
+          Files.move(target, renamed);
+          return renamed;
+        } catch (IOException moveFailed) {
+          LOG.debug("飞书图片重命名扩展名失败，保留原文件: {}", sanitize(moveFailed.getMessage()));
+        }
+      }
     }
     return target;
   }

--- a/oryxos-channel-feishu/src/test/java/io/oryxos/channel/feishu/FeishuInboundImageResolverTest.java
+++ b/oryxos-channel-feishu/src/test/java/io/oryxos/channel/feishu/FeishuInboundImageResolverTest.java
@@ -101,4 +101,38 @@ class FeishuInboundImageResolverTest {
     assertTrue(FeishuInboundImageResolver.safeSegment("img/../x").contains("_"));
     assertEquals("x", FeishuInboundImageResolver.safeSegment("???"));
   }
+
+  @Test
+  @DisplayName("无后缀但魔数为 PNG → 落盘为 .png")
+  void sniffsPngMagicWhenNoFilename() throws Exception {
+    Client client = mock(Client.class, RETURNS_DEEP_STUBS);
+    GetMessageResourceResp resp = new GetMessageResourceResp();
+    resp.setCode(0);
+    resp.setMsg("ok");
+    resp.setFileName(null);
+    ByteArrayOutputStream data = new ByteArrayOutputStream();
+    data.write(
+        new byte[] {(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x01, 0x02, 0x03, 0x04});
+    resp.setData(data);
+    when(client.im().messageResource().get(any())).thenReturn(resp);
+
+    FeishuInboundImageResolver resolver =
+        new FeishuInboundImageResolver(client, mediaRoot, "ops-feishu");
+    InboundMessage out =
+        resolver.resolve(
+            new InboundMessage(
+                "feishu",
+                "ops-feishu",
+                "om_msg_3",
+                ChatKind.P2P,
+                "ou_user",
+                "oc_chat",
+                "",
+                false,
+                false,
+                List.of(InboundAttachment.imageReference("img_magic"))));
+
+    String url = out.attachments().get(0).url();
+    assertTrue(url.endsWith(".png"), url);
+  }
 }

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentService.java
@@ -48,11 +48,22 @@ public class AgentService {
   }
 
   public String process(Session session, String userMessage) {
-    return process(session, userMessage, StreamListener.NOOP);
+    return process(session, userMessage, List.of(), StreamListener.NOOP);
+  }
+
+  /** 带入站 media（图片 URL/本地路径）的会话处理。 */
+  public String process(Session session, String userMessage, List<Message.MediaPart> media) {
+    return process(session, userMessage, media, StreamListener.NOOP);
   }
 
   /** 带流式观察者的会话处理（019）：锁与 ProfileContext 语义不变，listener 只是透传给 ReActLoop。 */
   public String process(Session session, String userMessage, StreamListener listener) {
+    return process(session, userMessage, List.of(), listener);
+  }
+
+  /** 带 media + 流式观察者的会话处理。 */
+  public String process(
+      Session session, String userMessage, List<Message.MediaPart> media, StreamListener listener) {
     // 同一会话的读写整段互斥；sessionId 理论上永不为 null（来自 SessionManager），mock 场景兜底防 NPE
     String sessionKey =
         session.sessionId() == null ? profileNameOrFallback(session) : session.sessionId();
@@ -73,11 +84,14 @@ public class AgentService {
                           "Session 引用的 Profile 不存在: " + activeSession.profileName()));
       ProfileContext.set(profile); // 工具执行时靠它知道"当前是哪个 Agent"
       try {
-        // NOOP 走三参原入口：保持对 ReActLoop 的既有交互契约（现存测试按三参 stub/verify），语义与四参 NOOP 等价
-        String reply =
-            listener == StreamListener.NOOP
-                ? reActLoop.run(activeSession, userMessage, profile)
-                : reActLoop.run(activeSession, userMessage, profile, listener);
+        List<Message.MediaPart> parts = media == null ? List.of() : media;
+        // 无 media 且 NOOP：走三参原入口，保持对 ReActLoop 的既有交互契约（现存测试按三参 stub/verify）
+        String reply;
+        if (parts.isEmpty() && listener == StreamListener.NOOP) {
+          reply = reActLoop.run(activeSession, userMessage, profile);
+        } else {
+          reply = reActLoop.run(activeSession, userMessage, parts, profile, listener);
+        }
         // 达到最大迭代上限时 ReAct 返回占位文本（不抛异常），这里检测并转为异常，
         // 让 triggerAsync 把执行记成失败状态（否则前端显示"执行成功"——错误引导用户）
         boolean exhausted = ReActLoop.MAX_ITERATIONS_REPLY.equals(reply);
@@ -118,12 +132,32 @@ public class AgentService {
    * 'feishu%'} 查询）。仍不创建持久会话。
    */
   public String processStateless(String agentName, String userMessage, String statelessSessionId) {
-    return processStateless(agentName, userMessage, statelessSessionId, StreamListener.NOOP);
+    return processStateless(
+        agentName, userMessage, List.of(), statelessSessionId, StreamListener.NOOP);
+  }
+
+  /** 无状态调用 + media（群聊入站图片等）。 */
+  public String processStateless(
+      String agentName,
+      String userMessage,
+      List<Message.MediaPart> media,
+      String statelessSessionId) {
+    return processStateless(agentName, userMessage, media, statelessSessionId, StreamListener.NOOP);
   }
 
   /** 无状态调用全参形态（019）：显式会话标识 + 流式观察者。 */
   public String processStateless(
       String agentName, String userMessage, String statelessSessionId, StreamListener listener) {
+    return processStateless(agentName, userMessage, List.of(), statelessSessionId, listener);
+  }
+
+  /** 无状态调用全参形态：会话标识 + media + 流式观察者。 */
+  public String processStateless(
+      String agentName,
+      String userMessage,
+      List<Message.MediaPart> media,
+      String statelessSessionId,
+      StreamListener listener) {
     Profile profile =
         profileRegistry
             .get(agentName)
@@ -132,11 +166,13 @@ public class AgentService {
     ProfileContext.set(profile);
     // 021：同 process——兜底开启 trace，已开启则复用
     try (TraceContext.Scope traceScope = TraceContext.openIfAbsent()) {
-      // 同 process：NOOP 走三参原入口，保持既有交互契约
-      String reply =
-          listener == StreamListener.NOOP
-              ? reActLoop.run(session, userMessage, profile)
-              : reActLoop.run(session, userMessage, profile, listener);
+      List<Message.MediaPart> parts = media == null ? List.of() : media;
+      String reply;
+      if (parts.isEmpty() && listener == StreamListener.NOOP) {
+        reply = reActLoop.run(session, userMessage, profile);
+      } else {
+        reply = reActLoop.run(session, userMessage, parts, profile, listener);
+      }
       if (ReActLoop.MAX_ITERATIONS_REPLY.equals(reply)) {
         throw new AgentMaxIterationsExceededException(reply);
       }

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/ReActLoop.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/ReActLoop.java
@@ -6,7 +6,9 @@ import io.oryxos.core.provider.ProviderRequest;
 import io.oryxos.core.provider.ProviderResponse;
 import io.oryxos.core.provider.ProviderService;
 import io.oryxos.core.provider.ToolCallRequest;
+import io.oryxos.core.session.Message;
 import io.oryxos.core.session.Session;
+import java.util.List;
 
 /**
  * ReAct 主循环——Agent 的大脑（宪法 I：自实现，不用框架 Agent 封装）。
@@ -36,7 +38,7 @@ public class ReActLoop {
   }
 
   public String run(Session session, String userMessage, Profile profile) {
-    return run(session, userMessage, profile, StreamListener.NOOP);
+    return run(session, userMessage, List.of(), profile, StreamListener.NOOP);
   }
 
   /**
@@ -44,7 +46,17 @@ public class ReActLoop {
    * {@code chatStream} 逐段回调 token，工具执行前后回调 start/end。回调全部同步、 循环调度逻辑零变化（宪法 I 的定制点，宪法 VII 的同步模型不动摇）。
    */
   public String run(Session session, String userMessage, Profile profile, StreamListener listener) {
-    session.appendUser(userMessage);
+    return run(session, userMessage, List.of(), profile, listener);
+  }
+
+  /** 带入站图片等 media 的运行：media 写入本轮 user 消息，供 provider 映射为 multimodal UserMessage。 */
+  public String run(
+      Session session,
+      String userMessage,
+      List<Message.MediaPart> media,
+      Profile profile,
+      StreamListener listener) {
+    session.appendUser(userMessage, media);
     // 最大轮数兜底（坑一）：模型可能反复要调工具永不收敛，转够强制退出
     for (int i = 0; i < profile.settings().maxIterations(); i++) {
       ProviderRequest prompt = promptBuilder.build(session, profile);

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaParts.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaParts.java
@@ -31,7 +31,7 @@ public final class InboundMediaParts {
   }
 
   private static String resolveMime(String url) {
-    if (url.startsWith("http://") || url.startsWith("https://")) {
+    if (ImageMime.isHttpUrl(url)) {
       return ImageMime.fromPath(url);
     }
     Path path = Path.of(url);

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaParts.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaParts.java
@@ -1,0 +1,43 @@
+package io.oryxos.core.channel;
+
+import io.oryxos.core.session.ImageMime;
+import io.oryxos.core.session.Message;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/** 从入站附件提取可交给 vision 模型的 {@link Message.MediaPart}（仅有可解析 {@code url} 的图片）。 */
+public final class InboundMediaParts {
+
+  private InboundMediaParts() {}
+
+  public static List<Message.MediaPart> from(InboundMessage message) {
+    if (message == null || message.attachments().isEmpty()) {
+      return List.of();
+    }
+    List<Message.MediaPart> parts = new ArrayList<>();
+    for (InboundAttachment attachment : message.attachments()) {
+      if (!InboundAttachment.TYPE_IMAGE.equals(attachment.type())) {
+        continue;
+      }
+      String url = attachment.url();
+      if (url == null || url.isBlank()) {
+        continue;
+      }
+      parts.add(new Message.MediaPart(resolveMime(url.strip()), url.strip()));
+    }
+    return List.copyOf(parts);
+  }
+
+  private static String resolveMime(String url) {
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      return ImageMime.fromPath(url);
+    }
+    Path path = Path.of(url);
+    if (Files.isRegularFile(path)) {
+      return ImageMime.probeFile(path);
+    }
+    return ImageMime.fromPath(url);
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
@@ -3,9 +3,11 @@ package io.oryxos.core.channel;
 import io.oryxos.core.agent.AgentExecutionService;
 import io.oryxos.core.agent.AgentService;
 import io.oryxos.core.profile.ProfileRegistry;
+import io.oryxos.core.session.Message;
 import io.oryxos.core.session.Session;
 import io.oryxos.core.session.SessionManager;
 import java.time.Duration;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -95,6 +97,7 @@ public class InboundMessageService {
           });
       return;
     }
+    List<Message.MediaPart> media = InboundMediaParts.from(msg);
     String sessionId;
     Runnable inference;
     if (msg.chatKind() == ChatKind.P2P) {
@@ -102,15 +105,24 @@ public class InboundMessageService {
       Session session = sessionManager.getOrCreate(msg.channelType(), msg.userId(), agent);
       sessionId = session.sessionId();
       inference =
-          () -> replyVia.sendReply(msg.chatId(), agentService.process(session, agentInput), null);
+          () ->
+              replyVia.sendReply(
+                  msg.chatId(),
+                  media.isEmpty()
+                      ? agentService.process(session, agentInput)
+                      : agentService.process(session, agentInput, media),
+                  null);
     } else {
       // B3：群聊每次 @ 为独立无状态问答，不落 sessions 表；渠道前缀让审计可辨（B10）
       sessionId = msg.channelType() + "-group:" + UUID.randomUUID();
+      String groupSessionId = sessionId;
       inference =
           () ->
               replyVia.sendReply(
                   msg.chatId(),
-                  agentService.processStateless(agent, agentInput, sessionId),
+                  media.isEmpty()
+                      ? agentService.processStateless(agent, agentInput, groupSessionId)
+                      : agentService.processStateless(agent, agentInput, media, groupSessionId),
                   replyTo);
     }
     CountDownLatch done = new CountDownLatch(1);

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
@@ -107,11 +107,7 @@ public class InboundMessageService {
       inference =
           () ->
               replyVia.sendReply(
-                  msg.chatId(),
-                  media.isEmpty()
-                      ? agentService.process(session, agentInput)
-                      : agentService.process(session, agentInput, media),
-                  null);
+                  msg.chatId(), agentService.process(session, agentInput, media), null);
     } else {
       // B3：群聊每次 @ 为独立无状态问答，不落 sessions 表；渠道前缀让审计可辨（B10）
       sessionId = msg.channelType() + "-group:" + UUID.randomUUID();
@@ -120,9 +116,7 @@ public class InboundMessageService {
           () ->
               replyVia.sendReply(
                   msg.chatId(),
-                  media.isEmpty()
-                      ? agentService.processStateless(agent, agentInput, groupSessionId)
-                      : agentService.processStateless(agent, agentInput, media, groupSessionId),
+                  agentService.processStateless(agent, agentInput, media, groupSessionId),
                   replyTo);
     }
     CountDownLatch done = new CountDownLatch(1);

--- a/oryxos-core/src/main/java/io/oryxos/core/session/ImageMime.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/session/ImageMime.java
@@ -1,0 +1,118 @@
+package io.oryxos.core.session;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+
+/** 图片 MIME / 扩展名推断：优先文件魔数，其次路径后缀；均未知时默认 {@code image/jpeg}（IM 入站图常见）。 */
+public final class ImageMime {
+
+  public static final String IMAGE_JPEG = "image/jpeg";
+  public static final String IMAGE_PNG = "image/png";
+  public static final String IMAGE_GIF = "image/gif";
+  public static final String IMAGE_WEBP = "image/webp";
+
+  private static final String EXT_JPG = ".jpg";
+  private static final String EXT_JPEG = ".jpeg";
+  private static final String EXT_PNG = ".png";
+  private static final String EXT_GIF = ".gif";
+  private static final String EXT_WEBP = ".webp";
+
+  private ImageMime() {}
+
+  /** 由本地文件推断 MIME；读魔数失败则回落到路径后缀，再默认 JPEG。 */
+  public static String probeFile(Path file) {
+    if (file == null) {
+      return IMAGE_JPEG;
+    }
+    String fromMagic = sniffMagic(file);
+    if (fromMagic != null) {
+      return fromMagic;
+    }
+    return fromPath(file.toString());
+  }
+
+  /** 由路径或 URL 字符串的后缀推断；无后缀则默认 JPEG。 */
+  public static String fromPath(String pathOrUrl) {
+    if (pathOrUrl == null || pathOrUrl.isBlank()) {
+      return IMAGE_JPEG;
+    }
+    String lower = pathOrUrl.toLowerCase(Locale.ROOT);
+    int q = lower.indexOf('?');
+    if (q >= 0) {
+      lower = lower.substring(0, q);
+    }
+    if (lower.endsWith(EXT_PNG)) {
+      return IMAGE_PNG;
+    }
+    if (lower.endsWith(EXT_GIF)) {
+      return IMAGE_GIF;
+    }
+    if (lower.endsWith(EXT_WEBP)) {
+      return IMAGE_WEBP;
+    }
+    if (lower.endsWith(EXT_JPG) || lower.endsWith(EXT_JPEG)) {
+      return IMAGE_JPEG;
+    }
+    return IMAGE_JPEG;
+  }
+
+  /** MIME → 安全扩展名（含点）；未知回落 {@code .jpg}。 */
+  public static String extensionFor(String mimeType) {
+    if (IMAGE_PNG.equals(mimeType)) {
+      return EXT_PNG;
+    }
+    if (IMAGE_GIF.equals(mimeType)) {
+      return EXT_GIF;
+    }
+    if (IMAGE_WEBP.equals(mimeType)) {
+      return EXT_WEBP;
+    }
+    return EXT_JPG;
+  }
+
+  private static String sniffMagic(Path file) {
+    if (!Files.isRegularFile(file)) {
+      return null;
+    }
+    try (InputStream in = Files.newInputStream(file)) {
+      byte[] header = in.readNBytes(12);
+      if (header.length >= 3
+          && (header[0] & 0xFF) == 0xFF
+          && (header[1] & 0xFF) == 0xD8
+          && (header[2] & 0xFF) == 0xFF) {
+        return IMAGE_JPEG;
+      }
+      if (header.length >= 8
+          && header[0] == (byte) 0x89
+          && header[1] == 0x50
+          && header[2] == 0x4E
+          && header[3] == 0x47) {
+        return IMAGE_PNG;
+      }
+      if (header.length >= 6
+          && header[0] == 'G'
+          && header[1] == 'I'
+          && header[2] == 'F'
+          && header[3] == '8') {
+        return IMAGE_GIF;
+      }
+      if (header.length >= 12
+          && header[0] == 'R'
+          && header[1] == 'I'
+          && header[2] == 'F'
+          && header[3] == 'F'
+          && header[8] == 'W'
+          && header[9] == 'E'
+          && header[10] == 'B'
+          && header[11] == 'P') {
+        return IMAGE_WEBP;
+      }
+      return null;
+    } catch (IOException e) {
+      return null;
+    }
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/session/ImageMime.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/session/ImageMime.java
@@ -14,13 +14,27 @@ public final class ImageMime {
   public static final String IMAGE_GIF = "image/gif";
   public static final String IMAGE_WEBP = "image/webp";
 
+  public static final String HTTP_PREFIX = "http://";
+  public static final String HTTPS_PREFIX = "https://";
+
   private static final String EXT_JPG = ".jpg";
   private static final String EXT_JPEG = ".jpeg";
   private static final String EXT_PNG = ".png";
   private static final String EXT_GIF = ".gif";
   private static final String EXT_WEBP = ".webp";
 
+  private static final int MAGIC_HEADER_BYTES = 12;
+  private static final int JPEG_MAGIC_MIN = 3;
+  private static final int PNG_MAGIC_MIN = 8;
+  private static final int GIF_MAGIC_MIN = 6;
+  private static final int WEBP_MAGIC_MIN = 12;
+
   private ImageMime() {}
+
+  /** 是否为远程 http(s) URL（用于区分本地绝对路径）。 */
+  public static boolean isHttpUrl(String uri) {
+    return uri != null && (uri.startsWith(HTTP_PREFIX) || uri.startsWith(HTTPS_PREFIX));
+  }
 
   /** 由本地文件推断 MIME；读魔数失败则回落到路径后缀，再默认 JPEG。 */
   public static String probeFile(Path file) {
@@ -78,28 +92,28 @@ public final class ImageMime {
       return null;
     }
     try (InputStream in = Files.newInputStream(file)) {
-      byte[] header = in.readNBytes(12);
-      if (header.length >= 3
+      byte[] header = in.readNBytes(MAGIC_HEADER_BYTES);
+      if (header.length >= JPEG_MAGIC_MIN
           && (header[0] & 0xFF) == 0xFF
           && (header[1] & 0xFF) == 0xD8
           && (header[2] & 0xFF) == 0xFF) {
         return IMAGE_JPEG;
       }
-      if (header.length >= 8
+      if (header.length >= PNG_MAGIC_MIN
           && header[0] == (byte) 0x89
           && header[1] == 0x50
           && header[2] == 0x4E
           && header[3] == 0x47) {
         return IMAGE_PNG;
       }
-      if (header.length >= 6
+      if (header.length >= GIF_MAGIC_MIN
           && header[0] == 'G'
           && header[1] == 'I'
           && header[2] == 'F'
           && header[3] == '8') {
         return IMAGE_GIF;
       }
-      if (header.length >= 12
+      if (header.length >= WEBP_MAGIC_MIN
           && header[0] == 'R'
           && header[1] == 'I'
           && header[2] == 'F'

--- a/oryxos-core/src/main/java/io/oryxos/core/session/ImageMime.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/session/ImageMime.java
@@ -49,6 +49,9 @@ public final class ImageMime {
   }
 
   /** 由路径或 URL 字符串的后缀推断；无后缀则默认 JPEG。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification = "仅对 ASCII 扩展名做 Locale.ROOT 小写匹配以判 MIME，不参与安全/身份比较")
   public static String fromPath(String pathOrUrl) {
     if (pathOrUrl == null || pathOrUrl.isBlank()) {
       return IMAGE_JPEG;

--- a/oryxos-core/src/main/java/io/oryxos/core/session/Message.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/session/Message.java
@@ -7,9 +7,16 @@ import java.util.List;
  *
  * <p>为支持多步 ReAct（31 节修复）保留 OpenAI 工具调用配对：assistant 消息带它发起的 {@code toolCalls}（每个含模型分配的 id）， tool
  * 消息带它回应的 {@code toolCallId}。旧三参构造保留（user / 简单 assistant / 无 id 的 tool），旧会话 JSON 反序列化时新字段缺省为空。
+ *
+ * <p>{@code media}：用户轮可选的多模态附件（图片 URL 或本地绝对路径）。历史 JSON 无此字段时反序列化为空列表。
  */
 public record Message(
-    String role, String content, String toolName, String toolCallId, List<ToolCall> toolCalls) {
+    String role,
+    String content,
+    String toolName,
+    String toolCallId,
+    List<ToolCall> toolCalls,
+    List<MediaPart> media) {
 
   public static final String ROLE_USER = "user";
   public static final String ROLE_ASSISTANT = "assistant";
@@ -17,12 +24,34 @@ public record Message(
 
   public Message {
     toolCalls = toolCalls == null ? List.of() : List.copyOf(toolCalls);
+    media = media == null ? List.of() : List.copyOf(media);
   }
 
   public Message(String role, String content, String toolName) {
-    this(role, content, toolName, null, List.of());
+    this(role, content, toolName, null, List.of(), List.of());
+  }
+
+  public Message(
+      String role, String content, String toolName, String toolCallId, List<ToolCall> toolCalls) {
+    this(role, content, toolName, toolCallId, toolCalls, List.of());
   }
 
   /** assistant 发起的一次工具调用（含模型分配的 id，回填结果时据此配对）。 */
   public record ToolCall(String id, String name, String argumentsJson) {}
+
+  /**
+   * 用户消息中的媒体引用。
+   *
+   * @param mimeType 如 {@code image/jpeg}；可空，由 provider 侧再嗅探
+   * @param uri {@code http(s)://} URL 或本地绝对路径（飞书落地文件）
+   */
+  public record MediaPart(String mimeType, String uri) {
+    public MediaPart {
+      if (uri == null || uri.isBlank()) {
+        throw new IllegalArgumentException("uri 不能为空");
+      }
+      uri = uri.strip();
+      mimeType = mimeType == null || mimeType.isBlank() ? null : mimeType.strip();
+    }
+  }
 }

--- a/oryxos-core/src/main/java/io/oryxos/core/session/Session.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/session/Session.java
@@ -72,7 +72,14 @@ public class Session {
   }
 
   public void appendUser(String content) {
-    messages.add(new Message(Message.ROLE_USER, content, null));
+    appendUser(content, List.of());
+  }
+
+  /** 追加用户消息；{@code media} 为 vision 附件（可空）。 */
+  public void appendUser(String content, List<Message.MediaPart> media) {
+    messages.add(
+        new Message(
+            Message.ROLE_USER, content, null, null, List.of(), media == null ? List.of() : media));
   }
 
   /** 累积模型响应；text 为 null 时按空串。带上模型这一轮发起的 tool_calls（含 id），下一轮回填结果时据此配对。 */

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMediaPartsTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMediaPartsTest.java
@@ -1,0 +1,48 @@
+package io.oryxos.core.channel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.oryxos.core.session.ImageMime;
+import io.oryxos.core.session.Message;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class InboundMediaPartsTest {
+
+  @Test
+  @DisplayName("仅提取带 url 的图片附件")
+  void extractsImageUrlsOnly() {
+    InboundMessage msg =
+        new InboundMessage(
+            "feishu",
+            "ops-feishu",
+            "m1",
+            ChatKind.P2P,
+            "u1",
+            "c1",
+            "",
+            false,
+            false,
+            List.of(
+                InboundAttachment.imageUrl("https://example.com/a.png"),
+                InboundAttachment.imageReference("img_only_key"),
+                InboundAttachment.imageUrl("C:\\tmp\\b.jpg")));
+
+    List<Message.MediaPart> parts = InboundMediaParts.from(msg);
+    assertEquals(2, parts.size());
+    assertEquals("https://example.com/a.png", parts.get(0).uri());
+    assertEquals(ImageMime.IMAGE_PNG, parts.get(0).mimeType());
+    assertTrue(parts.get(1).uri().endsWith("b.jpg"));
+  }
+
+  @Test
+  @DisplayName("无附件 → 空列表")
+  void emptyWhenNoAttachments() {
+    InboundMessage msg =
+        new InboundMessage(
+            "feishu", "ops-feishu", "m2", ChatKind.P2P, "u1", "c1", "hi", true, false, List.of());
+    assertTrue(InboundMediaParts.from(msg).isEmpty());
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceContractTestBase.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceContractTestBase.java
@@ -107,12 +107,12 @@ public abstract class InboundMessageServiceContractTestBase {
   void b1Deduplication() {
     InboundMessage msg = p2pMessage("dup-1", "你好");
     Session session = stubSession(msg.userId());
-    when(agentService.process(eq(session), anyString())).thenReturn("回答");
+    when(agentService.process(eq(session), anyString(), anyList())).thenReturn("回答");
 
     service.onMessage(msg, replyChannel);
     service.onMessage(msg, replyChannel);
 
-    verify(agentService, times(1)).process(eq(session), anyString());
+    verify(agentService, times(1)).process(eq(session), anyString(), anyList());
     assertEquals(1, replyChannel.sent().size());
   }
 
@@ -121,7 +121,7 @@ public abstract class InboundMessageServiceContractTestBase {
   void b2P2pPersistentSession() {
     InboundMessage msg = p2pMessage("p2p-1", "磁盘告警怎么处理");
     Session session = stubSession(msg.userId());
-    when(agentService.process(eq(session), anyString())).thenReturn("先看 df -h");
+    when(agentService.process(eq(session), anyString(), anyList())).thenReturn("先看 df -h");
 
     service.onMessage(msg, replyChannel);
 
@@ -134,13 +134,13 @@ public abstract class InboundMessageServiceContractTestBase {
   void b3GroupStateless() {
     InboundMessage msg = groupMessage("grp-1", "发布为什么回滚");
     when(agentService.processStateless(
-            eq(AGENT), anyString(), startsWith(channelType() + "-group:")))
+            eq(AGENT), anyString(), anyList(), startsWith(channelType() + "-group:")))
         .thenReturn("配置漂移");
 
     service.onMessage(msg, replyChannel);
 
     verify(agentService)
-        .processStateless(eq(AGENT), anyString(), startsWith(channelType() + "-group:"));
+        .processStateless(eq(AGENT), anyString(), anyList(), startsWith(channelType() + "-group:"));
     verifyNoInteractions(sessionManager);
   }
 
@@ -148,8 +148,9 @@ public abstract class InboundMessageServiceContractTestBase {
   @DisplayName("B4: 私聊直发；群聊回复引用原消息")
   void b4ReplyCorrelation() {
     Session session = stubSession(p2pMessage("x", "x").userId());
-    when(agentService.process(any(), anyString())).thenReturn("答");
-    when(agentService.processStateless(anyString(), anyString(), anyString())).thenReturn("答");
+    when(agentService.process(any(), anyString(), anyList())).thenReturn("答");
+    when(agentService.processStateless(anyString(), anyString(), anyList(), anyString()))
+        .thenReturn("答");
 
     service.onMessage(p2pMessage("corr-p2p", "问"), replyChannel);
     service.onMessage(groupMessage("corr-grp", "问"), replyChannel);
@@ -163,7 +164,7 @@ public abstract class InboundMessageServiceContractTestBase {
   void b5b10AuditViaTriggerAsync() {
     InboundMessage msg = p2pMessage("audit-1", "问");
     Session session = stubSession(msg.userId());
-    when(agentService.process(eq(session), anyString())).thenReturn("答");
+    when(agentService.process(eq(session), anyString(), anyList())).thenReturn("答");
 
     service.onMessage(msg, replyChannel);
 
@@ -176,7 +177,8 @@ public abstract class InboundMessageServiceContractTestBase {
   void b6ReadableFailure() {
     InboundMessage msg = p2pMessage("fail-1", "问");
     stubSession(msg.userId());
-    when(agentService.process(any(), anyString())).thenThrow(new IllegalStateException("boom"));
+    when(agentService.process(any(), anyString(), anyList()))
+        .thenThrow(new IllegalStateException("boom"));
 
     service.onMessage(msg, replyChannel);
 
@@ -223,7 +225,7 @@ public abstract class InboundMessageServiceContractTestBase {
   void b8NoNoticeOnFastPath() throws Exception {
     InboundMessage msg = p2pMessage("fast-1", "问");
     Session session = stubSession(msg.userId());
-    when(agentService.process(eq(session), anyString())).thenReturn("秒回");
+    when(agentService.process(eq(session), anyString(), anyList())).thenReturn("秒回");
 
     service.onMessage(msg, replyChannel);
     Thread.sleep(50);

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceContractTestBase.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceContractTestBase.java
@@ -3,6 +3,7 @@ package io.oryxos.core.channel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
@@ -197,11 +198,11 @@ public abstract class InboundMessageServiceContractTestBase {
   void b7ImageAttachmentProcessed() {
     InboundMessage img = imageMessage("img-2");
     Session session = stubSession(img.userId());
-    when(agentService.process(eq(session), anyString())).thenReturn("看到了图片");
+    when(agentService.process(eq(session), anyString(), anyList())).thenReturn("看到了图片");
 
     service.onMessage(img, replyChannel);
 
-    verify(agentService).process(eq(session), anyString());
+    verify(agentService).process(eq(session), anyString(), anyList());
     assertEquals("看到了图片", replyChannel.sent().get(0).text());
   }
 

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceTest.java
@@ -106,12 +106,12 @@ class InboundMessageServiceTest {
   void duplicateMessageProcessedOnce() {
     Session session = new Session("stub:user-1:" + AGENT, AGENT);
     when(sessionManager.getOrCreate("stub", "user-1", AGENT)).thenReturn(session);
-    when(agentService.process(session, "hi")).thenReturn("回答");
+    when(agentService.process(eq(session), eq("hi"), anyList())).thenReturn("回答");
 
     service.onMessage(p2p("m-1", "hi"), adapter);
     service.onMessage(p2p("m-1", "hi"), adapter);
 
-    verify(agentService, times(1)).process(session, "hi");
+    verify(agentService, times(1)).process(eq(session), eq("hi"), anyList());
     assertEquals(1, adapter.sent().size());
   }
 
@@ -120,7 +120,7 @@ class InboundMessageServiceTest {
   void p2pUsesPersistentSession() {
     Session session = new Session("stub:user-1:" + AGENT, AGENT);
     when(sessionManager.getOrCreate("stub", "user-1", AGENT)).thenReturn(session);
-    when(agentService.process(session, "磁盘告警怎么处理")).thenReturn("先看 df -h");
+    when(agentService.process(eq(session), eq("磁盘告警怎么处理"), anyList())).thenReturn("先看 df -h");
 
     service.onMessage(p2p("m-2", "磁盘告警怎么处理"), adapter);
 
@@ -134,12 +134,14 @@ class InboundMessageServiceTest {
   @Test
   @DisplayName("B3/B4/B10: 群聊走无状态问答（渠道前缀临时会话 id），回复引用原消息，不落持久会话")
   void groupIsStatelessWithChannelTag() {
-    when(agentService.processStateless(eq(AGENT), eq("发布为什么回滚"), startsWith("stub-group:")))
+    when(agentService.processStateless(
+            eq(AGENT), eq("发布为什么回滚"), anyList(), startsWith("stub-group:")))
         .thenReturn("因为配置漂移");
 
     service.onMessage(group("m-3", "发布为什么回滚"), adapter);
 
-    verify(agentService).processStateless(eq(AGENT), eq("发布为什么回滚"), startsWith("stub-group:"));
+    verify(agentService)
+        .processStateless(eq(AGENT), eq("发布为什么回滚"), anyList(), startsWith("stub-group:"));
     verifyNoInteractions(sessionManager);
     assertEquals(1, adapter.sent().size());
     assertEquals("m-3", adapter.sent().get(0).replyToMessageId());
@@ -152,7 +154,8 @@ class InboundMessageServiceTest {
   void failureRepliedReadably() {
     Session session = new Session("stub:user-1:" + AGENT, AGENT);
     when(sessionManager.getOrCreate("stub", "user-1", AGENT)).thenReturn(session);
-    when(agentService.process(any(), anyString())).thenThrow(new IllegalStateException("模型服务不可用"));
+    when(agentService.process(any(), anyString(), anyList()))
+        .thenThrow(new IllegalStateException("模型服务不可用"));
 
     service.onMessage(p2p("m-4", "hi"), adapter);
 
@@ -215,7 +218,7 @@ class InboundMessageServiceTest {
     Session session = new Session("stub:user-1:" + AGENT, AGENT);
     when(sessionManager.getOrCreate("stub", "user-1", AGENT)).thenReturn(session);
     CountDownLatch workDone = new CountDownLatch(1);
-    when(agentService.process(any(), anyString()))
+    when(agentService.process(any(), anyString(), anyList()))
         .thenAnswer(
             inv -> {
               Thread.sleep(400); // 超过 120ms 阈值
@@ -266,7 +269,7 @@ class InboundMessageServiceTest {
   void auditCarriesChannelSource() {
     Session session = new Session("stub:user-1:" + AGENT, AGENT);
     when(sessionManager.getOrCreate("stub", "user-1", AGENT)).thenReturn(session);
-    when(agentService.process(session, "hi")).thenReturn("ok");
+    when(agentService.process(eq(session), eq("hi"), anyList())).thenReturn("ok");
 
     service.onMessage(p2p("m-8", "hi"), adapter);
 
@@ -279,7 +282,7 @@ class InboundMessageServiceTest {
   void sendFailureDoesNotPropagate() {
     Session session = new Session("stub:user-1:" + AGENT, AGENT);
     when(sessionManager.getOrCreate("stub", "user-1", AGENT)).thenReturn(session);
-    when(agentService.process(session, "hi")).thenReturn("ok");
+    when(agentService.process(eq(session), eq("hi"), anyList())).thenReturn("ok");
     adapter.failSendsWith(new IllegalStateException("网络故障"));
 
     service.onMessage(p2p("m-9", "hi"), adapter); // 不抛出即通过

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceTest.java
@@ -3,6 +3,7 @@ package io.oryxos.core.channel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -200,11 +201,11 @@ class InboundMessageServiceTest {
             java.util.List.of(InboundAttachment.imageUrl("https://example/img.png")));
     Session session = new Session("stub:user-1:" + AGENT, AGENT);
     when(sessionManager.getOrCreate("stub", "user-1", AGENT)).thenReturn(session);
-    when(agentService.process(eq(session), anyString())).thenReturn("图片已收到");
+    when(agentService.process(eq(session), anyString(), anyList())).thenReturn("图片已收到");
 
     service.onMessage(img, adapter);
 
-    verify(agentService).process(eq(session), anyString());
+    verify(agentService).process(eq(session), anyString(), anyList());
     assertEquals("图片已收到", adapter.sent().get(0).text());
   }
 

--- a/oryxos-core/src/test/java/io/oryxos/core/session/ImageMimeTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/session/ImageMimeTest.java
@@ -1,0 +1,35 @@
+package io.oryxos.core.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ImageMimeTest {
+
+  @TempDir Path dir;
+
+  @Test
+  @DisplayName("路径后缀推断 MIME")
+  void fromPathByExtension() {
+    assertEquals(ImageMime.IMAGE_PNG, ImageMime.fromPath("a/b/c.PNG"));
+    assertEquals(ImageMime.IMAGE_JPEG, ImageMime.fromPath("https://x/img.jpg?token=1"));
+    assertEquals(ImageMime.IMAGE_WEBP, ImageMime.fromPath("x.webp"));
+    assertEquals(ImageMime.IMAGE_JPEG, ImageMime.fromPath("noext"));
+  }
+
+  @Test
+  @DisplayName("魔数优先于错误后缀")
+  void probeFilePrefersMagic() throws Exception {
+    Path fakeBin = dir.resolve("shot.bin");
+    // PNG signature
+    Files.write(
+        fakeBin,
+        new byte[] {(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x00});
+    assertEquals(ImageMime.IMAGE_PNG, ImageMime.probeFile(fakeBin));
+    assertEquals(".png", ImageMime.extensionFor(ImageMime.IMAGE_PNG));
+  }
+}

--- a/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
@@ -594,7 +594,7 @@ public class SpringAiProviderServiceImpl implements ProviderService {
     String uri = part.uri().strip();
     MimeType mime = resolveMime(part.mimeType(), uri);
     try {
-      if (uri.startsWith("http://") || uri.startsWith("https://")) {
+      if (ImageMime.isHttpUrl(uri)) {
         return new Media(mime, URI.create(uri));
       }
       Path path = Path.of(uri);
@@ -612,7 +612,7 @@ public class SpringAiProviderServiceImpl implements ProviderService {
   private static MimeType resolveMime(String declared, String uri) {
     String raw = declared;
     if (raw == null || raw.isBlank()) {
-      if (uri.startsWith("http://") || uri.startsWith("https://")) {
+      if (ImageMime.isHttpUrl(uri)) {
         raw = ImageMime.fromPath(uri);
       } else {
         raw = ImageMime.probeFile(Path.of(uri));

--- a/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
@@ -11,7 +11,11 @@ import io.oryxos.core.provider.ProviderResponse;
 import io.oryxos.core.provider.ProviderService;
 import io.oryxos.core.provider.ToolCallRequest;
 import io.oryxos.core.provider.Usage;
+import io.oryxos.core.session.ImageMime;
 import io.oryxos.core.session.Message;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -27,8 +31,12 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.tool.ToolCallback;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
 
 /**
  * Provider 前台（core {@link ProviderService} 契约的 Spring AI 实现）：按 Profile 显式路由到对应
@@ -120,6 +128,28 @@ public class SpringAiProviderServiceImpl implements ProviderService {
 
   /** 单次尝试（023）：attempt 的 name/model 贯穿路由、Prompt 与审计（R2）。 */
   private ProviderResponse chatOnce(
+      String sessionId,
+      Profile profile,
+      ProviderRequest request,
+      Attempt attempt,
+      ProviderDef def) {
+    try {
+      return invokeChat(sessionId, profile, request, attempt, def);
+    } catch (RuntimeException e) {
+      // 非 vision 模型拒收图片（常见 400）：剥掉 media 后用 enricher 文本再试一次，避免入站图硬失败
+      if (hasUserMedia(request) && isClientError(e)) {
+        LOG.warn(
+            "multimodal 被拒，降级纯文本重试（provider={} model={}）：{}",
+            sanitize(attempt.provider()),
+            sanitize(attempt.model()),
+            sanitize(e.getMessage()));
+        return invokeChat(sessionId, profile, stripMedia(request), attempt, def);
+      }
+      throw e;
+    }
+  }
+
+  private ProviderResponse invokeChat(
       String sessionId,
       Profile profile,
       ProviderRequest request,
@@ -217,12 +247,36 @@ public class SpringAiProviderServiceImpl implements ProviderService {
     throw last != null ? last : new ProviderNotFoundException(profile.provider().name());
   }
 
+  private ProviderResponse chatStreamOnce(
+      String sessionId,
+      Profile profile,
+      ProviderRequest request,
+      java.util.function.Consumer<String> onToken,
+      Attempt attempt,
+      ProviderDef def,
+      boolean[] contentStarted) {
+    try {
+      return invokeChatStream(sessionId, profile, request, onToken, attempt, def, contentStarted);
+    } catch (RuntimeException e) {
+      if (!contentStarted[0] && hasUserMedia(request) && isClientError(e)) {
+        LOG.warn(
+            "multimodal 流式被拒，降级纯文本重试（provider={} model={}）：{}",
+            sanitize(attempt.provider()),
+            sanitize(attempt.model()),
+            sanitize(e.getMessage()));
+        return invokeChatStream(
+            sessionId, profile, stripMedia(request), onToken, attempt, def, contentStarted);
+      }
+      throw e;
+    }
+  }
+
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
       justification =
           "Spring AI 注解声称 chunk 各字段非空，但流式 chunk 边界形态因 provider 而异，"
               + "对 generation/output 的防御性判空是有意保留的（019 裁决，信注解不如信线上流量）")
-  private ProviderResponse chatStreamOnce(
+  private ProviderResponse invokeChatStream(
       String sessionId,
       Profile profile,
       ProviderRequest request,
@@ -482,7 +536,11 @@ public class SpringAiProviderServiceImpl implements ProviderService {
 
   private static org.springframework.ai.chat.messages.Message toSpringMessage(Message message) {
     if (Message.ROLE_USER.equals(message.role())) {
-      return new UserMessage(message.content());
+      List<Media> media = toSpringMedia(message.media());
+      if (media.isEmpty()) {
+        return new UserMessage(message.content());
+      }
+      return UserMessage.builder().text(message.content()).media(media).build();
     }
     if (Message.ROLE_TOOL.equals(message.role())) {
       String id = message.toolCallId();
@@ -513,6 +571,139 @@ public class SpringAiProviderServiceImpl implements ProviderService {
         .properties(Map.of())
         .toolCalls(toolCalls)
         .build();
+  }
+
+  private static List<Media> toSpringMedia(List<Message.MediaPart> parts) {
+    if (parts == null || parts.isEmpty()) {
+      return List.of();
+    }
+    List<Media> media = new ArrayList<>(parts.size());
+    for (Message.MediaPart part : parts) {
+      Media m = toSpringMedia(part);
+      if (m != null) {
+        media.add(m);
+      }
+    }
+    return media;
+  }
+
+  private static Media toSpringMedia(Message.MediaPart part) {
+    if (part == null || part.uri() == null || part.uri().isBlank()) {
+      return null;
+    }
+    String uri = part.uri().strip();
+    MimeType mime = resolveMime(part.mimeType(), uri);
+    try {
+      if (uri.startsWith("http://") || uri.startsWith("https://")) {
+        return new Media(mime, URI.create(uri));
+      }
+      Path path = Path.of(uri);
+      if (!Files.isRegularFile(path)) {
+        LOG.warn("跳过不可读的本地图片: {}", sanitize(uri));
+        return null;
+      }
+      return new Media(mime, new FileSystemResource(path));
+    } catch (RuntimeException e) {
+      LOG.warn("构造 Media 失败（uri={}）：{}", sanitize(uri), sanitize(e.getMessage()));
+      return null;
+    }
+  }
+
+  private static MimeType resolveMime(String declared, String uri) {
+    String raw = declared;
+    if (raw == null || raw.isBlank()) {
+      if (uri.startsWith("http://") || uri.startsWith("https://")) {
+        raw = ImageMime.fromPath(uri);
+      } else {
+        raw = ImageMime.probeFile(Path.of(uri));
+      }
+    }
+    try {
+      return MimeTypeUtils.parseMimeType(raw);
+    } catch (RuntimeException e) {
+      return MimeTypeUtils.IMAGE_JPEG;
+    }
+  }
+
+  private static boolean hasUserMedia(ProviderRequest request) {
+    if (request == null || request.messages() == null) {
+      return false;
+    }
+    for (Message message : request.messages()) {
+      if (Message.ROLE_USER.equals(message.role()) && !message.media().isEmpty()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static ProviderRequest stripMedia(ProviderRequest request) {
+    List<Message> stripped = new ArrayList<>(request.messages().size());
+    for (Message message : request.messages()) {
+      if (message.media().isEmpty()) {
+        stripped.add(message);
+      } else {
+        stripped.add(
+            new Message(
+                message.role(),
+                message.content(),
+                message.toolName(),
+                message.toolCallId(),
+                message.toolCalls(),
+                List.of()));
+      }
+    }
+    return new ProviderRequest(request.systemPrompt(), stripped, request.availableTools());
+  }
+
+  /** 4xx 类客户端错误（模型拒收图片等）——值得剥 media 再试；5xx/网络交给既有 fallback。 */
+  private static boolean isClientError(RuntimeException e) {
+    Throwable t = e;
+    while (t != null) {
+      if (t instanceof org.springframework.web.client.RestClientResponseException rest) {
+        int code = rest.getStatusCode().value();
+        return code >= 400
+            && code < 500
+            && code != 401
+            && code != 403
+            && code != 408
+            && code != 429;
+      }
+      if (t
+          instanceof
+          org.springframework.web.reactive.function.client.WebClientResponseException web) {
+        int code = web.getStatusCode().value();
+        return code >= 400
+            && code < 500
+            && code != 401
+            && code != 403
+            && code != 408
+            && code != 429;
+      }
+      if (t instanceof org.springframework.ai.retry.NonTransientAiException
+          || t instanceof org.springframework.ai.retry.TransientAiException) {
+        Integer code = leadingHttpStatus(t.getMessage());
+        if (code != null) {
+          return code >= 400
+              && code < 500
+              && code != 401
+              && code != 403
+              && code != 408
+              && code != 429;
+        }
+      }
+      t = t.getCause();
+    }
+    return false;
+  }
+
+  private static Integer leadingHttpStatus(String message) {
+    if (message == null) {
+      return null;
+    }
+    java.util.regex.Matcher matcher =
+        java.util.regex.Pattern.compile("^(\\d{3}) - ").matcher(message);
+    return matcher.find() ? Integer.valueOf(matcher.group(1)) : null;
   }
 
   private static ProviderResponse toProviderResponse(ChatResponse response) {

--- a/oryxos-provider/src/test/java/io/oryxos/provider/ProviderServiceTest.java
+++ b/oryxos-provider/src/test/java/io/oryxos/provider/ProviderServiceTest.java
@@ -23,6 +23,7 @@ import io.oryxos.core.provider.LlmCallAuditor;
 import io.oryxos.core.provider.ProviderRequest;
 import io.oryxos.core.provider.ProviderResponse;
 import io.oryxos.core.provider.ProviderService;
+import io.oryxos.core.session.Message;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -316,5 +317,62 @@ class ProviderServiceTest {
     current.set(new io.oryxos.core.provider.ProviderDef("deepseek", "key-1", "https://a", null));
     cachedService.chat("s-1", profileUsing("deepseek"), ProviderRequest.of("hi"));
     assertEquals(3, builds.get()); // 换回旧配置也重建——旧条目已被替换而非累积保留
+  }
+
+  @Test
+  void 用户消息带图片URL_Prompt含Media() {
+    when(deepseek.call(any(Prompt.class))).thenReturn(textResponse("看到海浪"));
+    Message user =
+        new Message(
+            Message.ROLE_USER,
+            "[用户发送了一张图片]\n图片链接: https://example.com/a.png",
+            null,
+            null,
+            List.of(),
+            List.of(new Message.MediaPart("image/png", "https://example.com/a.png")));
+
+    service.chat(
+        "s-1", profileUsing("deepseek"), new ProviderRequest(null, List.of(user), List.of()));
+
+    ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+    verify(deepseek).call(captor.capture());
+    var springUser =
+        (org.springframework.ai.chat.messages.UserMessage)
+            captor.getValue().getInstructions().get(0);
+    assertEquals(1, springUser.getMedia().size());
+    assertEquals("image/png", springUser.getMedia().get(0).getMimeType().toString());
+  }
+
+  @Test
+  void multimodal被400拒绝_降级纯文本重试成功() {
+    org.springframework.web.client.HttpClientErrorException reject =
+        org.springframework.web.client.HttpClientErrorException.create(
+            org.springframework.http.HttpStatus.BAD_REQUEST,
+            "bad request",
+            org.springframework.http.HttpHeaders.EMPTY,
+            new byte[0],
+            null);
+    when(deepseek.call(any(Prompt.class))).thenThrow(reject).thenReturn(textResponse("仅看到链接说明"));
+
+    Message user =
+        new Message(
+            Message.ROLE_USER,
+            "图片链接: https://example.com/a.png",
+            null,
+            null,
+            List.of(),
+            List.of(new Message.MediaPart("image/png", "https://example.com/a.png")));
+
+    ProviderResponse response =
+        service.chat(
+            "s-1", profileUsing("deepseek"), new ProviderRequest(null, List.of(user), List.of()));
+
+    assertEquals("仅看到链接说明", response.text());
+    ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+    verify(deepseek, times(2)).call(captor.capture());
+    var second =
+        (org.springframework.ai.chat.messages.UserMessage)
+            captor.getAllValues().get(1).getInstructions().get(0);
+    assertTrue(second.getMedia().isEmpty());
   }
 }

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/SseStreamingTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/SseStreamingTest.java
@@ -101,7 +101,7 @@ class SseStreamingTest {
   @Test
   @DisplayName("流式_工具事件成对且顺序正确")
   void streaming_toolEventsPairedInOrder() throws Exception {
-    when(agentService.process(any(), anyString(), any()))
+    when(agentService.process(any(), anyString(), any(StreamListener.class)))
         .thenAnswer(
             inv -> {
               StreamListener listener = inv.getArgument(2, StreamListener.class);
@@ -124,7 +124,7 @@ class SseStreamingTest {
   @Test
   @DisplayName("流中异常_恰好一个error事件且无done_信息可读")
   void streaming_midStreamFailure_singleErrorTerminal() throws Exception {
-    when(agentService.process(any(), anyString(), any()))
+    when(agentService.process(any(), anyString(), any(StreamListener.class)))
         .thenAnswer(
             inv -> {
               StreamListener listener = inv.getArgument(2, StreamListener.class);
@@ -161,7 +161,7 @@ class SseStreamingTest {
     props.setHeartbeatSeconds(1);
     controller.setSseStreamSupport(new SseStreamSupport(new ObjectMapper(), props));
     MockMvc slowMvc = MockMvcBuilders.standaloneSetup(controller).build();
-    when(agentService.process(any(), anyString(), any()))
+    when(agentService.process(any(), anyString(), any(StreamListener.class)))
         .thenAnswer(
             inv -> {
               Thread.sleep(2500); // 静默期 > 2 个心跳间隔


### PR DESCRIPTION
Closes #384

## Summary
- Carry inbound image URL / local path on `Message.media` through ReAct → provider
- Map to Spring AI `UserMessage` + `Media` (HTTP or local file)
- Soft-fallback: if model returns 4xx on multimodal, retry text-only (enricher caption kept)
- Feishu download: sniff PNG/JPEG magic and rename `.bin` → correct extension

## Test plan
- [x] `ImageMimeTest`, `InboundMediaPartsTest`, `ProviderServiceTest` (Media + soft-fallback)
- [x] Feishu resolver magic rename + inbound image contract tests
- [ ] Optional real device: set `demo-agent` `provider.model: deepseek-v4-flash-vision-exp`, restart serve, send Feishu image → Agent describes the scene (not only the path)