### PR TITLE
feat(feishu): streaming progress interactive cards (#347)

### DIFF
--- a/docs/FeishuChannelSetup.md
+++ b/docs/FeishuChannelSetup.md
@@ -22,7 +22,8 @@
 
 | 权限 | 用途 |
 |------|------|
-| `im:message:send_as_bot`（以应用的身份发消息） | 发送回答 |
+| `im:message:send_as_bot`（以应用的身份发消息） | 发送回答 / 进度卡片 |
+| `im:message`（获取与发送单聊、群组消息）或文档所列「更新消息」类权限 | 流式进度卡片 PATCH 更新（#347） |
 | `im:message.p2p_msg:readonly`（读取用户发给机器人的单聊消息） | 私聊问答 |
 | `im:message.group_at_msg:readonly`（接收群聊中 @ 机器人消息事件） | 群聊 @ 问答 |
 

--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
@@ -220,6 +220,16 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
     active.send(chatId, text, replyToMessageId);
   }
 
+  @Override
+  public java.util.Optional<io.oryxos.core.channel.InboundProgressStream> openProgressStream(
+      String chatId, String replyToMessageId) {
+    FeishuMessageSender active = sender;
+    if (active == null) {
+      return java.util.Optional.empty();
+    }
+    return java.util.Optional.of(new FeishuStreamListener(active, chatId, replyToMessageId));
+  }
+
   /**
    * 事件入口：归一化 → 去重占用 →（需下载时先开「处理中」）→ 图片资源落地 → 编排。去重必须在下载前：飞书平台重推同一 message_id
    * 时，若先下载再去重会白耗带宽。任何异常只留日志——抛出会触发平台重推循环。

--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuMessageSender.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuMessageSender.java
@@ -6,9 +6,14 @@ import com.lark.oapi.Client;
 import com.lark.oapi.service.im.v1.model.CreateMessageReq;
 import com.lark.oapi.service.im.v1.model.CreateMessageReqBody;
 import com.lark.oapi.service.im.v1.model.CreateMessageResp;
+import com.lark.oapi.service.im.v1.model.CreateMessageRespBody;
+import com.lark.oapi.service.im.v1.model.PatchMessageReq;
+import com.lark.oapi.service.im.v1.model.PatchMessageReqBody;
+import com.lark.oapi.service.im.v1.model.PatchMessageResp;
 import com.lark.oapi.service.im.v1.model.ReplyMessageReq;
 import com.lark.oapi.service.im.v1.model.ReplyMessageReqBody;
 import com.lark.oapi.service.im.v1.model.ReplyMessageResp;
+import com.lark.oapi.service.im.v1.model.ReplyMessageRespBody;
 import io.oryxos.core.channel.OutboundGuard;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +28,8 @@ import org.slf4j.LoggerFactory;
  * 超长文本按可配段长分段顺序发送不丢内容（FR-009，平台请求体上限 150KB，默认段长 4000 字符留足 JSON 转义余量）； 每段带随机 uuid 幂等（平台 1 小时内同 uuid
  * 至多成功一条）；replyToMessageId 非空走 reply 引用原消息（B4）。
  *
- * <p>出站使用富文本 {@code post} + {@code md} 标签承载 Agent Markdown（对齐企微/钉钉出站）。
+ * <p>出站使用富文本 {@code post} + {@code md} 标签承载 Agent Markdown（对齐企微/钉钉出站）。 进度流另走 {@code interactive} 卡片
+ * create + patch（#347）。
  */
 public class FeishuMessageSender {
 
@@ -31,6 +37,7 @@ public class FeishuMessageSender {
 
   static final int DEFAULT_CHUNK_SIZE = 4000;
   private static final String MSG_TYPE_POST = "post";
+  private static final String MSG_TYPE_INTERACTIVE = "interactive";
   private static final String RECEIVE_ID_TYPE_CHAT = "chat_id";
   private static final String POST_LOCALE = "zh_cn";
   private static final String MD_TAG = "md";
@@ -75,6 +82,99 @@ public class FeishuMessageSender {
         throw new IllegalStateException("飞书消息发送失败: " + sanitize(e.getMessage()), e);
       }
     }
+  }
+
+  /**
+   * 发送交互卡片并返回 {@code message_id}（供后续 patch）。群聊时 {@code replyToMessageId} 非空走 reply。
+   *
+   * @param cardJson 卡片 JSON（非再包一层 content）
+   */
+  public String sendInteractive(String chatId, String cardJson, String replyToMessageId) {
+    guard.check(apiBaseUrl);
+    try {
+      if (replyToMessageId == null || replyToMessageId.isBlank()) {
+        return createInteractive(chatId, cardJson);
+      }
+      return replyInteractive(replyToMessageId, cardJson);
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("飞书交互卡片发送失败: " + sanitize(e.getMessage()), e);
+    }
+  }
+
+  /** 更新已发出的交互卡片内容（PATCH）。 */
+  public void patchInteractive(String messageId, String cardJson) {
+    if (messageId == null || messageId.isBlank()) {
+      throw new IllegalArgumentException("messageId 不能为空");
+    }
+    guard.check(apiBaseUrl);
+    try {
+      PatchMessageResp resp =
+          client
+              .im()
+              .message()
+              .patch(
+                  PatchMessageReq.newBuilder()
+                      .messageId(messageId)
+                      .patchMessageReqBody(
+                          PatchMessageReqBody.newBuilder().content(cardJson).build())
+                      .build());
+      requireSuccess(resp == null ? null : resp.getCode(), resp == null ? null : resp.getMsg());
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("飞书交互卡片更新失败: " + sanitize(e.getMessage()), e);
+    }
+  }
+
+  private String createInteractive(String chatId, String cardJson) throws Exception {
+    CreateMessageResp resp =
+        client
+            .im()
+            .message()
+            .create(
+                CreateMessageReq.newBuilder()
+                    .receiveIdType(RECEIVE_ID_TYPE_CHAT)
+                    .createMessageReqBody(
+                        CreateMessageReqBody.newBuilder()
+                            .receiveId(chatId)
+                            .msgType(MSG_TYPE_INTERACTIVE)
+                            .content(cardJson)
+                            .uuid(UUID.randomUUID().toString())
+                            .build())
+                    .build());
+    requireSuccess(resp == null ? null : resp.getCode(), resp == null ? null : resp.getMsg());
+    CreateMessageRespBody data = resp == null ? null : resp.getData();
+    String id = data == null ? null : data.getMessageId();
+    if (id == null || id.isBlank()) {
+      throw new IllegalStateException("飞书交互卡片发送成功但未返回 message_id");
+    }
+    return id;
+  }
+
+  private String replyInteractive(String replyToMessageId, String cardJson) throws Exception {
+    ReplyMessageResp resp =
+        client
+            .im()
+            .message()
+            .reply(
+                ReplyMessageReq.newBuilder()
+                    .messageId(replyToMessageId)
+                    .replyMessageReqBody(
+                        ReplyMessageReqBody.newBuilder()
+                            .msgType(MSG_TYPE_INTERACTIVE)
+                            .content(cardJson)
+                            .uuid(UUID.randomUUID().toString())
+                            .build())
+                    .build());
+    requireSuccess(resp == null ? null : resp.getCode(), resp == null ? null : resp.getMsg());
+    ReplyMessageRespBody data = resp == null ? null : resp.getData();
+    String id = data == null ? null : data.getMessageId();
+    if (id == null || id.isBlank()) {
+      throw new IllegalStateException("飞书交互卡片回复成功但未返回 message_id");
+    }
+    return id;
   }
 
   private void sendCreate(String chatId, String chunk) throws Exception {

--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuProgressCard.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuProgressCard.java
@@ -1,0 +1,44 @@
+package io.oryxos.channel.feishu;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+/** 飞书交互卡片 JSON（header 模板色 + lark_md 正文），供 create/patch。 */
+final class FeishuProgressCard {
+
+  static final String TEMPLATE_BLUE = "blue";
+  static final String TEMPLATE_GREEN = "green";
+  static final String TEMPLATE_RED = "red";
+
+  private static final String TAG_PLAIN = "plain_text";
+  private static final String TAG_DIV = "div";
+  private static final String TAG_LARK_MD = "lark_md";
+
+  private FeishuProgressCard() {}
+
+  static String build(String title, String template, String markdownBody) {
+    JsonObject titleObj = new JsonObject();
+    titleObj.addProperty("tag", TAG_PLAIN);
+    titleObj.addProperty("content", title == null ? "" : title);
+
+    JsonObject header = new JsonObject();
+    header.add("title", titleObj);
+    header.addProperty("template", template == null ? TEMPLATE_BLUE : template);
+
+    JsonObject md = new JsonObject();
+    md.addProperty("tag", TAG_LARK_MD);
+    md.addProperty("content", markdownBody == null ? "" : markdownBody);
+
+    JsonObject div = new JsonObject();
+    div.addProperty("tag", TAG_DIV);
+    div.add("text", md);
+
+    JsonArray elements = new JsonArray();
+    elements.add(div);
+
+    JsonObject card = new JsonObject();
+    card.add("header", header);
+    card.add("elements", elements);
+    return card.toString();
+  }
+}

--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuStreamListener.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuStreamListener.java
@@ -1,0 +1,167 @@
+package io.oryxos.channel.feishu;
+
+import io.oryxos.core.channel.InboundProgressStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 飞书进度流（#347）：交互卡片展示思考 → 工具 → 终态；token/工具回调节流 patch，避免频控。
+ *
+ * <p>回调均在 ReAct 线程同步执行；{@link #start()} 失败时由适配器返回 empty 降级。
+ */
+final class FeishuStreamListener implements InboundProgressStream {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FeishuStreamListener.class);
+
+  private static final String TITLE_THINKING = "正在思考…";
+  private static final String TITLE_WORKING = "处理中";
+  private static final String TITLE_DONE = "回答";
+  private static final String TITLE_FAILED = "处理失败";
+  private static final String PLACEHOLDER = "_等待模型输出…_";
+  private static final long FLUSH_INTERVAL_MS = 2_000L;
+  private static final int FLUSH_CHARS = 100;
+  private static final int CARD_BODY_MAX = 8_000;
+
+  private final FeishuMessageSender sender;
+  private final String chatId;
+  private final String replyToMessageId;
+  private final StringBuilder answer = new StringBuilder();
+  private final List<String> toolLines = new ArrayList<>();
+
+  private String messageId;
+  private long lastFlushAt;
+  private int charsSinceFlush;
+  private boolean finished;
+
+  FeishuStreamListener(FeishuMessageSender sender, String chatId, String replyToMessageId) {
+    this.sender = sender;
+    this.chatId = chatId;
+    this.replyToMessageId = replyToMessageId;
+  }
+
+  @Override
+  public void start() {
+    String card =
+        FeishuProgressCard.build(TITLE_THINKING, FeishuProgressCard.TEMPLATE_BLUE, PLACEHOLDER);
+    messageId = sender.sendInteractive(chatId, card, replyToMessageId);
+    lastFlushAt = System.currentTimeMillis();
+    charsSinceFlush = 0;
+  }
+
+  @Override
+  public void onToken(String delta) {
+    if (finished || delta == null || delta.isEmpty()) {
+      return;
+    }
+    answer.append(delta);
+    charsSinceFlush += delta.length();
+    maybeFlush(false);
+  }
+
+  @Override
+  public void onToolStart(String toolName) {
+    if (finished) {
+      return;
+    }
+    toolLines.add("🔧 正在执行 `" + safeName(toolName) + "` …");
+    flush(TITLE_WORKING, FeishuProgressCard.TEMPLATE_BLUE, false);
+  }
+
+  @Override
+  public void onToolEnd(String toolName, boolean success) {
+    if (finished) {
+      return;
+    }
+    String mark = success ? "✅" : "❌";
+    toolLines.add(mark + " 工具 `" + safeName(toolName) + "` " + (success ? "完成" : "失败"));
+    flush(TITLE_WORKING, FeishuProgressCard.TEMPLATE_BLUE, false);
+  }
+
+  @Override
+  public void finish(String finalText) {
+    if (finished) {
+      return;
+    }
+    finished = true;
+    if (finalText != null && !finalText.isBlank()) {
+      answer.setLength(0);
+      answer.append(finalText);
+    }
+    flush(TITLE_DONE, FeishuProgressCard.TEMPLATE_GREEN, true);
+  }
+
+  @Override
+  public void fail(String errorMessage) {
+    if (finished) {
+      return;
+    }
+    finished = true;
+    String body =
+        errorMessage == null || errorMessage.isBlank() ? "抱歉，这次处理失败了。" : errorMessage.strip();
+    patchQuiet(FeishuProgressCard.build(TITLE_FAILED, FeishuProgressCard.TEMPLATE_RED, body), true);
+  }
+
+  private void maybeFlush(boolean force) {
+    long now = System.currentTimeMillis();
+    if (!force && charsSinceFlush < FLUSH_CHARS && now - lastFlushAt < FLUSH_INTERVAL_MS) {
+      return;
+    }
+    flush(TITLE_WORKING, FeishuProgressCard.TEMPLATE_BLUE, false);
+  }
+
+  private void flush(String title, String template, boolean terminal) {
+    if (messageId == null) {
+      return;
+    }
+    patchQuiet(FeishuProgressCard.build(title, template, buildBody()), terminal);
+    lastFlushAt = System.currentTimeMillis();
+    charsSinceFlush = 0;
+  }
+
+  private String buildBody() {
+    StringBuilder body = new StringBuilder();
+    if (!toolLines.isEmpty()) {
+      for (String line : toolLines) {
+        body.append(line).append('\n');
+      }
+      body.append('\n');
+    }
+    if (answer.length() == 0) {
+      body.append(PLACEHOLDER);
+    } else {
+      body.append(truncate(answer.toString(), CARD_BODY_MAX));
+    }
+    return body.toString();
+  }
+
+  private void patchQuiet(String cardJson, boolean terminal) {
+    try {
+      sender.patchInteractive(messageId, cardJson);
+    } catch (RuntimeException e) {
+      if (terminal) {
+        throw e;
+      }
+      LOG.warn("飞书进度卡片更新失败（继续推理）: {}", sanitize(e.getMessage()));
+    }
+  }
+
+  private static String truncate(String text, int max) {
+    if (text.length() <= max) {
+      return text;
+    }
+    return text.substring(0, max) + "\n\n_（内容过长已截断）_";
+  }
+
+  private static String safeName(String toolName) {
+    if (toolName == null || toolName.isBlank()) {
+      return "tool";
+    }
+    return toolName.replace('`', '\'').strip();
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-feishu/src/test/java/io/oryxos/channel/feishu/FeishuMessageSenderTest.java
+++ b/oryxos-channel-feishu/src/test/java/io/oryxos/channel/feishu/FeishuMessageSenderTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import com.lark.oapi.Client;
 import com.lark.oapi.service.im.v1.model.CreateMessageReq;
 import com.lark.oapi.service.im.v1.model.CreateMessageResp;
+import com.lark.oapi.service.im.v1.model.CreateMessageRespBody;
 import com.lark.oapi.service.im.v1.model.ReplyMessageReq;
 import com.lark.oapi.service.im.v1.model.ReplyMessageResp;
 import io.oryxos.core.channel.OutboundGuard;
@@ -121,5 +122,31 @@ class FeishuMessageSenderTest {
   @DisplayName("textContent JSON 编码正确转义（对照）")
   void textContentEscapes() {
     assertEquals("{\"text\":\"a\\\"b\"}", FeishuMessageSender.textContent("a\"b"));
+  }
+
+  @Test
+  @DisplayName("interactive create 返回 message_id；patch 走 PATCH API")
+  void interactiveCreateAndPatch() throws Exception {
+    CreateMessageRespBody body = new CreateMessageRespBody();
+    body.setMessageId("om_card");
+    CreateMessageResp ok = new CreateMessageResp();
+    ok.setCode(0);
+    ok.setData(body);
+    when(client.im().message().create(any(CreateMessageReq.class))).thenReturn(ok);
+    com.lark.oapi.service.im.v1.model.PatchMessageResp patchOk =
+        new com.lark.oapi.service.im.v1.model.PatchMessageResp();
+    patchOk.setCode(0);
+    when(client.im().message().patch(any(com.lark.oapi.service.im.v1.model.PatchMessageReq.class)))
+        .thenReturn(patchOk);
+
+    String id = sender.sendInteractive("oc_1", "{\"header\":{}}", null);
+    assertEquals("om_card", id);
+    ArgumentCaptor<CreateMessageReq> create = ArgumentCaptor.forClass(CreateMessageReq.class);
+    verify(client.im().message()).create(create.capture());
+    assertEquals("interactive", create.getValue().getCreateMessageReqBody().getMsgType());
+
+    sender.patchInteractive("om_card", "{\"header\":{\"template\":\"green\"}}");
+    verify(client.im().message())
+        .patch(any(com.lark.oapi.service.im.v1.model.PatchMessageReq.class));
   }
 }

--- a/oryxos-channel-feishu/src/test/java/io/oryxos/channel/feishu/FeishuStreamListenerTest.java
+++ b/oryxos-channel-feishu/src/test/java/io/oryxos/channel/feishu/FeishuStreamListenerTest.java
@@ -1,0 +1,76 @@
+package io.oryxos.channel.feishu;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class FeishuStreamListenerTest {
+
+  private FeishuMessageSender sender;
+  private FeishuStreamListener listener;
+
+  @BeforeEach
+  void setUp() {
+    sender = mock(FeishuMessageSender.class);
+    when(sender.sendInteractive(anyString(), anyString(), any())).thenReturn("om_card_1");
+    listener = new FeishuStreamListener(sender, "oc_chat", null);
+  }
+
+  @Test
+  @DisplayName("start 发蓝卡；finish 绿卡含最终答案")
+  void startAndFinish() {
+    listener.start();
+    listener.onToken("你好");
+    listener.onToken("世界");
+    listener.finish("你好世界");
+
+    ArgumentCaptor<String> createCard = ArgumentCaptor.forClass(String.class);
+    verify(sender).sendInteractive(eq("oc_chat"), createCard.capture(), eq(null));
+    assertTrue(createCard.getValue().contains("blue"));
+    assertTrue(createCard.getValue().contains("正在思考"));
+
+    ArgumentCaptor<String> patchCard = ArgumentCaptor.forClass(String.class);
+    verify(sender, times(1)).patchInteractive(eq("om_card_1"), patchCard.capture());
+    String last = patchCard.getValue();
+    assertTrue(last.contains("green"));
+    assertTrue(last.contains("你好世界"));
+  }
+
+  @Test
+  @DisplayName("工具起止立刻 patch；fail 红卡")
+  void toolsAndFail() {
+    listener.start();
+    listener.onToolStart("http_get");
+    listener.onToolEnd("http_get", true);
+    listener.fail("抱歉，这次处理失败了，请稍后重试或联系管理员。");
+
+    ArgumentCaptor<String> patches = ArgumentCaptor.forClass(String.class);
+    verify(sender, times(3)).patchInteractive(eq("om_card_1"), patches.capture());
+    assertTrue(patches.getAllValues().get(0).contains("http_get"));
+    assertTrue(patches.getAllValues().get(1).contains("✅"));
+    String failed = patches.getAllValues().get(2);
+    assertTrue(failed.contains("red"));
+    assertTrue(failed.contains("处理失败"));
+  }
+
+  @Test
+  @DisplayName("卡片 JSON 含 header template 与 lark_md")
+  void cardShape() {
+    String json = FeishuProgressCard.build("回答", FeishuProgressCard.TEMPLATE_GREEN, "hi");
+    assertTrue(json.contains("\"template\":\"green\""));
+    assertTrue(json.contains("lark_md"));
+    assertTrue(json.contains("hi"));
+    assertEquals(true, json.contains("\"content\":\"回答\""));
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundChannelAdapter.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundChannelAdapter.java
@@ -1,5 +1,7 @@
 package io.oryxos.core.channel;
 
+import java.util.Optional;
+
 /**
  * 入站 IM 渠道适配器契约：一实例 = 一个平台应用的一条接入（017 FR-010）。
  *
@@ -31,9 +33,20 @@ public interface InboundChannelAdapter {
   /**
    * 发送回复到来源处（FR-007）。实现负责平台上限分段（FR-009）与出站沙箱校验（宪法 VI）。
    *
-   * @param chatId 回复目标（私聊会话或群）
+   * @param chatId 回复目标（私聊/群）
    * @param text 回复正文
    * @param replyToMessageId 非空时引用原消息（群聊必传，使回答与提问可对应）；私聊传 null 直发
    */
   void sendReply(String chatId, String text, String replyToMessageId);
+
+  /**
+   * 可选：打开进度流（如飞书交互卡片实时更新）。默认 empty，编排走整段 {@link #sendReply}。
+   *
+   * @param chatId 回复目标会话
+   * @param replyToMessageId 群聊引用原消息 id；私聊 null
+   */
+  default Optional<InboundProgressStream> openProgressStream(
+      String chatId, String replyToMessageId) {
+    return Optional.empty();
+  }
 }

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
@@ -149,13 +149,16 @@ public class InboundMessageService {
             job.inference().run();
           } catch (RuntimeException e) {
             // B6：失败以可读消息告知用户（不含堆栈），异常继续上抛让执行记录记为失败
-            safeReply(replyVia, msg.chatId(), FAILURE_REPLY, replyTo);
+            if (!job.streamed()) {
+              safeReply(replyVia, msg.chatId(), FAILURE_REPLY, replyTo);
+            }
             throw e;
           } finally {
             done.countDown();
           }
         });
-    if (preprocessingDone == null) {
+    // 进度流已发「思考中」卡片时不再发延迟「处理中」文本，避免双提示
+    if (preprocessingDone == null && !job.streamed()) {
       scheduleProcessingNotice(done, replyVia, msg.chatId(), replyTo);
     }
   }
@@ -211,21 +214,66 @@ public class InboundMessageService {
     if (msg.chatKind() == ChatKind.P2P) {
       // B2：私聊按「渠道 + 用户 + Agent」维持连续会话——隔离/历史窗口/并发锁全部由既有会话底座承担
       Session session = sessionManager.getOrCreate(msg.channelType(), msg.userId(), agent);
-      return new InferenceJob(
+      return progressOrPlain(
+          replyVia,
+          msg.chatId(),
+          replyTo,
           session.sessionId(),
-          () ->
-              replyVia.sendReply(
-                  msg.chatId(), agentService.process(session, agentInput, media), null));
+          () -> agentService.process(session, agentInput, media),
+          (stream) -> agentService.process(session, agentInput, media, stream));
     }
     // B3：群聊每次 @ 为独立无状态问答，不落 sessions 表；渠道前缀让审计可辨（B10）
     String groupSessionId = msg.channelType() + "-group:" + UUID.randomUUID();
-    return new InferenceJob(
+    return progressOrPlain(
+        replyVia,
+        msg.chatId(),
+        replyTo,
         groupSessionId,
-        () ->
-            replyVia.sendReply(
-                msg.chatId(),
-                agentService.processStateless(agent, agentInput, media, groupSessionId),
-                replyTo));
+        () -> agentService.processStateless(agent, agentInput, media, groupSessionId),
+        (stream) ->
+            agentService.processStateless(agent, agentInput, media, groupSessionId, stream));
+  }
+
+  private InferenceJob progressOrPlain(
+      InboundChannelAdapter replyVia,
+      String chatId,
+      String replyTo,
+      String sessionId,
+      java.util.function.Supplier<String> plainInference,
+      java.util.function.Function<io.oryxos.core.agent.StreamListener, String> streamedInference) {
+    var streamOpt = replyVia.openProgressStream(chatId, replyTo);
+    if (streamOpt.isEmpty()) {
+      return new InferenceJob(
+          sessionId, () -> replyVia.sendReply(chatId, plainInference.get(), replyTo), false);
+    }
+    InboundProgressStream stream = streamOpt.get();
+    try {
+      stream.start();
+    } catch (RuntimeException e) {
+      LOG.warn("渠道 {} 进度流启动失败，降级整段回复: {}", sanitize(replyVia.name()), sanitize(e.getMessage()));
+      return new InferenceJob(
+          sessionId, () -> replyVia.sendReply(chatId, plainInference.get(), replyTo), false);
+    }
+    return new InferenceJob(
+        sessionId,
+        () -> {
+          try {
+            String reply = streamedInference.apply(stream);
+            stream.finish(reply);
+          } catch (RuntimeException e) {
+            try {
+              stream.fail(FAILURE_REPLY);
+            } catch (RuntimeException failSend) {
+              LOG.warn(
+                  "渠道 {} 进度流失败态更新失败: {}",
+                  sanitize(replyVia.name()),
+                  sanitize(failSend.getMessage()));
+              safeReply(replyVia, chatId, FAILURE_REPLY, replyTo);
+            }
+            throw e;
+          }
+        },
+        true);
   }
 
   private static void release(CountDownLatch latch) {
@@ -234,7 +282,7 @@ public class InboundMessageService {
     }
   }
 
-  private record InferenceJob(String sessionId, Runnable inference) {}
+  private record InferenceJob(String sessionId, Runnable inference, boolean streamed) {}
 
   static boolean isNewSessionCommand(String agentInput) {
     return agentInput != null && NEW_SESSION_COMMAND.equals(agentInput.strip());

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundProgressStream.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundProgressStream.java
@@ -1,0 +1,22 @@
+package io.oryxos.core.channel;
+
+import io.oryxos.core.agent.StreamListener;
+
+/**
+ * 入站渠道可选的「进度流」：用平台可更新消息（如飞书交互卡片）展示思考/工具/终态。
+ *
+ * <p>生命周期：{@link #start()} → ReAct 中 {@link StreamListener} 回调 → {@link #finish(String)} 或 {@link
+ * #fail(String)}。实现须在失败时尽量把卡片标红；{@code start} 失败时应让 {@link
+ * InboundChannelAdapter#openProgressStream} 返回 empty，编排回落到整段 {@code sendReply}。
+ */
+public interface InboundProgressStream extends StreamListener {
+
+  /** 发送初始「思考中」占位（同步）。 */
+  void start();
+
+  /** 推理成功：写入最终答案并标为完成态。 */
+  void finish(String finalText);
+
+  /** 推理失败：写入错误说明并标为失败态。 */
+  void fail(String errorMessage);
+}


### PR DESCRIPTION
## Summary
- Add `InboundProgressStream` + optional `InboundChannelAdapter.openProgressStream`; Feishu implements live interactive cards (blue thinking → tools → green/red terminal).
- `FeishuMessageSender` gains interactive create/reply + PATCH; throttle card updates (~2s / 100 chars).
- Non-Feishu channels and card start failures fall back to existing whole-reply `sendReply`; skip delayed「处理中」 when a progress card is active.
- Docs: note message-update permission for card PATCH.

Closes #347

## Test plan
- [x] Unit: `FeishuStreamListenerTest`, `FeishuMessageSenderTest` interactive create/patch
- [x] Contract: `InboundMessageServiceTest`, `StubInboundContractTest`, `FeishuChannelContractTest`
- [x] Local `mvn -pl oryxos-core,oryxos-channel-feishu -am verify`
- [ ] Live Feishu P2P: send text → see blue card, then green final answer
- [ ] Live Feishu with tool call: tool lines appear on card
- [ ] CI green