### PR TITLE
fix: allow DingTalk OSS http temp download URLs

### DIFF
--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolver.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolver.java
@@ -298,7 +298,12 @@ final class DingTalkInboundImageResolver {
     if (apiHost != null && asciiLower(apiHost).equals(mediaHost)) {
       return true;
     }
-    if (!SCHEME_HTTPS.equals(scheme)) {
+    // 钉钉 messageFiles 临时链常落在 OSS（*.aliyuncs.com），可能是 http 或 https
+    return isAllowedMediaHost(mediaHost);
+  }
+
+  static boolean isAllowedMediaHost(String mediaHost) {
+    if (mediaHost == null || mediaHost.isBlank()) {
       return false;
     }
     return mediaHost.equals(HOST_DINGTALK)

--- a/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolverTest.java
+++ b/oryxos-channel-dingtalk/src/test/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolverTest.java
@@ -192,4 +192,14 @@ class DingTalkInboundImageResolverTest {
     assertEquals(input, out);
     assertEquals(0, tokenCalls.get());
   }
+
+  @Test
+  @DisplayName("钉钉 OSS 临时域名（含 http）在 allowlist 内")
+  void allowsDingTalkOssHosts() {
+    assertTrue(
+        DingTalkInboundImageResolver.isAllowedMediaHost(
+            "wukong-file-im-zjk.oss-cn-zhangjiakou.aliyuncs.com"));
+    assertTrue(DingTalkInboundImageResolver.isAllowedMediaHost("cdn.dingtalk.com"));
+    assertTrue(DingTalkInboundImageResolver.isAllowedMediaHost("img.alicdn.com"));
+  }
 }


### PR DESCRIPTION
## Summary
- Closes #400
- Live: `downloadUrl` host `wukong-file-im-zjk.oss-cn-zhangjiakou.aliyuncs.com` was rejected
- Root cause: media allowlist required https for CDN hosts; DingTalk may return http OSS URLs
- Allow http/https for dingtalk / alicdn / aliyuncs hosts; add regression test

## Test plan
- [x] `DingTalkInboundImageResolverTest`
- [ ] Live: DingTalk send picture → local media + vision describes image