### PR TITLE
fix(channel): WeCom fail-loud + WeCom/DingTalk lock-free reconnect

### DIFF
--- a/docs/FeishuChannelSetup.md
+++ b/docs/FeishuChannelSetup.md
@@ -99,7 +99,7 @@
 | status 为 ERROR：`app_secret 未配置或环境变量未解析` | 启动 shell 里没有 `FEISHU_APP_SECRET`；`source` env 文件后重启或经 REST 重建渠道 |
 | status 为 ERROR：`绑定的 Agent xxx 不存在` | `channels.yaml` 的 `agent` 必须是 `.oryxos/agents/` 下的目录名 |
 | 长连接建立失败 | 确认出方向可达 `open.feishu.cn:443`（HTTPS + WebSocket）；无需任何入方向端口 |
-| 收到「当前仅支持文本提问」 | 语音 / 文件等非图类型仍不在范围；**图片已支持**（入站下载后走 Vision）。若仍出现：确认事件含 image，且渠道进程可出站访问 `open.feishu.cn` |
+| 收到「当前仅支持文本或图片」 | 语音 / 文件等非图类型仍不在范围；**图片已支持**（入站下载后走 Vision）。若仍出现：确认事件含 image，且渠道进程可出站访问 `open.feishu.cn` |
 | 多个 Agent 接入 | 一应用一 Agent；再建一个飞书应用 + `channels.yaml` 加一个条目 |
 
 ## 九、审计口径

--- a/oryxos-channel-cli/src/main/java/io/oryxos/channel/cli/CliChannel.java
+++ b/oryxos-channel-cli/src/main/java/io/oryxos/channel/cli/CliChannel.java
@@ -60,11 +60,19 @@ public class CliChannel {
         continue;
       }
       TypewriterListener listener = new TypewriterListener(out);
-      String reply = agentService.process(session, line, listener);
-      if (listener.printedAny()) {
-        out.println(); // 打字机流结束补换行
-      } else {
-        out.println(reply); // 无任何 token 流出（如迭代耗尽占位文本）时回落整段输出
+      try {
+        String reply = agentService.process(session, line, listener);
+        if (listener.printedAny()) {
+          out.println(); // 打字机流结束补换行
+        } else {
+          out.println(reply); // 无任何 token 流出（如迭代耗尽占位文本）时回落整段输出
+        }
+      } catch (RuntimeException e) {
+        // 一轮出错（provider 400/超时等）不终结整个终端会话——对齐飞书/企微事件 handler 的保活口径
+        if (listener.printedAny()) {
+          out.println();
+        }
+        out.printf("[本轮出错: %s]%n", e.getMessage());
       }
     }
   }

--- a/oryxos-channel-cli/src/test/java/io/oryxos/channel/cli/CliChannelTest.java
+++ b/oryxos-channel-cli/src/test/java/io/oryxos/channel/cli/CliChannelTest.java
@@ -1,0 +1,54 @@
+package io.oryxos.channel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.oryxos.core.agent.AgentService;
+import io.oryxos.core.agent.StreamListener;
+import io.oryxos.core.session.Session;
+import io.oryxos.core.session.SessionManager;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** CliChannel 循环健壮性：单轮异常（provider 400/超时等）不终结整个终端会话。 */
+class CliChannelTest {
+
+  @Test
+  @DisplayName("一轮 process 抛异常_打印原因并继续下一轮（对齐飞书/企微 handler 保活口径）")
+  void processFailureDoesNotEndSession() {
+    AgentService agentService = mock(AgentService.class);
+    SessionManager sessionManager = mock(SessionManager.class);
+    Session session = mock(Session.class);
+    when(sessionManager.getOrCreate("cli", "u", "p")).thenReturn(session);
+    when(agentService.process(eq(session), eq("第一轮"), any(StreamListener.class)))
+        .thenThrow(new IllegalStateException("provider 400"));
+    when(agentService.process(eq(session), eq("第二轮"), any(StreamListener.class)))
+        .thenReturn("正常回复");
+
+    InputStream oldIn = System.in;
+    PrintStream oldOut = System.out;
+    ByteArrayOutputStream captured = new ByteArrayOutputStream();
+    try {
+      System.setIn(new ByteArrayInputStream("第一轮\n第二轮\n/quit\n".getBytes(StandardCharsets.UTF_8)));
+      System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+
+      new CliChannel(agentService, sessionManager).run("p", "u");
+    } finally {
+      System.setIn(oldIn);
+      System.setOut(oldOut);
+    }
+
+    String output = captured.toString(StandardCharsets.UTF_8);
+    assertThat(output).contains("[本轮出错: provider 400]");
+    assertThat(output).contains("正常回复");
+    assertThat(output).contains("再见。");
+  }
+}

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkChannelAdapter.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkChannelAdapter.java
@@ -169,6 +169,11 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
   }
 
   private void connectLocked() throws Exception {
+    streamRef.set(connect());
+  }
+
+  /** 建连并返回客户端；不写入 {@link #streamRef}——由调用方在持锁处决定是否接管（重连期间可能已被 stop）。 */
+  private DingTalkStreamClient connect() throws Exception {
     ensureOutboundStack();
     DingTalkStreamClient client =
         new DingTalkStreamClient(
@@ -178,7 +183,7 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
             this::handleBotMessage,
             this::handleDisconnected);
     client.connect(START_TIMEOUT);
-    streamRef.set(client);
+    return client;
   }
 
   /** 懒初始化出站/入站组件；重连复用同一 {@link DingTalkMessageSender} 以保留 sessionWebhook 映射。 */
@@ -246,13 +251,13 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
       if (!running) {
         return;
       }
-      try {
-        connectLocked();
-        reconnectAttempt = 0;
-        state = ChannelStatus.State.CONNECTED;
-        lastError = null;
-        LOG.info("钉钉渠道 {} Stream 已恢复", sanitize(config.name()));
-      } catch (Exception e) {
+    }
+    // 建连放锁外：Stream connect 可能长时间阻塞，锁内执行会把 stop()/管理端停用卡住
+    DingTalkStreamClient client;
+    try {
+      client = connect();
+    } catch (Exception e) {
+      synchronized (this) {
         reconnectAttempt++;
         lastError = "Stream 重连失败: " + sanitize(e.getMessage());
         LOG.warn(
@@ -260,8 +265,20 @@ public class DingTalkChannelAdapter implements InboundChannelAdapter {
             sanitize(config.name()),
             reconnectAttempt,
             sanitize(lastError));
-        scheduleReconnect();
       }
+      scheduleReconnect();
+      return;
+    }
+    synchronized (this) {
+      if (!running) {
+        client.closeQuietly();
+        return;
+      }
+      streamRef.set(client);
+      reconnectAttempt = 0;
+      state = ChannelStatus.State.CONNECTED;
+      lastError = null;
+      LOG.info("钉钉渠道 {} Stream 已恢复", sanitize(config.name()));
     }
   }
 

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComChannelAdapter.java
@@ -176,6 +176,11 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
   }
 
   private void connectLocked() throws Exception {
+    wsRef.set(connect());
+  }
+
+  /** 建连并返回客户端；不写入 {@link #wsRef}——由调用方在持锁处决定是否接管（重连期间可能已被 stop）。 */
+  private WeComWsClient connect() throws Exception {
     ensureOutboundStack();
     WeComWsClient client =
         new WeComWsClient(
@@ -186,7 +191,7 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
             this::handleDisconnected);
     transportRef.set(client::sendJson);
     client.connectAndSubscribe(START_TIMEOUT);
-    wsRef.set(client);
+    return client;
   }
 
   /** 懒初始化出站/入站组件；重连复用同一 {@link WeComMessageSender} 以保留 chatTypes 映射。 */
@@ -246,13 +251,13 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
       if (!running) {
         return;
       }
-      try {
-        connectLocked();
-        reconnectAttempt = 0;
-        state = ChannelStatus.State.CONNECTED;
-        lastError = null;
-        LOG.info("企微渠道 {} 长连接已恢复", sanitize(config.name()));
-      } catch (Exception e) {
+    }
+    // 建连放锁外：connectAndSubscribe 最坏阻塞 ~40s，锁内执行会把 stop()/管理端停用卡住
+    WeComWsClient client;
+    try {
+      client = connect();
+    } catch (Exception e) {
+      synchronized (this) {
         reconnectAttempt++;
         lastError = "长连接重连失败: " + sanitize(e.getMessage());
         LOG.warn(
@@ -260,8 +265,20 @@ public class WeComChannelAdapter implements InboundChannelAdapter {
             sanitize(config.name()),
             reconnectAttempt,
             sanitize(lastError));
-        scheduleReconnect();
       }
+      scheduleReconnect();
+      return;
+    }
+    synchronized (this) {
+      if (!running) {
+        client.closeQuietly();
+        return;
+      }
+      wsRef.set(client);
+      reconnectAttempt = 0;
+      state = ChannelStatus.State.CONNECTED;
+      lastError = null;
+      LOG.info("企微渠道 {} 长连接已恢复", sanitize(config.name()));
     }
   }
 

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComWsClient.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComWsClient.java
@@ -52,6 +52,10 @@ final class WeComWsClient implements WebSocket.Listener {
   private final StringBuilder textBuf = new StringBuilder();
   private final CountDownLatch subscribeLatch = new CountDownLatch(1);
   private volatile String subscribeError;
+
+  /** 承载 WebSocket 的 HttpClient：持有 selector 线程，连接生命周期内必须存活、关闭时必须释放。 */
+  private volatile HttpClient httpClient;
+
   private ScheduledExecutorService heartbeat;
   private ScheduledFuture<?> heartbeatTask;
 
@@ -71,12 +75,26 @@ final class WeComWsClient implements WebSocket.Listener {
   void connectAndSubscribe(Duration timeout) throws Exception {
     closed.set(false);
     HttpClient client = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    httpClient = client;
     CompletableFuture<WebSocket> future =
         client
             .newWebSocketBuilder()
             .connectTimeout(CONNECT_TIMEOUT)
             .buildAsync(URI.create(wsUrl), this);
-    WebSocket ws = future.get(timeout.toSeconds(), TimeUnit.SECONDS);
+    WebSocket ws;
+    try {
+      ws = future.get(timeout.toSeconds(), TimeUnit.SECONDS);
+    } catch (java.util.concurrent.TimeoutException e) {
+      // 不取消的话迟到连接会变幽灵：onOpen 照发订阅且可能成功，但无人持有引用
+      future.cancel(true);
+      closeQuietly();
+      throw e;
+    } catch (InterruptedException e) {
+      future.cancel(true);
+      closeQuietly();
+      Thread.currentThread().interrupt();
+      throw e;
+    }
     socket.set(ws);
     if (!subscribeLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
       closeQuietly();
@@ -120,6 +138,11 @@ final class WeComWsClient implements WebSocket.Listener {
       } catch (RuntimeException ignored) {
         // ignore
       }
+    }
+    HttpClient client = httpClient;
+    httpClient = null;
+    if (client != null) {
+      client.shutdownNow(); // 释放 selector 线程；不关会泄漏至 GC（重连风暴下累积）
     }
   }
 
@@ -226,7 +249,17 @@ final class WeComWsClient implements WebSocket.Listener {
     if (CMD_PONG.equals(cmd)) {
       return true;
     }
-    return cmd.isBlank() && root.has(FIELD_ERRCODE);
+    if (cmd.isBlank() && root.has(FIELD_ERRCODE)) {
+      int code = root.path(FIELD_ERRCODE).asInt(ERRCODE_OK);
+      if (code != ERRCODE_OK) {
+        // 无 cmd + errcode 的帧是平台对 fire-and-forget 发送（aibot_send_msg）的失败回执——
+        // 静默吞掉会让「回复没发出去」零痕迹（对齐 dingtalk #342 的 fail-loud 口径）
+        LOG.warn(
+            "企微平台回执错误 errcode={} errmsg={}", code, sanitize(root.path(FIELD_ERRMSG).asText("")));
+      }
+      return true;
+    }
+    return false;
   }
 
   private void startHeartbeat() {

--- a/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComWsClientTest.java
+++ b/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComWsClientTest.java
@@ -2,10 +2,17 @@ package io.oryxos.channel.wecom;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.net.http.WebSocket;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 class WeComWsClientTest {
 
@@ -31,5 +38,56 @@ class WeComWsClientTest {
 
     assertFalse(client.isSubscribed());
     assertTrue(disconnected.get());
+  }
+
+  @Test
+  @DisplayName("无 cmd + errcode≠0 的回执帧_WARN 落日志不静默")
+  void errorReceiptFrameIsLoggedNotSwallowed() {
+    Logger logger = (Logger) LoggerFactory.getLogger(WeComWsClient.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      WeComWsClient client =
+          new WeComWsClient("bot", "secret", WeComWsClient.DEFAULT_WS_URL, node -> {}, () -> {});
+      WebSocket ws = mock(WebSocket.class);
+      client.onText(ws, "{\"errcode\":0}", true);
+      assertTrue(client.isSubscribed());
+
+      client.onText(ws, "{\"errcode\":14,\"errmsg\":\"bad req_id\"}", true);
+
+      assertTrue(
+          appender.list.stream()
+              .anyMatch(
+                  e ->
+                      e.getLevel() == Level.WARN
+                          && e.getFormattedMessage().contains("errcode=14")
+                          && e.getFormattedMessage().contains("bad req_id")),
+          "平台错误回执必须 WARN 落日志");
+    } finally {
+      logger.detachAppender(appender);
+    }
+  }
+
+  @Test
+  @DisplayName("无 cmd + errcode=0 的控制帧_仍静默忽略")
+  void okControlFrameStaysSilent() {
+    Logger logger = (Logger) LoggerFactory.getLogger(WeComWsClient.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      WeComWsClient client =
+          new WeComWsClient("bot", "secret", WeComWsClient.DEFAULT_WS_URL, node -> {}, () -> {});
+      WebSocket ws = mock(WebSocket.class);
+      client.onText(ws, "{\"errcode\":0}", true);
+      int afterSubscribe = appender.list.size();
+
+      client.onText(ws, "{\"errcode\":0}", true);
+
+      assertTrue(appender.list.size() == afterSubscribe, "errcode=0 控制帧不得产生日志");
+    } finally {
+      logger.detachAppender(appender);
+    }
   }
 }

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMessageService.java
@@ -35,7 +35,7 @@ public class InboundMessageService {
   private static final String DEDUP_KEY_SEPARATOR = ":";
   private static final String STOP_COMMAND = "/stop";
 
-  static final String UNSUPPORTED_TYPE_REPLY = "当前仅支持文本提问，请用文字描述你的问题。";
+  static final String UNSUPPORTED_TYPE_REPLY = "当前仅支持文本或图片，请用文字描述或发送图片。";
   static final String AGENT_UNAVAILABLE_REPLY = "Agent 暂不可用（未找到绑定的 Agent），请联系管理员。";
   static final String FAILURE_REPLY = "抱歉，这次处理失败了，请稍后重试或联系管理员。";
   static final String PROCESSING_REPLY = "已收到，正在处理中，请稍候…";


### PR DESCRIPTION
## Summary
- **WeCom**: platform `errcode≠0` send receipts WARN (was swallowed); connect timeout cancels future + closes; `HttpClient.shutdownNow` on close.
- **WeCom/DingTalk**: `attemptReconnect` builds connection **outside** `synchronized` so `stop()` is not blocked ~40s; abort new client if stopped mid-connect. Preserves existing sender reuse (`ensureOutboundStack`).
- **CLI**: catch per-turn `RuntimeException`, print `[本轮出错: …]`, keep session alive.
- **Core**: `UNSUPPORTED_TYPE_REPLY` mentions text **or** image (docs FAQ aligned).

Supersedes stalled [#359](https://github.com/oryx-labs/oryxos/pull/359).

**Merge note:** small overlap with [#412](https://github.com/oryx-labs/oryxos/pull/412) (`InboundMessageService` + Feishu Setup). Prefer **merge #412 first, then rebase this PR**.

## Test plan
- [x] `WeComWsClientTest` (errcode WARN / silent OK)
- [x] `CliChannelTest` (failure then continue)
- [x] `InboundMessageServiceTest` / adapter lifecycle tests