### PR TITLE
feat(channel): harden IM inbound media SSRF, Whisper, TTL, and progress UX

### DIFF
--- a/docs/DingTalkChannelSetup.md
+++ b/docs/DingTalkChannelSetup.md
@@ -50,7 +50,8 @@
 - **图片**：Stream 回调常见 `downloadCode`（无直链）。渠道会调用开放平台「下载机器人接收消息的文件内容」换临时 URL 并落盘，再交给 Vision；`robotCode` 默认等于 ClientId（`app_id`）。
 - **文件**：同样经 `downloadCode`（或直链）落盘到 `.oryxos/inbound-media/`，正文提示本地路径供 `read_file`（**文本型 PDF 可抽正文**）；不走 Vision。
 - **语音**：`msgtype=audio` 经 `downloadCode` 落盘；配置 `OPENAI_API_KEY`（或 `ORYXOS_ASR_API_KEY`）后用 Whisper 转写进 Agent。非 Whisper 原生格式（如 silk/amr）会经本机 `ffmpeg`（`PATH` / `ORYXOS_FFMPEG`）转 wav；未安装则转写失败并提示。
-- **视频**：`msgtype=video` 经 `downloadCode` 落盘；有 Whisper + ffmpeg 时可抽音轨转写（不理解画面）。
+- **视频**：`msgtype=video` 经 `downloadCode` 落盘；有 Whisper + ffmpeg 时可抽音轨转写（不理解画面；`ORYXOS_VIDEO_ASR=0` 可关）。
+- **媒体根**：`.oryxos/inbound-media/`（≤50MB）；TTL/配额：`ORYXOS_INBOUND_MEDIA_TTL_HOURS` / `ORYXOS_INBOUND_MEDIA_MAX_MB`。临时链下载禁用自动跟跳，重定向逐跳校验钉钉/OSS 白名单。
 
 ## 四、与飞书/企微的差异（运维须知）
 
@@ -59,13 +60,14 @@
 | 凭证 | App ID / App Secret | BotID / 长连接 Secret | ClientId / ClientSecret |
 | 连接 | SDK 长连接 | `openws.work.weixin.qq.com` WS | `api.dingtalk.com` Stream WS |
 | 回复 | im API（post + md） | 长连接 `aibot_send_msg` | `sessionWebhook` POST markdown |
-| 进度提示 | 交互卡片原地 PATCH | 占位 + 至多一条工具进度 + 终态 | 占位 + 至多一条工具进度 + 终态 |
-| 入站图/文件 | message_id + image_key/file_key 下载 | COS URL + AES 落盘 | `downloadCode` → 临时 URL 落盘 |
+| 进度提示 | 交互卡片原地 PATCH | 占位 + 可选心跳 + 工具 + 终态 | 同企微（无原地 PATCH） |
+| 入站图/文件 | message_id + image_key/file_key 下载 | COS URL + AES 落盘 | `downloadCode` → 临时 URL 落盘（防 SSRF） |
+| ASR | Whisper + ffmpeg | 平台 ASR（可 Whisper 兜底） | Whisper + ffmpeg |
 | 群 @ 关联 | open_id / mentioned | `quote.msgid` | `at.atUserIds`（非真引用线程） |
 | 命令 | `/new`（私聊）；`/stop`（私聊/群聊进行中任务） | 同 | 同 |
 
 ## 五、非目标（本期不做）
 
 - HTTP 回调 + 加解密旧模式
-- 逐 token 刷屏 / 模板卡片 HITL
-- 视频画面理解 / 抽帧 Vision；未配置 Whisper / 未安装 ffmpeg 时飞书/钉钉非原生语音与视频音轨仅落盘无法听懂内容
+- 逐 token 刷屏 / 模板卡片 HITL / 钉钉原地 PATCH / 真·引用线程回复
+- 视频画面理解 / 抽帧 Vision；未配置 Whisper / 未安装 ffmpeg 时非原生语音与视频音轨仅落盘无法听懂内容

--- a/docs/FeishuChannelSetup.md
+++ b/docs/FeishuChannelSetup.md
@@ -53,8 +53,9 @@
 
 - **私聊**：飞书搜索机器人名字（或工作台找到应用）→ 直接发文本、图片、文件、语音或视频。
 - **群聊**：把机器人拉进群后 `@机器人 + 问题`（或图片/文件/语音/视频）。
-- **语音**：`message_type=audio` 经 `file_key` 落盘；配置 `OPENAI_API_KEY`（或 `ORYXOS_ASR_API_KEY`）后 Whisper 转写进 Agent。飞书音频常为 silk：服务端若检测到 silk/amr（或非 Whisper 原生格式）会调用本机 `ffmpeg`（`PATH` 或 `ORYXOS_FFMPEG`）转成 wav 再上传；未安装 ffmpeg 时转写失败并提示安装。
-- **视频**：`message_type=media` 经 `file_key` 落盘；有 Whisper + ffmpeg 时可抽音轨转写（不理解画面）。
+- **语音**：`message_type=audio` 经 `file_key` 落盘到 `.oryxos/inbound-media/`（≤50MB）；配置 `OPENAI_API_KEY`（或 `ORYXOS_ASR_API_KEY`）后 Whisper 转写进 Agent。飞书音频常为 silk：服务端若检测到 silk/amr（或非 Whisper 原生格式）会调用本机 `ffmpeg`（`PATH` 或 `ORYXOS_FFMPEG`）转成 wav 再上传；未安装 ffmpeg 时转写失败并提示安装。
+- **视频**：`message_type=media` 经 `file_key` 落盘；有 Whisper + ffmpeg 时可抽音轨转写（不理解画面；`ORYXOS_VIDEO_ASR=0` 可关）。
+- **媒体根 TTL/配额**：`ORYXOS_INBOUND_MEDIA_TTL_HOURS`（默认 24）、`ORYXOS_INBOUND_MEDIA_MAX_MB`（默认 2048）。
 - **群聊**：测试群 → 群设置 →「**群机器人**」→「添加机器人」→ 选择应用；之后 `@机器人 + 问题` 触发。群里**不 @** 机器人的消息 OryxOS 完全不读、不留任何记录。
 
 ## 七、OryxOS 侧：配置与启动
@@ -91,7 +92,13 @@
 
 4. **免重启管理**（可选）：`/api/v1/channels` 提供 CRUD——新增 / 改绑 / 停用渠道即时生效，无需重启进程；凭证在接口出入参中始终保持 `${ENV}` 字面量或掩码，不回显明文。
 
-**进度提示对照**：飞书用交互卡片原地更新（首 token 前 idle 心跳；`/stop` → 红卡「已停止」）；企微/钉钉无 PATCH，采用「正在思考…」占位、至多一条工具进度后再发终态。私聊 `/new`、私聊/群聊 `/stop`（仅进行中任务）由核心编排，三渠道一致。
+**进度提示对照**：飞书用交互卡片原地更新（首 token 前 idle 心跳；`/stop` → 红卡「已停止」）；企微/钉钉无 PATCH，采用「正在思考…」占位、可选长 TTFT 心跳（`ORYXOS_IM_PROGRESS_HEARTBEAT_MS`，默认 25s；0=关）、至多一条工具进度后再发终态；失败/`/stop` 用专用句。私聊 `/new`、私聊/群聊 `/stop`（仅进行中任务）由核心编排，三渠道一致。
+
+## 七·附、非目标（与企微/钉钉对齐）
+
+- Webhook 入站；逐 token 刷屏
+- 视频画面理解 / 抽帧 Vision（仅可选音轨 ASR）
+- 企微/钉钉级原地 PATCH（飞书独有能力，勿期望三渠一致）
 
 ## 八、常见问题
 

--- a/docs/WeComChannelSetup.md
+++ b/docs/WeComChannelSetup.md
@@ -42,8 +42,9 @@
 - **群聊**：将机器人拉入群后 `@机器人 + 问题`（或图片/文件/视频）；平台只推送 @ 本机器人的群消息。
 - **图片**：回调里的 COS 临时 URL 会先下载落盘再送 Vision（避免 provider 直拉临时链失败）。
 - **文件**：同样先下载落盘（优先 `.oryxos/inbound-media/`），正文提示本地路径供 Agent `read_file`（须在 FILE 沙箱白名单内；**文本型 PDF 可抽正文**）；不走 Vision。
-- **语音**：智能机器人回调已含平台 ASR（`voice.content`），直接当用户问题编排；**仅单聊**。
-- **视频**：`msgtype=video` 经 COS URL（及可选 AES）落盘；配置 Whisper + ffmpeg 时可抽音轨转写（不理解画面）。
+- **语音**：智能机器人回调已含平台 ASR（`voice.content`），直接当用户问题编排；**仅单聊**。空转写且带 `voice.url` 时落盘并走 Whisper 兜底；否则明确提示改发文字。
+- **视频**：`msgtype=video` 经 COS URL（及可选 AES）落盘；配置 Whisper + ffmpeg 时可抽音轨转写（不理解画面；`ORYXOS_VIDEO_ASR=0` 可关）。
+- **媒体根**：优先 `.oryxos/inbound-media/{channel}/`（单文件 ≤50MB）；TTL/配额见 `ORYXOS_INBOUND_MEDIA_TTL_HOURS`（默认 24）与 `ORYXOS_INBOUND_MEDIA_MAX_MB`（默认 2048）。COS 下载禁用自动跟跳，重定向逐跳校验白名单。
 
 ## 四、与飞书的差异（运维须知）
 
@@ -52,13 +53,14 @@
 | 凭证 | App ID / App Secret | BotID / 长连接 Secret |
 | 连接 | `open.feishu.cn` SDK 长连接 | `openws.work.weixin.qq.com` WebSocket |
 | 回复 | im/v1 messages API（post + md） | 长连接 `aibot_send_msg`（markdown） |
-| 进度提示 | 交互卡片原地 PATCH（思考→工具→终态；`/stop` 红卡「已停止」） | 占位 + 至多一条工具进度 + 终态（无原地编辑） |
-| 入站图/文件 | image_key 官方下载 | COS 临时 URL → AES 解密落盘 |
+| 进度提示 | 交互卡片原地 PATCH（思考→工具→终态；`/stop` 红卡「已停止」） | 占位 + 可选长 TTFT 心跳 + 至多一条工具 + 终态（无原地编辑；失败/`/stop` 专用句） |
+| 入站图/文件 | image_key 官方下载 | COS URL + AES 落盘（≤50MB；防重定向 SSRF） |
+| ASR | Whisper + ffmpeg（silk 常见） | 平台 ASR；空转写可 Whisper 兜底 |
 | 同一 Bot 连接数 | SDK 管理 | 同时仅一条有效长连接（新连踢旧） |
 | 命令 | 私聊 `/new` 清会话；私聊/群聊 `/stop` 停进行中推理（下一轮生效） | 同（核心编排，渠道无特殊实现） |
 
 ## 五、非目标（本期不做）
 
 - 自建应用 HTTP 回调 + AES 加解密（入站图 COS 解密除外）
-- 逐 token 刷屏 / 模板卡片 HITL
+- 逐 token 刷屏 / 模板卡片 HITL / 企微原地 PATCH
 - 群聊语音（平台仅单聊语音）；视频画面理解 / 抽帧 Vision

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolver.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolver.java
@@ -482,7 +482,8 @@ final class DingTalkInboundImageResolver {
   }
 
   private static String sanitize(String value) {
-    return InboundMediaPaths.sanitizeLog(value);
+    // 内联替换：SpotBugs CRLF_INJECTION_LOGS 需在本类内可见的 \r/\n 清洗
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
   }
 
   private record CachedToken(String token, long expiresAtMillis) {}

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolver.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkInboundImageResolver.java
@@ -4,7 +4,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMediaHttp;
+import io.oryxos.core.channel.InboundMediaJanitor;
+import io.oryxos.core.channel.InboundMediaLimits;
+import io.oryxos.core.channel.InboundMediaPaths;
 import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.LimitedMediaWriter;
 import io.oryxos.core.channel.OutboundGuard;
 import io.oryxos.core.session.ImageMime;
 import io.oryxos.core.session.InboundMediaExt;
@@ -37,12 +42,8 @@ final class DingTalkInboundImageResolver {
   private static final String DOWNLOAD_META_PATH = "/v1.0/robot/messageFiles/download";
   private static final String HEADER_ACCESS_TOKEN = "x-acs-dingtalk-access-token";
   private static final String DEFAULT_EXTENSION = ".bin";
-  private static final String FALLBACK_SEGMENT = "x";
   private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
-  private static final char PATH_SAFE_REPLACEMENT = '_';
-  private static final int MAX_SEGMENT_LEN = 96;
   private static final int DOWNLOAD_ATTEMPTS = 2;
-  private static final long MAX_FILE_BYTES = 50L * 1024 * 1024;
   private static final long TOKEN_SKEW_MS = 60_000L;
   private static final long DEFAULT_TOKEN_EXPIRE_SEC = 7200L;
   private static final long MIN_TOKEN_TTL_SEC = 60L;
@@ -64,6 +65,7 @@ final class DingTalkInboundImageResolver {
   private final String robotCode;
   private final Path mediaRoot;
   private final String channelName;
+  private final InboundMediaJanitor janitor;
   private final AtomicReference<CachedToken> tokenRef = new AtomicReference<>();
 
   DingTalkInboundImageResolver(
@@ -74,14 +76,15 @@ final class DingTalkInboundImageResolver {
       Path mediaRoot,
       String channelName) {
     this(
-        HttpClient.newBuilder().connectTimeout(HTTP_TIMEOUT).build(),
+        InboundMediaHttp.newNoRedirectClient(HTTP_TIMEOUT),
         guard,
         DingTalkStreamClient.API_BASE_URL,
         appKey,
         appSecret,
         robotCode,
         mediaRoot,
-        channelName);
+        channelName,
+        InboundMediaJanitor.fromEnv());
   }
 
   /** 单测注入：自定义 {@code apiBaseUrl}（本地 HttpServer）与 {@link HttpClient}。 */
@@ -94,6 +97,29 @@ final class DingTalkInboundImageResolver {
       String robotCode,
       Path mediaRoot,
       String channelName) {
+    this(
+        httpClient,
+        guard,
+        apiBaseUrl,
+        appKey,
+        appSecret,
+        robotCode,
+        mediaRoot,
+        channelName,
+        InboundMediaJanitor.fromEnv());
+  }
+
+  /** 单测可注入 janitor。 */
+  DingTalkInboundImageResolver(
+      HttpClient httpClient,
+      OutboundGuard guard,
+      String apiBaseUrl,
+      String appKey,
+      String appSecret,
+      String robotCode,
+      Path mediaRoot,
+      String channelName,
+      InboundMediaJanitor janitor) {
     this.httpClient = httpClient;
     this.guard = guard;
     this.apiBaseUrl = trimTrailingSlash(apiBaseUrl);
@@ -102,9 +128,11 @@ final class DingTalkInboundImageResolver {
     this.robotCode = robotCode;
     this.mediaRoot = mediaRoot;
     this.channelName = channelName;
+    this.janitor = janitor == null ? InboundMediaJanitor.fromEnv() : janitor;
   }
 
   InboundMessage resolve(InboundMessage message) {
+    janitor.sweepIfDue(mediaRoot);
     if (message.attachments().isEmpty()) {
       return message;
     }
@@ -191,7 +219,7 @@ final class DingTalkInboundImageResolver {
             file.toAbsolutePath().toString(),
             downloadCode,
             attachment.fileName());
-      } catch (IOException | InterruptedException | RuntimeException e) {
+      } catch (Exception e) {
         if (e instanceof InterruptedException) {
           Thread.currentThread().interrupt();
         }
@@ -231,7 +259,7 @@ final class DingTalkInboundImageResolver {
                 : attachment.reference();
         return new InboundAttachment(
             attachment.type(), file.toAbsolutePath().toString(), ref, attachment.fileName());
-      } catch (IOException | InterruptedException | RuntimeException e) {
+      } catch (Exception e) {
         if (e instanceof InterruptedException) {
           Thread.currentThread().interrupt();
         }
@@ -317,30 +345,27 @@ final class DingTalkInboundImageResolver {
   }
 
   private Path writeToMediaRoot(String messageId, String downloadCode, String downloadUrl)
-      throws IOException, InterruptedException {
+      throws Exception {
     URI uri = URI.create(downloadUrl);
     if (!isAllowedMediaUri(uri)) {
       throw new IllegalStateException("拒绝非钉钉域临时下载地址: " + sanitize(uri.getHost()));
     }
-    HttpRequest request = HttpRequest.newBuilder().uri(uri).timeout(HTTP_TIMEOUT).GET().build();
     HttpResponse<byte[]> response =
-        httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
-    if (response.statusCode() < HTTP_STATUS_OK_MIN
-        || response.statusCode() >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
-      throw new IllegalStateException("下载临时文件 HTTP " + response.statusCode());
-    }
+        InboundMediaHttp.getFollowingAllowlist(
+            httpClient, uri, HTTP_TIMEOUT, this::isAllowedMediaUri);
     byte[] bytes = response.body();
     if (bytes == null || bytes.length == 0) {
       throw new IllegalStateException("下载临时文件为空");
     }
-    if (bytes.length > MAX_FILE_BYTES) {
-      throw new IllegalStateException("入站文件超过上限 " + MAX_FILE_BYTES + " 字节");
+    if (bytes.length > InboundMediaLimits.MAX_FILE_BYTES) {
+      throw new IllegalStateException("入站文件超过上限 " + InboundMediaLimits.MAX_FILE_BYTES + " 字节");
     }
     String ext = extensionOf(uri.getPath());
     Path dir = mediaRoot.resolve(safeSegment(messageId));
     Files.createDirectories(dir);
     Path target = dir.resolve(safeSegment(downloadCode) + ext);
-    Files.write(target, bytes);
+    janitor.ensureQuotaOrThrow(mediaRoot);
+    LimitedMediaWriter.writeLimited(bytes, target, InboundMediaLimits.MAX_FILE_BYTES);
     // ext 经 asciiLower；用 equals 避免 equalsIgnoreCase 触发 SpotBugs IMPROPER_UNICODE
     if (DEFAULT_EXTENSION.equals(ext) || InboundMediaExt.EXT_FILE.equals(ext)) {
       String sniffed = ImageMime.probeFile(target);
@@ -446,17 +471,7 @@ final class DingTalkInboundImageResolver {
   }
 
   static String safeSegment(String raw) {
-    if (raw == null || raw.isBlank()) {
-      return FALLBACK_SEGMENT;
-    }
-    String cleaned = raw.replaceAll("[^a-zA-Z0-9._-]", String.valueOf(PATH_SAFE_REPLACEMENT));
-    if (cleaned.length() > MAX_SEGMENT_LEN) {
-      cleaned = cleaned.substring(0, MAX_SEGMENT_LEN);
-    }
-    if (cleaned.isBlank() || cleaned.chars().allMatch(ch -> ch == PATH_SAFE_REPLACEMENT)) {
-      return FALLBACK_SEGMENT;
-    }
-    return cleaned;
+    return InboundMediaPaths.safeSegment(raw);
   }
 
   private static String trimTrailingSlash(String url) {
@@ -467,9 +482,7 @@ final class DingTalkInboundImageResolver {
   }
 
   private static String sanitize(String value) {
-    return value == null
-        ? ""
-        : value.replace('\r', PATH_SAFE_REPLACEMENT).replace('\n', PATH_SAFE_REPLACEMENT);
+    return InboundMediaPaths.sanitizeLog(value);
   }
 
   private record CachedToken(String token, long expiresAtMillis) {}

--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuInboundImageResolver.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuInboundImageResolver.java
@@ -4,11 +4,17 @@ import com.lark.oapi.Client;
 import com.lark.oapi.service.im.v1.model.GetMessageResourceReq;
 import com.lark.oapi.service.im.v1.model.GetMessageResourceResp;
 import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMediaJanitor;
+import io.oryxos.core.channel.InboundMediaLimits;
+import io.oryxos.core.channel.InboundMediaPaths;
 import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.LimitedMediaWriter;
 import io.oryxos.core.session.ImageMime;
 import io.oryxos.core.session.InboundMediaExt;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -30,24 +36,29 @@ final class FeishuInboundImageResolver {
   private static final String RESOURCE_TYPE_IMAGE = "image";
   private static final String RESOURCE_TYPE_FILE = "file";
   private static final String DEFAULT_EXTENSION = ".bin";
-  private static final String FALLBACK_SEGMENT = "x";
   private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
-  private static final char PATH_SAFE_REPLACEMENT = '_';
-  private static final int MAX_SEGMENT_LEN = 96;
   private static final int DOWNLOAD_ATTEMPTS = 2;
-  private static final long MAX_FILE_BYTES = 50L * 1024 * 1024;
 
   private final Client client;
   private final Path mediaRoot;
   private final String channelName;
+  private final InboundMediaJanitor janitor;
 
   FeishuInboundImageResolver(Client client, Path mediaRoot, String channelName) {
+    this(client, mediaRoot, channelName, InboundMediaJanitor.fromEnv());
+  }
+
+  /** 单测可注入 janitor。 */
+  FeishuInboundImageResolver(
+      Client client, Path mediaRoot, String channelName, InboundMediaJanitor janitor) {
     this.client = client;
     this.mediaRoot = mediaRoot;
     this.channelName = channelName;
+    this.janitor = janitor == null ? InboundMediaJanitor.fromEnv() : janitor;
   }
 
   InboundMessage resolve(InboundMessage message) {
+    janitor.sweepIfDue(mediaRoot);
     if (message.attachments().isEmpty()) {
       return message;
     }
@@ -184,18 +195,8 @@ final class FeishuInboundImageResolver {
     Path dir = mediaRoot.resolve(safeSegment(messageId));
     Files.createDirectories(dir);
     Path target = dir.resolve(safeSegment(fileKey) + ext);
-    try (OutputStream out = Files.newOutputStream(target)) {
-      resp.getData().writeTo(out);
-    }
-    long size = Files.size(target);
-    if (size > MAX_FILE_BYTES) {
-      try {
-        Files.deleteIfExists(target);
-      } catch (IOException ignored) {
-        // 尽力删除超限文件
-      }
-      throw new IOException("入站文件超过上限 " + MAX_FILE_BYTES + " 字节");
-    }
+    janitor.ensureQuotaOrThrow(mediaRoot);
+    writeLimitedResource(resp.getData(), target);
     // 图片常无后缀：用魔数改扩展名；文件无后缀时嗅探 PDF
     if (!fileAttachment && DEFAULT_EXTENSION.equals(ext)) {
       String sniffed = ImageMime.probeFile(target);
@@ -224,6 +225,23 @@ final class FeishuInboundImageResolver {
     return target;
   }
 
+  /**
+   * SDK {@code getData()} 为 {@link ByteArrayOutputStream}；经 {@link LimitedMediaWriter#copyLimited}
+   * 限长落盘。
+   */
+  private static void writeLimitedResource(ByteArrayOutputStream data, Path target)
+      throws IOException {
+    if (data == null) {
+      throw new IOException("下载临时文件为空");
+    }
+    if (data.size() > InboundMediaLimits.MAX_FILE_BYTES) {
+      throw new IOException("入站文件超过上限 " + InboundMediaLimits.MAX_FILE_BYTES + " 字节");
+    }
+    try (InputStream in = new ByteArrayInputStream(data.toByteArray())) {
+      LimitedMediaWriter.copyLimited(in, target, InboundMediaLimits.MAX_FILE_BYTES);
+    }
+  }
+
   private static String extensionOf(String fileName) {
     if (fileName == null || fileName.isBlank()) {
       return DEFAULT_EXTENSION;
@@ -240,22 +258,10 @@ final class FeishuInboundImageResolver {
   }
 
   static String safeSegment(String raw) {
-    if (raw == null || raw.isBlank()) {
-      return FALLBACK_SEGMENT;
-    }
-    String cleaned = raw.replaceAll("[^a-zA-Z0-9._-]", String.valueOf(PATH_SAFE_REPLACEMENT));
-    if (cleaned.length() > MAX_SEGMENT_LEN) {
-      cleaned = cleaned.substring(0, MAX_SEGMENT_LEN);
-    }
-    if (cleaned.isBlank() || cleaned.chars().allMatch(ch -> ch == PATH_SAFE_REPLACEMENT)) {
-      return FALLBACK_SEGMENT;
-    }
-    return cleaned;
+    return InboundMediaPaths.safeSegment(raw);
   }
 
   private static String sanitize(String value) {
-    return value == null
-        ? ""
-        : value.replace('\r', PATH_SAFE_REPLACEMENT).replace('\n', PATH_SAFE_REPLACEMENT);
+    return InboundMediaPaths.sanitizeLog(value);
   }
 }

--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuInboundImageResolver.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuInboundImageResolver.java
@@ -133,7 +133,7 @@ final class FeishuInboundImageResolver {
           LOG.warn(
               "飞书渠道 {} 下载{}失败（messageId={}, key={}, code={}, msg={}），保留原引用",
               sanitize(channelName),
-              kind,
+              sanitize(kind),
               sanitize(messageId),
               sanitize(fileKey),
               resp == null ? -1 : resp.getCode(),
@@ -149,7 +149,7 @@ final class FeishuInboundImageResolver {
           LOG.warn(
               "飞书渠道 {} 下载{}超时重试 {}/{}（messageId={}, key={}）：{}",
               sanitize(channelName),
-              kind,
+              sanitize(kind),
               attempt,
               DOWNLOAD_ATTEMPTS,
               sanitize(messageId),
@@ -163,7 +163,7 @@ final class FeishuInboundImageResolver {
     LOG.warn(
         "飞书渠道 {} 下载{}异常（messageId={}, key={}）：{}，保留原引用",
         sanitize(channelName),
-        kind,
+        sanitize(kind),
         sanitize(messageId),
         sanitize(fileKey),
         sanitize(last == null ? null : last.getMessage()));
@@ -262,6 +262,7 @@ final class FeishuInboundImageResolver {
   }
 
   private static String sanitize(String value) {
-    return InboundMediaPaths.sanitizeLog(value);
+    // 内联替换：SpotBugs CRLF_INJECTION_LOGS 需在本类内可见的 \r/\n 清洗
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
   }
 }

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComEventNormalizer.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComEventNormalizer.java
@@ -87,11 +87,20 @@ public class WeComEventNormalizer {
       }
       content = content.strip();
     } else if (MSG_VOICE.equals(msgtype)) {
-      content = body.path("voice").path("content").asText("");
+      JsonNode voice = body.path("voice");
+      content = voice.path("content").asText("");
       content = content == null ? "" : content.strip();
-      textual = !content.isBlank();
       if (!content.isBlank()) {
+        textual = true;
         content = "[语音转写] " + content;
+      } else {
+        Optional<InboundAttachment> audio = extractVoice(voice);
+        if (audio.isPresent()) {
+          attachments.add(audio.get());
+        } else {
+          textual = true;
+          content = "企微仅单聊提供 ASR；空转写请改发文字";
+        }
       }
     } else if (MSG_IMAGE.equals(msgtype)) {
       extractImage(body.path("image")).ifPresent(attachments::add);
@@ -132,6 +141,19 @@ public class WeComEventNormalizer {
           new InboundAttachment(InboundAttachment.TYPE_FILE, fileUrl, aesKey, fileName));
     }
     return Optional.of(InboundAttachment.fileUrl(fileUrl, fileName));
+  }
+
+  /** 空 ASR 时若有临时 URL，按文件同款带可选 aeskey 落 TYPE_AUDIO，供本地下载/转写。 */
+  private static Optional<InboundAttachment> extractVoice(JsonNode voice) {
+    String voiceUrl = voice.path("url").asText(null);
+    if (voiceUrl == null || voiceUrl.isBlank()) {
+      return Optional.empty();
+    }
+    String aesKey = voice.path("aeskey").asText(null);
+    if (aesKey != null && !aesKey.isBlank()) {
+      return Optional.of(new InboundAttachment(InboundAttachment.TYPE_AUDIO, voiceUrl, aesKey));
+    }
+    return Optional.of(InboundAttachment.audioUrl(voiceUrl));
   }
 
   private static Optional<InboundAttachment> extractVideo(JsonNode video) {

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComInboundImageResolver.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComInboundImageResolver.java
@@ -1,13 +1,17 @@
 package io.oryxos.channel.wecom;
 
 import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMediaHttp;
+import io.oryxos.core.channel.InboundMediaJanitor;
+import io.oryxos.core.channel.InboundMediaLimits;
+import io.oryxos.core.channel.InboundMediaPaths;
 import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.LimitedMediaWriter;
 import io.oryxos.core.session.ImageMime;
 import io.oryxos.core.session.InboundMediaExt;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -28,15 +32,9 @@ final class WeComInboundImageResolver {
   private static final Logger LOG = LoggerFactory.getLogger(WeComInboundImageResolver.class);
 
   private static final String DEFAULT_EXTENSION = ".bin";
-  private static final String FALLBACK_SEGMENT = "x";
   private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
-  private static final char PATH_SAFE_REPLACEMENT = '_';
-  private static final int MAX_SEGMENT_LEN = 96;
   private static final int DOWNLOAD_ATTEMPTS = 2;
-  private static final long MAX_FILE_BYTES = 50L * 1024 * 1024;
   private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(60);
-  private static final int HTTP_STATUS_OK_MIN = 200;
-  private static final int HTTP_STATUS_OK_MAX_EXCLUSIVE = 300;
   private static final String SCHEME_HTTPS = "https";
   private static final String SCHEME_HTTP = "http";
   private static final String HOST_SUFFIX_MYQCLOUD = ".myqcloud.com";
@@ -48,29 +46,43 @@ final class WeComInboundImageResolver {
   private final Path mediaRoot;
   private final String channelName;
   private final boolean trustLoopback;
+  private final InboundMediaJanitor janitor;
 
   WeComInboundImageResolver(Path mediaRoot, String channelName) {
     this(
-        HttpClient.newBuilder().connectTimeout(HTTP_TIMEOUT).build(),
+        InboundMediaHttp.newNoRedirectClient(HTTP_TIMEOUT),
         mediaRoot,
         channelName,
-        false);
+        false,
+        InboundMediaJanitor.fromEnv());
   }
 
   WeComInboundImageResolver(HttpClient httpClient, Path mediaRoot, String channelName) {
-    this(httpClient, mediaRoot, channelName, false);
+    this(httpClient, mediaRoot, channelName, false, InboundMediaJanitor.fromEnv());
   }
 
   /** 单测：允许 127.0.0.1 / localhost 以便本地 HttpServer 验证落盘。 */
   WeComInboundImageResolver(
       HttpClient httpClient, Path mediaRoot, String channelName, boolean trustLoopback) {
+    this(httpClient, mediaRoot, channelName, trustLoopback, InboundMediaJanitor.fromEnv());
+  }
+
+  /** 单测可注入 janitor。 */
+  WeComInboundImageResolver(
+      HttpClient httpClient,
+      Path mediaRoot,
+      String channelName,
+      boolean trustLoopback,
+      InboundMediaJanitor janitor) {
     this.httpClient = httpClient;
     this.mediaRoot = mediaRoot;
     this.channelName = channelName;
     this.trustLoopback = trustLoopback;
+    this.janitor = janitor == null ? InboundMediaJanitor.fromEnv() : janitor;
   }
 
   InboundMessage resolve(InboundMessage message) {
+    janitor.sweepIfDue(mediaRoot);
     if (message.attachments().isEmpty()) {
       return message;
     }
@@ -142,7 +154,7 @@ final class WeComInboundImageResolver {
         Path path = writeToMediaRoot(messageId, remoteUrl, aesKey, fileLike);
         return new InboundAttachment(
             attachment.type(), path.toAbsolutePath().toString(), remoteUrl, attachment.fileName());
-      } catch (IOException | InterruptedException | RuntimeException e) {
+      } catch (Exception e) {
         if (e instanceof InterruptedException) {
           Thread.currentThread().interrupt();
         }
@@ -178,27 +190,26 @@ final class WeComInboundImageResolver {
   }
 
   private Path writeToMediaRoot(String messageId, String remoteUrl, String aesKey, boolean file)
-      throws IOException, InterruptedException {
+      throws Exception {
     URI uri = URI.create(remoteUrl);
     if (!isAllowedMediaUri(uri)) {
       throw new IllegalStateException("拒绝非企微图床临时下载地址: " + sanitize(uri.getHost()));
     }
-    HttpRequest request = HttpRequest.newBuilder().uri(uri).timeout(HTTP_TIMEOUT).GET().build();
     HttpResponse<byte[]> response =
-        httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
-    if (response.statusCode() < HTTP_STATUS_OK_MIN
-        || response.statusCode() >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
-      throw new IllegalStateException("下载临时文件 HTTP " + response.statusCode());
-    }
+        InboundMediaHttp.getFollowingAllowlist(
+            httpClient, uri, HTTP_TIMEOUT, this::isAllowedMediaUri);
     byte[] bytes = response.body();
     if (bytes == null || bytes.length == 0) {
       throw new IllegalStateException("下载临时文件为空");
     }
-    if (bytes.length > MAX_FILE_BYTES) {
-      throw new IllegalStateException("入站文件超过上限 " + MAX_FILE_BYTES + " 字节");
+    if (bytes.length > InboundMediaLimits.MAX_FILE_BYTES) {
+      throw new IllegalStateException("入站文件超过上限 " + InboundMediaLimits.MAX_FILE_BYTES + " 字节");
     }
     if (aesKey != null) {
       bytes = WeComMediaAesDecrypt.decrypt(bytes, aesKey);
+      if (bytes.length > InboundMediaLimits.MAX_FILE_BYTES) {
+        throw new IllegalStateException("入站文件超过上限 " + InboundMediaLimits.MAX_FILE_BYTES + " 字节");
+      }
     } else if (!file && !ImageMime.hasRecognizedMagic(bytes)) {
       throw new IllegalStateException("下载内容非明文图片且消息缺 aeskey，无法解密");
     }
@@ -207,7 +218,8 @@ final class WeComInboundImageResolver {
     Files.createDirectories(dir);
     String stem = safeSegment(Integer.toHexString(remoteUrl.hashCode()));
     Path target = dir.resolve(stem + ext);
-    Files.write(target, bytes);
+    janitor.ensureQuotaOrThrow(mediaRoot);
+    LimitedMediaWriter.writeLimited(bytes, target, InboundMediaLimits.MAX_FILE_BYTES);
     if (!file) {
       if (!ImageMime.hasRecognizedMagic(target)) {
         try {
@@ -321,17 +333,7 @@ final class WeComInboundImageResolver {
   }
 
   static String safeSegment(String raw) {
-    if (raw == null || raw.isBlank()) {
-      return FALLBACK_SEGMENT;
-    }
-    String cleaned = raw.replaceAll("[^a-zA-Z0-9._-]", String.valueOf(PATH_SAFE_REPLACEMENT));
-    if (cleaned.length() > MAX_SEGMENT_LEN) {
-      cleaned = cleaned.substring(0, MAX_SEGMENT_LEN);
-    }
-    if (cleaned.isBlank() || cleaned.chars().allMatch(ch -> ch == PATH_SAFE_REPLACEMENT)) {
-      return FALLBACK_SEGMENT;
-    }
-    return cleaned;
+    return InboundMediaPaths.safeSegment(raw);
   }
 
   private static String asciiLower(String value) {
@@ -346,8 +348,6 @@ final class WeComInboundImageResolver {
   }
 
   private static String sanitize(String value) {
-    return value == null
-        ? ""
-        : value.replace('\r', PATH_SAFE_REPLACEMENT).replace('\n', PATH_SAFE_REPLACEMENT);
+    return InboundMediaPaths.sanitizeLog(value);
   }
 }

--- a/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComInboundImageResolver.java
+++ b/oryxos-channel-wecom/src/main/java/io/oryxos/channel/wecom/WeComInboundImageResolver.java
@@ -348,6 +348,7 @@ final class WeComInboundImageResolver {
   }
 
   private static String sanitize(String value) {
-    return InboundMediaPaths.sanitizeLog(value);
+    // 内联替换：SpotBugs CRLF_INJECTION_LOGS 需在本类内可见的 \r/\n 清洗
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
   }
 }

--- a/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComEventNormalizerTest.java
+++ b/oryxos-channel-wecom/src/test/java/io/oryxos/channel/wecom/WeComEventNormalizerTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -106,6 +107,41 @@ class WeComEventNormalizerTest {
     assertTrue(msg.processable());
     assertTrue(msg.content().contains("明天开会吗"));
     assertTrue(msg.attachments().isEmpty());
+  }
+
+  @Test
+  @DisplayName("空 ASR 无 url → 明确提示文案")
+  void emptyVoiceAsrPrompt() throws Exception {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgid", "m-voice-empty");
+    body.put("chattype", "single");
+    body.put("msgtype", "voice");
+    body.putObject("from").put("userid", "u1");
+    body.putObject("voice").put("content", "");
+
+    InboundMessage msg = normalizer.normalize(body).orElseThrow();
+    assertTrue(msg.textual());
+    assertTrue(msg.content().contains("空转写"));
+    assertTrue(msg.attachments().isEmpty());
+  }
+
+  @Test
+  @DisplayName("空 ASR 有 url → TYPE_AUDIO 附件")
+  void emptyVoiceWithUrlBecomesAudio() throws Exception {
+    ObjectNode body = mapper.createObjectNode();
+    body.put("msgid", "m-voice-url");
+    body.put("chattype", "single");
+    body.put("msgtype", "voice");
+    body.putObject("from").put("userid", "u1");
+    body.putObject("voice")
+        .put("content", "")
+        .put("url", "https://example.myqcloud.com/v.silk")
+        .put("aeskey", "AES1");
+
+    InboundMessage msg = normalizer.normalize(body).orElseThrow();
+    assertEquals(1, msg.attachments().size());
+    assertEquals(InboundAttachment.TYPE_AUDIO, msg.attachments().get(0).type());
+    assertEquals("https://example.myqcloud.com/v.silk", msg.attachments().get(0).url());
   }
 
   @Test

--- a/oryxos-cli/src/main/java/io/oryxos/cli/FfmpegAudioConverter.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/FfmpegAudioConverter.java
@@ -1,5 +1,6 @@
 package io.oryxos.cli;
 
+import io.oryxos.core.channel.InboundMediaLimits;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -13,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 /**
- * 调用本机 ffmpeg 将 silk/amr 等转成 Whisper 友好的 wav（16kHz mono）。
+ * 调用本机 ffmpeg 将 silk/amr/视频音轨等转成 Whisper 友好的 wav（16kHz mono）。
  *
  * <p>可执行文件：环境变量 {@code ORYXOS_FFMPEG}，否则 {@code ffmpeg}（依赖 PATH）。
  */
@@ -22,7 +23,7 @@ public final class FfmpegAudioConverter {
   static final String ERR_FFMPEG_MISSING = "需安装 ffmpeg";
   static final String ERR_FFMPEG_FAILED = "ffmpeg 转码失败";
 
-  private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(60);
+  private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(90);
   private static final int SAMPLE_RATE = 16_000;
   private static final int EXIT_COMMAND_NOT_FOUND = 127;
   private static final String EXT_WAV = ".wav";
@@ -52,15 +53,22 @@ public final class FfmpegAudioConverter {
   }
 
   /**
-   * 将 {@code input} 转为同目录临时 wav；调用方负责删除。若输入已是 Whisper 原生格式则原样返回（不创建临时文件）。
+   * 将 {@code input} 转为同目录临时 wav；调用方负责删除。若输入已是 Whisper 原生音频格式则原样返回（不创建临时文件）。
    *
    * @throws IOException 找不到 ffmpeg、超时或非零退出
    */
   public Path toWhisperWav(Path input) throws IOException {
+    return toWhisperWav(input, false);
+  }
+
+  /**
+   * @param extractAudioTrack true 时强制 {@code -vn} 抽音轨（视频）；并限制时长与输出大小
+   */
+  public Path toWhisperWav(Path input, boolean extractAudioTrack) throws IOException {
     if (input == null || !Files.isRegularFile(input)) {
       throw new IOException("音频文件不存在: " + input);
     }
-    if (isWhisperNative(input)) {
+    if (!extractAudioTrack && isWhisperNative(input)) {
       return input;
     }
     Path parent = input.getParent();
@@ -73,11 +81,27 @@ public final class FfmpegAudioConverter {
     cmd.add("-y");
     cmd.add("-i");
     cmd.add(input.toAbsolutePath().toString());
+    if (extractAudioTrack) {
+      cmd.add("-vn");
+      cmd.add("-t");
+      cmd.add(Integer.toString(InboundMediaLimits.MAX_VIDEO_ASR_SECONDS));
+    }
     cmd.add("-ar");
     cmd.add(Integer.toString(SAMPLE_RATE));
     cmd.add("-ac");
     cmd.add("1");
     cmd.add(output.toAbsolutePath().toString());
+    runFfmpeg(cmd, output);
+    long size = Files.size(output);
+    if (size > InboundMediaLimits.MAX_ASR_UPLOAD_BYTES) {
+      deleteQuietly(output);
+      throw new IOException(
+          ERR_FFMPEG_FAILED + ": 输出超过 " + InboundMediaLimits.MAX_ASR_UPLOAD_BYTES + " 字节");
+    }
+    return output;
+  }
+
+  private void runFfmpeg(List<String> cmd, Path output) throws IOException {
     Process process;
     try {
       process = processStarter.apply(cmd);
@@ -110,7 +134,6 @@ public final class FfmpegAudioConverter {
         deleteQuietly(output);
         throw new IOException(ERR_FFMPEG_FAILED + ": 输出为空");
       }
-      return output;
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       deleteQuietly(output);
@@ -136,9 +159,28 @@ public final class FfmpegAudioConverter {
         || lower.endsWith(".flac");
   }
 
+  /** 路径像视频容器（需 -vn 抽轨，不可当原生音频直传 Whisper）。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification = "仅对 ASCII 视频扩展名做 Locale.ROOT 小写匹配")
+  static boolean looksLikeVideo(Path file) {
+    Path name = file.getFileName();
+    if (name == null) {
+      return false;
+    }
+    String lower = name.toString().toLowerCase(Locale.ROOT);
+    return lower.endsWith(".mp4")
+        || lower.endsWith(".mov")
+        || lower.endsWith(".mkv")
+        || lower.endsWith(".avi");
+  }
+
   static boolean needsFfmpegConversion(Path file, byte[] header) {
     if (isWhisperNative(file)) {
       return false;
+    }
+    if (looksLikeVideo(file)) {
+      return true;
     }
     if (io.oryxos.core.session.InboundMediaExt.isOggMagic(header)) {
       return false;

--- a/oryxos-cli/src/main/java/io/oryxos/cli/MicrometerMetricsRecorder.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/MicrometerMetricsRecorder.java
@@ -116,6 +116,47 @@ public class MicrometerMetricsRecorder implements MetricsRecorder {
     }
   }
 
+  @Override
+  public void recordInboundAsr(String channel, String mediaType, boolean success, String reason) {
+    try {
+      registry
+          .counter(
+              "oryxos_inbound_asr_total",
+              "channel",
+              tag(channel),
+              "media",
+              tag(mediaType),
+              "outcome",
+              success ? "success" : "failure",
+              "reason",
+              tag(reason))
+          .increment();
+    } catch (RuntimeException e) {
+      LOG.debug("入站 ASR 指标记录失败（主链路不受影响）", e);
+    }
+  }
+
+  @Override
+  public void recordInboundMediaDownload(
+      String channel, String mediaType, boolean success, String reason) {
+    try {
+      registry
+          .counter(
+              "oryxos_inbound_media_download_total",
+              "channel",
+              tag(channel),
+              "media",
+              tag(mediaType),
+              "outcome",
+              success ? "success" : "failure",
+              "reason",
+              tag(reason))
+          .increment();
+    } catch (RuntimeException e) {
+      LOG.debug("入站媒体下载指标记录失败（主链路不受影响）", e);
+    }
+  }
+
   private static String tag(String value) {
     return value == null || value.isBlank() ? "unknown" : value;
   }

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -981,7 +981,8 @@ public class OryxOsRuntime {
       ProfileRegistry profileRegistry,
       AgentExecutionService agentExecutionService,
       io.oryxos.core.channel.MessageDeduplicator messageDeduplicator,
-      InterruptManager interruptManager) {
+      InterruptManager interruptManager,
+      io.oryxos.core.metrics.MetricsRecorder metricsRecorder) {
     return new io.oryxos.core.channel.InboundMessageService(
         agentService,
         sessionManager,
@@ -989,8 +990,8 @@ public class OryxOsRuntime {
         agentExecutionService,
         messageDeduplicator,
         new io.oryxos.core.channel.DefaultInboundMediaEnricher(
-            io.oryxos.cli.WhisperHttpTranscriber.fromEnv()),
-        java.time.Duration.ofSeconds(15), // 「处理中」提示阈值（Edge Case：先行告知）
+            io.oryxos.cli.WhisperHttpTranscriber.fromEnv(), metricsRecorder),
+        java.time.Duration.ofSeconds(15), // 「处理中」提示延迟（Edge Case：先行告知）
         interruptManager);
   }
 

--- a/oryxos-cli/src/main/java/io/oryxos/cli/WhisperHttpTranscriber.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/WhisperHttpTranscriber.java
@@ -1,8 +1,10 @@
 package io.oryxos.cli;
 
+import io.oryxos.core.channel.InboundMediaLimits;
 import io.oryxos.core.channel.InboundSpeechTranscriber;
 import io.oryxos.core.session.InboundMediaExt;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -16,7 +18,9 @@ import java.util.UUID;
 /**
  * OpenAI 兼容 Whisper 转写（{@code POST /v1/audio/transcriptions}）。 环境变量：{@code ORYXOS_ASR_API_KEY} 或
  * {@code OPENAI_API_KEY}；可选 {@code ORYXOS_ASR_BASE_URL} / {@code OPENAI_BASE_URL}（默认 {@code
- * https://api.openai.com}）。silk/amr 等非原生格式经 {@link FfmpegAudioConverter} 转 wav 后再上传。
+ * https://api.openai.com}）。silk/amr/视频音轨等经 {@link FfmpegAudioConverter} 转 wav 后再上传。
+ *
+ * <p>只读文件头做魔数判断，避免视频整文件 {@code readAllBytes}；上传前仍读取最终音频字节（通常已是抽轨 wav）。
  */
 public final class WhisperHttpTranscriber implements InboundSpeechTranscriber {
 
@@ -76,22 +80,27 @@ public final class WhisperHttpTranscriber implements InboundSpeechTranscriber {
     if (audioFile == null || !Files.isRegularFile(audioFile)) {
       throw new IOException("音频文件不存在: " + audioFile);
     }
-    byte[] header = Files.readAllBytes(audioFile);
-    if (header.length == 0) {
+    long fileSize = Files.size(audioFile);
+    if (fileSize == 0) {
       throw new IOException("音频文件为空");
     }
+    byte[] header = readHeader(audioFile);
     Path uploadPath = audioFile;
     Path tempWav = null;
     try {
-      if (FfmpegAudioConverter.needsFfmpegConversion(audioFile, header)) {
-        tempWav = audioConverter.toWhisperWav(audioFile);
+      boolean video = FfmpegAudioConverter.looksLikeVideo(audioFile);
+      if (video || FfmpegAudioConverter.needsFfmpegConversion(audioFile, header)) {
+        tempWav = audioConverter.toWhisperWav(audioFile, video);
         uploadPath = tempWav;
       } else if (!FfmpegAudioConverter.isWhisperNative(audioFile)
           && InboundMediaExt.isOggMagic(header)) {
-        // 占位名但内容是 Ogg：不转码，上传时改文件名
         uploadPath = audioFile;
       }
-      byte[] bodyBytes = uploadPath.equals(audioFile) ? header : Files.readAllBytes(uploadPath);
+      long uploadSize = Files.size(uploadPath);
+      if (uploadSize > InboundMediaLimits.MAX_ASR_UPLOAD_BYTES) {
+        throw new IOException("ASR 上传超过上限 " + InboundMediaLimits.MAX_ASR_UPLOAD_BYTES + " 字节");
+      }
+      byte[] bodyBytes = Files.readAllBytes(uploadPath);
       String boundary = "----oryxos" + UUID.randomUUID().toString().replace("-", "");
       String fileName = whisperFileName(uploadPath, bodyBytes);
       byte[] multipart = buildMultipart(boundary, fileName, bodyBytes);
@@ -128,6 +137,12 @@ public final class WhisperHttpTranscriber implements InboundSpeechTranscriber {
     }
   }
 
+  private static byte[] readHeader(Path file) throws IOException {
+    try (InputStream in = Files.newInputStream(file)) {
+      return in.readNBytes(InboundMediaLimits.HEADER_SNIFF_BYTES);
+    }
+  }
+
   /** Whisper 按上传文件名判格式：占位 .bin 但内容是 Ogg 时改成 .ogg；转码后的 wav 用固定名。 */
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "IMPROPER_UNICODE",
@@ -157,8 +172,7 @@ public final class WhisperHttpTranscriber implements InboundSpeechTranscriber {
     return name;
   }
 
-  private static byte[] buildMultipart(String boundary, String fileName, byte[] fileBytes)
-      throws IOException {
+  private static byte[] buildMultipart(String boundary, String fileName, byte[] fileBytes) {
     String preamble =
         "--"
             + boundary

--- a/oryxos-cli/src/test/java/io/oryxos/cli/FfmpegAudioConverterTest.java
+++ b/oryxos-cli/src/test/java/io/oryxos/cli/FfmpegAudioConverterTest.java
@@ -90,6 +90,33 @@ class FfmpegAudioConverterTest {
     assertFalse(FfmpegAudioConverter.needsFfmpegConversion(Path.of("a.bin"), ogg));
     assertTrue(FfmpegAudioConverter.needsFfmpegConversion(Path.of("a.bin"), silk));
     assertFalse(FfmpegAudioConverter.needsFfmpegConversion(Path.of("a.wav"), silk));
+    assertTrue(FfmpegAudioConverter.looksLikeVideo(Path.of("v.mp4")));
+  }
+
+  @Test
+  @DisplayName("视频抽轨传入 -vn 与 -t")
+  void videoExtractPassesVn() throws Exception {
+    Path mp4 = dir.resolve("clip.mp4");
+    Files.writeString(mp4, "fake-mp4");
+    AtomicReference<List<String>> seen = new AtomicReference<>();
+    FfmpegAudioConverter converter =
+        new FfmpegAudioConverter(
+            cmd -> {
+              seen.set(List.copyOf(cmd));
+              Path out = Path.of(cmd.get(cmd.size() - 1));
+              try {
+                Files.writeString(out, "RIFF....WAVEfmt ");
+              } catch (IOException e) {
+                throw new IllegalStateException(e);
+              }
+              return new SuccessfulProcess();
+            },
+            "ffmpeg-bin",
+            Duration.ofSeconds(5));
+    Path wav = converter.toWhisperWav(mp4, true);
+    assertTrue(seen.get().contains("-vn"));
+    assertTrue(seen.get().contains("-t"));
+    Files.deleteIfExists(wav);
   }
 
   private static final class SuccessfulProcess extends Process {

--- a/oryxos-cli/src/test/java/io/oryxos/cli/WhisperHttpTranscriberTest.java
+++ b/oryxos-cli/src/test/java/io/oryxos/cli/WhisperHttpTranscriberTest.java
@@ -1,0 +1,127 @@
+package io.oryxos.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WhisperHttpTranscriberTest {
+
+  @TempDir Path dir;
+  private HttpServer server;
+  private String base;
+
+  @BeforeEach
+  void start() throws IOException {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext(
+        "/v1/audio/transcriptions",
+        ex -> {
+          byte[] body = "{\"text\":\"你好\"}".getBytes(StandardCharsets.UTF_8);
+          ex.getResponseHeaders().add("Content-Type", "application/json");
+          ex.sendResponseHeaders(200, body.length);
+          try (OutputStream out = ex.getResponseBody()) {
+            out.write(body);
+          }
+        });
+    server.start();
+    base = "http://127.0.0.1:" + server.getAddress().getPort();
+  }
+
+  @AfterEach
+  void stop() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  @DisplayName("mp4 走 -vn 抽轨后再上传，不整文件当音频")
+  void videoUsesExtractTrack() throws Exception {
+    Path mp4 = dir.resolve("clip.mp4");
+    // 故意写大一点的假内容：若整文件进 ffmpeg 输入路径仍 OK；关键是 cmd 含 -vn
+    Files.write(mp4, ("fake-mp4-" + "x".repeat(2000)).getBytes(StandardCharsets.US_ASCII));
+    AtomicReference<List<String>> ffmpegCmd = new AtomicReference<>();
+    FfmpegAudioConverter converter =
+        new FfmpegAudioConverter(
+            cmd -> {
+              ffmpegCmd.set(List.copyOf(cmd));
+              Path out = Path.of(cmd.get(cmd.size() - 1));
+              try {
+                Files.writeString(out, "RIFFWAVEfmt ");
+              } catch (IOException e) {
+                throw new IllegalStateException(e);
+              }
+              return new Process() {
+                @Override
+                public OutputStream getOutputStream() {
+                  return OutputStream.nullOutputStream();
+                }
+
+                @Override
+                public java.io.InputStream getInputStream() {
+                  return java.io.InputStream.nullInputStream();
+                }
+
+                @Override
+                public java.io.InputStream getErrorStream() {
+                  return java.io.InputStream.nullInputStream();
+                }
+
+                @Override
+                public int waitFor() {
+                  return 0;
+                }
+
+                @Override
+                public boolean waitFor(long timeout, java.util.concurrent.TimeUnit unit) {
+                  return true;
+                }
+
+                @Override
+                public int exitValue() {
+                  return 0;
+                }
+
+                @Override
+                public void destroy() {}
+
+                @Override
+                public Process destroyForcibly() {
+                  return this;
+                }
+
+                @Override
+                public boolean isAlive() {
+                  return false;
+                }
+              };
+            },
+            "ffmpeg",
+            Duration.ofSeconds(5));
+    WhisperHttpTranscriber t =
+        new WhisperHttpTranscriber(
+            "sk-test",
+            base,
+            HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build(),
+            converter);
+    String text = t.transcribe(mp4);
+    assertEquals("你好", text);
+    assertTrue(ffmpegCmd.get().contains("-vn"));
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/DefaultInboundMediaEnricher.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/DefaultInboundMediaEnricher.java
@@ -1,5 +1,6 @@
 package io.oryxos.core.channel;
 
+import io.oryxos.core.metrics.MetricsRecorder;
 import io.oryxos.core.session.ImageMime;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -28,19 +29,36 @@ public final class DefaultInboundMediaEnricher implements InboundMediaEnricher {
   private static final String AUDIO_ASR_FAIL = "\n语音转写失败: ";
   private static final String VIDEO_WITH_URL = "[用户发送了一段视频]\n本地路径: ";
   private static final String VIDEO_WITH_REF = "[用户发送了一段视频]\n视频资源: ";
-  private static final String VIDEO_HINT = "\n视频已落盘；可用工具处理本地文件（不自动理解画面）。";
+  private static final String VIDEO_HINT =
+      "\n视频已落盘；可用工具处理本地文件（不自动理解画面；音轨 ASR 可用 ORYXOS_VIDEO_ASR=0 关闭）。";
   private static final String VIDEO_AUDIO_PREFIX = "\n音轨转写: ";
+  private static final String VIDEO_AUDIO_FFMPEG =
+      "\n音轨转写失败（需 ffmpeg 抽轨，请安装 ffmpeg 或设置 ORYXOS_FFMPEG）: ";
+  private static final String VIDEO_AUDIO_NO_ASR =
+      "\n未配置音轨转写（设置 OPENAI_API_KEY 或 ORYXOS_ASR_API_KEY）。";
   private static final String VIDEO_AUDIO_FAIL = "\n音轨转写失败: ";
+  private static final String VIDEO_ASR_DISABLED = "\n音轨转写已关闭（ORYXOS_VIDEO_ASR=0）。";
   private static final String MARKER_FFMPEG = "需安装 ffmpeg";
+  private static final String MEDIA_AUDIO = "audio";
+  private static final String MEDIA_VIDEO = "video";
 
   private final InboundSpeechTranscriber speechTranscriber;
+  private final MetricsRecorder metrics;
+  private final boolean videoAsrEnabled;
 
   public DefaultInboundMediaEnricher() {
-    this(null);
+    this(null, MetricsRecorder.NOOP);
   }
 
   public DefaultInboundMediaEnricher(InboundSpeechTranscriber speechTranscriber) {
+    this(speechTranscriber, MetricsRecorder.NOOP);
+  }
+
+  public DefaultInboundMediaEnricher(
+      InboundSpeechTranscriber speechTranscriber, MetricsRecorder metrics) {
     this.speechTranscriber = speechTranscriber;
+    this.metrics = metrics == null ? MetricsRecorder.NOOP : metrics;
+    this.videoAsrEnabled = resolveVideoAsrEnabled();
   }
 
   @Override
@@ -59,9 +77,9 @@ public final class DefaultInboundMediaEnricher implements InboundMediaEnricher {
       } else if (InboundAttachment.TYPE_FILE.equals(attachment.type())) {
         parts.add(enrichFile(attachment));
       } else if (InboundAttachment.TYPE_AUDIO.equals(attachment.type())) {
-        parts.add(enrichAudio(attachment));
+        parts.add(enrichAudio(attachment, message.channelType()));
       } else if (InboundAttachment.TYPE_VIDEO.equals(attachment.type())) {
-        parts.add(enrichVideo(attachment));
+        parts.add(enrichVideo(attachment, message.channelType()));
       }
     }
     return String.join("\n\n", parts).strip();
@@ -85,7 +103,7 @@ public final class DefaultInboundMediaEnricher implements InboundMediaEnricher {
     return sb.toString();
   }
 
-  private String enrichAudio(InboundAttachment attachment) {
+  private String enrichAudio(InboundAttachment attachment, String channel) {
     String path =
         attachment.url() != null && !attachment.url().isBlank()
             ? attachment.url().strip()
@@ -97,11 +115,15 @@ public final class DefaultInboundMediaEnricher implements InboundMediaEnricher {
       try {
         String text = speechTranscriber.transcribe(Path.of(attachment.url().strip()));
         if (text != null && !text.isBlank()) {
+          metrics.recordInboundAsr(channel, MEDIA_AUDIO, true, "ok");
           return AUDIO_PREFIX + text.strip();
         }
+        metrics.recordInboundAsr(channel, MEDIA_AUDIO, false, "empty");
       } catch (Exception e) {
         LOG.warn("入站语音转写失败: {}", sanitize(e.getMessage()));
         String detail = sanitize(e.getMessage());
+        String reason = isFfmpegRelated(detail) ? "ffmpeg" : "whisper";
+        metrics.recordInboundAsr(channel, MEDIA_AUDIO, false, reason);
         if (isFfmpegRelated(detail)) {
           return AUDIO_PATH + path + AUDIO_FFMPEG + detail;
         }
@@ -109,12 +131,13 @@ public final class DefaultInboundMediaEnricher implements InboundMediaEnricher {
       }
     }
     if (speechTranscriber == null) {
+      metrics.recordInboundAsr(channel, MEDIA_AUDIO, false, "no_asr");
       return AUDIO_PATH + path + AUDIO_NO_ASR;
     }
     return AUDIO_PATH + path;
   }
 
-  private String enrichVideo(InboundAttachment attachment) {
+  private String enrichVideo(InboundAttachment attachment, String channel) {
     StringBuilder sb = new StringBuilder();
     String path =
         attachment.url() != null && !attachment.url().isBlank()
@@ -126,15 +149,31 @@ public final class DefaultInboundMediaEnricher implements InboundMediaEnricher {
         sb.append(FILE_NAME_LINE).append(attachment.fileName().strip());
       }
       sb.append(VIDEO_HINT);
-      if (speechTranscriber != null && !ImageMime.isHttpUrl(attachment.url())) {
+      if (!videoAsrEnabled) {
+        sb.append(VIDEO_ASR_DISABLED);
+        metrics.recordInboundAsr(channel, MEDIA_VIDEO, false, "disabled");
+      } else if (speechTranscriber == null) {
+        sb.append(VIDEO_AUDIO_NO_ASR);
+        metrics.recordInboundAsr(channel, MEDIA_VIDEO, false, "no_asr");
+      } else if (!ImageMime.isHttpUrl(attachment.url())) {
         try {
           String text = speechTranscriber.transcribe(Path.of(attachment.url().strip()));
           if (text != null && !text.isBlank()) {
             sb.append(VIDEO_AUDIO_PREFIX).append(text.strip());
+            metrics.recordInboundAsr(channel, MEDIA_VIDEO, true, "ok");
+          } else {
+            metrics.recordInboundAsr(channel, MEDIA_VIDEO, false, "empty");
           }
         } catch (Exception e) {
           LOG.warn("入站视频音轨转写失败: {}", sanitize(e.getMessage()));
-          sb.append(VIDEO_AUDIO_FAIL).append(sanitize(e.getMessage()));
+          String detail = sanitize(e.getMessage());
+          String reason = isFfmpegRelated(detail) ? "ffmpeg" : "whisper";
+          metrics.recordInboundAsr(channel, MEDIA_VIDEO, false, reason);
+          if (isFfmpegRelated(detail)) {
+            sb.append(VIDEO_AUDIO_FFMPEG).append(detail);
+          } else {
+            sb.append(VIDEO_AUDIO_FAIL).append(detail);
+          }
         }
       }
     } else if (attachment.reference() != null && !attachment.reference().isBlank()) {
@@ -144,6 +183,19 @@ public final class DefaultInboundMediaEnricher implements InboundMediaEnricher {
       }
     }
     return sb.toString();
+  }
+
+  static boolean resolveVideoAsrEnabled() {
+    String raw = System.getenv("ORYXOS_VIDEO_ASR");
+    if (raw == null || raw.isBlank()) {
+      return true;
+    }
+    String v = raw.strip();
+    return !(v.equals("0") || equalsIgnoreAscii(v, "false") || equalsIgnoreAscii(v, "off"));
+  }
+
+  private static boolean equalsIgnoreAscii(String a, String b) {
+    return a.length() == b.length() && a.regionMatches(true, 0, b, 0, b.length());
   }
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaHttp.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaHttp.java
@@ -1,0 +1,107 @@
+package io.oryxos.core.channel;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * 入站媒体 HTTP：默认 {@link HttpClient.Redirect#NEVER}，避免白名单仅验首次 URL 后被 302 打到内网。
+ *
+ * <p>若需跟随重定向，使用 {@link #getFollowingAllowlist}：每跳重验 Location host。
+ */
+public final class InboundMediaHttp {
+
+  private static final int HTTP_STATUS_OK_MIN = 200;
+  private static final int HTTP_STATUS_OK_MAX_EXCLUSIVE = 300;
+  private static final int HTTP_STATUS_REDIRECT_MIN = 300;
+  private static final int HTTP_STATUS_REDIRECT_MAX_EXCLUSIVE = 400;
+  private static final int MAX_REDIRECTS = 5;
+  private static final String HEADER_LOCATION = "Location";
+
+  private InboundMediaHttp() {}
+
+  public static HttpClient newNoRedirectClient(Duration connectTimeout) {
+    return HttpClient.newBuilder()
+        .connectTimeout(connectTimeout == null ? Duration.ofSeconds(60) : connectTimeout)
+        .followRedirects(HttpClient.Redirect.NEVER)
+        .build();
+  }
+
+  /** GET 媒体；不跟随重定向。3xx 直接失败（调用方应改用 {@link #getFollowingAllowlist}）。 */
+  public static HttpResponse<byte[]> getNoRedirect(
+      HttpClient client, URI uri, Duration requestTimeout) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(uri)
+            .timeout(requestTimeout == null ? Duration.ofSeconds(60) : requestTimeout)
+            .GET()
+            .build();
+    HttpResponse<byte[]> response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+    int code = response.statusCode();
+    if (code >= HTTP_STATUS_REDIRECT_MIN && code < HTTP_STATUS_REDIRECT_MAX_EXCLUSIVE) {
+      throw new IllegalStateException("媒体下载收到重定向 HTTP " + code + "（已禁用自动跟随；请使用 allowlist 逐跳校验）");
+    }
+    if (code < HTTP_STATUS_OK_MIN || code >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
+      throw new IllegalStateException("下载临时文件 HTTP " + code);
+    }
+    return response;
+  }
+
+  /** GET 并最多跟随 {@value #MAX_REDIRECTS} 次；每一跳的 URI 须通过 {@code uriAllowed}。 */
+  public static HttpResponse<byte[]> getFollowingAllowlist(
+      HttpClient client, URI start, Duration requestTimeout, Predicate<URI> uriAllowed)
+      throws Exception {
+    if (start == null || uriAllowed == null) {
+      throw new IllegalArgumentException("uri/allowlist 不可空");
+    }
+    URI current = start;
+    Duration timeout = requestTimeout == null ? Duration.ofSeconds(60) : requestTimeout;
+    for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      if (!uriAllowed.test(current)) {
+        throw new IllegalStateException(
+            "拒绝非允许域临时下载地址: " + InboundMediaPaths.sanitizeLog(hostOf(current)));
+      }
+      HttpRequest request = HttpRequest.newBuilder().uri(current).timeout(timeout).GET().build();
+      HttpResponse<byte[]> response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+      int code = response.statusCode();
+      if (code >= HTTP_STATUS_OK_MIN && code < HTTP_STATUS_OK_MAX_EXCLUSIVE) {
+        return response;
+      }
+      if (code >= HTTP_STATUS_REDIRECT_MIN && code < HTTP_STATUS_REDIRECT_MAX_EXCLUSIVE) {
+        Optional<URI> next = resolveRedirect(current, response);
+        if (next.isEmpty()) {
+          throw new IllegalStateException("下载临时文件重定向缺 Location HTTP " + code);
+        }
+        current = next.get();
+        continue;
+      }
+      throw new IllegalStateException("下载临时文件 HTTP " + code);
+    }
+    throw new IllegalStateException("媒体下载重定向超过上限 " + MAX_REDIRECTS);
+  }
+
+  private static Optional<URI> resolveRedirect(URI current, HttpResponse<?> response) {
+    Optional<String> loc =
+        response.headers().firstValue(HEADER_LOCATION).filter(s -> s != null && !s.isBlank());
+    if (loc.isEmpty()) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(current.resolve(loc.get().strip()));
+    } catch (IllegalArgumentException | IllegalStateException e) {
+      return Optional.empty();
+    }
+  }
+
+  private static String hostOf(URI uri) {
+    if (uri == null || uri.getHost() == null) {
+      return "";
+    }
+    return uri.getHost().toLowerCase(Locale.ROOT);
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaJanitor.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaJanitor.java
@@ -1,0 +1,227 @@
+package io.oryxos.core.channel;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 入站媒体根目录 TTL + 总配额清理。环境变量：
+ *
+ * <ul>
+ *   <li>{@code ORYXOS_INBOUND_MEDIA_TTL_HOURS}（默认 24）
+ *   <li>{@code ORYXOS_INBOUND_MEDIA_MAX_MB}（默认 2048；0=不按配额删）
+ * </ul>
+ */
+public final class InboundMediaJanitor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InboundMediaJanitor.class);
+
+  private static final Duration DEFAULT_TTL = Duration.ofHours(24);
+  private static final long DEFAULT_MAX_BYTES = 2048L * 1024 * 1024;
+  private static final long MIN_SWEEP_INTERVAL_MS = 60_000L;
+
+  private final Duration ttl;
+  private final long maxBytes;
+  private final AtomicLong lastSweepMs = new AtomicLong(0L);
+
+  public InboundMediaJanitor() {
+    this(resolveTtl(), resolveMaxBytes());
+  }
+
+  InboundMediaJanitor(Duration ttl, long maxBytes) {
+    this.ttl = ttl == null || ttl.isNegative() || ttl.isZero() ? DEFAULT_TTL : ttl;
+    this.maxBytes = Math.max(0L, maxBytes);
+  }
+
+  public static InboundMediaJanitor fromEnv() {
+    return new InboundMediaJanitor();
+  }
+
+  /** 节流：同一进程内至少间隔 60s；删过期 message 目录，再按 mtime 旧优先削配额。 */
+  public void sweepIfDue(Path mediaRoot) {
+    if (mediaRoot == null || !Files.isDirectory(mediaRoot)) {
+      return;
+    }
+    long now = System.currentTimeMillis();
+    long prev = lastSweepMs.get();
+    if (now - prev < MIN_SWEEP_INTERVAL_MS) {
+      return;
+    }
+    if (!lastSweepMs.compareAndSet(prev, now)) {
+      return;
+    }
+    try {
+      sweep(mediaRoot, Instant.ofEpochMilli(now));
+    } catch (RuntimeException e) {
+      LOG.warn("入站媒体清理失败: {}", InboundMediaPaths.sanitizeLog(e.getMessage()));
+    }
+  }
+
+  void sweep(Path mediaRoot, Instant now) {
+    Instant cutoff = now.minus(ttl);
+    List<DirStat> dirs = new ArrayList<>();
+    try (var stream = Files.list(mediaRoot)) {
+      stream
+          .filter(Files::isDirectory)
+          .forEach(
+              dir -> {
+                try {
+                  DirStat stat = statDir(dir);
+                  if (stat.newestMtime().isBefore(cutoff)) {
+                    deleteRecursively(dir);
+                    LOG.info(
+                        "入站媒体 TTL 清理: {}",
+                        InboundMediaPaths.sanitizeLog(dir.getFileName().toString()));
+                  } else {
+                    dirs.add(stat);
+                  }
+                } catch (IOException e) {
+                  LOG.debug(
+                      "入站媒体目录扫描失败 {}: {}",
+                      InboundMediaPaths.sanitizeLog(String.valueOf(dir.getFileName())),
+                      InboundMediaPaths.sanitizeLog(e.getMessage()));
+                }
+              });
+    } catch (IOException e) {
+      LOG.warn("入站媒体根扫描失败: {}", InboundMediaPaths.sanitizeLog(e.getMessage()));
+      return;
+    }
+    if (maxBytes <= 0) {
+      return;
+    }
+    long total = dirs.stream().mapToLong(DirStat::bytes).sum();
+    if (total <= maxBytes) {
+      return;
+    }
+    dirs.sort(Comparator.comparing(DirStat::newestMtime));
+    for (DirStat stat : dirs) {
+      if (total <= maxBytes) {
+        break;
+      }
+      try {
+        deleteRecursively(stat.path());
+        total -= stat.bytes();
+        LOG.info(
+            "入站媒体配额清理: {} ({} bytes)",
+            InboundMediaPaths.sanitizeLog(stat.path().getFileName().toString()),
+            stat.bytes());
+      } catch (IOException e) {
+        LOG.debug("入站媒体配额删除失败: {}", InboundMediaPaths.sanitizeLog(e.getMessage()));
+      }
+    }
+  }
+
+  /** 写盘前粗检：根已超配额则先 sweep，仍超则抛错。 */
+  public void ensureQuotaOrThrow(Path mediaRoot) throws IOException {
+    if (mediaRoot == null || maxBytes <= 0 || !Files.isDirectory(mediaRoot)) {
+      return;
+    }
+    long total = sizeOf(mediaRoot);
+    if (total <= maxBytes) {
+      return;
+    }
+    sweepIfDue(mediaRoot);
+    total = sizeOf(mediaRoot);
+    if (total > maxBytes) {
+      throw new IOException("入站媒体目录超过配额 " + maxBytes + " 字节（可调 ORYXOS_INBOUND_MEDIA_MAX_MB / TTL）");
+    }
+  }
+
+  private static DirStat statDir(Path dir) throws IOException {
+    AtomicLong bytes = new AtomicLong(0L);
+    AtomicLong newest = new AtomicLong(0L);
+    Files.walkFileTree(
+        dir,
+        new SimpleFileVisitor<>() {
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            bytes.addAndGet(attrs.size());
+            newest.accumulateAndGet(attrs.lastModifiedTime().toMillis(), Math::max);
+            return FileVisitResult.CONTINUE;
+          }
+        });
+    long ms = newest.get();
+    if (ms <= 0L) {
+      ms = Files.getLastModifiedTime(dir).toMillis();
+    }
+    return new DirStat(dir, bytes.get(), Instant.ofEpochMilli(ms));
+  }
+
+  private static long sizeOf(Path root) throws IOException {
+    AtomicLong bytes = new AtomicLong(0L);
+    Files.walkFileTree(
+        root,
+        new SimpleFileVisitor<>() {
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            bytes.addAndGet(attrs.size());
+            return FileVisitResult.CONTINUE;
+          }
+        });
+    return bytes.get();
+  }
+
+  private static void deleteRecursively(Path dir) throws IOException {
+    Files.walkFileTree(
+        dir,
+        new SimpleFileVisitor<>() {
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+              throws IOException {
+            Files.deleteIfExists(file);
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult postVisitDirectory(Path d, IOException exc) throws IOException {
+            Files.deleteIfExists(d);
+            return FileVisitResult.CONTINUE;
+          }
+        });
+  }
+
+  private static Duration resolveTtl() {
+    String raw = System.getenv("ORYXOS_INBOUND_MEDIA_TTL_HOURS");
+    if (raw == null || raw.isBlank()) {
+      return DEFAULT_TTL;
+    }
+    try {
+      long hours = Long.parseLong(raw.strip());
+      if (hours <= 0) {
+        return DEFAULT_TTL;
+      }
+      return Duration.ofHours(hours);
+    } catch (NumberFormatException e) {
+      return DEFAULT_TTL;
+    }
+  }
+
+  private static long resolveMaxBytes() {
+    String raw = System.getenv("ORYXOS_INBOUND_MEDIA_MAX_MB");
+    if (raw == null || raw.isBlank()) {
+      return DEFAULT_MAX_BYTES;
+    }
+    try {
+      long mb = Long.parseLong(raw.strip());
+      if (mb < 0) {
+        return DEFAULT_MAX_BYTES;
+      }
+      return mb * 1024L * 1024L;
+    } catch (NumberFormatException e) {
+      return DEFAULT_MAX_BYTES;
+    }
+  }
+
+  private record DirStat(Path path, long bytes, Instant newestMtime) {}
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaJanitor.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaJanitor.java
@@ -80,16 +80,14 @@ public final class InboundMediaJanitor {
                   DirStat stat = statDir(dir);
                   if (stat.newestMtime().isBefore(cutoff)) {
                     deleteRecursively(dir);
-                    LOG.info(
-                        "入站媒体 TTL 清理: {}",
-                        InboundMediaPaths.sanitizeLog(dir.getFileName().toString()));
+                    LOG.info("入站媒体 TTL 清理: {}", InboundMediaPaths.sanitizeLog(pathLabel(dir)));
                   } else {
                     dirs.add(stat);
                   }
                 } catch (IOException e) {
                   LOG.debug(
                       "入站媒体目录扫描失败 {}: {}",
-                      InboundMediaPaths.sanitizeLog(String.valueOf(dir.getFileName())),
+                      InboundMediaPaths.sanitizeLog(pathLabel(dir)),
                       InboundMediaPaths.sanitizeLog(e.getMessage()));
                 }
               });
@@ -114,12 +112,20 @@ public final class InboundMediaJanitor {
         total -= stat.bytes();
         LOG.info(
             "入站媒体配额清理: {} ({} bytes)",
-            InboundMediaPaths.sanitizeLog(stat.path().getFileName().toString()),
+            InboundMediaPaths.sanitizeLog(pathLabel(stat.path())),
             stat.bytes());
       } catch (IOException e) {
         LOG.debug("入站媒体配额删除失败: {}", InboundMediaPaths.sanitizeLog(e.getMessage()));
       }
     }
+  }
+
+  private static String pathLabel(Path path) {
+    if (path == null) {
+      return "";
+    }
+    Path name = path.getFileName();
+    return name == null ? path.toString() : name.toString();
   }
 
   /** 写盘前粗检：根已超配额则先 sweep，仍超则抛错。 */

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaLimits.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaLimits.java
@@ -1,0 +1,19 @@
+package io.oryxos.core.channel;
+
+/** 入站媒体大小与嗅探常量（三渠 Resolver / Whisper 共用）。 */
+public final class InboundMediaLimits {
+
+  /** 单文件下载上限（字节）。 */
+  public static final long MAX_FILE_BYTES = 50L * 1024 * 1024;
+
+  /** 魔数嗅探读取上限（避免整文件进内存）。 */
+  public static final int HEADER_SNIFF_BYTES = 64;
+
+  /** Whisper 上传 wav/音频上限（抽轨后）。 */
+  public static final long MAX_ASR_UPLOAD_BYTES = 25L * 1024 * 1024;
+
+  /** 视频抽轨最长秒数（ffmpeg -t）。 */
+  public static final int MAX_VIDEO_ASR_SECONDS = 120;
+
+  private InboundMediaLimits() {}
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaPaths.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaPaths.java
@@ -1,0 +1,31 @@
+package io.oryxos.core.channel;
+
+/** 入站媒体路径段清理（messageId / fileKey 等）。 */
+public final class InboundMediaPaths {
+
+  private static final String FALLBACK_SEGMENT = "x";
+  private static final char PATH_SAFE_REPLACEMENT = '_';
+  private static final int MAX_SEGMENT_LEN = 96;
+
+  private InboundMediaPaths() {}
+
+  public static String safeSegment(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return FALLBACK_SEGMENT;
+    }
+    String cleaned = raw.replaceAll("[^a-zA-Z0-9._-]", String.valueOf(PATH_SAFE_REPLACEMENT));
+    if (cleaned.length() > MAX_SEGMENT_LEN) {
+      cleaned = cleaned.substring(0, MAX_SEGMENT_LEN);
+    }
+    if (cleaned.isBlank() || cleaned.chars().allMatch(ch -> ch == PATH_SAFE_REPLACEMENT)) {
+      return FALLBACK_SEGMENT;
+    }
+    return cleaned;
+  }
+
+  public static String sanitizeLog(String value) {
+    return value == null
+        ? ""
+        : value.replace('\r', PATH_SAFE_REPLACEMENT).replace('\n', PATH_SAFE_REPLACEMENT);
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaRoots.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaRoots.java
@@ -55,6 +55,7 @@ public final class InboundMediaRoots {
   }
 
   private static String sanitize(String value) {
-    return InboundMediaPaths.sanitizeLog(value);
+    // 内联替换：SpotBugs CRLF_INJECTION_LOGS 需在本类内可见的 \r/\n 清洗
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
   }
 }

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaRoots.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaRoots.java
@@ -15,7 +15,6 @@ public final class InboundMediaRoots {
   private static final Logger LOG = LoggerFactory.getLogger(InboundMediaRoots.class);
   private static final String INBOUND_MEDIA = "inbound-media";
   private static final String FALLBACK_TEMP_PREFIX = "oryxos-inbound-media-";
-  private static final int MAX_SEGMENT_LEN = 96;
 
   private InboundMediaRoots() {}
 
@@ -52,17 +51,10 @@ public final class InboundMediaRoots {
   }
 
   static String safeSegment(String raw) {
-    if (raw == null || raw.isBlank()) {
-      return "x";
-    }
-    String cleaned = raw.replaceAll("[^a-zA-Z0-9._-]", "_");
-    if (cleaned.length() > MAX_SEGMENT_LEN) {
-      cleaned = cleaned.substring(0, MAX_SEGMENT_LEN);
-    }
-    return cleaned.isBlank() ? "x" : cleaned;
+    return InboundMediaPaths.safeSegment(raw);
   }
 
   private static String sanitize(String value) {
-    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+    return InboundMediaPaths.sanitizeLog(value);
   }
 }

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/LimitedMediaWriter.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/LimitedMediaWriter.java
@@ -1,0 +1,72 @@
+package io.oryxos.core.channel;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** 流式写盘并强制字节上限：超限删目标并抛错，避免「整包进内存再判」与「先写再删」不一致。 */
+public final class LimitedMediaWriter {
+
+  private LimitedMediaWriter() {}
+
+  /**
+   * 将 {@code in} 写入 {@code target}，最多 {@code maxBytes} 字节。
+   *
+   * @throws IOException 超限或 IO 失败（超限时尽力删除 target）
+   */
+  public static long copyLimited(InputStream in, Path target, long maxBytes) throws IOException {
+    if (in == null) {
+      throw new IOException("输入流为空");
+    }
+    if (maxBytes <= 0) {
+      throw new IOException("入站文件上限无效");
+    }
+    long written = 0L;
+    byte[] buf = new byte[8192];
+    try (OutputStream out = Files.newOutputStream(target)) {
+      int n;
+      while ((n = in.read(buf)) >= 0) {
+        if (n == 0) {
+          continue;
+        }
+        written += n;
+        if (written > maxBytes) {
+          throw new IOException("入站文件超过上限 " + maxBytes + " 字节");
+        }
+        out.write(buf, 0, n);
+      }
+    } catch (IOException e) {
+      deleteQuietly(target);
+      throw e;
+    }
+    if (written == 0) {
+      deleteQuietly(target);
+      throw new IOException("下载临时文件为空");
+    }
+    return written;
+  }
+
+  /** 整包字节写盘（调用方已限长时用）。 */
+  public static void writeLimited(byte[] bytes, Path target, long maxBytes) throws IOException {
+    if (bytes == null || bytes.length == 0) {
+      throw new IOException("下载临时文件为空");
+    }
+    if (bytes.length > maxBytes) {
+      throw new IOException("入站文件超过上限 " + maxBytes + " 字节");
+    }
+    Files.write(target, bytes);
+  }
+
+  private static void deleteQuietly(Path path) {
+    if (path == null) {
+      return;
+    }
+    try {
+      Files.deleteIfExists(path);
+    } catch (IOException ignored) {
+      // best-effort
+    }
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/PlaceholderProgressStream.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/PlaceholderProgressStream.java
@@ -1,10 +1,15 @@
 package io.oryxos.core.channel;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * 无原地 PATCH 的 IM 进度流：占位 → 至多一条工具行 → 终态（企微/钉钉）。
+ * 无原地 PATCH 的 IM 进度流：占位 → 可选长 TTFT 心跳 → 至多一条工具行 → 终态（企微/钉钉）。
  *
  * <p>出站由 {@link ReplyFn} 完成，渠道侧只提供 sender 绑定。
  */
@@ -14,6 +19,11 @@ public final class PlaceholderProgressStream implements InboundProgressStream {
 
   public static final String DEFAULT_THINKING = "⏳ 正在思考…";
   public static final String DEFAULT_FAILED = "抱歉，这次处理失败了，请稍后重试或联系管理员。";
+  public static final String DEFAULT_STOPPED = "⛔ 已停止";
+  public static final String DEFAULT_HEARTBEAT = "⏳ 仍在处理…";
+
+  /** 首 token / 工具 / 终态前多久发心跳；0=关闭。可用 {@code ORYXOS_IM_PROGRESS_HEARTBEAT_MS}。 */
+  private static final long DEFAULT_HEARTBEAT_MS = 25_000L;
 
   /** 发送一条回复；失败应抛运行时异常。 */
   @FunctionalInterface
@@ -26,13 +36,28 @@ public final class PlaceholderProgressStream implements InboundProgressStream {
   private final String replyToMessageId;
   private final String thinkingReply;
   private final String failedReply;
+  private final String stoppedReply;
+  private final String heartbeatReply;
   private final String logLabel;
-  private boolean finished;
-  private boolean toolNotified;
+  private final long heartbeatMs;
+  private final AtomicBoolean finished = new AtomicBoolean(false);
+  private volatile boolean toolNotified;
+  private volatile boolean heartbeatSent;
+  private ScheduledExecutorService heartbeatScheduler;
+  private ScheduledFuture<?> heartbeatFuture;
 
   public PlaceholderProgressStream(
       ReplyFn replyFn, String chatId, String replyToMessageId, String logLabel) {
-    this(replyFn, chatId, replyToMessageId, DEFAULT_THINKING, DEFAULT_FAILED, logLabel);
+    this(
+        replyFn,
+        chatId,
+        replyToMessageId,
+        DEFAULT_THINKING,
+        DEFAULT_FAILED,
+        DEFAULT_STOPPED,
+        DEFAULT_HEARTBEAT,
+        resolveHeartbeatMs(),
+        logLabel);
   }
 
   public PlaceholderProgressStream(
@@ -42,29 +67,56 @@ public final class PlaceholderProgressStream implements InboundProgressStream {
       String thinkingReply,
       String failedReply,
       String logLabel) {
+    this(
+        replyFn,
+        chatId,
+        replyToMessageId,
+        thinkingReply,
+        failedReply,
+        DEFAULT_STOPPED,
+        DEFAULT_HEARTBEAT,
+        resolveHeartbeatMs(),
+        logLabel);
+  }
+
+  PlaceholderProgressStream(
+      ReplyFn replyFn,
+      String chatId,
+      String replyToMessageId,
+      String thinkingReply,
+      String failedReply,
+      String stoppedReply,
+      String heartbeatReply,
+      long heartbeatMs,
+      String logLabel) {
     this.replyFn = replyFn;
     this.chatId = chatId;
     this.replyToMessageId = replyToMessageId;
     this.thinkingReply = thinkingReply == null ? DEFAULT_THINKING : thinkingReply;
     this.failedReply = failedReply == null ? DEFAULT_FAILED : failedReply;
+    this.stoppedReply = stoppedReply == null ? DEFAULT_STOPPED : stoppedReply;
+    this.heartbeatReply = heartbeatReply == null ? DEFAULT_HEARTBEAT : heartbeatReply;
+    this.heartbeatMs = Math.max(0L, heartbeatMs);
     this.logLabel = logLabel == null ? "IM" : logLabel;
   }
 
   @Override
   public void start() {
     replyFn.send(chatId, thinkingReply, replyToMessageId);
+    scheduleHeartbeat();
   }
 
   @Override
   public void onToken(String delta) {
-    // 无原地更新；忽略增量
+    cancelHeartbeat();
   }
 
   @Override
   public void onToolStart(String toolName) {
-    if (finished || toolNotified) {
+    if (finished.get() || toolNotified) {
       return;
     }
+    cancelHeartbeat();
     toolNotified = true;
     replyFn.send(chatId, "🔧 正在执行 `" + safeName(toolName) + "` …", replyToMessageId);
   }
@@ -76,27 +128,94 @@ public final class PlaceholderProgressStream implements InboundProgressStream {
 
   @Override
   public void finish(String finalText) {
-    if (finished) {
+    if (!finished.compareAndSet(false, true)) {
       return;
     }
-    finished = true;
+    cancelHeartbeat();
     String body = finalText == null || finalText.isBlank() ? "（空回复）" : finalText;
     replyFn.send(chatId, body, replyToMessageId);
   }
 
   @Override
   public void fail(String errorMessage) {
-    if (finished) {
+    if (!finished.compareAndSet(false, true)) {
       return;
     }
-    finished = true;
-    String body =
-        errorMessage == null || errorMessage.isBlank() ? failedReply : errorMessage.strip();
+    cancelHeartbeat();
+    String body = resolveFailBody(errorMessage);
     try {
       replyFn.send(chatId, body, replyToMessageId);
     } catch (RuntimeException e) {
       LOG.warn("{}进度流失败态发送失败: {}", sanitize(logLabel), sanitize(e.getMessage()));
       throw e;
+    }
+  }
+
+  private String resolveFailBody(String errorMessage) {
+    if (errorMessage == null || errorMessage.isBlank()) {
+      return failedReply;
+    }
+    String stripped = errorMessage.strip();
+    if (looksLikeStopped(stripped)) {
+      return stoppedReply;
+    }
+    return stripped;
+  }
+
+  private static boolean looksLikeStopped(String msg) {
+    return msg.contains("已停止") || msg.contains("已取消") || msg.contains("中断");
+  }
+
+  private void scheduleHeartbeat() {
+    if (heartbeatMs <= 0L) {
+      return;
+    }
+    heartbeatScheduler =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              Thread t = new Thread(r, "oryxos-im-progress-hb");
+              t.setDaemon(true);
+              return t;
+            });
+    heartbeatFuture =
+        heartbeatScheduler.schedule(
+            () -> {
+              if (finished.get() || toolNotified || heartbeatSent) {
+                return;
+              }
+              heartbeatSent = true;
+              try {
+                replyFn.send(chatId, heartbeatReply, replyToMessageId);
+              } catch (RuntimeException e) {
+                LOG.debug("{}进度心跳发送失败: {}", sanitize(logLabel), sanitize(e.getMessage()));
+              }
+            },
+            heartbeatMs,
+            TimeUnit.MILLISECONDS);
+  }
+
+  private void cancelHeartbeat() {
+    ScheduledFuture<?> f = heartbeatFuture;
+    if (f != null) {
+      f.cancel(false);
+    }
+    ScheduledExecutorService s = heartbeatScheduler;
+    if (s != null) {
+      s.shutdownNow();
+    }
+    heartbeatFuture = null;
+    heartbeatScheduler = null;
+  }
+
+  private static long resolveHeartbeatMs() {
+    String raw = System.getenv("ORYXOS_IM_PROGRESS_HEARTBEAT_MS");
+    if (raw == null || raw.isBlank()) {
+      return DEFAULT_HEARTBEAT_MS;
+    }
+    try {
+      return Long.parseLong(raw.strip());
+    } catch (NumberFormatException e) {
+      return DEFAULT_HEARTBEAT_MS;
     }
   }
 

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/PlaceholderProgressStream.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/PlaceholderProgressStream.java
@@ -1,8 +1,8 @@
 package io.oryxos.core.channel;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
@@ -170,13 +170,16 @@ public final class PlaceholderProgressStream implements InboundProgressStream {
     if (heartbeatMs <= 0L) {
       return;
     }
-    heartbeatScheduler =
-        Executors.newSingleThreadScheduledExecutor(
+    ScheduledThreadPoolExecutor pool =
+        new ScheduledThreadPoolExecutor(
+            1,
             r -> {
               Thread t = new Thread(r, "oryxos-im-progress-hb");
               t.setDaemon(true);
               return t;
             });
+    pool.setRemoveOnCancelPolicy(true);
+    heartbeatScheduler = pool;
     heartbeatFuture =
         heartbeatScheduler.schedule(
             () -> {

--- a/oryxos-core/src/main/java/io/oryxos/core/metrics/MetricsRecorder.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/metrics/MetricsRecorder.java
@@ -28,4 +28,22 @@ public interface MetricsRecorder {
 
   /** 一次 fallback 切换（from → to）。 */
   default void recordFallbackSwitch(String from, String to) {}
+
+  /**
+   * 入站 ASR（语音/视频音轨）一次尝试。
+   *
+   * @param channel 渠道类型（feishu/wecom/dingtalk）
+   * @param mediaType audio / video
+   * @param success 是否得到非空转写
+   * @param reason ok / empty / ffmpeg / whisper / no_asr / disabled / host_denied / oversized …
+   */
+  default void recordInboundAsr(String channel, String mediaType, boolean success, String reason) {}
+
+  /**
+   * 入站媒体下载一次。
+   *
+   * @param reason ok / http / host_denied / oversized / decrypt / timeout / other
+   */
+  default void recordInboundMediaDownload(
+      String channel, String mediaType, boolean success, String reason) {}
 }

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMediaHttpTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMediaHttpTest.java
@@ -1,0 +1,115 @@
+package io.oryxos.core.channel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class InboundMediaHttpTest {
+
+  private HttpServer server;
+  private String base;
+
+  @BeforeEach
+  void start() throws IOException {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    AtomicInteger hits = new AtomicInteger();
+    server.createContext(
+        "/ok",
+        ex -> {
+          hits.incrementAndGet();
+          byte[] body = "IMG".getBytes(StandardCharsets.UTF_8);
+          ex.sendResponseHeaders(200, body.length);
+          try (OutputStream out = ex.getResponseBody()) {
+            out.write(body);
+          }
+        });
+    server.createContext(
+        "/redir",
+        ex -> {
+          hits.incrementAndGet();
+          ex.getResponseHeaders().add("Location", base + "/ok");
+          ex.sendResponseHeaders(302, -1);
+          ex.close();
+        });
+    server.createContext(
+        "/evil-redir",
+        ex -> {
+          ex.getResponseHeaders().add("Location", "http://127.0.0.1:9/internal");
+          ex.sendResponseHeaders(302, -1);
+          ex.close();
+        });
+    server.start();
+    base = "http://127.0.0.1:" + server.getAddress().getPort();
+  }
+
+  @AfterEach
+  void stop() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  @DisplayName("NEVER 客户端遇 302 不自动跟随")
+  void noRedirectClientRejects302() {
+    HttpClient client = InboundMediaHttp.newNoRedirectClient(Duration.ofSeconds(5));
+    Exception ex =
+        assertThrows(
+            Exception.class,
+            () ->
+                InboundMediaHttp.getNoRedirect(
+                    client, URI.create(base + "/redir"), Duration.ofSeconds(5)));
+    assertTrue(ex.getMessage().contains("重定向") || ex.getMessage().contains("302"));
+  }
+
+  @Test
+  @DisplayName("allowlist 逐跳跟随同主机 302")
+  void followAllowlistSameHost() throws Exception {
+    HttpClient client = InboundMediaHttp.newNoRedirectClient(Duration.ofSeconds(5));
+    HttpResponse<byte[]> resp =
+        InboundMediaHttp.getFollowingAllowlist(
+            client,
+            URI.create(base + "/redir"),
+            Duration.ofSeconds(5),
+            uri -> "127.0.0.1".equals(uri.getHost()));
+    assertEquals(200, resp.statusCode());
+    assertEquals("IMG", new String(resp.body(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  @DisplayName("重定向到非白名单 host 拒绝")
+  void followDenyOffAllowlist() {
+    HttpClient client = InboundMediaHttp.newNoRedirectClient(Duration.ofSeconds(5));
+    int port = server.getAddress().getPort();
+    Exception ex =
+        assertThrows(
+            Exception.class,
+            () ->
+                InboundMediaHttp.getFollowingAllowlist(
+                    client,
+                    URI.create(base + "/evil-redir"),
+                    Duration.ofSeconds(5),
+                    uri ->
+                        "127.0.0.1".equals(uri.getHost())
+                            && uri.getPort() == port
+                            && uri.getPath() != null
+                            && (uri.getPath().equals("/evil-redir")
+                                || uri.getPath().equals("/ok"))));
+    assertTrue(ex.getMessage().contains("拒绝") || ex.getMessage().contains("非允许"));
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMediaJanitorTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/InboundMediaJanitorTest.java
@@ -1,0 +1,48 @@
+package io.oryxos.core.channel;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class InboundMediaJanitorTest {
+
+  @TempDir Path root;
+
+  @Test
+  @DisplayName("TTL 过期目录被删")
+  void sweepsExpired() throws Exception {
+    Path oldDir = root.resolve("old-msg");
+    Files.createDirectories(oldDir);
+    Files.writeString(oldDir.resolve("a.bin"), "x");
+    Files.setLastModifiedTime(
+        oldDir.resolve("a.bin"),
+        java.nio.file.attribute.FileTime.from(Instant.now().minus(Duration.ofHours(48))));
+    Files.setLastModifiedTime(
+        oldDir, java.nio.file.attribute.FileTime.from(Instant.now().minus(Duration.ofHours(48))));
+
+    InboundMediaJanitor janitor = new InboundMediaJanitor(Duration.ofHours(24), 0L);
+    janitor.sweep(root, Instant.now());
+    assertFalse(Files.exists(oldDir));
+  }
+
+  @Test
+  @DisplayName("超限 copyLimited 删除目标")
+  void copyLimitedEnforcesMax() throws IOException {
+    Path target = root.resolve("big.bin");
+    byte[] data = "0123456789".getBytes(StandardCharsets.UTF_8);
+    assertThrows(
+        IOException.class,
+        () -> LimitedMediaWriter.copyLimited(new ByteArrayInputStream(data), target, 5));
+    assertFalse(Files.exists(target));
+  }
+}

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/PlaceholderProgressStreamTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/PlaceholderProgressStreamTest.java
@@ -1,0 +1,45 @@
+package io.oryxos.core.channel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PlaceholderProgressStreamTest {
+
+  @Test
+  @DisplayName("fail 含已停止 → 专用停止文案")
+  void failStoppedUsesStoppedReply() {
+    List<String> sent = new ArrayList<>();
+    PlaceholderProgressStream stream =
+        new PlaceholderProgressStream(
+            (chat, text, replyTo) -> sent.add(text),
+            "c1",
+            "m1",
+            PlaceholderProgressStream.DEFAULT_THINKING,
+            PlaceholderProgressStream.DEFAULT_FAILED,
+            PlaceholderProgressStream.DEFAULT_STOPPED,
+            PlaceholderProgressStream.DEFAULT_HEARTBEAT,
+            0L,
+            "测");
+    stream.start();
+    stream.fail("任务已停止");
+    assertEquals(2, sent.size());
+    assertEquals(PlaceholderProgressStream.DEFAULT_THINKING, sent.get(0));
+    assertEquals(PlaceholderProgressStream.DEFAULT_STOPPED, sent.get(1));
+  }
+
+  @Test
+  @DisplayName("finish 发出终态正文")
+  void finishSendsBody() {
+    List<String> sent = new ArrayList<>();
+    PlaceholderProgressStream stream =
+        new PlaceholderProgressStream((chat, text, replyTo) -> sent.add(text), "c1", null, "测");
+    stream.start();
+    stream.finish("答案");
+    assertTrue(sent.contains("答案"));
+  }
+}


### PR DESCRIPTION
## Summary
- Harden post-#415 inbound media: Whisper header-only sniff + video `-vn` extract; WeCom/DingTalk download never auto-follows redirects (allowlist per hop); `inbound-media` TTL/quota janitor; shared limits/paths/limited writer for resolvers.
- Progress UX for WeCom/DingTalk: stopped/fail copy + optional TTFT heartbeat; WeCom empty ASR explicit prompt or audio URL Whisper fallback; `ORYXOS_VIDEO_ASR` switch; ASR metrics; channel setup docs aligned.

## Test plan
- [ ] `mvn -pl oryxos-core,oryxos-cli,oryxos-channel-wecom,oryxos-channel-dingtalk,oryxos-channel-feishu -am test -Dtest=InboundMediaHttpTest,InboundMediaJanitorTest,PlaceholderProgressStreamTest,WhisperHttpTranscriberTest,FfmpegAudioConverterTest,WeComEventNormalizerTest,WeComInboundImageResolverTest,DingTalkInboundImageResolverTest,FeishuInboundImageResolverTest -Dsurefire.failIfNoSpecifiedTests=false`
- [ ] SpotBugs/PMD/OWASP CI green on PR
- [ ] Manual: WeCom/DingTalk media URL that 302s off-allowlist is rejected; Feishu silk + video ASR still works with ffmpeg
- [ ] Confirm `ORYXOS_INBOUND_MEDIA_TTL_HOURS` / `ORYXOS_VIDEO_ASR=0` / `ORYXOS_IM_PROGRESS_HEARTBEAT_MS=0` behave as documented

Made with [Cursor](https://cursor.com)