### PR TITLE
fix(core): 历史多图只保留最近一条 user media

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/agent/PromptBuilder.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/PromptBuilder.java
@@ -77,9 +77,44 @@ public class PromptBuilder {
     }
     // ③ 会话历史：结构化透传（不再拍平成文本），保留 assistant tool_calls / tool tool_call_id 配对——
     //    多步 ReAct 里模型才能看出工具已调过、继续下一步（31 节修复）；仍只留最近 N 轮（坑二）
-    List<Message> history = session.recentTurns(profile.settings().maxHistoryTurns());
+    List<Message> history =
+        pruneHistoricalMedia(session.recentTurns(profile.settings().maxHistoryTurns()));
     // ④ 工具列表经 availableTools 传递，Provider 侧翻译成 Function Calling 格式
     return new ProviderRequest(system.toString(), history, resolveTools(profile));
+  }
+
+  /**
+   * 历史里只保留「最近一条带 media 的 user」附件；更早的图只留正文。
+   *
+   * <p>IM 连测多图后，若不裁剪，纯文本轮也会把窗口内全部本地图重传给 Vision，流式动辄数分钟。
+   */
+  static List<Message> pruneHistoricalMedia(List<Message> history) {
+    if (history == null || history.isEmpty()) {
+      return history == null ? List.of() : history;
+    }
+    int keepMediaAt = -1;
+    for (int i = history.size() - 1; i >= 0; i--) {
+      Message m = history.get(i);
+      if (Message.ROLE_USER.equals(m.role()) && !m.media().isEmpty()) {
+        keepMediaAt = i;
+        break;
+      }
+    }
+    if (keepMediaAt < 0) {
+      return history;
+    }
+    List<Message> out = new ArrayList<>(history.size());
+    for (int i = 0; i < history.size(); i++) {
+      Message m = history.get(i);
+      if (i != keepMediaAt && !m.media().isEmpty()) {
+        out.add(
+            new Message(
+                m.role(), m.content(), m.toolName(), m.toolCallId(), m.toolCalls(), List.of()));
+      } else {
+        out.add(m);
+      }
+    }
+    return out;
   }
 
   private List<OryxTool> resolveTools(Profile profile) {

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/PromptBuilderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/PromptBuilderTest.java
@@ -11,6 +11,8 @@ import io.oryxos.core.OryxTool;
 import io.oryxos.core.context.ContextLoader;
 import io.oryxos.core.profile.Profile;
 import io.oryxos.core.provider.ProviderRequest;
+import io.oryxos.core.provider.ProviderResponse;
+import io.oryxos.core.session.Message;
 import io.oryxos.core.session.Session;
 import java.time.Clock;
 import java.time.Instant;
@@ -132,6 +134,29 @@ class PromptBuilderTest {
     assertFalse(hasMsg(request, "结果1"), "轮内工具消息随轮整体截掉，不撕裂");
     assertTrue(hasMsg(request, "问题2") && hasMsg(request, "结果2"));
     assertTrue(hasMsg(request, "问题3") && hasMsg(request, "结果3"));
+  }
+
+  @Test
+  @DisplayName("历史多图只保留最近一条 user media，避免纯文本轮重传旧图")
+  void pruneHistoricalMediaKeepsOnlyLatestUserMedia() {
+    Session session = new Session("s-media", "ops-agent");
+    session.appendUser("图1", List.of(new Message.MediaPart("image/jpeg", "C:\\tmp\\a.jpg")));
+    session.appendAssistant(new ProviderResponse("看过图1", List.of(), null));
+    session.appendUser("图2", List.of(new Message.MediaPart("image/jpeg", "C:\\tmp\\b.jpg")));
+    session.appendAssistant(new ProviderResponse("看过图2", List.of(), null));
+    session.appendUser("纯文本提问");
+
+    ProviderRequest request = builder.build(session, profile(20, List.of()));
+
+    List<Message> withMedia =
+        request.messages().stream().filter(m -> !m.media().isEmpty()).toList();
+    assertEquals(1, withMedia.size(), "窗口内只保留最近一条带图 user");
+    assertEquals("图2", withMedia.getFirst().content());
+    assertTrue(hasMsg(request, "图1"), "旧图正文仍在历史");
+    assertTrue(
+        request.messages().stream().anyMatch(m -> "图1".equals(m.content()) && m.media().isEmpty()),
+        "旧图附件已剥掉");
+    assertTrue(hasMsg(request, "纯文本提问"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- 飞书/企微连测多图后，纯文本轮仍会把 `max_history_turns` 窗口内全部本地图重传给 Vision，`chatStream` 实测可达数分钟（例如 ~8min）
- `PromptBuilder` 组装历史时：只保留**最近一条带 media 的 user** 附件，更早的图只留正文

## Test plan
- [x] `mvn -pl oryxos-core -Dtest=PromptBuilderTest test`
- [ ] 飞书私聊：先发几张图，再发短文本，确认回复明显变快且识图仍对「最新一张」生效