### PR TITLE
feat: IM /new clears session; Feishu dedup before image download

### DIFF
--- a/oryxos-channel-cli/pom.xml
+++ b/oryxos-channel-cli/pom.xml
@@ -20,6 +20,11 @@
             <artifactId>oryxos-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/oryxos-channel-cli/src/main/java/io/oryxos/channel/cli/CliChannel.java
+++ b/oryxos-channel-cli/src/main/java/io/oryxos/channel/cli/CliChannel.java
@@ -13,7 +13,7 @@ import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 
 /**
- * chat 命令的交互通道：读 stdin、写 stdout，维护当前 Session，每行交给引擎，{@code /quit} 退出。
+ * chat 命令的交互通道：读 stdin、写 stdout，维护当前 Session，每行交给引擎，{@code /quit} 退出、{@code /new} 清空历史。
  *
  * <p>CLI 是消息进出的门，不是干活的人——本类没有任何 Agent 智能，就是读—转交—打印的壳（课件骨架）。 channel 字面量 "cli" 只作为三元组参数提供，session_id
  * 拼接在 SessionManager 内部（H4④）。
@@ -21,9 +21,13 @@ import java.nio.charset.Charset;
  * <p>stdin 编码：有 {@link System#console()} 用 console reader；否则 {@link Charset#defaultCharset()}。不硬编码
  * UTF-8。
  */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "AgentService/SessionManager 均为 Runtime 装配单例，共享引用正是意图")
 public class CliChannel {
 
   private static final String QUIT = "/quit";
+  private static final String NEW = "/new";
 
   private final AgentService agentService;
   private final SessionManager sessionManager;
@@ -36,7 +40,7 @@ public class CliChannel {
   public void run(String profileName, String userId) {
     Session session = sessionManager.getOrCreate("cli", userId, profileName);
     PrintStream out = System.out;
-    out.printf("已连接 Agent [%s]，输入 %s 退出。%n", profileName, QUIT);
+    out.printf("已连接 Agent [%s]，输入 %s 退出，%s 开新会话。%n", profileName, QUIT, NEW);
     BufferedReader in = stdinReader();
     while (true) {
       out.print("> ");
@@ -47,6 +51,12 @@ public class CliChannel {
         return;
       }
       if (line.isBlank()) {
+        continue;
+      }
+      if (NEW.equals(line.trim())) {
+        sessionManager.clearHistory(session.sessionId());
+        session = sessionManager.getOrCreate("cli", userId, profileName);
+        out.println("已开启新会话，之前的对话上下文已清空。");
         continue;
       }
       TypewriterListener listener = new TypewriterListener(out);

--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
@@ -218,15 +218,22 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
     active.send(chatId, text, replyToMessageId);
   }
 
-  /** 事件入口：归一化 → 图片资源落地 → 编排；任何异常只留日志——抛出会触发平台重推循环（去重会拦但用户收不到回答）。 */
+  /**
+   * 事件入口：归一化 → 去重占用 → 图片资源落地 → 编排。去重必须在下载前：飞书平台重推同一 message_id 时，若先下载再去重会白耗
+   * 带宽并拉长「处理中」窗口。任何异常只留日志——抛出会触发平台重推循环。
+   */
   private void handleEvent(P2MessageReceiveV1 event) {
     try {
       Optional<InboundMessage> msg = normalizer.normalize(event);
       msg.ifPresent(
           m -> {
+            if (!inboundMessageService.tryClaim(m.channelName(), m.messageId())) {
+              LOG.info("渠道 {} 重复事件已忽略: {}", sanitize(m.channelName()), sanitize(m.messageId()));
+              return;
+            }
             FeishuInboundImageResolver resolver = imageResolver;
             InboundMessage enriched = resolver == null ? m : resolver.resolve(m);
-            inboundMessageService.onMessage(enriched, this);
+            inboundMessageService.onClaimedMessage(enriched, this);
           });
     } catch (RuntimeException e) {
       LOG.error("飞书渠道 {} 事件处理异常: {}", sanitize(config.name()), sanitize(e.getMessage()));

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
@@ -34,6 +34,8 @@ public class InboundMessageService {
   static final String AGENT_UNAVAILABLE_REPLY = "Agent 暂不可用（未找到绑定的 Agent），请联系管理员。";
   static final String FAILURE_REPLY = "抱歉，这次处理失败了，请稍后重试或联系管理员。";
   static final String PROCESSING_REPLY = "已收到，正在处理中，请稍候…";
+  static final String NEW_SESSION_REPLY = "已开启新会话，之前的对话上下文已清空。";
+  private static final String NEW_SESSION_COMMAND = "/new";
 
   private final AgentService agentService;
   private final SessionManager sessionManager;
@@ -63,6 +65,11 @@ public class InboundMessageService {
     this.processingNoticeDelay = processingNoticeDelay;
   }
 
+  /** 在昂贵预处理（飞书入站图下载等）前占用 message_id。返回 false 表示重复事件，调用方应直接丢弃且勿再下载。 */
+  public boolean tryClaim(String channelName, String messageId) {
+    return deduplicator.markIfFirst(channelName + DEDUP_KEY_SEPARATOR + messageId);
+  }
+
   /**
    * 归一化消息唯一入口：确认线程内快速返回（去重 + 提交），推理与回发在虚拟线程（B5）。
    *
@@ -70,8 +77,19 @@ public class InboundMessageService {
    * @param replyVia 回复通道（即产生本消息的适配器）
    */
   public void onMessage(InboundMessage msg, InboundChannelAdapter replyVia) {
+    onMessage(msg, replyVia, true);
+  }
+
+  /** 调用方已通过 {@link #tryClaim} 占用 message_id 时使用（避免下载完成后二次去重把合法首条丢掉）。 */
+  public void onClaimedMessage(InboundMessage msg, InboundChannelAdapter replyVia) {
+    onMessage(msg, replyVia, false);
+  }
+
+  private void onMessage(
+      InboundMessage msg, InboundChannelAdapter replyVia, boolean claimMessageId) {
     // B1：同一渠道同一 message_id 只处理一次（平台超时重推场景用户只收到一条回答）
-    if (!deduplicator.markIfFirst(msg.channelName() + DEDUP_KEY_SEPARATOR + msg.messageId())) {
+    if (claimMessageId
+        && !deduplicator.markIfFirst(msg.channelName() + DEDUP_KEY_SEPARATOR + msg.messageId())) {
       LOG.info("渠道 {} 重复事件已忽略: {}", sanitize(msg.channelName()), sanitize(msg.messageId()));
       return;
     }
@@ -95,6 +113,13 @@ public class InboundMessageService {
             throw new IllegalStateException(
                 "渠道 " + msg.channelName() + " 绑定的 Agent " + agent + " 不存在");
           });
+      return;
+    }
+    // 私聊 /new：清空固定三元组会话历史（飞书等 IM 无独立「新会话」键）
+    if (msg.chatKind() == ChatKind.P2P && msg.textual() && isNewSessionCommand(agentInput)) {
+      Session session = sessionManager.getOrCreate(msg.channelType(), msg.userId(), agent);
+      sessionManager.clearHistory(session.sessionId());
+      safeReply(replyVia, msg.chatId(), NEW_SESSION_REPLY, null);
       return;
     }
     List<Message.MediaPart> media = InboundMediaParts.from(msg);
@@ -137,6 +162,10 @@ public class InboundMessageService {
           }
         });
     scheduleProcessingNotice(done, replyVia, msg.chatId(), replyTo);
+  }
+
+  static boolean isNewSessionCommand(String agentInput) {
+    return agentInput != null && NEW_SESSION_COMMAND.equalsIgnoreCase(agentInput.strip());
   }
 
   /** B8：超过阈值仍未完成时先行告知「处理中」；纯虚拟线程 + CountDownLatch，同步阻塞语义。 */

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
@@ -8,6 +8,7 @@ import io.oryxos.core.session.Session;
 import io.oryxos.core.session.SessionManager;
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -165,7 +166,8 @@ public class InboundMessageService {
   }
 
   static boolean isNewSessionCommand(String agentInput) {
-    return agentInput != null && NEW_SESSION_COMMAND.equalsIgnoreCase(agentInput.strip());
+    return agentInput != null
+        && NEW_SESSION_COMMAND.equals(agentInput.strip().toLowerCase(Locale.ROOT));
   }
 
   /** B8：超过阈值仍未完成时先行告知「处理中」；纯虚拟线程 + CountDownLatch，同步阻塞语义。 */

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
@@ -8,7 +8,6 @@ import io.oryxos.core.session.Session;
 import io.oryxos.core.session.SessionManager;
 import java.time.Duration;
 import java.util.List;
-import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -166,8 +165,7 @@ public class InboundMessageService {
   }
 
   static boolean isNewSessionCommand(String agentInput) {
-    return agentInput != null
-        && NEW_SESSION_COMMAND.equals(agentInput.strip().toLowerCase(Locale.ROOT));
+    return agentInput != null && NEW_SESSION_COMMAND.equals(agentInput.strip());
   }
 
   /** B8：超过阈值仍未完成时先行告知「处理中」；纯虚拟线程 + CountDownLatch，同步阻塞语义。 */

--- a/oryxos-core/src/main/java/io/oryxos/core/session/SessionManager.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/session/SessionManager.java
@@ -34,6 +34,14 @@ public interface SessionManager {
   boolean archive(String sessionId);
 
   /**
+   * 清空对话历史并保持（或恢复为）active——IM 私聊 {@code /new} 用。同一 session_id 保留，避免与 channel:user:profile
+   * 固定键冲突；不等同于 {@link #archive}（归档仍保留正文，下次 getOrCreate 会读回）。
+   *
+   * @return {@code true} 已清空，{@code false} 会话不存在
+   */
+  boolean clearHistory(String sessionId);
+
+  /**
    * 列出最近会话的摘要（按 last_active_at 倒序取前 {@code limit} 条），不含对话正文——供 27 节 GET /api/v1/sessions
    * 与管理台"会话"列表。返回摘要投影而非领域 {@link Session}：领域对象不带 channel/status/时间戳等展示字段。
    */

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceTest.java
@@ -295,7 +295,7 @@ class InboundMessageServiceTest {
     when(sessionManager.getOrCreate("stub", "user-1", AGENT)).thenReturn(session);
     when(sessionManager.clearHistory(session.sessionId())).thenReturn(true);
 
-    service.onMessage(p2p("m-new", " /new "), adapter);
+    service.onMessage(p2p("m-new", "/new"), adapter);
 
     verify(sessionManager).clearHistory(session.sessionId());
     verifyNoInteractions(agentService);

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceTest.java
@@ -287,4 +287,33 @@ class InboundMessageServiceTest {
 
     service.onMessage(p2p("m-9", "hi"), adapter); // 不抛出即通过
   }
+
+  @Test
+  @DisplayName("私聊 /new 清空会话历史，不进 Agent")
+  void p2pNewClearsHistoryWithoutAgent() {
+    Session session = new Session("stub:user-1:" + AGENT, AGENT);
+    when(sessionManager.getOrCreate("stub", "user-1", AGENT)).thenReturn(session);
+    when(sessionManager.clearHistory(session.sessionId())).thenReturn(true);
+
+    service.onMessage(p2p("m-new", " /new "), adapter);
+
+    verify(sessionManager).clearHistory(session.sessionId());
+    verifyNoInteractions(agentService);
+    assertEquals(1, adapter.sent().size());
+    assertEquals(InboundMessageService.NEW_SESSION_REPLY, adapter.sent().get(0).text());
+  }
+
+  @Test
+  @DisplayName("tryClaim 后 onClaimedMessage 不再二次去重")
+  void claimedMessageSkipsSecondDedup() {
+    Session session = new Session("stub:user-1:" + AGENT, AGENT);
+    when(sessionManager.getOrCreate("stub", "user-1", AGENT)).thenReturn(session);
+    when(agentService.process(eq(session), eq("hi"), anyList())).thenReturn("回答");
+
+    assertTrue(service.tryClaim("stub-chan", "m-claimed"));
+    service.onClaimedMessage(p2p("m-claimed", "hi"), adapter);
+
+    verify(agentService, times(1)).process(eq(session), eq("hi"), anyList());
+    assertEquals(1, adapter.sent().size());
+  }
 }

--- a/oryxos-storage/src/main/java/io/oryxos/storage/JpaSessionManager.java
+++ b/oryxos-storage/src/main/java/io/oryxos/storage/JpaSessionManager.java
@@ -109,6 +109,21 @@ public class JpaSessionManager implements SessionManager {
   }
 
   @Override
+  public boolean clearHistory(String sessionId) {
+    Optional<Session> found = repository.findById(sessionId);
+    if (found.isEmpty()) {
+      return false;
+    }
+    Session entity = found.get();
+    entity.setMessagesJson("[]");
+    entity.setStatus("active");
+    entity.setArchivedAt(null);
+    entity.setLastActiveAt(Instant.now());
+    repository.save(entity);
+    return true;
+  }
+
+  @Override
   public SessionStats stats() {
     int active = (int) repository.countByStatus("active");
     int archived = (int) repository.countByStatus("archived");

--- a/oryxos-storage/src/test/java/io/oryxos/storage/SessionManagerTest.java
+++ b/oryxos-storage/src/test/java/io/oryxos/storage/SessionManagerTest.java
@@ -105,4 +105,22 @@ class SessionManagerTest {
   void archiveMissingReturnsFalse() {
     assertFalse(manager().archive("web:nobody:default"));
   }
+
+  @Test
+  @DisplayName("clearHistory 清空正文并恢复 active（IM /new）")
+  void clearHistoryEmptiesMessagesAndReactivates() {
+    JpaSessionManager manager = manager();
+    var session = manager.getOrCreate("feishu", "ou_user", "demo-agent");
+    session.appendUser("旧消息", java.util.List.of());
+    manager.save(session);
+    manager.archive(session.sessionId());
+
+    assertTrue(manager.clearHistory(session.sessionId()));
+
+    Session entity = repository.findById(session.sessionId()).orElseThrow();
+    assertEquals("active", entity.getStatus());
+    assertTrue(entity.getArchivedAt() == null);
+    assertEquals("[]", entity.getMessagesJson());
+    assertTrue(manager.get(session.sessionId()).orElseThrow().messages().isEmpty());
+  }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/SessionApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/SessionApiController.java
@@ -32,9 +32,9 @@ import org.springframework.web.bind.annotation.RestController;
  * channel 固定 "web"（人推的另一入口，与 CLI 共享同一份会话存储）。
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-    value = "SPRING_ENDPOINT",
+    value = {"SPRING_ENDPOINT", "EI_EXPOSE_REP2"},
     justification =
-        "core-stage web API is unauthenticated by design (internal network + gateway); auth is extension-phase")
+        "core-stage web API is unauthenticated by design (internal network + gateway); auth is extension-phase; AgentService/SessionManager 为 Runtime 单例共享引用")
 @RestController
 @RequestMapping("/api/v1/sessions")
 public class SessionApiController {


### PR DESCRIPTION
## Summary
- P2P text `/new` → `SessionManager.clearHistory` (empty messages, stay active)
- Feishu: `tryClaim` before image download; `onClaimedMessage` skips second dedup

Closes #390

## Test plan
- [x] `InboundMessageServiceTest` (`/new`, tryClaim)
- [x] `SessionManagerTest.clearHistory`
- [ ] CI green
- [ ] Feishu AIBOT: send `/new` → then image → vision without poisoned history