### PR TITLE
fix: send processing notice when Feishu image download starts

### DIFF
--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
@@ -236,7 +236,7 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
             String replyTo = m.chatKind() == ChatKind.GROUP ? m.messageId() : null;
             java.util.concurrent.CountDownLatch slowWork = null;
             if (needsImageDownload(m)) {
-              // 下载常超过默认「处理中」阈值；计时从下载前开始，避免用户长时间无反馈
+              // 下载前立刻「处理中」：默认 15s 阈值对识图偏长，延迟计时会导致「识别完才提示」
               slowWork = inboundMessageService.beginSlowWork(this, m.chatId(), replyTo);
             }
             try {

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
@@ -81,13 +81,16 @@ public class InboundMessageService {
   }
 
   /**
-   * 昂贵预处理（如下载图片）开始前启动 B8「处理中」计时。返回的 latch 必须在整条入站链路结束时 {@code countDown}，并交给 {@link
-   * #onClaimedMessage(InboundMessage, InboundChannelAdapter, CountDownLatch)}，避免下载后再开一个提示。
+   * 昂贵预处理（如下载图片）开始前立刻发 B8「处理中」（仍受合并窗约束）。下载+识图常在默认阈值（15s）内结束，若仍走延迟计时，用户会感到「识别完 才提示」。返回的 latch
+   * 必须在整条入站链路结束时 {@code countDown}，并交给 {@link #onClaimedMessage(InboundMessage,
+   * InboundChannelAdapter, CountDownLatch)}，避免推理阶段再开一个提示。
    */
   public CountDownLatch beginSlowWork(
       InboundChannelAdapter replyVia, String chatId, String replyToMessageId) {
     CountDownLatch done = new CountDownLatch(1);
-    scheduleProcessingNotice(done, replyVia, chatId, replyToMessageId);
+    if (shouldSendProcessingNotice(chatId)) {
+      safeReply(replyVia, chatId, PROCESSING_REPLY, replyToMessageId);
+    }
     return done;
   }
 

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMessageServiceTest.java
@@ -333,7 +333,7 @@ class InboundMessageServiceTest {
   }
 
   @Test
-  @DisplayName("beginSlowWork + onClaimedMessage 共享 latch：只提示一次处理中")
+  @DisplayName("beginSlowWork 立即提示处理中，与 onClaimedMessage 共享 latch 不二次提示")
   void slowWorkSharesProcessingNoticeLatch() throws Exception {
     Session session = new Session("stub:user-1:" + AGENT, AGENT);
     when(sessionManager.getOrCreate("stub", "user-1", AGENT)).thenReturn(session);
@@ -361,13 +361,26 @@ class InboundMessageServiceTest {
         .triggerAsync(anyString(), anyString(), any(), any());
 
     CountDownLatch slow = service.beginSlowWork(adapter, "chat-p2p", null);
+    assertEquals(1, adapter.sent().size());
+    assertEquals(InboundMessageService.PROCESSING_REPLY, adapter.sent().get(0).text());
+
     assertTrue(service.tryClaim("stub-chan", "m-slow"));
     service.onClaimedMessage(p2p("m-slow", "hi"), adapter, slow);
 
     assertTrue(workDone.await(3, TimeUnit.SECONDS));
-    Thread.sleep(100);
+    Thread.sleep(150);
     assertEquals(2, adapter.sent().size());
-    assertEquals(InboundMessageService.PROCESSING_REPLY, adapter.sent().get(0).text());
     assertEquals("慢回答", adapter.sent().get(1).text());
+  }
+
+  @Test
+  @DisplayName("beginSlowWork 合并窗内同 chat 不重复发处理中")
+  void slowWorkCoalescesProcessingNotice() {
+    CountDownLatch first = service.beginSlowWork(adapter, "chat-p2p", null);
+    CountDownLatch second = service.beginSlowWork(adapter, "chat-p2p", null);
+    first.countDown();
+    second.countDown();
+    assertEquals(1, adapter.sent().size());
+    assertEquals(InboundMessageService.PROCESSING_REPLY, adapter.sent().get(0).text());
   }
 }


### PR DESCRIPTION
## Summary
- Closes #396
- `beginSlowWork` sends 「处理中」 immediately (still coalesced) instead of waiting for the default 15s B8 delay
- Image download + vision often finishes under 15s; delayed notice made it feel like feedback only after recognition

## Test plan
- [x] `InboundMessageServiceTest` (immediate notice + coalesce)
- [ ] Feishu: send image → 「已收到，正在处理中…」 appears before the vision answer