### PR TITLE
fix: Feishu OkHttp readTimeout 180s for inbound image download

### DIFF
--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
@@ -3,9 +3,11 @@ package io.oryxos.channel.feishu;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.lark.oapi.core.httpclient.OkHttpTransport;
 import com.lark.oapi.core.response.RawResponse;
 import com.lark.oapi.core.token.AccessTokenType;
 import com.lark.oapi.event.EventDispatcher;
+import com.lark.oapi.okhttp.OkHttpClient;
 import com.lark.oapi.service.im.ImService;
 import com.lark.oapi.service.im.v1.model.P2MessageReceiveV1;
 import io.oryxos.core.channel.ChannelConfig;
@@ -50,8 +52,14 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
   private static final long READY_TIMEOUT_MS = 15_000;
   private static final long READY_PROBE_TIMEOUT_MS = 50;
 
-  /** 入站图片下载可能较大；SDK 默认超时偏紧，真机易 SocketTimeout。 */
-  private static final long API_REQUEST_TIMEOUT_SEC = 60;
+  /**
+   * 入站图片下载超时。SDK {@code requestTimeout} 只设置 OkHttp {@code callTimeout}，仍保留默认 {@code
+   * readTimeout=10s}，慢网/大图会在读 body 时 {@code client time out}。须自定义 transport 同时拉长 read/call。
+   */
+  private static final long API_CONNECT_TIMEOUT_SEC = 30;
+
+  private static final long API_READ_TIMEOUT_SEC = 180;
+  private static final long API_CALL_TIMEOUT_SEC = 180;
 
   private final ChannelConfig config; // resolved 口径（凭证为真实值，仅存活内存）
   private final ProfileRegistry profileRegistry;
@@ -107,7 +115,14 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
     try {
       apiClient =
           com.lark.oapi.Client.newBuilder(config.appId(), config.appSecret())
-              .requestTimeout(API_REQUEST_TIMEOUT_SEC, TimeUnit.SECONDS)
+              .httpTransport(
+                  new OkHttpTransport(
+                      new OkHttpClient.Builder()
+                          .connectTimeout(API_CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS)
+                          .readTimeout(API_READ_TIMEOUT_SEC, TimeUnit.SECONDS)
+                          .writeTimeout(API_CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS)
+                          .callTimeout(API_CALL_TIMEOUT_SEC, TimeUnit.SECONDS)
+                          .build()))
               .build();
       sender =
           new FeishuMessageSender(

--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuInboundImageResolver.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuInboundImageResolver.java
@@ -32,6 +32,7 @@ final class FeishuInboundImageResolver {
   private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
   private static final char PATH_SAFE_REPLACEMENT = '_';
   private static final int MAX_SEGMENT_LEN = 96;
+  private static final int DOWNLOAD_ATTEMPTS = 2;
 
   private final Client client;
   private final Path mediaRoot;
@@ -83,39 +84,72 @@ final class FeishuInboundImageResolver {
 
   private InboundAttachment downloadOrKeep(String messageId, InboundAttachment attachment) {
     String imageKey = attachment.reference();
-    try {
-      GetMessageResourceResp resp =
-          client
-              .im()
-              .messageResource()
-              .get(
-                  GetMessageResourceReq.newBuilder()
-                      .messageId(messageId)
-                      .fileKey(imageKey)
-                      .type(RESOURCE_TYPE_IMAGE)
-                      .build());
-      if (resp == null || !resp.success() || resp.getData() == null) {
-        LOG.warn(
-            "飞书渠道 {} 下载图片失败（messageId={}, imageKey={}, code={}, msg={}），保留 image_key",
-            sanitize(channelName),
-            sanitize(messageId),
-            sanitize(imageKey),
-            resp == null ? -1 : resp.getCode(),
-            sanitize(resp == null ? null : resp.getMsg()));
-        return attachment;
+    Exception last = null;
+    for (int attempt = 1; attempt <= DOWNLOAD_ATTEMPTS; attempt++) {
+      try {
+        GetMessageResourceResp resp =
+            client
+                .im()
+                .messageResource()
+                .get(
+                    GetMessageResourceReq.newBuilder()
+                        .messageId(messageId)
+                        .fileKey(imageKey)
+                        .type(RESOURCE_TYPE_IMAGE)
+                        .build());
+        if (resp == null || !resp.success() || resp.getData() == null) {
+          LOG.warn(
+              "飞书渠道 {} 下载图片失败（messageId={}, imageKey={}, code={}, msg={}），保留 image_key",
+              sanitize(channelName),
+              sanitize(messageId),
+              sanitize(imageKey),
+              resp == null ? -1 : resp.getCode(),
+              sanitize(resp == null ? null : resp.getMsg()));
+          return attachment;
+        }
+        Path file = writeToMediaRoot(messageId, imageKey, resp);
+        return new InboundAttachment(
+            InboundAttachment.TYPE_IMAGE, file.toAbsolutePath().toString(), imageKey);
+      } catch (Exception e) {
+        last = e;
+        if (attempt < DOWNLOAD_ATTEMPTS && isTransientTimeout(e)) {
+          LOG.warn(
+              "飞书渠道 {} 下载图片超时重试 {}/{}（messageId={}, imageKey={}）：{}",
+              sanitize(channelName),
+              attempt,
+              DOWNLOAD_ATTEMPTS,
+              sanitize(messageId),
+              sanitize(imageKey),
+              sanitize(e.getMessage()));
+          continue;
+        }
+        break;
       }
-      Path file = writeToMediaRoot(messageId, imageKey, resp);
-      return new InboundAttachment(
-          InboundAttachment.TYPE_IMAGE, file.toAbsolutePath().toString(), imageKey);
-    } catch (Exception e) {
-      LOG.warn(
-          "飞书渠道 {} 下载图片异常（messageId={}, imageKey={}）：{}，保留 image_key",
-          sanitize(channelName),
-          sanitize(messageId),
-          sanitize(imageKey),
-          sanitize(e.getMessage()));
-      return attachment;
     }
+    LOG.warn(
+        "飞书渠道 {} 下载图片异常（messageId={}, imageKey={}）：{}，保留 image_key",
+        sanitize(channelName),
+        sanitize(messageId),
+        sanitize(imageKey),
+        sanitize(last == null ? null : last.getMessage()));
+    return attachment;
+  }
+
+  private static boolean isTransientTimeout(Throwable error) {
+    for (Throwable t = error; t != null; t = t.getCause()) {
+      String name = t.getClass().getName();
+      if (name.contains("Timeout") || name.contains("InterruptedIO")) {
+        return true;
+      }
+      String msg = t.getMessage();
+      if (msg != null) {
+        String lower = msg.toLowerCase(Locale.ROOT);
+        if (lower.contains("timeout") || lower.contains("timed out")) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private Path writeToMediaRoot(String messageId, String imageKey, GetMessageResourceResp resp)


### PR DESCRIPTION
## Summary
- Custom `OkHttpTransport`: connect 30s, read/write/call 180s (SDK `requestTimeout` only sets `callTimeout`, leaving default `readTimeout=10s`)
- Retry once on transient download timeout

Closes #388

## Test plan
- [x] `FeishuInboundImageResolverTest`
- [ ] CI green
- [ ] Feishu AIBOT pure image → session `media` non-empty + vision describes image