### PR TITLE
fix: WeCom AES decrypt + Vision remote-media strip

### DIFF
--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComEventNormalizer.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComEventNormalizer.java
@@ -70,7 +70,13 @@ public class WeComEventNormalizer {
     } else if (MSG_IMAGE.equals(msgtype)) {
       String imageUrl = body.path("image").path("url").asText(null);
       if (imageUrl != null && !imageUrl.isBlank()) {
-        attachments.add(InboundAttachment.imageUrl(imageUrl));
+        String aesKey = body.path("image").path("aeskey").asText(null);
+        if (aesKey != null && !aesKey.isBlank()) {
+          // reference 暂存 aeskey，下载解密后由 resolver 改回远程 URL
+          attachments.add(new InboundAttachment(InboundAttachment.TYPE_IMAGE, imageUrl, aesKey));
+        } else {
+          attachments.add(InboundAttachment.imageUrl(imageUrl));
+        }
       }
     }
     return Optional.of(

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComInboundImageResolver.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComInboundImageResolver.java
@@ -180,11 +180,7 @@ final class WeComInboundImageResolver {
     } else if (!ImageMime.hasRecognizedMagic(bytes)) {
       throw new IllegalStateException("下载内容非明文图片且消息缺 aeskey，无法解密");
     }
-    String sniffedMime = mimeFromBytes(bytes);
     String ext = extensionOf(uri.getPath());
-    if (DEFAULT_EXTENSION.equals(ext) && sniffedMime != null) {
-      ext = ImageMime.extensionFor(sniffedMime);
-    }
     Path dir = mediaRoot.resolve(safeSegment(messageId));
     Files.createDirectories(dir);
     String stem = safeSegment(Integer.toHexString(remoteUrl.hashCode()));
@@ -198,26 +194,19 @@ final class WeComInboundImageResolver {
       }
       throw new IllegalStateException("解密/下载后仍非可识别图片格式");
     }
+    if (DEFAULT_EXTENSION.equals(ext)) {
+      String betterExt = ImageMime.extensionFor(ImageMime.probeFile(target));
+      if (!DEFAULT_EXTENSION.equals(betterExt) && !betterExt.equals(ext)) {
+        Path renamed = dir.resolve(stem + betterExt);
+        try {
+          Files.move(target, renamed);
+          return renamed;
+        } catch (IOException moveFailed) {
+          LOG.debug("企微图片重命名扩展名失败，保留原文件: {}", sanitize(moveFailed.getMessage()));
+        }
+      }
+    }
     return target;
-  }
-
-  private static String mimeFromBytes(byte[] bytes) {
-    if (!ImageMime.hasRecognizedMagic(bytes)) {
-      return null;
-    }
-    if ((bytes[0] & 0xFF) == 0xFF) {
-      return ImageMime.IMAGE_JPEG;
-    }
-    if (bytes[0] == (byte) 0x89) {
-      return ImageMime.IMAGE_PNG;
-    }
-    if (bytes[0] == 'G') {
-      return ImageMime.IMAGE_GIF;
-    }
-    if (bytes[0] == 'R') {
-      return ImageMime.IMAGE_WEBP;
-    }
-    return null;
   }
 
   private static final String HOST_LOOPBACK_IP = "127.0.0.1";

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComInboundImageResolver.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComInboundImageResolver.java
@@ -116,10 +116,11 @@ final class WeComInboundImageResolver {
 
   private InboundAttachment downloadOrKeep(String messageId, InboundAttachment attachment) {
     String remoteUrl = attachment.url().strip();
+    String aesKey = mediaAesKey(attachment);
     Exception last = null;
     for (int attempt = 1; attempt <= DOWNLOAD_ATTEMPTS; attempt++) {
       try {
-        Path file = writeToMediaRoot(messageId, remoteUrl);
+        Path file = writeToMediaRoot(messageId, remoteUrl, aesKey);
         return new InboundAttachment(
             InboundAttachment.TYPE_IMAGE, file.toAbsolutePath().toString(), remoteUrl);
       } catch (IOException | InterruptedException | RuntimeException e) {
@@ -148,7 +149,16 @@ final class WeComInboundImageResolver {
     return attachment;
   }
 
-  private Path writeToMediaRoot(String messageId, String remoteUrl)
+  /** normalizer 把 aeskey 放在 reference；已是 http(s) 的 reference 视为旧远程 URL，不是密钥。 */
+  private static String mediaAesKey(InboundAttachment attachment) {
+    String ref = attachment.reference();
+    if (ref == null || ref.isBlank() || ImageMime.isHttpUrl(ref.strip())) {
+      return null;
+    }
+    return ref.strip();
+  }
+
+  private Path writeToMediaRoot(String messageId, String remoteUrl, String aesKey)
       throws IOException, InterruptedException {
     URI uri = URI.create(remoteUrl);
     if (!isAllowedMediaUri(uri)) {
@@ -165,26 +175,49 @@ final class WeComInboundImageResolver {
     if (bytes == null || bytes.length == 0) {
       throw new IllegalStateException("下载临时文件为空");
     }
+    if (aesKey != null) {
+      bytes = WeComMediaAesDecrypt.decrypt(bytes, aesKey);
+    } else if (!ImageMime.hasRecognizedMagic(bytes)) {
+      throw new IllegalStateException("下载内容非明文图片且消息缺 aeskey，无法解密");
+    }
+    String sniffedMime = mimeFromBytes(bytes);
     String ext = extensionOf(uri.getPath());
+    if (DEFAULT_EXTENSION.equals(ext) && sniffedMime != null) {
+      ext = ImageMime.extensionFor(sniffedMime);
+    }
     Path dir = mediaRoot.resolve(safeSegment(messageId));
     Files.createDirectories(dir);
     String stem = safeSegment(Integer.toHexString(remoteUrl.hashCode()));
     Path target = dir.resolve(stem + ext);
     Files.write(target, bytes);
-    if (DEFAULT_EXTENSION.equals(ext)) {
-      String sniffed = ImageMime.probeFile(target);
-      String betterExt = ImageMime.extensionFor(sniffed);
-      if (!DEFAULT_EXTENSION.equals(betterExt) && !betterExt.equals(ext)) {
-        Path renamed = dir.resolve(stem + betterExt);
-        try {
-          Files.move(target, renamed);
-          return renamed;
-        } catch (IOException moveFailed) {
-          LOG.debug("企微图片重命名扩展名失败，保留原文件: {}", sanitize(moveFailed.getMessage()));
-        }
+    if (!ImageMime.hasRecognizedMagic(target)) {
+      try {
+        Files.deleteIfExists(target);
+      } catch (IOException ignored) {
+        // 尽力删除坏文件
       }
+      throw new IllegalStateException("解密/下载后仍非可识别图片格式");
     }
     return target;
+  }
+
+  private static String mimeFromBytes(byte[] bytes) {
+    if (!ImageMime.hasRecognizedMagic(bytes)) {
+      return null;
+    }
+    if ((bytes[0] & 0xFF) == 0xFF) {
+      return ImageMime.IMAGE_JPEG;
+    }
+    if (bytes[0] == (byte) 0x89) {
+      return ImageMime.IMAGE_PNG;
+    }
+    if (bytes[0] == 'G') {
+      return ImageMime.IMAGE_GIF;
+    }
+    if (bytes[0] == 'R') {
+      return ImageMime.IMAGE_WEBP;
+    }
+    return null;
   }
 
   private static final String HOST_LOOPBACK_IP = "127.0.0.1";

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComMediaAesDecrypt.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComMediaAesDecrypt.java
@@ -11,6 +11,11 @@ import javax.crypto.spec.SecretKeySpec;
  *
  * <p>对齐官方 aibot SDK（{@code decrypt_file}）与文档「多媒体资源解密」。
  */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "CIPHER_INTEGRITY",
+    justification =
+        "企微长连接多媒体协议固定为 AES-256-CBC（官方文档/SDK），无法改用带完整性的 AEAD；"
+            + "密钥为每条消息独立 aeskey，仅用于解密平台侧已加密的临时资源。")
 final class WeComMediaAesDecrypt {
 
   private static final int AES_BLOCK = 16;

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComMediaAesDecrypt.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComMediaAesDecrypt.java
@@ -1,0 +1,85 @@
+package io.oryxos.channel.wecom;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * 企微智能机器人长连接入站媒体解密：AES-256-CBC，IV 为密钥前 16 字节，PKCS#7（填充长度可达 32）。
+ *
+ * <p>对齐官方 aibot SDK（{@code decrypt_file}）与文档「多媒体资源解密」。
+ */
+final class WeComMediaAesDecrypt {
+
+  private static final int AES_BLOCK = 16;
+  private static final int MAX_PKCS7_PAD = 32;
+  private static final int AES_256_KEY_LEN = 32;
+  private static final String TRANSFORMATION = "AES/CBC/NoPadding";
+
+  private WeComMediaAesDecrypt() {}
+
+  static byte[] decrypt(byte[] encrypted, String aesKeyBase64) {
+    if (encrypted == null || encrypted.length == 0) {
+      throw new IllegalArgumentException("encrypted_data is empty");
+    }
+    if (aesKeyBase64 == null || aesKeyBase64.isBlank()) {
+      throw new IllegalArgumentException("aes_key must be a non-empty string");
+    }
+    byte[] key = decodeAesKey(aesKeyBase64.strip());
+    if (key.length != AES_256_KEY_LEN) {
+      throw new IllegalArgumentException("aes_key decoded length must be 32, got " + key.length);
+    }
+    byte[] iv = new byte[AES_BLOCK];
+    System.arraycopy(key, 0, iv, 0, AES_BLOCK);
+    byte[] aligned = alignToBlock(encrypted);
+    try {
+      Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+      cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
+      byte[] decrypted = cipher.doFinal(aligned);
+      return stripPkcs7(decrypted);
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("WeCom media AES decrypt failed: " + e.getMessage(), e);
+    }
+  }
+
+  private static byte[] decodeAesKey(String aesKeyBase64) {
+    String padded = aesKeyBase64;
+    int rem = padded.length() % 4;
+    if (rem != 0) {
+      padded = padded + "=".repeat(4 - rem);
+    }
+    return Base64.getDecoder().decode(padded.getBytes(StandardCharsets.US_ASCII));
+  }
+
+  private static byte[] alignToBlock(byte[] encrypted) {
+    int rem = encrypted.length % AES_BLOCK;
+    if (rem == 0) {
+      return encrypted;
+    }
+    byte[] aligned = new byte[encrypted.length + (AES_BLOCK - rem)];
+    System.arraycopy(encrypted, 0, aligned, 0, encrypted.length);
+    return aligned;
+  }
+
+  private static byte[] stripPkcs7(byte[] decrypted) {
+    if (decrypted.length == 0) {
+      throw new IllegalStateException("Decrypted data is empty");
+    }
+    int padLen = decrypted[decrypted.length - 1] & 0xFF;
+    if (padLen < 1 || padLen > MAX_PKCS7_PAD || padLen > decrypted.length) {
+      throw new IllegalStateException("Invalid PKCS#7 padding value: " + padLen);
+    }
+    for (int i = decrypted.length - padLen; i < decrypted.length; i++) {
+      if ((decrypted[i] & 0xFF) != padLen) {
+        throw new IllegalStateException("Invalid PKCS#7 padding: padding bytes mismatch");
+      }
+    }
+    byte[] plain = new byte[decrypted.length - padLen];
+    System.arraycopy(decrypted, 0, plain, 0, plain.length);
+    return plain;
+  }
+}

--- a/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComEventNormalizerTest.java
+++ b/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComEventNormalizerTest.java
@@ -62,13 +62,14 @@ class WeComEventNormalizerTest {
     body.put("chattype", "single");
     body.put("msgtype", "image");
     body.putObject("from").put("userid", "u1");
-    body.putObject("image").put("url", "https://x");
+    body.putObject("image").put("url", "https://x").put("aeskey", "AESKEY123");
 
     InboundMessage msg = normalizer.normalize(body).orElseThrow();
     assertFalse(msg.textual());
     assertEquals("", msg.content());
     assertEquals(1, msg.attachments().size());
     assertEquals("https://x", msg.attachments().get(0).url());
+    assertEquals("AESKEY123", msg.attachments().get(0).reference());
   }
 
   @Test

--- a/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComMediaAesDecryptTest.java
+++ b/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComMediaAesDecryptTest.java
@@ -1,0 +1,153 @@
+package io.oryxos.channel.wecom;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpServer;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.session.ImageMime;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WeComMediaAesDecryptTest {
+
+  @TempDir Path mediaRoot;
+
+  private HttpServer server;
+  private String baseUrl;
+  private byte[] encryptedJpeg;
+  private String aesKeyB64;
+
+  @BeforeEach
+  void startServer() throws Exception {
+    byte[] key = new byte[32];
+    for (int i = 0; i < key.length; i++) {
+      key[i] = (byte) (i + 1);
+    }
+    aesKeyB64 = Base64.getEncoder().encodeToString(key);
+    byte[] jpeg =
+        new byte[] {
+          (byte) 0xFF,
+          (byte) 0xD8,
+          (byte) 0xFF,
+          0x01,
+          0x02,
+          0x03,
+          0x04,
+          0x05,
+          0x06,
+          0x07,
+          0x08,
+          0x09,
+          0x0A,
+          0x0B,
+          0x0C,
+          0x0D
+        };
+    encryptedJpeg = encryptPkcs7To32(jpeg, key);
+
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    server.createContext(
+        "/enc",
+        exchange -> {
+          exchange.sendResponseHeaders(200, encryptedJpeg.length);
+          try (OutputStream out = exchange.getResponseBody()) {
+            out.write(encryptedJpeg);
+          }
+        });
+    server.start();
+  }
+
+  @AfterEach
+  void stopServer() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  @DisplayName("AES 往返解密得到明文")
+  void decryptRoundTrip() {
+    byte[] plain = new byte[] {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, 1, 2, 3};
+    byte[] key = new byte[32];
+    for (int i = 0; i < 32; i++) {
+      key[i] = (byte) (40 + i);
+    }
+    byte[] enc = encryptPkcs7To32(plain, key);
+    byte[] out = WeComMediaAesDecrypt.decrypt(enc, Base64.getEncoder().encodeToString(key));
+    assertArrayEquals(plain, out);
+  }
+
+  @Test
+  @DisplayName("带 aeskey 下载后落盘为可识别 JPEG")
+  void downloadsAndDecryptsToLocalJpeg() throws Exception {
+    String remote = baseUrl + "/enc";
+    WeComInboundImageResolver resolver =
+        new WeComInboundImageResolver(
+            HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build(),
+            mediaRoot,
+            "ops-wecom",
+            true);
+    InboundMessage input =
+        new InboundMessage(
+            "wecom",
+            "ops-wecom",
+            "msg-enc",
+            ChatKind.P2P,
+            "u1",
+            "chat-1",
+            "",
+            false,
+            false,
+            List.of(new InboundAttachment(InboundAttachment.TYPE_IMAGE, remote, aesKeyB64)));
+
+    InboundMessage out = resolver.resolve(input);
+
+    assertEquals(1, out.attachments().size());
+    InboundAttachment att = out.attachments().get(0);
+    assertEquals(remote, att.reference());
+    Path local = Path.of(att.url());
+    assertTrue(Files.isRegularFile(local), att.url());
+    assertTrue(ImageMime.hasRecognizedMagic(local), "decrypted file should have jpeg magic");
+  }
+
+  /** 企微文档：PKCS#7 填充至 32 字节倍数后 AES-CBC。 */
+  private static byte[] encryptPkcs7To32(byte[] plain, byte[] key) {
+    try {
+      int padLen = 32 - (plain.length % 32);
+      if (padLen == 0) {
+        padLen = 32;
+      }
+      byte[] padded = new byte[plain.length + padLen];
+      System.arraycopy(plain, 0, padded, 0, plain.length);
+      for (int i = plain.length; i < padded.length; i++) {
+        padded[i] = (byte) padLen;
+      }
+      Cipher cipher = Cipher.getInstance("AES/CBC/NoPadding");
+      byte[] iv = new byte[16];
+      System.arraycopy(key, 0, iv, 0, 16);
+      cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
+      return cipher.doFinal(padded);
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/session/ImageMime.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/session/ImageMime.java
@@ -48,6 +48,16 @@ public final class ImageMime {
     return fromPath(file.toString());
   }
 
+  /** 本地文件是否具备可识别的图片魔数（jpeg/png/gif/webp）；密文或损坏文件为 false。 */
+  public static boolean hasRecognizedMagic(Path file) {
+    return sniffMagic(file) != null;
+  }
+
+  /** 字节头是否为可识别图片魔数。 */
+  public static boolean hasRecognizedMagic(byte[] header) {
+    return sniffMagicBytes(header) != null;
+  }
+
   /** 由路径或 URL 字符串的后缀推断；无后缀则默认 JPEG。 */
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",
@@ -95,41 +105,47 @@ public final class ImageMime {
       return null;
     }
     try (InputStream in = Files.newInputStream(file)) {
-      byte[] header = in.readNBytes(MAGIC_HEADER_BYTES);
-      if (header.length >= JPEG_MAGIC_MIN
-          && (header[0] & 0xFF) == 0xFF
-          && (header[1] & 0xFF) == 0xD8
-          && (header[2] & 0xFF) == 0xFF) {
-        return IMAGE_JPEG;
-      }
-      if (header.length >= PNG_MAGIC_MIN
-          && header[0] == (byte) 0x89
-          && header[1] == 0x50
-          && header[2] == 0x4E
-          && header[3] == 0x47) {
-        return IMAGE_PNG;
-      }
-      if (header.length >= GIF_MAGIC_MIN
-          && header[0] == 'G'
-          && header[1] == 'I'
-          && header[2] == 'F'
-          && header[3] == '8') {
-        return IMAGE_GIF;
-      }
-      if (header.length >= WEBP_MAGIC_MIN
-          && header[0] == 'R'
-          && header[1] == 'I'
-          && header[2] == 'F'
-          && header[3] == 'F'
-          && header[8] == 'W'
-          && header[9] == 'E'
-          && header[10] == 'B'
-          && header[11] == 'P') {
-        return IMAGE_WEBP;
-      }
-      return null;
+      return sniffMagicBytes(in.readNBytes(MAGIC_HEADER_BYTES));
     } catch (IOException e) {
       return null;
     }
+  }
+
+  private static String sniffMagicBytes(byte[] header) {
+    if (header == null) {
+      return null;
+    }
+    if (header.length >= JPEG_MAGIC_MIN
+        && (header[0] & 0xFF) == 0xFF
+        && (header[1] & 0xFF) == 0xD8
+        && (header[2] & 0xFF) == 0xFF) {
+      return IMAGE_JPEG;
+    }
+    if (header.length >= PNG_MAGIC_MIN
+        && header[0] == (byte) 0x89
+        && header[1] == 0x50
+        && header[2] == 0x4E
+        && header[3] == 0x47) {
+      return IMAGE_PNG;
+    }
+    if (header.length >= GIF_MAGIC_MIN
+        && header[0] == 'G'
+        && header[1] == 'I'
+        && header[2] == 'F'
+        && header[3] == '8') {
+      return IMAGE_GIF;
+    }
+    if (header.length >= WEBP_MAGIC_MIN
+        && header[0] == 'R'
+        && header[1] == 'I'
+        && header[2] == 'F'
+        && header[3] == 'F'
+        && header[8] == 'W'
+        && header[9] == 'E'
+        && header[10] == 'B'
+        && header[11] == 'P') {
+      return IMAGE_WEBP;
+    }
+    return null;
   }
 }

--- a/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
@@ -136,8 +136,25 @@ public class SpringAiProviderServiceImpl implements ProviderService {
     try {
       return invokeChat(sessionId, profile, request, attempt, def);
     } catch (RuntimeException e) {
-      // 非 vision 模型拒收图片（常见 400）：剥掉 media 后用 enricher 文本再试一次，避免入站图硬失败
+      // 非 vision / 远程图链失效（常见 400）：先剔 http(s) media 保留本地图；仍失败再剥全部 media
       if (hasUserMedia(request) && isClientError(e)) {
+        ProviderRequest withoutRemote = stripRemoteHttpMedia(request);
+        if (hasUserMedia(withoutRemote)
+            && countUserMedia(withoutRemote) < countUserMedia(request)) {
+          LOG.warn(
+              "multimodal 被拒，去掉远程 URL 图片后重试（provider={} model={}）：{}",
+              sanitize(attempt.provider()),
+              sanitize(attempt.model()),
+              sanitize(e.getMessage()));
+          try {
+            return invokeChat(sessionId, profile, withoutRemote, attempt, def);
+          } catch (RuntimeException e2) {
+            if (!(hasUserMedia(withoutRemote) && isClientError(e2))) {
+              throw e2;
+            }
+            e = e2;
+          }
+        }
         LOG.warn(
             "multimodal 被拒，降级纯文本重试（provider={} model={}）：{}",
             sanitize(attempt.provider()),
@@ -259,6 +276,24 @@ public class SpringAiProviderServiceImpl implements ProviderService {
       return invokeChatStream(sessionId, profile, request, onToken, attempt, def, contentStarted);
     } catch (RuntimeException e) {
       if (!contentStarted[0] && hasUserMedia(request) && isClientError(e)) {
+        ProviderRequest withoutRemote = stripRemoteHttpMedia(request);
+        if (hasUserMedia(withoutRemote)
+            && countUserMedia(withoutRemote) < countUserMedia(request)) {
+          LOG.warn(
+              "multimodal 流式被拒，去掉远程 URL 图片后重试（provider={} model={}）：{}",
+              sanitize(attempt.provider()),
+              sanitize(attempt.model()),
+              sanitize(e.getMessage()));
+          try {
+            return invokeChatStream(
+                sessionId, profile, withoutRemote, onToken, attempt, def, contentStarted);
+          } catch (RuntimeException e2) {
+            if (contentStarted[0] || !(hasUserMedia(withoutRemote) && isClientError(e2))) {
+              throw e2;
+            }
+            e = e2;
+          }
+        }
         LOG.warn(
             "multimodal 流式被拒，降级纯文本重试（provider={} model={}）：{}",
             sanitize(attempt.provider()),
@@ -602,6 +637,10 @@ public class SpringAiProviderServiceImpl implements ProviderService {
         LOG.warn("跳过不可读的本地图片: {}", sanitize(uri));
         return null;
       }
+      if (!ImageMime.hasRecognizedMagic(path)) {
+        LOG.warn("跳过无有效图片魔数的本地文件: {}", sanitize(uri));
+        return null;
+      }
       return new Media(mime, new FileSystemResource(path));
     } catch (RuntimeException e) {
       LOG.warn("构造 Media 失败（uri={}）：{}", sanitize(uri), sanitize(e.getMessage()));
@@ -626,15 +665,48 @@ public class SpringAiProviderServiceImpl implements ProviderService {
   }
 
   private static boolean hasUserMedia(ProviderRequest request) {
+    return countUserMedia(request) > 0;
+  }
+
+  private static int countUserMedia(ProviderRequest request) {
     if (request == null || request.messages() == null) {
-      return false;
+      return 0;
     }
+    int n = 0;
     for (Message message : request.messages()) {
-      if (Message.ROLE_USER.equals(message.role()) && !message.media().isEmpty()) {
-        return true;
+      if (Message.ROLE_USER.equals(message.role())) {
+        n += message.media().size();
       }
     }
-    return false;
+    return n;
+  }
+
+  /** 去掉 http(s) 远程 media，保留本地路径。会话历史里过期 COS/OSS 签名链常导致整包 multimodal 400； 入站通道已落盘的新图应仍可送 Vision。 */
+  private static ProviderRequest stripRemoteHttpMedia(ProviderRequest request) {
+    List<Message> stripped = new ArrayList<>(request.messages().size());
+    for (Message message : request.messages()) {
+      if (message.media().isEmpty()) {
+        stripped.add(message);
+        continue;
+      }
+      List<Message.MediaPart> localOnly =
+          message.media().stream()
+              .filter(p -> p != null && p.uri() != null && !ImageMime.isHttpUrl(p.uri().strip()))
+              .toList();
+      if (localOnly.size() == message.media().size()) {
+        stripped.add(message);
+      } else {
+        stripped.add(
+            new Message(
+                message.role(),
+                message.content(),
+                message.toolName(),
+                message.toolCallId(),
+                message.toolCalls(),
+                localOnly));
+      }
+    }
+    return new ProviderRequest(request.systemPrompt(), stripped, request.availableTools());
   }
 
   private static ProviderRequest stripMedia(ProviderRequest request) {

--- a/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
+++ b/oryxos-provider/src/main/java/io/oryxos/provider/SpringAiProviderServiceImpl.java
@@ -149,7 +149,7 @@ public class SpringAiProviderServiceImpl implements ProviderService {
           try {
             return invokeChat(sessionId, profile, withoutRemote, attempt, def);
           } catch (RuntimeException e2) {
-            if (!(hasUserMedia(withoutRemote) && isClientError(e2))) {
+            if (!canRetryWithoutAllMedia(withoutRemote, e2)) {
               throw e2;
             }
             e = e2;
@@ -288,7 +288,8 @@ public class SpringAiProviderServiceImpl implements ProviderService {
             return invokeChatStream(
                 sessionId, profile, withoutRemote, onToken, attempt, def, contentStarted);
           } catch (RuntimeException e2) {
-            if (contentStarted[0] || !(hasUserMedia(withoutRemote) && isClientError(e2))) {
+            boolean alreadyStreaming = contentStarted[0];
+            if (alreadyStreaming || !canRetryWithoutAllMedia(withoutRemote, e2)) {
               throw e2;
             }
             e = e2;
@@ -666,6 +667,11 @@ public class SpringAiProviderServiceImpl implements ProviderService {
 
   private static boolean hasUserMedia(ProviderRequest request) {
     return countUserMedia(request) > 0;
+  }
+
+  /** multimodal 二次降级（剥全部 media）前：请求仍有 user media 且错误为可剥的客户端 4xx。 */
+  private static boolean canRetryWithoutAllMedia(ProviderRequest request, RuntimeException error) {
+    return hasUserMedia(request) && isClientError(error);
   }
 
   private static int countUserMedia(ProviderRequest request) {


### PR DESCRIPTION
## Summary
- Decrypt WeCom aibot COS downloads with per-message `image.aeskey` (AES-256-CBC) before Vision; reject non-image ciphertext without a key.
- On multimodal 400, strip remote `http(s)` media first and keep local files, then fall back to text-only; skip local files without image magic.
- Verified live on WeCom P2P: valid JPEG on disk + coastal scene description from `deepseek-v4-flash-vision-exp`.

## Test plan
- [x] Unit: `WeComMediaAesDecryptTest`, `WeComEventNormalizerTest`, `WeComInboundImageResolverTest`
- [x] Live WeCom: `/new` then send image → processing + correct vision reply
- [ ] CI green on this PR