### PR TITLE
feat: DingTalk downloadCode image download + IM notice parity

### DIFF
--- a/docs/DingTalkChannelSetup.md
+++ b/docs/DingTalkChannelSetup.md
@@ -45,8 +45,9 @@
 
 ## 三、使用方式
 
-- **单聊**：在钉钉中打开该机器人会话，直接发文本。
-- **群聊**：将机器人拉入群后 `@机器人 + 问题`；平台只推送 `isInAtList=true` 的群消息。
+- **单聊**：在钉钉中打开该机器人会话，直接发文本或图片。
+- **群聊**：将机器人拉入群后 `@机器人 + 问题`（或图片）；平台只推送 `isInAtList=true` 的群消息。
+- **图片**：Stream 回调常见 `downloadCode`（无直链）。渠道会调用开放平台「下载机器人接收消息的文件内容」换临时 URL 并落盘，再交给 Vision；`robotCode` 默认等于 ClientId（`app_id`）。
 
 ## 四、与飞书/企微的差异（运维须知）
 
@@ -55,6 +56,7 @@
 | 凭证 | App ID / App Secret | BotID / 长连接 Secret | ClientId / ClientSecret |
 | 连接 | SDK 长连接 | `openws.work.weixin.qq.com` WS | `api.dingtalk.com` Stream WS |
 | 回复 | im API | 长连接 `aibot_send_msg` | `sessionWebhook` POST |
+| 入站图 | message_id + image_key 下载 | payload 直链 URL | `downloadCode` → 临时 URL 落盘 |
 | 群 @ 关联 | open_id / mentioned | `quote.msgid` | `at.atUserIds`（B4） |
 
 ## 五、非目标（本期不做）
@@ -62,3 +64,4 @@
 - HTTP 回调 + 加解密旧模式
 - 流式逐 token 刷屏（Agent 仍整段推理后再回发）
 - 模板卡片 / 富媒体 / HITL
+- 语音 / 视频 / 文件入站（仅图片 + 文本）

--- a/docs/FeishuChannelSetup.md
+++ b/docs/FeishuChannelSetup.md
@@ -96,7 +96,7 @@
 | status 为 ERROR：`app_secret 未配置或环境变量未解析` | 启动 shell 里没有 `FEISHU_APP_SECRET`；`source` env 文件后重启或经 REST 重建渠道 |
 | status 为 ERROR：`绑定的 Agent xxx 不存在` | `channels.yaml` 的 `agent` 必须是 `.oryxos/agents/` 下的目录名 |
 | 长连接建立失败 | 确认出方向可达 `open.feishu.cn:443`（HTTPS + WebSocket）；无需任何入方向端口 |
-| 收到「当前仅支持文本提问」 | 设计如此：图片 / 语音 / 文件入站不在当前范围 |
+| 收到「当前仅支持文本提问」 | 语音 / 文件等非图类型仍不在范围；**图片已支持**（入站下载后走 Vision）。若仍出现：确认事件含 image，且渠道进程可出站访问 `open.feishu.cn` |
 | 多个 Agent 接入 | 一应用一 Agent；再建一个飞书应用 + `channels.yaml` 加一个条目 |
 
 ## 九、审计口径

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkChannelAdapter.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkChannelAdapter.java
@@ -3,13 +3,17 @@ package io.oryxos.channel.dingtalk;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.oryxos.core.channel.ChannelConfig;
 import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.ChatKind;
 import io.oryxos.core.channel.InboundChannelAdapter;
 import io.oryxos.core.channel.InboundMessage;
 import io.oryxos.core.channel.InboundMessageService;
 import io.oryxos.core.channel.OutboundGuard;
 import io.oryxos.core.profile.ProfileRegistry;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -36,6 +40,8 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
   private static final long RECONNECT_BASE_MS = 2_000L;
   private static final long RECONNECT_MAX_MS = 60_000L;
   private static final int RECONNECT_MAX_SHIFT = 5;
+  private static final String MEDIA_DIR_PREFIX = "oryxos-dingtalk-media-";
+  private static final String MEDIA_FALLBACK_DIR = "oryxos-dingtalk-media";
 
   private final ChannelConfig config;
   private final ProfileRegistry profileRegistry;
@@ -45,6 +51,7 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
   private final AtomicReference<DingTalkStreamClient> streamRef = new AtomicReference<>();
   private volatile DingTalkMessageSender sender;
   private volatile DingTalkEventNormalizer normalizer;
+  private volatile DingTalkInboundImageResolver imageResolver;
   private volatile DingTalkDisconnectKind lastDisconnectKind = DingTalkDisconnectKind.ABRUPT;
   private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
   private volatile String lastError;
@@ -119,6 +126,7 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
     }
     sender = null;
     normalizer = null;
+    imageResolver = null;
     state = ChannelStatus.State.DISCONNECTED;
   }
 
@@ -163,13 +171,24 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
     streamRef.set(client);
   }
 
-  /** 懒初始化出站组件；重连复用同一 {@link DingTalkMessageSender} 以保留 sessionWebhook 映射（#338 后续）。 */
+  /** 懒初始化出站/入站组件；重连复用同一 {@link DingTalkMessageSender} 以保留 sessionWebhook 映射。 */
   private void ensureOutboundStack() {
     if (normalizer == null) {
       normalizer = new DingTalkEventNormalizer(config.name());
     }
     if (sender == null) {
       sender = new DingTalkMessageSender(guard, DingTalkMessageSender.DEFAULT_CHUNK_SIZE);
+    }
+    if (imageResolver == null) {
+      // robotCode：企业内部应用机器人通常等于 ClientId（app_id）
+      imageResolver =
+          new DingTalkInboundImageResolver(
+              guard,
+              config.appId(),
+              config.appSecret(),
+              config.appId(),
+              createMediaRoot(),
+              config.name());
     }
   }
 
@@ -271,6 +290,7 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
     }
   }
 
+  /** 归一化 → 去重占用 →（有图时即时「处理中」）→ downloadCode 落盘 → 编排。去重在下载前，避免平台重推白下图。 */
   private void handleBotMessage(JsonNode body) {
     try {
       String conversationId = body.path("conversationId").asText(null);
@@ -281,9 +301,51 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
       }
       sender.rememberSession(conversationId, sessionWebhook, atUserId);
       Optional<InboundMessage> msg = normalizer.normalize(body);
-      msg.ifPresent(m -> inboundMessageService.onMessage(m, this));
+      msg.ifPresent(this::dispatchClaimed);
     } catch (RuntimeException e) {
       LOG.error("钉钉渠道 {} 事件处理异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
+    }
+  }
+
+  private void dispatchClaimed(InboundMessage m) {
+    if (!inboundMessageService.tryClaim(m.channelName(), m.messageId())) {
+      LOG.info("渠道 {} 重复事件已忽略: {}", sanitize(m.channelName()), sanitize(m.messageId()));
+      return;
+    }
+    String replyTo = m.chatKind() == ChatKind.GROUP ? m.messageId() : null;
+    CountDownLatch slowWork = null;
+    if (DingTalkInboundImageResolver.hasImage(m)) {
+      slowWork = inboundMessageService.beginSlowWork(this, m.chatId(), replyTo);
+    }
+    try {
+      DingTalkInboundImageResolver resolver = imageResolver;
+      InboundMessage enriched = resolver == null ? m : resolver.resolve(m);
+      if (slowWork != null) {
+        inboundMessageService.onClaimedMessage(enriched, this, slowWork);
+      } else {
+        inboundMessageService.onClaimedMessage(enriched, this);
+      }
+    } catch (RuntimeException e) {
+      if (slowWork != null) {
+        slowWork.countDown();
+      }
+      throw e;
+    }
+  }
+
+  private Path createMediaRoot() {
+    String channelSeg = DingTalkInboundImageResolver.safeSegment(config.name());
+    try {
+      Path root = Files.createTempDirectory(MEDIA_DIR_PREFIX);
+      Path channelDir = root.resolve(channelSeg);
+      Files.createDirectories(channelDir);
+      return channelDir;
+    } catch (Exception e) {
+      LOG.warn(
+          "钉钉渠道 {} 创建图片缓存目录失败（{}），入站图片将保留 downloadCode",
+          sanitize(config.name()),
+          sanitize(e.getMessage()));
+      return Path.of(System.getProperty("java.io.tmpdir"), MEDIA_FALLBACK_DIR, channelSeg);
     }
   }
 

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolver.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolver.java
@@ -1,0 +1,369 @@
+package io.oryxos.channel.dingtalk;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.session.ImageMime;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 钉钉 Stream 入站图片：官方常只给 {@code downloadCode}（无直链），须换临时 URL 再落盘。成功后写入 {@link
+ * InboundAttachment#url()}，Vision 才能吃到二进制。
+ *
+ * <p>失败保留原 reference（降级，不阻断编排）。{@code robotCode} 默认取 ClientId（{@code app_id}）。
+ */
+final class DingTalkInboundImageResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DingTalkInboundImageResolver.class);
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String OAUTH_PATH = "/v1.0/oauth2/accessToken";
+  private static final String DOWNLOAD_META_PATH = "/v1.0/robot/messageFiles/download";
+  private static final String HEADER_ACCESS_TOKEN = "x-acs-dingtalk-access-token";
+  private static final String DEFAULT_EXTENSION = ".bin";
+  private static final String FALLBACK_SEGMENT = "x";
+  private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
+  private static final char PATH_SAFE_REPLACEMENT = '_';
+  private static final int MAX_SEGMENT_LEN = 96;
+  private static final int DOWNLOAD_ATTEMPTS = 2;
+  private static final long TOKEN_SKEW_MS = 60_000L;
+  private static final long DEFAULT_TOKEN_EXPIRE_SEC = 7200L;
+  private static final long MIN_TOKEN_TTL_SEC = 60L;
+  private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(60);
+  private static final int HTTP_STATUS_OK_MIN = 200;
+  private static final int HTTP_STATUS_OK_MAX_EXCLUSIVE = 300;
+  private static final String SCHEME_HTTPS = "https";
+  private static final String SCHEME_HTTP = "http";
+  private static final String HOST_DINGTALK = "dingtalk.com";
+  private static final String HOST_SUFFIX_DINGTALK = ".dingtalk.com";
+  private static final String HOST_SUFFIX_ALICDN = ".alicdn.com";
+  private static final String HOST_SUFFIX_ALIYUNCS = ".aliyuncs.com";
+
+  private final HttpClient httpClient;
+  private final OutboundGuard guard;
+  private final String apiBaseUrl;
+  private final String appKey;
+  private final String appSecret;
+  private final String robotCode;
+  private final Path mediaRoot;
+  private final String channelName;
+  private final AtomicReference<CachedToken> tokenRef = new AtomicReference<>();
+
+  DingTalkInboundImageResolver(
+      OutboundGuard guard,
+      String appKey,
+      String appSecret,
+      String robotCode,
+      Path mediaRoot,
+      String channelName) {
+    this(
+        HttpClient.newBuilder().connectTimeout(HTTP_TIMEOUT).build(),
+        guard,
+        DingTalkStreamClient.API_BASE_URL,
+        appKey,
+        appSecret,
+        robotCode,
+        mediaRoot,
+        channelName);
+  }
+
+  /** 单测注入：自定义 {@code apiBaseUrl}（本地 HttpServer）与 {@link HttpClient}。 */
+  DingTalkInboundImageResolver(
+      HttpClient httpClient,
+      OutboundGuard guard,
+      String apiBaseUrl,
+      String appKey,
+      String appSecret,
+      String robotCode,
+      Path mediaRoot,
+      String channelName) {
+    this.httpClient = httpClient;
+    this.guard = guard;
+    this.apiBaseUrl = trimTrailingSlash(apiBaseUrl);
+    this.appKey = appKey;
+    this.appSecret = appSecret;
+    this.robotCode = robotCode;
+    this.mediaRoot = mediaRoot;
+    this.channelName = channelName;
+  }
+
+  InboundMessage resolve(InboundMessage message) {
+    if (message.attachments().isEmpty()) {
+      return message;
+    }
+    List<InboundAttachment> resolved = new ArrayList<>(message.attachments().size());
+    boolean changed = false;
+    for (InboundAttachment attachment : message.attachments()) {
+      if (!needsDownload(attachment)) {
+        resolved.add(attachment);
+        continue;
+      }
+      InboundAttachment next = downloadOrKeep(message.messageId(), attachment);
+      changed |= next != attachment;
+      resolved.add(next);
+    }
+    if (!changed) {
+      return message;
+    }
+    return new InboundMessage(
+        message.channelType(),
+        message.channelName(),
+        message.messageId(),
+        message.chatKind(),
+        message.userId(),
+        message.chatId(),
+        message.content(),
+        message.textual(),
+        message.mentionedBot(),
+        resolved);
+  }
+
+  static boolean needsDownload(InboundAttachment attachment) {
+    return InboundAttachment.TYPE_IMAGE.equals(attachment.type())
+        && (attachment.url() == null || attachment.url().isBlank())
+        && attachment.reference() != null
+        && !attachment.reference().isBlank();
+  }
+
+  static boolean hasImage(InboundMessage message) {
+    for (InboundAttachment attachment : message.attachments()) {
+      if (InboundAttachment.TYPE_IMAGE.equals(attachment.type())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private InboundAttachment downloadOrKeep(String messageId, InboundAttachment attachment) {
+    String downloadCode = attachment.reference();
+    Exception last = null;
+    for (int attempt = 1; attempt <= DOWNLOAD_ATTEMPTS; attempt++) {
+      try {
+        String token = accessToken();
+        String downloadUrl = resolveDownloadUrl(token, downloadCode);
+        Path file = writeToMediaRoot(messageId, downloadCode, downloadUrl);
+        return new InboundAttachment(
+            InboundAttachment.TYPE_IMAGE, file.toAbsolutePath().toString(), downloadCode);
+      } catch (Exception e) {
+        last = e;
+        if (attempt < DOWNLOAD_ATTEMPTS && isTransientTimeout(e)) {
+          LOG.warn(
+              "钉钉渠道 {} 下载图片超时重试 {}/{}（messageId={}）：{}",
+              sanitize(channelName),
+              attempt,
+              DOWNLOAD_ATTEMPTS,
+              sanitize(messageId),
+              sanitize(e.getMessage()));
+          continue;
+        }
+        break;
+      }
+    }
+    LOG.warn(
+        "钉钉渠道 {} 下载图片失败（messageId={}, downloadCode={}）：{}，保留 downloadCode",
+        sanitize(channelName),
+        sanitize(messageId),
+        sanitize(downloadCode),
+        sanitize(last == null ? null : last.getMessage()));
+    return attachment;
+  }
+
+  private String accessToken() throws IOException, InterruptedException {
+    CachedToken cached = tokenRef.get();
+    long now = System.currentTimeMillis();
+    if (cached != null && now < cached.expiresAtMillis()) {
+      return cached.token();
+    }
+    guard.check(apiBaseUrl);
+    ObjectNode body = MAPPER.createObjectNode();
+    body.put("appKey", appKey);
+    body.put("appSecret", appSecret);
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(apiBaseUrl + OAUTH_PATH))
+            .timeout(HTTP_TIMEOUT)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body)))
+            .build();
+    HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() < HTTP_STATUS_OK_MIN
+        || response.statusCode() >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
+      throw new IllegalStateException("oauth2 accessToken HTTP " + response.statusCode());
+    }
+    JsonNode root = MAPPER.readTree(response.body());
+    String token = root.path("accessToken").asText(null);
+    if (token == null || token.isBlank()) {
+      throw new IllegalStateException("oauth2 accessToken 响应缺 accessToken");
+    }
+    long expireInSec = root.path("expireIn").asLong(DEFAULT_TOKEN_EXPIRE_SEC);
+    long expiresAt = now + Math.max(MIN_TOKEN_TTL_SEC, expireInSec) * 1000L - TOKEN_SKEW_MS;
+    tokenRef.set(new CachedToken(token, expiresAt));
+    return token;
+  }
+
+  private String resolveDownloadUrl(String accessToken, String downloadCode)
+      throws IOException, InterruptedException {
+    guard.check(apiBaseUrl);
+    ObjectNode body = MAPPER.createObjectNode();
+    body.put("downloadCode", downloadCode);
+    body.put("robotCode", robotCode);
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(apiBaseUrl + DOWNLOAD_META_PATH))
+            .timeout(HTTP_TIMEOUT)
+            .header("Content-Type", "application/json")
+            .header(HEADER_ACCESS_TOKEN, accessToken)
+            .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body)))
+            .build();
+    HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() < HTTP_STATUS_OK_MIN
+        || response.statusCode() >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
+      throw new IllegalStateException("messageFiles/download HTTP " + response.statusCode());
+    }
+    String downloadUrl = MAPPER.readTree(response.body()).path("downloadUrl").asText(null);
+    if (downloadUrl == null || downloadUrl.isBlank()) {
+      throw new IllegalStateException("messageFiles/download 响应缺 downloadUrl");
+    }
+    return downloadUrl;
+  }
+
+  private Path writeToMediaRoot(String messageId, String downloadCode, String downloadUrl)
+      throws IOException, InterruptedException {
+    URI uri = URI.create(downloadUrl);
+    if (!isAllowedMediaUri(uri)) {
+      throw new IllegalStateException("拒绝非钉钉域临时下载地址: " + sanitize(uri.getHost()));
+    }
+    HttpRequest request = HttpRequest.newBuilder().uri(uri).timeout(HTTP_TIMEOUT).GET().build();
+    HttpResponse<byte[]> response =
+        httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+    if (response.statusCode() < HTTP_STATUS_OK_MIN
+        || response.statusCode() >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
+      throw new IllegalStateException("下载临时文件 HTTP " + response.statusCode());
+    }
+    byte[] bytes = response.body();
+    if (bytes == null || bytes.length == 0) {
+      throw new IllegalStateException("下载临时文件为空");
+    }
+    String ext = extensionOf(uri.getPath());
+    Path dir = mediaRoot.resolve(safeSegment(messageId));
+    Files.createDirectories(dir);
+    Path target = dir.resolve(safeSegment(downloadCode) + ext);
+    Files.write(target, bytes);
+    if (DEFAULT_EXTENSION.equals(ext)) {
+      String sniffed = ImageMime.probeFile(target);
+      String betterExt = ImageMime.extensionFor(sniffed);
+      if (!DEFAULT_EXTENSION.equals(betterExt) && !betterExt.equals(ext)) {
+        Path renamed = dir.resolve(safeSegment(downloadCode) + betterExt);
+        try {
+          Files.move(target, renamed);
+          return renamed;
+        } catch (IOException moveFailed) {
+          LOG.debug("钉钉图片重命名扩展名失败，保留原文件: {}", sanitize(moveFailed.getMessage()));
+        }
+      }
+    }
+    return target;
+  }
+
+  private boolean isAllowedMediaUri(URI uri) {
+    if (uri == null || uri.getHost() == null || uri.getScheme() == null) {
+      return false;
+    }
+    String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+    if (!SCHEME_HTTPS.equals(scheme) && !SCHEME_HTTP.equals(scheme)) {
+      return false;
+    }
+    // 单测：apiBase 指向本地 HttpServer 时允许同主机
+    URI api = URI.create(apiBaseUrl);
+    if (api.getHost() != null && api.getHost().equalsIgnoreCase(uri.getHost())) {
+      return true;
+    }
+    if (!SCHEME_HTTPS.equals(scheme)) {
+      return false;
+    }
+    String host = uri.getHost().toLowerCase(Locale.ROOT);
+    return host.equals(HOST_DINGTALK)
+        || host.endsWith(HOST_SUFFIX_DINGTALK)
+        || host.endsWith(HOST_SUFFIX_ALICDN)
+        || host.endsWith(HOST_SUFFIX_ALIYUNCS);
+  }
+
+  private static boolean isTransientTimeout(Throwable error) {
+    for (Throwable t = error; t != null; t = t.getCause()) {
+      String name = t.getClass().getName();
+      if (name.contains("Timeout") || name.contains("InterruptedIO")) {
+        return true;
+      }
+      String msg = t.getMessage();
+      if (msg != null) {
+        String lower = msg.toLowerCase(Locale.ROOT);
+        if (lower.contains("timeout") || lower.contains("timed out")) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static String extensionOf(String path) {
+    if (path == null || path.isBlank()) {
+      return DEFAULT_EXTENSION;
+    }
+    int slash = path.lastIndexOf('/');
+    String fileName = slash >= 0 ? path.substring(slash + 1) : path;
+    int dot = fileName.lastIndexOf('.');
+    if (dot < 0 || dot == fileName.length() - 1) {
+      return DEFAULT_EXTENSION;
+    }
+    String ext = fileName.substring(dot).toLowerCase(Locale.ROOT);
+    if (!ext.matches(SAFE_EXTENSION_PATTERN)) {
+      return DEFAULT_EXTENSION;
+    }
+    return ext;
+  }
+
+  static String safeSegment(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return FALLBACK_SEGMENT;
+    }
+    String cleaned = raw.replaceAll("[^a-zA-Z0-9._-]", String.valueOf(PATH_SAFE_REPLACEMENT));
+    if (cleaned.length() > MAX_SEGMENT_LEN) {
+      cleaned = cleaned.substring(0, MAX_SEGMENT_LEN);
+    }
+    if (cleaned.isBlank() || cleaned.chars().allMatch(ch -> ch == PATH_SAFE_REPLACEMENT)) {
+      return FALLBACK_SEGMENT;
+    }
+    return cleaned;
+  }
+
+  private static String trimTrailingSlash(String url) {
+    if (url == null || url.isBlank()) {
+      return DingTalkStreamClient.API_BASE_URL;
+    }
+    return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+  }
+
+  private static String sanitize(String value) {
+    return value == null
+        ? ""
+        : value.replace('\r', PATH_SAFE_REPLACEMENT).replace('\n', PATH_SAFE_REPLACEMENT);
+  }
+
+  private record CachedToken(String token, long expiresAtMillis) {}
+}

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolver.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolver.java
@@ -17,7 +17,6 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -288,15 +287,15 @@ final class DingTalkInboundImageResolver {
     if (uri == null || uri.getHost() == null || uri.getScheme() == null) {
       return false;
     }
-    String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+    String scheme = asciiLower(uri.getScheme());
     if (!SCHEME_HTTPS.equals(scheme) && !SCHEME_HTTP.equals(scheme)) {
       return false;
     }
     // 单测：apiBase 指向本地 HttpServer 时允许同主机
     URI api = URI.create(apiBaseUrl);
     String apiHost = api.getHost();
-    String mediaHost = uri.getHost().toLowerCase(Locale.ROOT);
-    if (apiHost != null && apiHost.toLowerCase(Locale.ROOT).equals(mediaHost)) {
+    String mediaHost = asciiLower(uri.getHost());
+    if (apiHost != null && asciiLower(apiHost).equals(mediaHost)) {
       return true;
     }
     if (!SCHEME_HTTPS.equals(scheme)) {
@@ -308,6 +307,18 @@ final class DingTalkInboundImageResolver {
         || mediaHost.endsWith(HOST_SUFFIX_ALIYUNCS);
   }
 
+  /** ASCII-only 小写，避免 SpotBugs IMPROPER_UNICODE（scheme/host 均为 ASCII）。 */
+  private static String asciiLower(String value) {
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
+  }
+
   private static boolean isTransientTimeout(Throwable error) {
     for (Throwable t = error; t != null; t = t.getCause()) {
       String name = t.getClass().getName();
@@ -316,7 +327,7 @@ final class DingTalkInboundImageResolver {
       }
       String msg = t.getMessage();
       if (msg != null) {
-        String lower = msg.toLowerCase(Locale.ROOT);
+        String lower = asciiLower(msg);
         if (lower.contains("timeout") || lower.contains("timed out")) {
           return true;
         }
@@ -335,7 +346,7 @@ final class DingTalkInboundImageResolver {
     if (dot < 0 || dot == fileName.length() - 1) {
       return DEFAULT_EXTENSION;
     }
-    String ext = fileName.substring(dot).toLowerCase(Locale.ROOT);
+    String ext = asciiLower(fileName.substring(dot));
     if (!ext.matches(SAFE_EXTENSION_PATTERN)) {
       return DEFAULT_EXTENSION;
     }

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolver.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolver.java
@@ -160,7 +160,10 @@ final class DingTalkInboundImageResolver {
         Path file = writeToMediaRoot(messageId, downloadCode, downloadUrl);
         return new InboundAttachment(
             InboundAttachment.TYPE_IMAGE, file.toAbsolutePath().toString(), downloadCode);
-      } catch (Exception e) {
+      } catch (IOException | InterruptedException | RuntimeException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         last = e;
         if (attempt < DOWNLOAD_ATTEMPTS && isTransientTimeout(e)) {
           LOG.warn(
@@ -291,17 +294,18 @@ final class DingTalkInboundImageResolver {
     }
     // 单测：apiBase 指向本地 HttpServer 时允许同主机
     URI api = URI.create(apiBaseUrl);
-    if (api.getHost() != null && api.getHost().equalsIgnoreCase(uri.getHost())) {
+    String apiHost = api.getHost();
+    String mediaHost = uri.getHost().toLowerCase(Locale.ROOT);
+    if (apiHost != null && apiHost.toLowerCase(Locale.ROOT).equals(mediaHost)) {
       return true;
     }
     if (!SCHEME_HTTPS.equals(scheme)) {
       return false;
     }
-    String host = uri.getHost().toLowerCase(Locale.ROOT);
-    return host.equals(HOST_DINGTALK)
-        || host.endsWith(HOST_SUFFIX_DINGTALK)
-        || host.endsWith(HOST_SUFFIX_ALICDN)
-        || host.endsWith(HOST_SUFFIX_ALIYUNCS);
+    return mediaHost.equals(HOST_DINGTALK)
+        || mediaHost.endsWith(HOST_SUFFIX_DINGTALK)
+        || mediaHost.endsWith(HOST_SUFFIX_ALICDN)
+        || mediaHost.endsWith(HOST_SUFFIX_ALIYUNCS);
   }
 
   private static boolean isTransientTimeout(Throwable error) {

--- a/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolverTest.java
+++ b/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolverTest.java
@@ -1,0 +1,195 @@
+package io.oryxos.channel.dingtalk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpServer;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMessage;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DingTalkInboundImageResolverTest {
+
+  @TempDir Path mediaRoot;
+
+  private HttpServer server;
+  private String baseUrl;
+  private final AtomicInteger tokenCalls = new AtomicInteger();
+  private final AtomicInteger metaCalls = new AtomicInteger();
+
+  @BeforeEach
+  void startServer() throws IOException {
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    int port = server.getAddress().getPort();
+    baseUrl = "http://127.0.0.1:" + port;
+    server.createContext(
+        "/v1.0/oauth2/accessToken",
+        exchange -> {
+          tokenCalls.incrementAndGet();
+          byte[] body =
+              "{\"accessToken\":\"tok-1\",\"expireIn\":7200}".getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().add("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, body.length);
+          try (OutputStream out = exchange.getResponseBody()) {
+            out.write(body);
+          }
+        });
+    server.createContext(
+        "/v1.0/robot/messageFiles/download",
+        exchange -> {
+          metaCalls.incrementAndGet();
+          String downloadUrl = baseUrl + "/file.bin";
+          byte[] body =
+              ("{\"downloadUrl\":\"" + downloadUrl + "\"}").getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().add("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, body.length);
+          try (OutputStream out = exchange.getResponseBody()) {
+            out.write(body);
+          }
+        });
+    server.createContext(
+        "/file.bin",
+        exchange -> {
+          // Minimal JPEG SOI so ImageMime can sniff
+          byte[] body = new byte[] {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, 0x01, 0x02, 0x03};
+          exchange.sendResponseHeaders(200, body.length);
+          try (OutputStream out = exchange.getResponseBody()) {
+            out.write(body);
+          }
+        });
+    server.start();
+  }
+
+  @AfterEach
+  void stopServer() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  @DisplayName("downloadCode → 临时 URL → 本地绝对路径，保留 reference")
+  void downloadsDownloadCodeToLocalPath() throws Exception {
+    DingTalkInboundImageResolver resolver =
+        new DingTalkInboundImageResolver(
+            HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build(),
+            url -> {},
+            baseUrl,
+            "app-key",
+            "app-secret",
+            "app-key",
+            mediaRoot,
+            "ops-dingtalk");
+    InboundMessage input =
+        new InboundMessage(
+            "dingtalk",
+            "ops-dingtalk",
+            "msg-1",
+            ChatKind.P2P,
+            "u1",
+            "conv-1",
+            "",
+            false,
+            false,
+            List.of(InboundAttachment.imageReference("dl-code-1")));
+
+    InboundMessage out = resolver.resolve(input);
+
+    assertEquals(1, out.attachments().size());
+    InboundAttachment att = out.attachments().get(0);
+    assertEquals("dl-code-1", att.reference());
+    assertTrue(att.url() != null && !att.url().isBlank());
+    assertTrue(Files.isRegularFile(Path.of(att.url())), att.url());
+    assertEquals(1, tokenCalls.get());
+    assertEquals(1, metaCalls.get());
+  }
+
+  @Test
+  @DisplayName("下载元信息失败时保留 downloadCode，不抛异常")
+  void downloadFailureKeepsReference() throws Exception {
+    server.removeContext("/v1.0/robot/messageFiles/download");
+    server.createContext(
+        "/v1.0/robot/messageFiles/download",
+        exchange -> {
+          byte[] body = "{\"code\":\"InvalidParameter\"}".getBytes(StandardCharsets.UTF_8);
+          exchange.sendResponseHeaders(400, body.length);
+          try (OutputStream out = exchange.getResponseBody()) {
+            out.write(body);
+          }
+        });
+    DingTalkInboundImageResolver resolver =
+        new DingTalkInboundImageResolver(
+            HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build(),
+            url -> {},
+            baseUrl,
+            "app-key",
+            "app-secret",
+            "app-key",
+            mediaRoot,
+            "ops-dingtalk");
+    InboundMessage input =
+        new InboundMessage(
+            "dingtalk",
+            "ops-dingtalk",
+            "msg-2",
+            ChatKind.P2P,
+            "u1",
+            "conv-1",
+            "",
+            false,
+            false,
+            List.of(InboundAttachment.imageReference("dl-bad")));
+
+    InboundMessage out = resolver.resolve(input);
+
+    assertEquals("dl-bad", out.attachments().get(0).reference());
+    assertTrue(out.attachments().get(0).url() == null || out.attachments().get(0).url().isBlank());
+  }
+
+  @Test
+  @DisplayName("已有 picURL 的附件跳过下载")
+  void skipsWhenUrlPresent() {
+    DingTalkInboundImageResolver resolver =
+        new DingTalkInboundImageResolver(
+            HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build(),
+            url -> {},
+            baseUrl,
+            "app-key",
+            "app-secret",
+            "app-key",
+            mediaRoot,
+            "ops-dingtalk");
+    InboundMessage input =
+        new InboundMessage(
+            "dingtalk",
+            "ops-dingtalk",
+            "msg-3",
+            ChatKind.P2P,
+            "u1",
+            "conv-1",
+            "",
+            false,
+            false,
+            List.of(InboundAttachment.imageUrl("https://example.com/a.jpg")));
+
+    InboundMessage out = resolver.resolve(input);
+
+    assertEquals(input, out);
+    assertEquals(0, tokenCalls.get());
+  }
+}

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.oryxos.core.channel.ChannelConfig;
 import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundChannelAdapter;
 import io.oryxos.core.channel.InboundMessage;
 import io.oryxos.core.channel.InboundMessageService;
@@ -11,6 +13,7 @@ import io.oryxos.core.channel.OutboundGuard;
 import io.oryxos.core.profile.ProfileRegistry;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -290,11 +293,40 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
       msg.ifPresent(
           m -> {
             sender.rememberChatType(m.chatId(), WeComEventNormalizer.chatTypeCode(body));
-            inboundMessageService.onMessage(m, this);
+            dispatchClaimed(m);
           });
     } catch (RuntimeException e) {
       LOG.error("企微渠道 {} 事件处理异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
     }
+  }
+
+  /** 有图时即时「处理中」（识图常低于默认 15s 阈值）；文本仍走 onMessage 内延迟提示。 */
+  private void dispatchClaimed(InboundMessage m) {
+    if (!inboundMessageService.tryClaim(m.channelName(), m.messageId())) {
+      LOG.info("渠道 {} 重复事件已忽略: {}", sanitize(m.channelName()), sanitize(m.messageId()));
+      return;
+    }
+    if (!hasImage(m)) {
+      inboundMessageService.onClaimedMessage(m, this);
+      return;
+    }
+    String replyTo = m.chatKind() == ChatKind.GROUP ? m.messageId() : null;
+    CountDownLatch slowWork = inboundMessageService.beginSlowWork(this, m.chatId(), replyTo);
+    try {
+      inboundMessageService.onClaimedMessage(m, this, slowWork);
+    } catch (RuntimeException e) {
+      slowWork.countDown();
+      throw e;
+    }
+  }
+
+  private static boolean hasImage(InboundMessage message) {
+    for (InboundAttachment attachment : message.attachments()) {
+      if (InboundAttachment.TYPE_IMAGE.equals(attachment.type())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static String sanitize(String value) {


### PR DESCRIPTION
## Summary
- Closes #398
- **DingTalk**: `downloadCode` → oauth2 + `messageFiles/download` → local file URL (Feishu-style); `tryClaim` + immediate `beginSlowWork` before download
- **Docs**: Feishu FAQ no longer claims images unsupported; DingTalk setup documents image flow
- **WeCom**: image inbound also calls `beginSlowWork` (vision often finishes under the 15s text delay)

## Test plan
- [x] `DingTalkInboundImageResolverTest` + channel contract/lifecycle tests
- [x] WeCom contract test / PMD
- [ ] Live: DingTalk send picture → processing notice then vision reply
- [ ] Live: WeCom send picture → processing notice first