### PR TITLE
feat(channel): /stop interrupt + format_sql/export_excel（承接 #407 review）

### DIFF
--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -9,6 +9,7 @@ import io.oryxos.core.agent.AgentLoader;
 import io.oryxos.core.agent.AgentScheduler;
 import io.oryxos.core.agent.AgentService;
 import io.oryxos.core.agent.AgentStore;
+import io.oryxos.core.agent.InterruptManager;
 import io.oryxos.core.agent.PromptBuilder;
 import io.oryxos.core.agent.ReActLoop;
 import io.oryxos.core.agent.ScheduledTaskStore;
@@ -79,6 +80,7 @@ import io.oryxos.storage.WebUserRepository;
 import io.oryxos.storage.WebUserService;
 import io.oryxos.tool.ToolRegistry;
 import io.oryxos.tool.builtin.FileTools;
+import io.oryxos.tool.builtin.FormatTools;
 import io.oryxos.tool.builtin.HttpTools;
 import io.oryxos.tool.builtin.InteractionTools;
 import io.oryxos.tool.builtin.NotifyTools;
@@ -785,6 +787,7 @@ public class OryxOsRuntime {
     registry.registerAnnotated(new UtilTools()); // current_time / json_extract（纯计算，无沙箱）
     registry.registerAnnotated(
         new WebSearchTools(sandbox, new DuckDuckGoSearchProvider(restClient, sandbox)));
+    registry.registerAnnotated(new FormatTools()); // format_sql / export_excel（数据格式化）
     // chat → ConsoleUserInteraction；serve/gateway → UnsupportedUserInteraction（见 userInteraction
     // bean）
     registry.registerAnnotated(new InteractionTools(userInteraction));
@@ -891,9 +894,19 @@ public class OryxOsRuntime {
   }
 
   @Bean
+  InterruptManager interruptManager() {
+    return new InterruptManager();
+  }
+
+  @Bean
   ReActLoop reActLoop(
-      PromptBuilder promptBuilder, ProviderService providerService, ToolExecutor toolExecutor) {
-    return new ReActLoop(promptBuilder, providerService, toolExecutor);
+      PromptBuilder promptBuilder,
+      ProviderService providerService,
+      ToolExecutor toolExecutor,
+      InterruptManager interruptManager) {
+    ReActLoop loop = new ReActLoop(promptBuilder, providerService, toolExecutor);
+    loop.setInterruptManager(interruptManager);
+    return loop;
   }
 
   @Bean
@@ -968,15 +981,19 @@ public class OryxOsRuntime {
       SessionManager sessionManager,
       ProfileRegistry profileRegistry,
       AgentExecutionService agentExecutionService,
-      io.oryxos.core.channel.MessageDeduplicator messageDeduplicator) {
-    return new io.oryxos.core.channel.InboundMessageService(
-        agentService,
-        sessionManager,
-        profileRegistry,
-        agentExecutionService,
-        messageDeduplicator,
-        new io.oryxos.core.channel.DefaultInboundMediaEnricher(),
-        java.time.Duration.ofSeconds(15)); // 「处理中」提示阈值（Edge Case：先行告知）
+      io.oryxos.core.channel.MessageDeduplicator messageDeduplicator,
+      InterruptManager interruptManager) {
+    io.oryxos.core.channel.InboundMessageService service =
+        new io.oryxos.core.channel.InboundMessageService(
+            agentService,
+            sessionManager,
+            profileRegistry,
+            agentExecutionService,
+            messageDeduplicator,
+            new io.oryxos.core.channel.DefaultInboundMediaEnricher(),
+            java.time.Duration.ofSeconds(15)); // 「处理中」提示阈值（Edge Case：先行告知）
+    service.setInterruptManager(interruptManager);
+    return service;
   }
 
   /** 渠道出站守卫：渠道自建 HTTP 不被沙箱自动拦截，经此显式复用 http 域名白名单（宪法 VI / 017 R7）。 */

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -787,7 +787,8 @@ public class OryxOsRuntime {
     registry.registerAnnotated(new UtilTools()); // current_time / json_extract（纯计算，无沙箱）
     registry.registerAnnotated(
         new WebSearchTools(sandbox, new DuckDuckGoSearchProvider(restClient, sandbox)));
-    registry.registerAnnotated(new FormatTools()); // format_sql / export_excel（数据格式化）
+    registry.registerAnnotated(
+        new FormatTools(sandbox)); // format_sql / export_excel（写路径过 FILE 白名单）
     // chat → ConsoleUserInteraction；serve/gateway → UnsupportedUserInteraction（见 userInteraction
     // bean）
     registry.registerAnnotated(new InteractionTools(userInteraction));
@@ -904,9 +905,7 @@ public class OryxOsRuntime {
       ProviderService providerService,
       ToolExecutor toolExecutor,
       InterruptManager interruptManager) {
-    ReActLoop loop = new ReActLoop(promptBuilder, providerService, toolExecutor);
-    loop.setInterruptManager(interruptManager);
-    return loop;
+    return new ReActLoop(promptBuilder, providerService, toolExecutor, interruptManager);
   }
 
   @Bean
@@ -983,17 +982,15 @@ public class OryxOsRuntime {
       AgentExecutionService agentExecutionService,
       io.oryxos.core.channel.MessageDeduplicator messageDeduplicator,
       InterruptManager interruptManager) {
-    io.oryxos.core.channel.InboundMessageService service =
-        new io.oryxos.core.channel.InboundMessageService(
-            agentService,
-            sessionManager,
-            profileRegistry,
-            agentExecutionService,
-            messageDeduplicator,
-            new io.oryxos.core.channel.DefaultInboundMediaEnricher(),
-            java.time.Duration.ofSeconds(15)); // 「处理中」提示阈值（Edge Case：先行告知）
-    service.setInterruptManager(interruptManager);
-    return service;
+    return new io.oryxos.core.channel.InboundMessageService(
+        agentService,
+        sessionManager,
+        profileRegistry,
+        agentExecutionService,
+        messageDeduplicator,
+        new io.oryxos.core.channel.DefaultInboundMediaEnricher(),
+        java.time.Duration.ofSeconds(15), // 「处理中」提示阈值（Edge Case：先行告知）
+        interruptManager);
   }
 
   /** 渠道出站守卫：渠道自建 HTTP 不被沙箱自动拦截，经此显式复用 http 域名白名单（宪法 VI / 017 R7）。 */

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/InterruptManager.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/InterruptManager.java
@@ -1,0 +1,64 @@
+package io.oryxos.core.agent;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 中断管理器：支持用户通过 /stop 命令手动中断正在执行的 Agent 推理。
+ *
+ * <p>线程安全：使用 ConcurrentHashMap 存储中断标志，支持多线程并发访问。
+ *
+ * <p>使用场景：
+ *
+ * <ul>
+ *   <li>用户发送 /stop 命令时，InboundMessageService 调用 {@link #interrupt(String)} 设置中断标志
+ *   <li>ReActLoop 每轮迭代前调用 {@link #isInterrupted(String)} 检查是否需要中断
+ *   <li>推理结束后调用 {@link #clear(String)} 清除中断标志
+ * </ul>
+ */
+public class InterruptManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InterruptManager.class);
+
+  private final Set<String> interruptedSessions = ConcurrentHashMap.newKeySet();
+
+  /**
+   * 设置指定 Session 的中断标志。
+   *
+   * @param sessionId Session ID
+   */
+  public void interrupt(String sessionId) {
+    if (sessionId != null) {
+      interruptedSessions.add(sessionId);
+      LOG.info("设置中断标志: {}", sanitize(sessionId));
+    }
+  }
+
+  /**
+   * 检查指定 Session 是否已被中断。
+   *
+   * @param sessionId Session ID
+   * @return true 如果已被中断
+   */
+  public boolean isInterrupted(String sessionId) {
+    return sessionId != null && interruptedSessions.contains(sessionId);
+  }
+
+  /**
+   * 清除指定 Session 的中断标志。
+   *
+   * @param sessionId Session ID
+   */
+  public void clear(String sessionId) {
+    if (sessionId != null) {
+      interruptedSessions.remove(sessionId);
+      LOG.debug("清除中断标志: {}", sanitize(sessionId));
+    }
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/ReActLoop.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/ReActLoop.java
@@ -27,26 +27,26 @@ public class ReActLoop {
   private final PromptBuilder promptBuilder;
   private final ProviderService providerService;
   private final ToolExecutor toolExecutor;
-  private InterruptManager interruptManager;
+  private final InterruptManager interruptManager;
+
+  public ReActLoop(
+      PromptBuilder promptBuilder, ProviderService providerService, ToolExecutor toolExecutor) {
+    this(promptBuilder, providerService, toolExecutor, null);
+  }
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "EI_EXPOSE_REP2",
       justification =
-          "promptBuilder/toolExecutor 为 Spring 装配的共享单例（020 起带策略 setter 故为可变类），"
+          "promptBuilder/toolExecutor/interruptManager 为 Runtime 装配的共享单例，"
               + "构造注入存同一引用正是意图（镜像既有 SuppressFBWarnings 模式）。")
   public ReActLoop(
-      PromptBuilder promptBuilder, ProviderService providerService, ToolExecutor toolExecutor) {
+      PromptBuilder promptBuilder,
+      ProviderService providerService,
+      ToolExecutor toolExecutor,
+      InterruptManager interruptManager) {
     this.promptBuilder = promptBuilder;
     this.providerService = providerService;
     this.toolExecutor = toolExecutor;
-  }
-
-  /**
-   * 设置中断管理器（可选）。
-   *
-   * @param interruptManager 中断管理器
-   */
-  public void setInterruptManager(InterruptManager interruptManager) {
     this.interruptManager = interruptManager;
   }
 

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/ReActLoop.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/ReActLoop.java
@@ -21,9 +21,13 @@ public class ReActLoop {
   /** 转满最大轮数的强制收尾答复（课件字面量，harness 断言点）。 */
   static final String MAX_ITERATIONS_REPLY = "达到最大轮数，已停止";
 
+  /** 用户手动中断的收尾答复。 */
+  static final String INTERRUPTED_REPLY = "已收到停止指令，推理已中断";
+
   private final PromptBuilder promptBuilder;
   private final ProviderService providerService;
   private final ToolExecutor toolExecutor;
+  private InterruptManager interruptManager;
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "EI_EXPOSE_REP2",
@@ -35,6 +39,15 @@ public class ReActLoop {
     this.promptBuilder = promptBuilder;
     this.providerService = providerService;
     this.toolExecutor = toolExecutor;
+  }
+
+  /**
+   * 设置中断管理器（可选）。
+   *
+   * @param interruptManager 中断管理器
+   */
+  public void setInterruptManager(InterruptManager interruptManager) {
+    this.interruptManager = interruptManager;
   }
 
   public String run(Session session, String userMessage, Profile profile) {
@@ -59,6 +72,12 @@ public class ReActLoop {
     session.appendUser(userMessage, media);
     // 最大轮数兜底（坑一）：模型可能反复要调工具永不收敛，转够强制退出
     for (int i = 0; i < profile.settings().maxIterations(); i++) {
+      // 检查中断标志
+      if (interruptManager != null && interruptManager.isInterrupted(session.sessionId())) {
+        interruptManager.clear(session.sessionId());
+        return INTERRUPTED_REPLY;
+      }
+
       ProviderRequest prompt = promptBuilder.build(session, profile);
       // sessionId 随调用传递：llm_calls 审计按 session 关联；流式与否审计同口径（FR-012）
       ProviderResponse response =

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
@@ -2,6 +2,7 @@ package io.oryxos.core.channel;
 
 import io.oryxos.core.agent.AgentExecutionService;
 import io.oryxos.core.agent.AgentService;
+import io.oryxos.core.agent.InterruptManager;
 import io.oryxos.core.profile.ProfileRegistry;
 import io.oryxos.core.session.Message;
 import io.oryxos.core.session.Session;
@@ -31,12 +32,15 @@ public class InboundMessageService {
   private static final Logger LOG = LoggerFactory.getLogger(InboundMessageService.class);
 
   private static final String DEDUP_KEY_SEPARATOR = ":";
+  private static final String STOP_COMMAND = "/stop";
 
   static final String UNSUPPORTED_TYPE_REPLY = "当前仅支持文本提问，请用文字描述你的问题。";
   static final String AGENT_UNAVAILABLE_REPLY = "Agent 暂不可用（未找到绑定的 Agent），请联系管理员。";
   static final String FAILURE_REPLY = "抱歉，这次处理失败了，请稍后重试或联系管理员。";
   static final String PROCESSING_REPLY = "已收到，正在处理中，请稍候…";
   static final String NEW_SESSION_REPLY = "已开启新会话，之前的对话上下文已清空。";
+  static final String STOP_REPLY = "已发送停止信号，正在执行的任务将在下一轮停止。";
+  static final String STOP_NO_SESSION_REPLY = "当前没有正在执行的任务。";
   private static final String NEW_SESSION_COMMAND = "/new";
 
   /** 飞书等可能对同一意图连推多条不同 message_id；短窗内只确认一次。 */
@@ -54,6 +58,7 @@ public class InboundMessageService {
   private final Duration processingNoticeDelay;
   private final Map<String, Long> recentNewSessionAckMs = new ConcurrentHashMap<>();
   private final Map<String, Long> recentProcessingNoticeMs = new ConcurrentHashMap<>();
+  private InterruptManager interruptManager;
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "EI_EXPOSE_REP2",
@@ -73,6 +78,15 @@ public class InboundMessageService {
     this.deduplicator = deduplicator;
     this.mediaEnricher = mediaEnricher == null ? new DefaultInboundMediaEnricher() : mediaEnricher;
     this.processingNoticeDelay = processingNoticeDelay;
+  }
+
+  /**
+   * 设置中断管理器（可选）。
+   *
+   * @param interruptManager 中断管理器
+   */
+  public void setInterruptManager(InterruptManager interruptManager) {
+    this.interruptManager = interruptManager;
   }
 
   /** 在昂贵预处理（飞书入站图下载等）前占用 message_id。返回 false 表示重复事件，调用方应直接丢弃且勿再下载。 */
@@ -170,6 +184,12 @@ public class InboundMessageService {
       CountDownLatch preprocessingDone,
       String replyTo,
       String agentInput) {
+    // 处理 /stop 命令
+    if (msg.textual() && isStopCommand(agentInput)) {
+      release(preprocessingDone);
+      handleStopCommand(msg, replyVia, replyTo);
+      return true;
+    }
     // B7：不可处理的消息（非文本且无附件）回能力说明，不进推理、不落执行记录
     if (!msg.processable() || agentInput.isBlank()) {
       release(preprocessingDone);
@@ -202,6 +222,27 @@ public class InboundMessageService {
       return true;
     }
     return false;
+  }
+
+  private void handleStopCommand(
+      InboundMessage msg, InboundChannelAdapter replyVia, String replyTo) {
+    if (interruptManager == null) {
+      safeReply(replyVia, msg.chatId(), STOP_NO_SESSION_REPLY, replyTo);
+      return;
+    }
+    String agent = replyVia.boundAgent();
+    if (msg.chatKind() == ChatKind.P2P) {
+      Session session = sessionManager.getOrCreate(msg.channelType(), msg.userId(), agent);
+      interruptManager.interrupt(session.sessionId());
+      safeReply(replyVia, msg.chatId(), STOP_REPLY, replyTo);
+    } else {
+      // 群聊无状态，无法中断
+      safeReply(replyVia, msg.chatId(), STOP_NO_SESSION_REPLY, replyTo);
+    }
+  }
+
+  private boolean isStopCommand(String text) {
+    return STOP_COMMAND.equalsIgnoreCase(text.trim());
   }
 
   private InferenceJob buildInference(

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
@@ -56,9 +56,28 @@ public class InboundMessageService {
   private final MessageDeduplicator deduplicator;
   private final InboundMediaEnricher mediaEnricher;
   private final Duration processingNoticeDelay;
+  private final InterruptManager interruptManager;
   private final Map<String, Long> recentNewSessionAckMs = new ConcurrentHashMap<>();
   private final Map<String, Long> recentProcessingNoticeMs = new ConcurrentHashMap<>();
-  private InterruptManager interruptManager;
+
+  public InboundMessageService(
+      AgentService agentService,
+      SessionManager sessionManager,
+      ProfileRegistry profileRegistry,
+      AgentExecutionService executionService,
+      MessageDeduplicator deduplicator,
+      InboundMediaEnricher mediaEnricher,
+      Duration processingNoticeDelay) {
+    this(
+        agentService,
+        sessionManager,
+        profileRegistry,
+        executionService,
+        deduplicator,
+        mediaEnricher,
+        processingNoticeDelay,
+        null);
+  }
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "EI_EXPOSE_REP2",
@@ -70,7 +89,8 @@ public class InboundMessageService {
       AgentExecutionService executionService,
       MessageDeduplicator deduplicator,
       InboundMediaEnricher mediaEnricher,
-      Duration processingNoticeDelay) {
+      Duration processingNoticeDelay,
+      InterruptManager interruptManager) {
     this.agentService = agentService;
     this.sessionManager = sessionManager;
     this.profileRegistry = profileRegistry;
@@ -78,14 +98,6 @@ public class InboundMessageService {
     this.deduplicator = deduplicator;
     this.mediaEnricher = mediaEnricher == null ? new DefaultInboundMediaEnricher() : mediaEnricher;
     this.processingNoticeDelay = processingNoticeDelay;
-  }
-
-  /**
-   * 设置中断管理器（可选）。
-   *
-   * @param interruptManager 中断管理器
-   */
-  public void setInterruptManager(InterruptManager interruptManager) {
     this.interruptManager = interruptManager;
   }
 
@@ -241,8 +253,32 @@ public class InboundMessageService {
     }
   }
 
-  private boolean isStopCommand(String text) {
-    return STOP_COMMAND.equalsIgnoreCase(text.trim());
+  private static boolean isStopCommand(String text) {
+    if (text == null) {
+      return false;
+    }
+    return asciiEqualsIgnoreCase(text.strip(), STOP_COMMAND);
+  }
+
+  /** 仅 ASCII 大小写折叠，避免 equalsIgnoreCase 触发 SpotBugs IMPROPER_UNICODE。 */
+  private static boolean asciiEqualsIgnoreCase(String left, String right) {
+    if (left.length() != right.length()) {
+      return false;
+    }
+    for (int i = 0; i < left.length(); i++) {
+      char a = left.charAt(i);
+      char b = right.charAt(i);
+      if (a >= 'A' && a <= 'Z') {
+        a = (char) (a + ('a' - 'A'));
+      }
+      if (b >= 'A' && b <= 'Z') {
+        b = (char) (b + ('a' - 'A'));
+      }
+      if (a != b) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private InferenceJob buildInference(

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/InterruptManagerTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/InterruptManagerTest.java
@@ -1,0 +1,33 @@
+package io.oryxos.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class InterruptManagerTest {
+
+  @Test
+  @DisplayName("interrupt / isInterrupted / clear 闭环")
+  void interruptClearRoundTrip() {
+    InterruptManager mgr = new InterruptManager();
+    assertFalse(mgr.isInterrupted("s1"));
+    mgr.interrupt("s1");
+    assertTrue(mgr.isInterrupted("s1"));
+    assertFalse(mgr.isInterrupted("s2"));
+    mgr.clear("s1");
+    assertFalse(mgr.isInterrupted("s1"));
+  }
+
+  @Test
+  @DisplayName("null sessionId 安全忽略")
+  void nullSafe() {
+    InterruptManager mgr = new InterruptManager();
+    mgr.interrupt(null);
+    assertFalse(mgr.isInterrupted(null));
+    mgr.clear(null);
+    assertEquals(false, mgr.isInterrupted(""));
+  }
+}

--- a/oryxos-tool/pom.xml
+++ b/oryxos-tool/pom.xml
@@ -52,6 +52,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
+        <!-- Apache POI for Excel export (format_sql / export_excel tools) -->
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.2.5</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FormatTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FormatTools.java
@@ -1,9 +1,15 @@
 package io.oryxos.tool.builtin;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.FileOutputStream;
+import io.oryxos.tool.sandbox.ActionType;
+import io.oryxos.tool.sandbox.Sandbox;
+import io.oryxos.tool.sandbox.SandboxAction;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.poi.ss.usermodel.Cell;
@@ -23,13 +29,19 @@ import org.springframework.ai.tool.annotation.ToolParam;
  *
  * <ul>
  *   <li>{@code format_sql} - 将 SQL 查询结果格式化为 Markdown 表格
- *   <li>{@code export_excel} - 将数据导出为 Excel 文件
+ *   <li>{@code export_excel} - 将数据导出为 Excel 文件（写路径必须过 FILE 沙箱白名单）
  * </ul>
  */
 public class FormatTools {
 
   private static final Logger LOG = LoggerFactory.getLogger(FormatTools.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final Sandbox sandbox;
+
+  public FormatTools(Sandbox sandbox) {
+    this.sandbox = sandbox;
+  }
 
   @Tool(
       name = "format_sql",
@@ -64,7 +76,7 @@ public class FormatTools {
       }
 
       return formatAsMarkdownTable(headers, rows);
-    } catch (Exception e) {
+    } catch (JsonProcessingException | RuntimeException e) {
       LOG.error("格式化 SQL 结果失败", e);
       return "格式化失败: " + e.getMessage();
     }
@@ -94,6 +106,9 @@ public class FormatTools {
         return "错误: 缺少 rows 参数或格式错误";
       }
 
+      // 写前校验 + 落盘前复检（与 write_file / download_file 同款，防 TOCTOU）
+      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, filePath));
+
       List<String> headers = new ArrayList<>();
       for (JsonNode header : headersNode) {
         headers.add(header.asText());
@@ -108,28 +123,26 @@ public class FormatTools {
         rows.add(row);
       }
 
-      exportToExcel(filePath, sheetName, headers, rows);
+      sandbox.enforce(new SandboxAction(ActionType.FILE_WRITE, filePath));
+      exportToExcel(Path.of(filePath), sheetName, headers, rows);
       return "Excel 文件已导出到: " + filePath;
-    } catch (Exception e) {
+    } catch (IOException | RuntimeException e) {
       LOG.error("导出 Excel 失败", e);
       return "导出失败: " + e.getMessage();
     }
   }
 
-  private String formatAsMarkdownTable(List<String> headers, List<List<String>> rows) {
+  private static String formatAsMarkdownTable(List<String> headers, List<List<String>> rows) {
     StringBuilder sb = new StringBuilder();
 
-    // 表头
     sb.append("| ");
     sb.append(String.join(" | ", headers));
     sb.append(" |\n");
 
-    // 分隔线
     sb.append("| ");
     sb.append(String.join(" | ", headers.stream().map(h -> "---").toList()));
     sb.append(" |\n");
 
-    // 数据行
     for (List<String> row : rows) {
       sb.append("| ");
       sb.append(String.join(" | ", row));
@@ -139,20 +152,22 @@ public class FormatTools {
     return sb.toString();
   }
 
-  private void exportToExcel(
-      String filePath, String sheetName, List<String> headers, List<List<String>> rows)
+  private static void exportToExcel(
+      Path file, String sheetName, List<String> headers, List<List<String>> rows)
       throws IOException {
+    Path parent = file.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
     try (Workbook workbook = new XSSFWorkbook()) {
       Sheet sheet = workbook.createSheet(sheetName);
 
-      // 写入表头
       Row headerRow = sheet.createRow(0);
       for (int i = 0; i < headers.size(); i++) {
         Cell cell = headerRow.createCell(i);
         cell.setCellValue(headers.get(i));
       }
 
-      // 写入数据行
       int rowNum = 1;
       for (List<String> rowData : rows) {
         Row row = sheet.createRow(rowNum++);
@@ -162,13 +177,11 @@ public class FormatTools {
         }
       }
 
-      // 自动调整列宽
       for (int i = 0; i < headers.size(); i++) {
         sheet.autoSizeColumn(i);
       }
 
-      // 写入文件
-      try (FileOutputStream outputStream = new FileOutputStream(filePath)) {
+      try (OutputStream outputStream = Files.newOutputStream(file)) {
         workbook.write(outputStream);
       }
     }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FormatTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FormatTools.java
@@ -1,0 +1,176 @@
+package io.oryxos.tool.builtin;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+/**
+ * 格式化工具：提供 SQL 结果表格化和 Excel 导出功能。
+ *
+ * <p>包含两个工具：
+ *
+ * <ul>
+ *   <li>{@code format_sql} - 将 SQL 查询结果格式化为 Markdown 表格
+ *   <li>{@code export_excel} - 将数据导出为 Excel 文件
+ * </ul>
+ */
+public class FormatTools {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FormatTools.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Tool(
+      name = "format_sql",
+      description =
+          "将 SQL 查询结果格式化为 Markdown 表格。输入 JSON 格式：{\"headers\": [\"列1\", \"列2\"], \"rows\": [[\"值1\", \"值2\"]]}")
+  public String formatSql(
+      @ToolParam(description = "JSON 格式的查询结果，包含 headers 和 rows 字段") String resultJson) {
+    try {
+      JsonNode root = MAPPER.readTree(resultJson);
+      JsonNode headersNode = root.get("headers");
+      JsonNode rowsNode = root.get("rows");
+
+      if (headersNode == null || !headersNode.isArray()) {
+        return "错误: 缺少 headers 参数或格式错误";
+      }
+      if (rowsNode == null || !rowsNode.isArray()) {
+        return "错误: 缺少 rows 参数或格式错误";
+      }
+
+      List<String> headers = new ArrayList<>();
+      for (JsonNode header : headersNode) {
+        headers.add(header.asText());
+      }
+
+      List<List<String>> rows = new ArrayList<>();
+      for (JsonNode rowNode : rowsNode) {
+        List<String> row = new ArrayList<>();
+        for (JsonNode cell : rowNode) {
+          row.add(cell.asText(""));
+        }
+        rows.add(row);
+      }
+
+      return formatAsMarkdownTable(headers, rows);
+    } catch (Exception e) {
+      LOG.error("格式化 SQL 结果失败", e);
+      return "格式化失败: " + e.getMessage();
+    }
+  }
+
+  @Tool(
+      name = "export_excel",
+      description =
+          "将数据导出为 Excel 文件。输入 JSON 格式：{\"file_path\": \"/path/to/file.xlsx\", \"sheet_name\": \"Sheet1\", \"headers\": [\"列1\"], \"rows\": [[\"值1\"]]}")
+  public String exportExcel(
+      @ToolParam(description = "JSON 格式的导出参数，包含 file_path, sheet_name, headers, rows")
+          String paramsJson) {
+    try {
+      JsonNode root = MAPPER.readTree(paramsJson);
+      String filePath = root.path("file_path").asText();
+      String sheetName = root.path("sheet_name").asText("Sheet1");
+      JsonNode headersNode = root.get("headers");
+      JsonNode rowsNode = root.get("rows");
+
+      if (filePath == null || filePath.isBlank()) {
+        return "错误: 缺少 file_path 参数";
+      }
+      if (headersNode == null || !headersNode.isArray()) {
+        return "错误: 缺少 headers 参数或格式错误";
+      }
+      if (rowsNode == null || !rowsNode.isArray()) {
+        return "错误: 缺少 rows 参数或格式错误";
+      }
+
+      List<String> headers = new ArrayList<>();
+      for (JsonNode header : headersNode) {
+        headers.add(header.asText());
+      }
+
+      List<List<String>> rows = new ArrayList<>();
+      for (JsonNode rowNode : rowsNode) {
+        List<String> row = new ArrayList<>();
+        for (JsonNode cell : rowNode) {
+          row.add(cell.asText(""));
+        }
+        rows.add(row);
+      }
+
+      exportToExcel(filePath, sheetName, headers, rows);
+      return "Excel 文件已导出到: " + filePath;
+    } catch (Exception e) {
+      LOG.error("导出 Excel 失败", e);
+      return "导出失败: " + e.getMessage();
+    }
+  }
+
+  private String formatAsMarkdownTable(List<String> headers, List<List<String>> rows) {
+    StringBuilder sb = new StringBuilder();
+
+    // 表头
+    sb.append("| ");
+    sb.append(String.join(" | ", headers));
+    sb.append(" |\n");
+
+    // 分隔线
+    sb.append("| ");
+    sb.append(String.join(" | ", headers.stream().map(h -> "---").toList()));
+    sb.append(" |\n");
+
+    // 数据行
+    for (List<String> row : rows) {
+      sb.append("| ");
+      sb.append(String.join(" | ", row));
+      sb.append(" |\n");
+    }
+
+    return sb.toString();
+  }
+
+  private void exportToExcel(
+      String filePath, String sheetName, List<String> headers, List<List<String>> rows)
+      throws IOException {
+    try (Workbook workbook = new XSSFWorkbook()) {
+      Sheet sheet = workbook.createSheet(sheetName);
+
+      // 写入表头
+      Row headerRow = sheet.createRow(0);
+      for (int i = 0; i < headers.size(); i++) {
+        Cell cell = headerRow.createCell(i);
+        cell.setCellValue(headers.get(i));
+      }
+
+      // 写入数据行
+      int rowNum = 1;
+      for (List<String> rowData : rows) {
+        Row row = sheet.createRow(rowNum++);
+        for (int i = 0; i < rowData.size(); i++) {
+          Cell cell = row.createCell(i);
+          cell.setCellValue(rowData.get(i));
+        }
+      }
+
+      // 自动调整列宽
+      for (int i = 0; i < headers.size(); i++) {
+        sheet.autoSizeColumn(i);
+      }
+
+      // 写入文件
+      try (FileOutputStream outputStream = new FileOutputStream(filePath)) {
+        workbook.write(outputStream);
+      }
+    }
+  }
+}

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FormatToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FormatToolsTest.java
@@ -1,0 +1,41 @@
+package io.oryxos.tool.builtin;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.oryxos.tool.sandbox.Sandbox;
+import io.oryxos.tool.sandbox.SandboxAction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FormatToolsTest {
+
+  @Test
+  @DisplayName("format_sql 输出 Markdown 表头与分隔线")
+  void formatSqlMarkdown() {
+    FormatTools tools = new FormatTools(mock(Sandbox.class));
+    String out =
+        tools.formatSql("{\"headers\":[\"a\",\"b\"],\"rows\":[[\"1\",\"2\"],[\"3\",\"4\"]]}");
+    assertTrue(out.contains("| a | b |"));
+    assertTrue(out.contains("| --- | --- |"));
+    assertTrue(out.contains("| 1 | 2 |"));
+  }
+
+  @Test
+  @DisplayName("export_excel 写前 enforce FILE_WRITE；拒绝时不写盘")
+  void exportExcelEnforcesSandbox() {
+    Sandbox sandbox = mock(Sandbox.class);
+    doThrow(new IllegalStateException("path not allowed"))
+        .when(sandbox)
+        .enforce(any(SandboxAction.class));
+    FormatTools tools = new FormatTools(sandbox);
+    String out =
+        tools.exportExcel(
+            "{\"file_path\":\"C:\\\\tmp\\\\out.xlsx\",\"headers\":[\"a\"],\"rows\":[[\"1\"]]}");
+    assertTrue(out.startsWith("导出失败"));
+    verify(sandbox).enforce(any(SandboxAction.class));
+  }
+}


### PR DESCRIPTION
## Summary
- 承接已关闭的 #407（作者注明误提、需先本地验证）：在 rebase 到当前 `main` 后按 review 代修落地
- `/stop` + `InterruptManager`：构造注入（无 setter），ASCII 大小写匹配，私聊可中断 ReAct
- `format_sql` / `export_excel`：`export_excel` 写前与落盘前 `FILE_WRITE` 沙箱 enforce；NIO 落盘避开 PATH_TRAVERSAL
- 补 `InterruptManagerTest`、`FormatToolsTest`；本地相关单测 + SpotBugs verify 通过

## 相对 #407 的修正
- SpotBugs：去掉 setter 注入、`/stop` 不用 `equalsIgnoreCase`
- `export_excel` 纳入 FILE 白名单（双次 enforce）
- 未包含 PR 原文声称的「群聊引用历史」（diff 中本就没有）

## Test plan
- [ ] `mvn -pl oryxos-core,oryxos-tool -am -Dtest=InterruptManagerTest,FormatToolsTest test`
- [ ] `mvn -pl oryxos-core,oryxos-tool -am -DskipTests verify`（SpotBugs）
- [ ] 私聊发长任务后发 `/stop`，应收到停止确认且推理收尾为中断文案
- [ ] Agent 配 `export_excel` 且路径在 FILE 白名单内外各测一次

Closes discussion from #407 (supersedes closed PR with review fixes).