### PR TITLE
fix: Feishu processing notice before image download

### DIFF
--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
@@ -12,6 +12,8 @@ import com.lark.oapi.service.im.ImService;
 import com.lark.oapi.service.im.v1.model.P2MessageReceiveV1;
 import io.oryxos.core.channel.ChannelConfig;
 import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundChannelAdapter;
 import io.oryxos.core.channel.InboundMessage;
 import io.oryxos.core.channel.InboundMessageService;
@@ -219,8 +221,8 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
   }
 
   /**
-   * 事件入口：归一化 → 去重占用 → 图片资源落地 → 编排。去重必须在下载前：飞书平台重推同一 message_id 时，若先下载再去重会白耗
-   * 带宽并拉长「处理中」窗口。任何异常只留日志——抛出会触发平台重推循环。
+   * 事件入口：归一化 → 去重占用 →（需下载时先开「处理中」）→ 图片资源落地 → 编排。去重必须在下载前：飞书平台重推同一 message_id
+   * 时，若先下载再去重会白耗带宽。任何异常只留日志——抛出会触发平台重推循环。
    */
   private void handleEvent(P2MessageReceiveV1 event) {
     try {
@@ -231,13 +233,42 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
               LOG.info("渠道 {} 重复事件已忽略: {}", sanitize(m.channelName()), sanitize(m.messageId()));
               return;
             }
-            FeishuInboundImageResolver resolver = imageResolver;
-            InboundMessage enriched = resolver == null ? m : resolver.resolve(m);
-            inboundMessageService.onClaimedMessage(enriched, this);
+            String replyTo = m.chatKind() == ChatKind.GROUP ? m.messageId() : null;
+            java.util.concurrent.CountDownLatch slowWork = null;
+            if (needsImageDownload(m)) {
+              // 下载常超过默认「处理中」阈值；计时从下载前开始，避免用户长时间无反馈
+              slowWork = inboundMessageService.beginSlowWork(this, m.chatId(), replyTo);
+            }
+            try {
+              FeishuInboundImageResolver resolver = imageResolver;
+              InboundMessage enriched = resolver == null ? m : resolver.resolve(m);
+              if (slowWork != null) {
+                inboundMessageService.onClaimedMessage(enriched, this, slowWork);
+              } else {
+                inboundMessageService.onClaimedMessage(enriched, this);
+              }
+            } catch (RuntimeException e) {
+              if (slowWork != null) {
+                slowWork.countDown();
+              }
+              throw e;
+            }
           });
     } catch (RuntimeException e) {
       LOG.error("飞书渠道 {} 事件处理异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
     }
+  }
+
+  private static boolean needsImageDownload(InboundMessage message) {
+    for (InboundAttachment attachment : message.attachments()) {
+      if (InboundAttachment.TYPE_IMAGE.equals(attachment.type())
+          && (attachment.url() == null || attachment.url().isBlank())
+          && attachment.reference() != null
+          && !attachment.reference().isBlank()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /** 入站图片落盘目录：进程临时目录下按渠道隔离；失败不阻断 start（解析器会降级保留 image_key）。 */

--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
@@ -261,14 +261,21 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
 
   private static boolean needsImageDownload(InboundMessage message) {
     for (InboundAttachment attachment : message.attachments()) {
-      if (InboundAttachment.TYPE_IMAGE.equals(attachment.type())
-          && (attachment.url() == null || attachment.url().isBlank())
-          && attachment.reference() != null
-          && !attachment.reference().isBlank()) {
+      if (isUnresolvedImageAttachment(attachment)) {
         return true;
       }
     }
     return false;
+  }
+
+  private static boolean isUnresolvedImageAttachment(InboundAttachment attachment) {
+    if (!InboundAttachment.TYPE_IMAGE.equals(attachment.type())) {
+      return false;
+    }
+    if (attachment.url() != null && !attachment.url().isBlank()) {
+      return false;
+    }
+    return attachment.reference() != null && !attachment.reference().isBlank();
   }
 
   /** 入站图片落盘目录：进程临时目录下按渠道隔离；失败不阻断 start（解析器会降级保留 image_key）。 */

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
@@ -42,6 +42,9 @@ public class InboundMessageService {
   /** 飞书等可能对同一意图连推多条不同 message_id；短窗内只确认一次。 */
   private static final long NEW_SESSION_ACK_COALESCE_MS = 5_000;
 
+  /** 「处理中」提示合并窗：下载+推理链路很长时避免重推/重复调度刷屏。 */
+  private static final long PROCESSING_NOTICE_COALESCE_MS = 30_000;
+
   private final AgentService agentService;
   private final SessionManager sessionManager;
   private final ProfileRegistry profileRegistry;
@@ -50,6 +53,7 @@ public class InboundMessageService {
   private final InboundMediaEnricher mediaEnricher;
   private final Duration processingNoticeDelay;
   private final Map<String, Long> recentNewSessionAckMs = new ConcurrentHashMap<>();
+  private final Map<String, Long> recentProcessingNoticeMs = new ConcurrentHashMap<>();
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "EI_EXPOSE_REP2",
@@ -77,22 +81,45 @@ public class InboundMessageService {
   }
 
   /**
+   * 昂贵预处理（如下载图片）开始前启动 B8「处理中」计时。返回的 latch 必须在整条入站链路结束时 {@code countDown}，并交给 {@link
+   * #onClaimedMessage(InboundMessage, InboundChannelAdapter, CountDownLatch)}，避免下载后再开一个提示。
+   */
+  public CountDownLatch beginSlowWork(
+      InboundChannelAdapter replyVia, String chatId, String replyToMessageId) {
+    CountDownLatch done = new CountDownLatch(1);
+    scheduleProcessingNotice(done, replyVia, chatId, replyToMessageId);
+    return done;
+  }
+
+  /**
    * 归一化消息唯一入口：确认线程内快速返回（去重 + 提交），推理与回发在虚拟线程（B5）。
    *
    * @param msg 归一化入站消息（群聊必须已在适配器层过滤为 @ 机器人的消息）
    * @param replyVia 回复通道（即产生本消息的适配器）
    */
   public void onMessage(InboundMessage msg, InboundChannelAdapter replyVia) {
-    onMessage(msg, replyVia, true);
+    onMessage(msg, replyVia, true, null);
   }
 
   /** 调用方已通过 {@link #tryClaim} 占用 message_id 时使用（避免下载完成后二次去重把合法首条丢掉）。 */
   public void onClaimedMessage(InboundMessage msg, InboundChannelAdapter replyVia) {
-    onMessage(msg, replyVia, false);
+    onMessage(msg, replyVia, false, null);
+  }
+
+  /**
+   * 同 {@link #onClaimedMessage(InboundMessage, InboundChannelAdapter)}，复用预处理阶段已启动的
+   * latch（不再二次调度「处理中」）。
+   */
+  public void onClaimedMessage(
+      InboundMessage msg, InboundChannelAdapter replyVia, CountDownLatch preprocessingDone) {
+    onMessage(msg, replyVia, false, preprocessingDone);
   }
 
   private void onMessage(
-      InboundMessage msg, InboundChannelAdapter replyVia, boolean claimMessageId) {
+      InboundMessage msg,
+      InboundChannelAdapter replyVia,
+      boolean claimMessageId,
+      CountDownLatch preprocessingDone) {
     // B1：同一渠道同一 message_id 只处理一次（平台超时重推场景用户只收到一条回答）
     if (claimMessageId
         && !deduplicator.markIfFirst(msg.channelName() + DEDUP_KEY_SEPARATOR + msg.messageId())) {
@@ -104,12 +131,18 @@ public class InboundMessageService {
     // B7：不可处理的消息（非文本且无附件）回能力说明，不进推理、不落执行记录
     String agentInput = mediaEnricher.toAgentInput(msg);
     if (!msg.processable() || agentInput.isBlank()) {
+      if (preprocessingDone != null) {
+        preprocessingDone.countDown();
+      }
       safeReply(replyVia, msg.chatId(), UNSUPPORTED_TYPE_REPLY, replyTo);
       return;
     }
     String agent = replyVia.boundAgent();
     // B9：绑定 Agent 不存在（底座无停用态，不存在即不可用）——可读回复 + 失败执行留痕
     if (profileRegistry.get(agent).isEmpty()) {
+      if (preprocessingDone != null) {
+        preprocessingDone.countDown();
+      }
       safeReply(replyVia, msg.chatId(), AGENT_UNAVAILABLE_REPLY, replyTo);
       executionService.triggerAsync(
           agent,
@@ -123,6 +156,9 @@ public class InboundMessageService {
     }
     // 私聊 /new：清空固定三元组会话历史（飞书等 IM 无独立「新会话」键）
     if (msg.chatKind() == ChatKind.P2P && msg.textual() && isNewSessionCommand(agentInput)) {
+      if (preprocessingDone != null) {
+        preprocessingDone.countDown();
+      }
       Session session = sessionManager.getOrCreate(msg.channelType(), msg.userId(), agent);
       sessionManager.clearHistory(session.sessionId());
       if (shouldAckNewSession(session.sessionId())) {
@@ -152,7 +188,7 @@ public class InboundMessageService {
                   agentService.processStateless(agent, agentInput, media, groupSessionId),
                   replyTo);
     }
-    CountDownLatch done = new CountDownLatch(1);
+    CountDownLatch done = preprocessingDone != null ? preprocessingDone : new CountDownLatch(1);
     // B5/B10：推理在虚拟线程后台跑并落 agent_executions（source = 渠道类型）
     executionService.triggerAsync(
         agent,
@@ -169,7 +205,9 @@ public class InboundMessageService {
             done.countDown();
           }
         });
-    scheduleProcessingNotice(done, replyVia, msg.chatId(), replyTo);
+    if (preprocessingDone == null) {
+      scheduleProcessingNotice(done, replyVia, msg.chatId(), replyTo);
+    }
   }
 
   static boolean isNewSessionCommand(String agentInput) {
@@ -192,12 +230,20 @@ public class InboundMessageService {
             () -> {
               try {
                 if (!done.await(processingNoticeDelay.toMillis(), TimeUnit.MILLISECONDS)) {
-                  safeReply(replyVia, chatId, PROCESSING_REPLY, replyTo);
+                  if (shouldSendProcessingNotice(chatId)) {
+                    safeReply(replyVia, chatId, PROCESSING_REPLY, replyTo);
+                  }
                 }
               } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
               }
             });
+  }
+
+  private boolean shouldSendProcessingNotice(String chatId) {
+    long now = System.currentTimeMillis();
+    Long prev = recentProcessingNoticeMs.put(chatId, now);
+    return prev == null || now - prev >= PROCESSING_NOTICE_COALESCE_MS;
   }
 
   /** 回复失败不影响主流程（发送异常只留日志——用户侧丢一条提示优于整条链路炸掉）。 */

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
@@ -128,75 +128,22 @@ public class InboundMessageService {
     }
     // B4：群聊回复引用原消息使问答可对应；私聊直发
     String replyTo = msg.chatKind() == ChatKind.GROUP ? msg.messageId() : null;
-    // B7：不可处理的消息（非文本且无附件）回能力说明，不进推理、不落执行记录
     String agentInput = mediaEnricher.toAgentInput(msg);
-    if (!msg.processable() || agentInput.isBlank()) {
-      if (preprocessingDone != null) {
-        preprocessingDone.countDown();
-      }
-      safeReply(replyVia, msg.chatId(), UNSUPPORTED_TYPE_REPLY, replyTo);
+    if (finishWithoutInference(msg, replyVia, preprocessingDone, replyTo, agentInput)) {
       return;
     }
     String agent = replyVia.boundAgent();
-    // B9：绑定 Agent 不存在（底座无停用态，不存在即不可用）——可读回复 + 失败执行留痕
-    if (profileRegistry.get(agent).isEmpty()) {
-      if (preprocessingDone != null) {
-        preprocessingDone.countDown();
-      }
-      safeReply(replyVia, msg.chatId(), AGENT_UNAVAILABLE_REPLY, replyTo);
-      executionService.triggerAsync(
-          agent,
-          msg.channelType(),
-          null,
-          () -> {
-            throw new IllegalStateException(
-                "渠道 " + msg.channelName() + " 绑定的 Agent " + agent + " 不存在");
-          });
-      return;
-    }
-    // 私聊 /new：清空固定三元组会话历史（飞书等 IM 无独立「新会话」键）
-    if (msg.chatKind() == ChatKind.P2P && msg.textual() && isNewSessionCommand(agentInput)) {
-      if (preprocessingDone != null) {
-        preprocessingDone.countDown();
-      }
-      Session session = sessionManager.getOrCreate(msg.channelType(), msg.userId(), agent);
-      sessionManager.clearHistory(session.sessionId());
-      if (shouldAckNewSession(session.sessionId())) {
-        safeReply(replyVia, msg.chatId(), NEW_SESSION_REPLY, null);
-      }
-      return;
-    }
     List<Message.MediaPart> media = InboundMediaParts.from(msg);
-    String sessionId;
-    Runnable inference;
-    if (msg.chatKind() == ChatKind.P2P) {
-      // B2：私聊按「渠道 + 用户 + Agent」维持连续会话——隔离/历史窗口/并发锁全部由既有会话底座承担
-      Session session = sessionManager.getOrCreate(msg.channelType(), msg.userId(), agent);
-      sessionId = session.sessionId();
-      inference =
-          () ->
-              replyVia.sendReply(
-                  msg.chatId(), agentService.process(session, agentInput, media), null);
-    } else {
-      // B3：群聊每次 @ 为独立无状态问答，不落 sessions 表；渠道前缀让审计可辨（B10）
-      sessionId = msg.channelType() + "-group:" + UUID.randomUUID();
-      String groupSessionId = sessionId;
-      inference =
-          () ->
-              replyVia.sendReply(
-                  msg.chatId(),
-                  agentService.processStateless(agent, agentInput, media, groupSessionId),
-                  replyTo);
-    }
+    InferenceJob job = buildInference(msg, replyVia, agent, agentInput, media, replyTo);
     CountDownLatch done = preprocessingDone != null ? preprocessingDone : new CountDownLatch(1);
     // B5/B10：推理在虚拟线程后台跑并落 agent_executions（source = 渠道类型）
     executionService.triggerAsync(
         agent,
         msg.channelType(),
-        sessionId,
+        job.sessionId(),
         () -> {
           try {
-            inference.run();
+            job.inference().run();
           } catch (RuntimeException e) {
             // B6：失败以可读消息告知用户（不含堆栈），异常继续上抛让执行记录记为失败
             safeReply(replyVia, msg.chatId(), FAILURE_REPLY, replyTo);
@@ -209,6 +156,82 @@ public class InboundMessageService {
       scheduleProcessingNotice(done, replyVia, msg.chatId(), replyTo);
     }
   }
+
+  /** B7/B9/私聊 /new：不进推理时释放预处理 latch 并回即时答复。 */
+  private boolean finishWithoutInference(
+      InboundMessage msg,
+      InboundChannelAdapter replyVia,
+      CountDownLatch preprocessingDone,
+      String replyTo,
+      String agentInput) {
+    // B7：不可处理的消息（非文本且无附件）回能力说明，不进推理、不落执行记录
+    if (!msg.processable() || agentInput.isBlank()) {
+      release(preprocessingDone);
+      safeReply(replyVia, msg.chatId(), UNSUPPORTED_TYPE_REPLY, replyTo);
+      return true;
+    }
+    String agent = replyVia.boundAgent();
+    // B9：绑定 Agent 不存在（底座无停用态，不存在即不可用）——可读回复 + 失败执行留痕
+    if (profileRegistry.get(agent).isEmpty()) {
+      release(preprocessingDone);
+      safeReply(replyVia, msg.chatId(), AGENT_UNAVAILABLE_REPLY, replyTo);
+      executionService.triggerAsync(
+          agent,
+          msg.channelType(),
+          null,
+          () -> {
+            throw new IllegalStateException(
+                "渠道 " + msg.channelName() + " 绑定的 Agent " + agent + " 不存在");
+          });
+      return true;
+    }
+    // 私聊 /new：清空固定三元组会话历史（飞书等 IM 无独立「新会话」键）
+    if (msg.chatKind() == ChatKind.P2P && msg.textual() && isNewSessionCommand(agentInput)) {
+      release(preprocessingDone);
+      Session session = sessionManager.getOrCreate(msg.channelType(), msg.userId(), agent);
+      sessionManager.clearHistory(session.sessionId());
+      if (shouldAckNewSession(session.sessionId())) {
+        safeReply(replyVia, msg.chatId(), NEW_SESSION_REPLY, null);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  private InferenceJob buildInference(
+      InboundMessage msg,
+      InboundChannelAdapter replyVia,
+      String agent,
+      String agentInput,
+      List<Message.MediaPart> media,
+      String replyTo) {
+    if (msg.chatKind() == ChatKind.P2P) {
+      // B2：私聊按「渠道 + 用户 + Agent」维持连续会话——隔离/历史窗口/并发锁全部由既有会话底座承担
+      Session session = sessionManager.getOrCreate(msg.channelType(), msg.userId(), agent);
+      return new InferenceJob(
+          session.sessionId(),
+          () ->
+              replyVia.sendReply(
+                  msg.chatId(), agentService.process(session, agentInput, media), null));
+    }
+    // B3：群聊每次 @ 为独立无状态问答，不落 sessions 表；渠道前缀让审计可辨（B10）
+    String groupSessionId = msg.channelType() + "-group:" + UUID.randomUUID();
+    return new InferenceJob(
+        groupSessionId,
+        () ->
+            replyVia.sendReply(
+                msg.chatId(),
+                agentService.processStateless(agent, agentInput, media, groupSessionId),
+                replyTo));
+  }
+
+  private static void release(CountDownLatch latch) {
+    if (latch != null) {
+      latch.countDown();
+    }
+  }
+
+  private record InferenceJob(String sessionId, Runnable inference) {}
 
   static boolean isNewSessionCommand(String agentInput) {
     return agentInput != null && NEW_SESSION_COMMAND.equals(agentInput.strip());

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceTest.java
@@ -331,4 +331,43 @@ class InboundMessageServiceTest {
     verify(agentService, times(1)).process(eq(session), eq("hi"), anyList());
     assertEquals(1, adapter.sent().size());
   }
+
+  @Test
+  @DisplayName("beginSlowWork + onClaimedMessage 共享 latch：只提示一次处理中")
+  void slowWorkSharesProcessingNoticeLatch() throws Exception {
+    Session session = new Session("stub:user-1:" + AGENT, AGENT);
+    when(sessionManager.getOrCreate("stub", "user-1", AGENT)).thenReturn(session);
+    when(agentService.process(eq(session), eq("hi"), anyList()))
+        .thenAnswer(
+            inv -> {
+              Thread.sleep(400);
+              return "慢回答";
+            });
+    CountDownLatch workDone = new CountDownLatch(1);
+    doAnswer(
+            inv -> {
+              Thread.ofVirtual()
+                  .start(
+                      () -> {
+                        try {
+                          ((Runnable) inv.getArgument(3)).run();
+                        } finally {
+                          workDone.countDown();
+                        }
+                      });
+              return 1L;
+            })
+        .when(executionService)
+        .triggerAsync(anyString(), anyString(), any(), any());
+
+    CountDownLatch slow = service.beginSlowWork(adapter, "chat-p2p", null);
+    assertTrue(service.tryClaim("stub-chan", "m-slow"));
+    service.onClaimedMessage(p2p("m-slow", "hi"), adapter, slow);
+
+    assertTrue(workDone.await(3, TimeUnit.SECONDS));
+    Thread.sleep(100);
+    assertEquals(2, adapter.sent().size());
+    assertEquals(InboundMessageService.PROCESSING_REPLY, adapter.sent().get(0).text());
+    assertEquals("慢回答", adapter.sent().get(1).text());
+  }
 }


### PR DESCRIPTION
## Summary
- Start B8「处理中」before Feishu image download via shared latch
- Coalesce processing notices per chat (30s)

Closes #394

## Test plan
- [x] `InboundMessageServiceTest.slowWorkSharesProcessingNoticeLatch`
- [ ] CI green
- [ ] Feishu image: notice appears during download, not only after