### PR TITLE
fix(channel-feishu): bound WS client close so shutdown no longer stalls ~32s

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ OryxOS 启动后在当前目录创建 `.oryxos/` 工作区：
 - 全部状态在 `/data` 卷（`config/` + 工作区 + `oryxos.db` + `logs/`）；`ORYXOS_ROOT=/data/.oryxos` 走环境变量原生支持。镜像非 root（uid 1000）+ 内置 healthcheck（`/api/v1/health`）。
 - 流水线：`ci.yml` 的 `docker-build` job 做 PR 门禁（只构建不推送）；`release.yml` 在 tar.gz Release 之后 buildx 推 `ghcr.io/oryx-labs/oryxos:v<版本>` + `:latest` 到 GHCR（需 `packages: write`，已加）。
 - 本地构建：`make docker`（依赖 `make build` 的胖 jar）。改 Dockerfile/entrypoint/.dockerignore 时，`docker-build` 门禁会自动验证。
-- 停机行为（2026-08 实测）：SIGTERM 能被处理，但某第三方渠道客户端（长连接 WS）的 Lifecycle stop 不回调，Spring 等 30s latch 超时后才完成关闭——**总耗时 ~32s，exit 143**。compose 已配 `stop_grace_period: 40s` 兜住；裸 `docker stop`（默认 10s）会 SIGKILL，SQLite WAL 保证数据安全。tar.gz 路径同病：`bin/stop.sh` 等 10s 后 kill -9。根治需修那个 bean 的 stop 回调（或给它配 lifecycleProcessor 超时），属上游依赖问题。
+- 停机行为：曾实测（2026-08）SIGTERM 能被处理，但飞书 SDK `ws.Client.close()` 存在阻塞不返回的实现路径，把停机拖满 ~32s（exit 143）。现 `FeishuChannelAdapter.closeQuietly` 将 close 放守护线程限时 join（2s 超时放弃等待），stop 不再阻塞 `ChannelAdminService.stopAll` 与进程停机链路；`spring.lifecycle.timeout-per-shutdown-phase: 10s` 另兜 SmartLifecycle 阶段（注意 destroy-method 回调不受其约束，长连接类资源须各自限时关闭）。compose 的 `stop_grace_period: 40s` 保留作余量；裸 `docker stop`（默认 10s）与 `bin/stop.sh`（等 10s kill -9）在限时关闭下均不再踩超时。
 
 ---
 

--- a/oryxos-boot/src/main/resources/application.yml
+++ b/oryxos-boot/src/main/resources/application.yml
@@ -34,6 +34,11 @@ spring:
     locations: classpath:db/migration/{vendor}
     baseline-on-migrate: true
     baseline-version: 0
+  lifecycle:
+    # SmartLifecycle 停机阶段限时（默认 30s）：个别阶段卡住（如 executor「运行中任务数」不归零，
+    # #332 同类）时最多等 10s 就继续。注：destroy-method 回调不受此约束，长连接类资源须各自限时关闭
+    # （飞书渠道 WS close 限时见 FeishuChannelAdapter.closeQuietly）。
+    timeout-per-shutdown-phase: 10s
 
 server:
   port: 8080

--- a/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
+++ b/oryxos-channel-feishu/src/main/java/io/oryxos/channel/feishu/FeishuChannelAdapter.java
@@ -53,6 +53,12 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
   private static final long READY_PROBE_TIMEOUT_MS = 50;
 
   /**
+   * WS 关闭限时。SDK {@code ws.Client.close()} 存在不返回的实现路径（2026-08 容器停机实测：SIGTERM 后被它拖满 ~30s 才完成关闭，裸
+   * {@code docker stop} 直接 SIGKILL），关闭动作放守护线程限时 join，超时放弃等待、停机链路继续。
+   */
+  private static final long WS_CLOSE_TIMEOUT_MS = 2_000;
+
+  /**
    * 入站图片下载超时。SDK {@code requestTimeout} 只设置 OkHttp {@code callTimeout}，仍保留默认 {@code
    * readTimeout=10s}，慢网/大图会在读 body 时 {@code client time out}。须自定义 transport 同时拉长 read/call。
    */
@@ -168,6 +174,7 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
     }
   }
 
+  /** 停止：断开长连接（限时，见 {@link #closeQuietly}）并置位。SDK close 阻塞不再拖死 stopAll/进程停机。 */
   @Override
   public synchronized void stop() {
     com.lark.oapi.ws.Client ws = wsClient;
@@ -178,12 +185,36 @@ public class FeishuChannelAdapter implements InboundChannelAdapter {
     state = ChannelStatus.State.DISCONNECTED;
   }
 
-  /** 关闭 WS 客户端，异常仅告警不上抛——断开路径的异常不影响调用方语义。 */
+  /**
+   * 关闭 WS 客户端：异常仅告警不上抛（断开路径的异常不影响调用方语义），且限时等待——SDK {@code close()} 阻塞时放弃等待、守护线程后台继续，{@code stop()}
+   * 不拖死 ChannelAdminService.stopAll 与进程停机链路。
+   */
   private void closeQuietly(com.lark.oapi.ws.Client ws) {
+    // 平台守护线程而非虚拟线程：SDK close 内部有 synchronized 路径（Client.disconnect），虚拟线程在此 pin 住 carrier
+    Thread closer =
+        Thread.ofPlatform()
+            .daemon(true) // 守护：被放弃的 close 不得阻止 JVM 退出
+            .name("oryxos-feishu-ws-close")
+            .unstarted(
+                () -> {
+                  try {
+                    ws.close();
+                  } catch (RuntimeException e) {
+                    LOG.warn(
+                        "飞书渠道 {} 断开时异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
+                  }
+                });
+    closer.start();
     try {
-      ws.close();
-    } catch (RuntimeException e) {
-      LOG.warn("飞书渠道 {} 断开时异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
+      closer.join(WS_CLOSE_TIMEOUT_MS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    if (closer.isAlive()) {
+      LOG.warn(
+          "飞书渠道 {} WS close {}ms 未返回，放弃等待（SDK close 阻塞，守护线程后台继续）",
+          sanitize(config.name()),
+          WS_CLOSE_TIMEOUT_MS);
     }
   }
 

--- a/oryxos-channel-feishu/src/test/java/io/oryxos/channel/feishu/FeishuChannelAdapterStopTest.java
+++ b/oryxos-channel-feishu/src/test/java/io/oryxos/channel/feishu/FeishuChannelAdapterStopTest.java
@@ -1,0 +1,108 @@
+package io.oryxos.channel.feishu;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.lark.oapi.ws.Client;
+import io.oryxos.core.channel.ChannelConfig;
+import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.InboundMessageService;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 2026-08 容器停机实录回归：SDK {@code ws.Client.close()} 存在不返回的实现路径，SIGTERM 后被它拖满 ~30s 才完成关闭。 closeQuietly
+ * 必须限时——close 阻塞时 {@code stop()} 快速返回、断开动作留在守护线程，停机链路与 ChannelAdminService.stopAll 不被拖死。
+ */
+class FeishuChannelAdapterStopTest {
+
+  private static final long STOP_DEADLINE_MS = 5_000;
+
+  private FeishuChannelAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    ChannelConfig config =
+        new ChannelConfig("feishu-test", "feishu", "cli_a", "sec", "demo-agent", true);
+    adapter =
+        new FeishuChannelAdapter(
+            config,
+            mock(ProfileRegistry.class),
+            mock(InboundMessageService.class),
+            mock(OutboundGuard.class));
+  }
+
+  @Test
+  @DisplayName("SDK close 阻塞不返回时 stop() 限时返回，断开留在守护线程")
+  void stopReturnsPromptlyWhenWsCloseBlocks() throws Exception {
+    Client ws = mock(Client.class);
+    CountDownLatch entered = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    doAnswer(
+            invocation -> {
+              entered.countDown();
+              try {
+                release.await();
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              return null;
+            })
+        .when(ws)
+        .close();
+    setWsClient(ws);
+
+    long start = System.nanoTime();
+    adapter.stop();
+    long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+    assertTrue(
+        elapsedMs < STOP_DEADLINE_MS, () -> "stop() 不应等待阻塞的 SDK close，实际耗时 " + elapsedMs + "ms");
+
+    assertTrue(entered.await(STOP_DEADLINE_MS, TimeUnit.MILLISECONDS), "close 应已在守护线程被调起");
+    verify(ws).close();
+    release.countDown();
+
+    assertEquals(
+        ChannelStatus.State.DISCONNECTED, adapter.status().state(), "关闭后渠道状态应为 DISCONNECTED");
+  }
+
+  @Test
+  @DisplayName("SDK close 抛异常不破坏 stop 语义（仅告警），渠道仍置为 DISCONNECTED")
+  void closeThrowingStillStopsChannel() {
+    Client ws = mock(Client.class);
+    doThrow(new RuntimeException("boom")).when(ws).close();
+    setWsClient(ws);
+
+    adapter.stop();
+
+    assertEquals(ChannelStatus.State.DISCONNECTED, adapter.status().state());
+    verify(ws).close();
+  }
+
+  @Test
+  @DisplayName("未启动（无 ws 客户端）时 stop 安全无副作用")
+  void stopWithoutStartIsSafe() {
+    adapter.stop();
+    assertEquals(ChannelStatus.State.DISCONNECTED, adapter.status().state());
+  }
+
+  private void setWsClient(Client ws) {
+    try {
+      Field field = FeishuChannelAdapter.class.getDeclaredField("wsClient");
+      field.setAccessible(true);
+      field.set(adapter, ws);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("注入 wsClient 失败", e);
+    }
+  }
+}


### PR DESCRIPTION
## 动机

CLAUDE.md「停机行为（2026-08 实测）」记录的遗留问题：SIGTERM 能被处理，但飞书 SDK
`com.lark.oapi.ws.Client.close()` 存在阻塞不返回的实现路径，`FeishuChannelAdapter.stop()`
同步等待它，把 `ChannelAdminService.stopAll`（destroyMethod 回调）与整个进程停机拖满
~32s（exit 143）。后果：

- 裸 `docker stop`（默认 10s）必然 SIGKILL，全靠 SQLite WAL 兜数据安全；
- `bin/stop.sh` 等 10s 后 kill -9，同病；
- 管理台「停用/更新渠道」（走 `stopOne`）同样被 SDK close 卡住。

原文判定「属上游依赖问题」，但停机链路不必等 SDK：close 放守护线程限时等待即可——
超时放弃、后台继续，对调用方语义不变。

## 改动（2 生产文件 + 1 测试文件 + 1 文档，+149/-5）

- `FeishuChannelAdapter.closeQuietly`：close 动作放**平台守护线程**
  （`Thread.ofPlatform().daemon(true)`；不用虚拟线程——SDK close 内部有 synchronized
  路径会 pin carrier；工厂写法同时过 PMD AvoidManuallyCreateThreadRule），限时 join 2s，
  超时 WARN 放弃等待、close 留在后台。`start()` 失败路径的幽灵连接 close 同款受益。
- `oryxos-boot/application.yml`：加 `spring.lifecycle.timeout-per-shutdown-phase: 10s`
  （默认 30s），兜 SmartLifecycle 阶段卡住（#332 同类 executor latch）。注意
  destroy-method 回调不受此配置约束——bounded close 是主修复，此配置只是第二层。
  `application.yml.example` 按其「框架内部管道不重复」原则未动（jar 内置默认即生效）。
- `CLAUDE.md`：「停机行为」段从「未修复/上游依赖问题」改写为已修口径。

## 测试（3 新用例，`FeishuChannelAdapterStopTest`）

- `stopReturnsPromptlyWhenWsCloseBlocks`：mock SDK close 阻塞（latch）→ `stop()` 在
  2s 限时处返回（断言 <5s），close 确已在守护线程调起，渠道置 DISCONNECTED；
- `closeThrowingStillStopsChannel`：close 抛异常仅告警、stop 语义不变（保留原
  closeQuietly 行为）；
- `stopWithoutStartIsSafe`：未启动（无 ws 客户端）时 stop 安全。

## 本地验证（Windows）

- `oryxos-channel-feishu`：40 run / 0 failure / 0 error（含 3 新用例）；
- spotless / checkstyle / PMD / SpotBugs 门禁全过（PMD 曾抓
  AvoidManuallyCreateThread，已改 Thread.ofPlatform 工厂写法）；
- `oryxos-core` 存在一个 Windows 预存失败 `MasterKeyResolverTest`（POSIX 0600 →
  UnsupportedOperation，016 验收报告已记录的遗留项），与本 PR 无关（本 PR 未触碰
  core），Linux CI 不受影响；
- 真机容器 SIGTERM 走查待评审环境补充（本机 Windows 无 docker 停机场景），欢迎指出
  需要追加的验证项。
