### PR TITLE
feat(agent/tool): IM web_search defaults + Instant Answer HTML fallback

### DIFF
--- a/docs/DingTalkChannelSetup.md
+++ b/docs/DingTalkChannelSetup.md
@@ -52,6 +52,7 @@
 - **语音**：`msgtype=audio` 经 `downloadCode` 落盘；配置 `OPENAI_API_KEY`（或 `ORYXOS_ASR_API_KEY`）后用 Whisper 转写进 Agent。非 Whisper 原生格式（如 silk/amr）会经本机 `ffmpeg`（`PATH` / `ORYXOS_FFMPEG`）转 wav；未安装则转写失败并提示。
 - **视频**：`msgtype=video` 经 `downloadCode` 落盘；有 Whisper + ffmpeg 时可抽音轨转写（不理解画面；`ORYXOS_VIDEO_ASR=0` 可关）。
 - **媒体根**：`.oryxos/inbound-media/`（≤100MB）；TTL/配额：`ORYXOS_INBOUND_MEDIA_TTL_HOURS` / `ORYXOS_INBOUND_MEDIA_MAX_MB`。临时链下载禁用自动跟跳，重定向逐跳校验钉钉/OSS 白名单。
+- **联网检索**：渠道只负责把消息交给绑定的 Agent。要让机器人「搜一下 / 查最新」，须在该 Agent 的 `AGENT.md` `tools:` 中显式加入 `web_search`（建议同时加 `http_get`、`fetch_webpage`），并在正文要求先调工具再答。详见 [Tool 体系 · 给 IM Agent 开联网检索](../website/zh/docs/tool.md)。
 
 ## 四、与飞书/企微的差异（运维须知）
 

--- a/docs/FeishuChannelSetup.md
+++ b/docs/FeishuChannelSetup.md
@@ -57,6 +57,7 @@
 - **视频**：`message_type=media` 经 `file_key` 落盘；有 Whisper + ffmpeg 时可抽音轨转写（不理解画面；`ORYXOS_VIDEO_ASR=0` 可关）。
 - **媒体根 TTL/配额**：`ORYXOS_INBOUND_MEDIA_TTL_HOURS`（默认 24）、`ORYXOS_INBOUND_MEDIA_MAX_MB`（默认 2048）。
 - **群聊**：测试群 → 群设置 →「**群机器人**」→「添加机器人」→ 选择应用；之后 `@机器人 + 问题` 触发。群里**不 @** 机器人的消息 OryxOS 完全不读、不留任何记录。
+- **联网检索**：渠道只负责把消息交给绑定的 Agent。要让机器人「搜一下 / 查最新」，须在该 Agent 的 `AGENT.md` `tools:` 中显式加入 `web_search`（建议同时加 `http_get`、`fetch_webpage`），并在正文要求先调工具再答。详见 [Tool 体系 · 给 IM Agent 开联网检索](../website/zh/docs/tool.md)。
 
 ## 七、OryxOS 侧：配置与启动
 

--- a/docs/WeComChannelSetup.md
+++ b/docs/WeComChannelSetup.md
@@ -45,6 +45,7 @@
 - **语音**：智能机器人回调已含平台 ASR（`voice.content`），直接当用户问题编排；**仅单聊**。空转写且带 `voice.url` 时落盘并走 Whisper 兜底；否则明确提示改发文字。
 - **视频**：`msgtype=video` 经 COS URL（及可选 AES）落盘；配置 Whisper + ffmpeg 时可抽音轨转写（不理解画面；`ORYXOS_VIDEO_ASR=0` 可关）。
 - **媒体根**：优先 `.oryxos/inbound-media/{channel}/`（单文件 ≤100MB）；TTL/配额见 `ORYXOS_INBOUND_MEDIA_TTL_HOURS`（默认 24）与 `ORYXOS_INBOUND_MEDIA_MAX_MB`（默认 2048）。COS 下载禁用自动跟跳，重定向逐跳校验白名单。
+- **联网检索**：渠道只负责把消息交给绑定的 Agent。要让机器人「搜一下 / 查最新」，须在该 Agent 的 `AGENT.md` `tools:` 中显式加入 `web_search`（建议同时加 `http_get`、`fetch_webpage`），并在正文要求先调工具再答。详见 [Tool 体系 · 给 IM Agent 开联网检索](../website/zh/docs/tool.md)。
 
 ## 四、与飞书的差异（运维须知）
 

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgencyAgentsImporter.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgencyAgentsImporter.java
@@ -17,7 +17,8 @@ import org.yaml.snakeyaml.Yaml;
 public final class AgencyAgentsImporter {
 
   /** 导入器内置的「默认安全工具集」——源文件工具无关（frontmatter 无 tools），落地时给专家一套可跑的安全能力。 */
-  private static final List<String> DEFAULT_TOOLS = List.of("read_file", "shell", "notify");
+  private static final List<String> DEFAULT_TOOLS =
+      List.of("read_file", "shell", "notify", "web_search", "http_get", "fetch_webpage");
 
   /**
    * 3 参便捷重载：name 从 displayName 派生（slug 化）、model 落占位，与 5 参 {@link #toMarkdown} 行为一致。缺 name 时

--- a/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/agent/AgentLifecycleService.java
@@ -53,6 +53,7 @@ public class AgentLifecycleService {
   private static final String AGENT_MD_BODY =
       """
       在这里写这个 Agent 的任务指令（正文）。被触发时它会照做。
+      - 需要搜索 / 查最新 / 联网核实实时信息时：先调用 web_search；若结果为空再用 fetch_webpage 或 http_get，不要只凭训练知识编造；
       - 已绑定 Skill 的 name、description 与本地 SKILL.md 入口会自动列入提示；需要时再用 read_file 按需读正文；
       - 参考资料放 REFERENCE.md，拿不准时用 read_file 读；
       - 脚本放 scripts/，正文让 shell/python 跑，产出进上下文、代码不进；
@@ -95,8 +96,8 @@ public class AgentLifecycleService {
       1. AGENT.md 以 YAML frontmatter 开头结尾（--- 与 ---），frontmatter 必须含 name、description、identity(agent_name/prompt)、\
       provider(name/model)、tools、settings(max_iterations/max_history_turns)；有定时需求再加 schedules。
       2. name 必须是「{name}」；provider.name 必须是「{provider}」；model 必须是「{model}」（若该 provider 下没有这个 exact 模型名，就填该 provider 下合理的默认模型名）。
-      3. tools 只能从下面【可用工具】里按需挑选，**绝不允许编造清单以外的工具名**。常见映射：查网页/接口数据用 http_get / http_post；\
-      抓网页正文用 fetch_webpage；读写文件用 read_file / write_file；跑脚本用 shell。
+      3. tools 只能从下面【可用工具】里按需挑选，**绝不允许编造清单以外的工具名**。常见映射：搜索/查最新用 web_search；\
+      查网页/接口数据用 http_get / http_post；抓网页正文用 fetch_webpage；读写文件用 read_file / write_file；跑脚本用 shell。
       4. schedules 每条必须包含：key（Agent 内唯一的配置键）、name（展示名称）、cron（Spring 6 段 cron，如 "0 0 9 * * *" 表示每天 9 点）、\
       zone（时区，如 Asia/Shanghai）、message（到点发给 Agent 的触发语）。不要输出 legacy id、timezone、action 等字段。
       5. 通知：{notify}
@@ -424,7 +425,9 @@ public class AgentLifecycleService {
     providerMap.put("name", provider);
     providerMap.put("model", model);
     frontmatter.put("provider", providerMap);
-    frontmatter.put("tools", List.of("read_file", "shell", "notify"));
+    frontmatter.put(
+        "tools",
+        List.of("read_file", "shell", "notify", "web_search", "http_get", "fetch_webpage"));
     frontmatter.put("bootstrap", List.of("AGENTS.md"));
     Map<String, Object> settings = new LinkedHashMap<>();
     settings.put("max_iterations", Profile.Settings.defaults().maxIterations());

--- a/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleCreateScaffoldTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/agent/AgentLifecycleCreateScaffoldTest.java
@@ -9,6 +9,7 @@ import io.oryxos.core.profile.Profile;
 import io.oryxos.core.profile.ProfileRegistry;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,10 +62,15 @@ class AgentLifecycleCreateScaffoldTest {
 
     assertTrue(created.schedules().isEmpty(), "description 换行不得登记 schedules");
     assertEquals(
+        List.of("read_file", "shell", "notify", "web_search", "http_get", "fetch_webpage"),
+        created.tools(),
+        "脚手架默认挂上网检索工具");
+    assertEquals(
         "每日巡检\nschedules:\n  - key: pwn\n    name: pwn\n    cron: \"0 * * * * *\"\n    zone: UTC\n    message: pwned",
         created.description().strip());
     String markdown = Files.readString(root.resolve("agents/ops/AGENT.md"));
     assertTrue(markdown.contains("每日巡检"), "描述原文保留");
+    assertTrue(markdown.contains("web_search"), "正文提示联网检索");
   }
 
   @Test

--- a/oryxos-persona/src/test/java/io/oryxos/persona/PersonaPresetsGoldenTest.java
+++ b/oryxos-persona/src/test/java/io/oryxos/persona/PersonaPresetsGoldenTest.java
@@ -52,7 +52,12 @@ class PersonaPresetsGoldenTest {
   private String render(PersonaPresetCatalog.Preset p) {
     ParsedExpert expert = new AgencyAgentsParser().parse(catalog.sourceContent(p));
     return new AgencyAgentsImporter()
-        .toMarkdown(expert, "deepseek", Set.of("read_file", "shell", "notify"), p.key(), null);
+        .toMarkdown(
+            expert,
+            "deepseek",
+            Set.of("read_file", "shell", "notify", "web_search", "http_get", "fetch_webpage"),
+            p.key(),
+            null);
   }
 
   private static String readGolden(String key) {

--- a/oryxos-persona/src/test/resources/personas-golden/ai-engineer.md
+++ b/oryxos-persona/src/test/resources/personas-golden/ai-engineer.md
@@ -36,6 +36,9 @@ tools:
 - read_file
 - shell
 - notify
+- web_search
+- http_get
+- fetch_webpage
 channels:
 - cli
 settings:

--- a/oryxos-persona/src/test/resources/personas-golden/api-tester.md
+++ b/oryxos-persona/src/test/resources/personas-golden/api-tester.md
@@ -43,6 +43,9 @@ tools:
 - read_file
 - shell
 - notify
+- web_search
+- http_get
+- fetch_webpage
 channels:
 - cli
 settings:

--- a/oryxos-persona/src/test/resources/personas-golden/backend-architect.md
+++ b/oryxos-persona/src/test/resources/personas-golden/backend-architect.md
@@ -41,6 +41,9 @@ tools:
 - read_file
 - shell
 - notify
+- web_search
+- http_get
+- fetch_webpage
 channels:
 - cli
 settings:

--- a/oryxos-persona/src/test/resources/personas-golden/code-reviewer.md
+++ b/oryxos-persona/src/test/resources/personas-golden/code-reviewer.md
@@ -54,6 +54,9 @@ tools:
 - read_file
 - shell
 - notify
+- web_search
+- http_get
+- fetch_webpage
 channels:
 - cli
 settings:

--- a/oryxos-persona/src/test/resources/personas-golden/devops-automator.md
+++ b/oryxos-persona/src/test/resources/personas-golden/devops-automator.md
@@ -46,6 +46,9 @@ tools:
 - read_file
 - shell
 - notify
+- web_search
+- http_get
+- fetch_webpage
 channels:
 - cli
 settings:

--- a/oryxos-persona/src/test/resources/personas-golden/embedded-qa-engineer.md
+++ b/oryxos-persona/src/test/resources/personas-golden/embedded-qa-engineer.md
@@ -61,6 +61,9 @@ tools:
 - read_file
 - shell
 - notify
+- web_search
+- http_get
+- fetch_webpage
 channels:
 - cli
 settings:

--- a/oryxos-persona/src/test/resources/personas-golden/frontend-developer.md
+++ b/oryxos-persona/src/test/resources/personas-golden/frontend-developer.md
@@ -41,6 +41,9 @@ tools:
 - read_file
 - shell
 - notify
+- web_search
+- http_get
+- fetch_webpage
 channels:
 - cli
 settings:

--- a/oryxos-persona/src/test/resources/personas-golden/performance-benchmarker.md
+++ b/oryxos-persona/src/test/resources/personas-golden/performance-benchmarker.md
@@ -36,6 +36,9 @@ tools:
 - read_file
 - shell
 - notify
+- web_search
+- http_get
+- fetch_webpage
 channels:
 - cli
 settings:

--- a/oryxos-persona/src/test/resources/personas-golden/product-manager.md
+++ b/oryxos-persona/src/test/resources/personas-golden/product-manager.md
@@ -82,6 +82,9 @@ tools:
 - read_file
 - shell
 - notify
+- web_search
+- http_get
+- fetch_webpage
 channels:
 - cli
 settings:

--- a/oryxos-persona/src/test/resources/personas-golden/senior-developer.md
+++ b/oryxos-persona/src/test/resources/personas-golden/senior-developer.md
@@ -52,6 +52,9 @@ tools:
 - read_file
 - shell
 - notify
+- web_search
+- http_get
+- fetch_webpage
 channels:
 - cli
 settings:

--- a/oryxos-persona/src/test/resources/personas-golden/support-responder.md
+++ b/oryxos-persona/src/test/resources/personas-golden/support-responder.md
@@ -49,6 +49,9 @@ tools:
 - read_file
 - shell
 - notify
+- web_search
+- http_get
+- fetch_webpage
 channels:
 - cli
 settings:

--- a/oryxos-persona/src/test/resources/personas-golden/ui-designer.md
+++ b/oryxos-persona/src/test/resources/personas-golden/ui-designer.md
@@ -46,6 +46,9 @@ tools:
 - read_file
 - shell
 - notify
+- web_search
+- http_get
+- fetch_webpage
 channels:
 - cli
 settings:

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/WebSearchTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/WebSearchTools.java
@@ -34,7 +34,7 @@ public class WebSearchTools {
     sandbox.enforce(new SandboxAction(ActionType.HTTP_READ, "web_search:" + query));
     List<SearchProvider.SearchResult> results = provider.search(query);
     if (results.isEmpty()) {
-      return "（未搜到相关结果）";
+      return "（未搜到相关结果；可改用 fetch_webpage 打开公开搜索页，或 http_get 调公开 API）";
     }
     return results.stream()
         .limit(MAX_RESULTS)

--- a/oryxos-tool/src/main/java/io/oryxos/tool/web/DuckDuckGoSearchProvider.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/web/DuckDuckGoSearchProvider.java
@@ -6,44 +6,70 @@ import io.oryxos.tool.sandbox.ActionType;
 import io.oryxos.tool.sandbox.PinnedHttpReadClient;
 import io.oryxos.tool.sandbox.Sandbox;
 import io.oryxos.tool.sandbox.SandboxAction;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
 
 /**
  * 核心阶段唯一搜索实现：DuckDuckGo Instant Answer API（无需 API key，返回 JSON）。
  *
- * <p>端点由构造传入（默认公网），便于测试指向假服务；抓取 RelatedTopics 里的 Text/FirstURL 作为结果条目。搜不到即空列表——由上层工具决定怎么表达"没搜到"。
- *
- * <p>出网策略与 {@code HttpTools} 读路径对齐：对<strong>真实 endpoint</strong>过 {@code HTTP_READ}（SSRF
- * 兜底），且<strong>禁自动重定向</strong>——Instant Answer 无需跟跳；避免共用 RestClient 默认跟随把公网入口 302 到内网/元数据。
+ * <p>先抓 RelatedTopics / Abstract；若仍为空（中文与时效查询常见），再请求 HTML 轻量结果页并解析标题链接——同样过 {@code HTTP_READ}
+ * 且禁自动重定向。测试构造可关掉 HTML 兜底，只打假 Instant Answer 端点。
  */
 public class DuckDuckGoSearchProvider implements SearchProvider {
 
   private static final String DEFAULT_ENDPOINT = "https://api.duckduckgo.com/";
+  private static final String DEFAULT_HTML_ENDPOINT = "https://html.duckduckgo.com/html/";
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
   private static final Duration READ_TIMEOUT = Duration.ofSeconds(20);
+  private static final int MAX_HTML_RESULTS = 8;
+  private static final int TITLE_SNIPPET_CAP = 60;
+  private static final Pattern HTML_RESULT_LINK =
+      Pattern.compile(
+          "<a[^>]*class=\"[^\"]*result__a[^\"]*\"[^>]*href=\"([^\"]+)\"[^>]*>(.*?)</a>",
+          Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+  private static final Pattern TAG_STRIP = Pattern.compile("<[^>]+>");
+  private static final Pattern UDDG = Pattern.compile("[?&]uddg=([^&]+)");
 
   private final String endpoint;
+  private final String htmlFallbackEndpoint;
   private final Sandbox sandbox;
 
   public DuckDuckGoSearchProvider(RestClient restClient, Sandbox sandbox) {
-    this(restClient, DEFAULT_ENDPOINT, sandbox);
+    this(restClient, DEFAULT_ENDPOINT, DEFAULT_HTML_ENDPOINT, sandbox);
   }
 
+  /** 单测用：只打 Instant Answer 端点，关闭 HTML 兜底。 */
   public DuckDuckGoSearchProvider(RestClient restClient, String endpoint, Sandbox sandbox) {
+    this(restClient, endpoint, null, sandbox);
+  }
+
+  public DuckDuckGoSearchProvider(
+      RestClient restClient, String endpoint, String htmlFallbackEndpoint, Sandbox sandbox) {
     Objects.requireNonNull(restClient, "restClient 不能为空"); // 保留签名，供 Spring 装配
     this.sandbox = Objects.requireNonNull(sandbox, "sandbox 不能为空");
     this.endpoint = Objects.requireNonNull(endpoint, "endpoint 不能为空");
+    this.htmlFallbackEndpoint = htmlFallbackEndpoint;
   }
 
   @Override
   public List<SearchResult> search(String query) {
-    // 伪目标 web_search:query 只做工具层标签；真实出网 URL 必须再过 HTTP_READ / SSRF
+    List<SearchResult> instant = searchInstantAnswer(query);
+    if (!instant.isEmpty() || htmlFallbackEndpoint == null || htmlFallbackEndpoint.isBlank()) {
+      return instant;
+    }
+    return searchHtmlLite(query);
+  }
+
+  private List<SearchResult> searchInstantAnswer(String query) {
     sandbox.enforce(new SandboxAction(ActionType.HTTP_READ, endpoint));
     ResponseEntity<String> resp;
     try (PinnedHttpReadClient client =
@@ -59,29 +85,109 @@ public class DuckDuckGoSearchProvider implements SearchProvider {
     if (resp.getStatusCode().is3xxRedirection()) {
       throw new IllegalStateException("搜索端点返回重定向，拒绝跟随: " + endpoint);
     }
-    return parse(resp.getBody());
+    return parseInstantAnswer(resp.getBody());
   }
 
-  private static List<SearchResult> parse(String body) {
+  private List<SearchResult> searchHtmlLite(String query) {
+    sandbox.enforce(new SandboxAction(ActionType.HTTP_READ, htmlFallbackEndpoint));
+    ResponseEntity<String> resp;
+    try (PinnedHttpReadClient client =
+        PinnedHttpReadClient.open(sandbox, CONNECT_TIMEOUT, READ_TIMEOUT)) {
+      resp =
+          client
+              .restClient()
+              .get()
+              .uri(htmlFallbackEndpoint + "?q={q}", query)
+              .retrieve()
+              .toEntity(String.class);
+    }
+    if (resp.getStatusCode().is3xxRedirection()) {
+      throw new IllegalStateException("搜索 HTML 端点返回重定向，拒绝跟随: " + htmlFallbackEndpoint);
+    }
+    return parseHtmlResults(resp.getBody());
+  }
+
+  static List<SearchResult> parseInstantAnswer(String body) {
     List<SearchResult> results = new ArrayList<>();
     if (body == null || body.isBlank()) {
       return results;
     }
     try {
       JsonNode root = MAPPER.readTree(body);
-      JsonNode topics = root.path("RelatedTopics");
-      for (JsonNode topic : topics) {
-        JsonNode text = topic.get("Text");
-        JsonNode url = topic.get("FirstURL");
-        if (text != null && url != null) {
-          String snippet = text.asText();
-          String title = snippet.length() > 60 ? snippet.substring(0, 60) : snippet;
-          results.add(new SearchResult(title, url.asText(), snippet));
+      collectTopics(root.path("RelatedTopics"), results);
+      if (results.isEmpty()) {
+        String abstractText = textOrEmpty(root.get("AbstractText"));
+        if (abstractText.isBlank()) {
+          abstractText = textOrEmpty(root.get("Abstract"));
+        }
+        String url = textOrEmpty(root.get("AbstractURL"));
+        String heading = textOrEmpty(root.get("Heading"));
+        if (!abstractText.isBlank() && !url.isBlank()) {
+          String title = heading.isBlank() ? clip(abstractText, TITLE_SNIPPET_CAP) : heading;
+          results.add(new SearchResult(title, url, abstractText));
         }
       }
     } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
       throw new IllegalStateException("搜索结果解析失败", e);
     }
     return results;
+  }
+
+  private static void collectTopics(JsonNode topics, List<SearchResult> results) {
+    if (topics == null || !topics.isArray()) {
+      return;
+    }
+    for (JsonNode topic : topics) {
+      JsonNode nested = topic.get("Topics");
+      if (nested != null && nested.isArray()) {
+        collectTopics(nested, results);
+        continue;
+      }
+      JsonNode text = topic.get("Text");
+      JsonNode url = topic.get("FirstURL");
+      if (text != null && url != null) {
+        String snippet = text.asText();
+        results.add(new SearchResult(clip(snippet, TITLE_SNIPPET_CAP), url.asText(), snippet));
+      }
+    }
+  }
+
+  static List<SearchResult> parseHtmlResults(String body) {
+    List<SearchResult> results = new ArrayList<>();
+    if (body == null || body.isBlank()) {
+      return results;
+    }
+    Matcher matcher = HTML_RESULT_LINK.matcher(body);
+    while (matcher.find() && results.size() < MAX_HTML_RESULTS) {
+      String href = unwrapUddg(matcher.group(1));
+      String title = TAG_STRIP.matcher(matcher.group(2)).replaceAll("").strip();
+      if (href.isBlank() || title.isBlank()) {
+        continue;
+      }
+      results.add(new SearchResult(title, href, title));
+    }
+    return results;
+  }
+
+  private static String unwrapUddg(String href) {
+    if (href == null || href.isBlank()) {
+      return "";
+    }
+    Matcher m = UDDG.matcher(href);
+    if (m.find()) {
+      return URLDecoder.decode(m.group(1), StandardCharsets.UTF_8);
+    }
+    return href.strip();
+  }
+
+  private static String textOrEmpty(JsonNode node) {
+    return node == null || node.isNull() ? "" : node.asText("").strip();
+  }
+
+  private static String clip(String text, int max) {
+    if (text == null) {
+      return "";
+    }
+    return text.length() > max ? text.substring(0, max) : text;
   }
 }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/WebSearchToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/WebSearchToolsTest.java
@@ -79,7 +79,9 @@ class WebSearchToolsTest {
   void webSearchNoResult() {
     WebSearchTools tools = new WebSearchTools(new PermissiveSandbox(), query -> List.of());
 
-    assertEquals("（未搜到相关结果）", tools.webSearch("zzz"));
+    String result = tools.webSearch("zzz");
+    assertTrue(result.contains("未搜到相关结果"));
+    assertTrue(result.contains("fetch_webpage"));
   }
 
   @Test

--- a/oryxos-tool/src/test/java/io/oryxos/tool/web/DuckDuckGoSearchProviderTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/web/DuckDuckGoSearchProviderTest.java
@@ -1,0 +1,100 @@
+package io.oryxos.tool.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.sun.net.httpserver.HttpServer;
+import io.oryxos.tool.sandbox.PermissiveSandbox;
+import io.oryxos.tool.sandbox.Sandbox;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+/** Instant Answer 空结果时的 Abstract / HTML 兜底（假 HTTP，不碰真网）。 */
+class DuckDuckGoSearchProviderTest {
+
+  private HttpServer instant;
+  private HttpServer html;
+
+  @AfterEach
+  void stop() {
+    if (instant != null) {
+      instant.stop(0);
+    }
+    if (html != null) {
+      html.stop(0);
+    }
+  }
+
+  @Test
+  @DisplayName("RelatedTopics 空时用 Abstract/AbstractURL")
+  void parseAbstractWhenTopicsEmpty() {
+    List<SearchProvider.SearchResult> results =
+        DuckDuckGoSearchProvider.parseInstantAnswer(
+            "{\"RelatedTopics\":[],\"Heading\":\"北京\","
+                + "\"AbstractText\":\"首都\",\"AbstractURL\":\"https://example.com/beijing\"}");
+    assertEquals(1, results.size());
+    assertEquals("北京", results.get(0).title());
+    assertEquals("https://example.com/beijing", results.get(0).url());
+  }
+
+  @Test
+  @DisplayName("Instant Answer 空时跟 HTML lite 兜底")
+  void emptyInstantFallsBackToHtml() throws IOException {
+    AtomicInteger htmlHits = new AtomicInteger();
+    instant = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    html = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    instant.createContext(
+        "/",
+        exchange -> {
+          byte[] body = "{\"RelatedTopics\":[]}".getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().add("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, body.length);
+          exchange.getResponseBody().write(body);
+          exchange.close();
+        });
+    html.createContext(
+        "/",
+        exchange -> {
+          htmlHits.incrementAndGet();
+          String page =
+              "<a class=\"result__a\" href=\"https://weather.example/bj\">Beijing weather</a>";
+          byte[] body = page.getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().add("Content-Type", "text/html; charset=utf-8");
+          exchange.sendResponseHeaders(200, body.length);
+          exchange.getResponseBody().write(body);
+          exchange.close();
+        });
+    instant.start();
+    html.start();
+
+    String instantUrl = "http://127.0.0.1:" + instant.getAddress().getPort() + "/";
+    String htmlUrl = "http://127.0.0.1:" + html.getAddress().getPort() + "/";
+    Sandbox sandbox = new PermissiveSandbox();
+    SearchProvider provider =
+        new DuckDuckGoSearchProvider(RestClient.create(), instantUrl, htmlUrl, sandbox);
+
+    List<SearchProvider.SearchResult> results = provider.search("beijing weather");
+    assertEquals(1, htmlHits.get(), "should hit HTML fallback");
+    assertEquals(1, results.size(), "results=" + results);
+    assertEquals("Beijing weather", results.get(0).title());
+    assertEquals("https://weather.example/bj", results.get(0).url());
+  }
+
+  @Test
+  @DisplayName("解析 HTML 结果并解开 uddg 跳转")
+  void parseHtmlUnwrapsUddg() {
+    String page =
+        "<a class=\"result__a\" href=\"https://duckduckgo.com/l/?uddg=https%3A%2F%2Fnews.example%2Fa\">"
+            + "新闻标题</a>";
+    List<SearchProvider.SearchResult> results = DuckDuckGoSearchProvider.parseHtmlResults(page);
+    assertEquals(1, results.size());
+    assertEquals("https://news.example/a", results.get(0).url());
+    assertEquals("新闻标题", results.get(0).title());
+  }
+}

--- a/website/docs/profile.md
+++ b/website/docs/profile.md
@@ -147,9 +147,13 @@ Built-in tool names:
 | `shell` | Execute a shell command (command whitelist enforced) |
 | `http_get` | HTTP GET request (default allow + SSRF blocklist) |
 | `http_post` | HTTP POST request (domain whitelist enforced) |
+| `fetch_webpage` | Fetch a page and extract readable text (default allow + SSRF) |
+| `web_search` | Web search (default allow + SSRF; must be listed in `tools:`) |
 | `save_memory` | Append a note to `MEMORY.md` |
 | `recall_memory` | Keyword search over `MEMORY.md` |
 | `notify` | Push a message to a notify channel referenced by name |
+
+> For Feishu / WeCom / DingTalk inbound agents that should answer “search the web” / live facts, list `web_search` in `tools:` (and usually `http_get` + `fetch_webpage`). A `CONNECTED` channel is not enough — unlisted tools never reach the model. See [Tool system](/docs/tool) (“Enabling web search for IM / business agents”).
 
 MCP tools from configured `mcp_servers` are available by their server-declared names (e.g. `github_create_pr`). Run `oryxos tool list` to see all registered names. See the [Tool system](/docs/tool) for details, including how the `notify` tool resolves a channel by name.
 

--- a/website/docs/tool.md
+++ b/website/docs/tool.md
@@ -184,6 +184,8 @@ The three whitelists are also **manageable at runtime** via the `/api/v1/sandbox
 
 `web_search`, `http_get`, and `fetch_webpage` are registered globally at runtime, but **only tools listed in that agent’s `AGENT.md` `tools:` frontmatter are exposed to the model** (see “Tool registry” filtering below). A common pitfall: the channel is `CONNECTED`, the user asks to “search the web”, and no tool is ever called — usually because the profile only lists `read_file` / `shell` / `notify`.
 
+The Admin / API **create-agent scaffold** now includes the tools below by default; existing agents still need a manual update:
+
 ```yaml
 tools:
   - read_file

--- a/website/docs/tool.md
+++ b/website/docs/tool.md
@@ -196,7 +196,7 @@ tools:
   - fetch_webpage
 ```
 
-In the agent body, require calling `web_search` first for live facts. The core-stage provider is DuckDuckGo Instant Answer; **Chinese or time-sensitive queries often return empty**. Fall back to `fetch_webpage` (for example `https://html.duckduckgo.com/html/?q=` + a URL-encoded query) or `http_get` against a public API (weather via `api.open-meteo.com` is already in the default write-whitelist examples; reads do not need that whitelist).
+In the agent body, require calling `web_search` first for live facts. The core-stage provider is DuckDuckGo: **when Instant Answer JSON is empty (common for Chinese / time-sensitive queries), it automatically retries the HTML lite results page**. If still empty, fall back to `fetch_webpage` or `http_get` against a public API (e.g. weather via `api.open-meteo.com`).
 
 If a tool call fails the sandbox check, `ToolExecutor` returns a non-retryable `ToolResult` with a clear error message describing which whitelist was violated. The call is still recorded in `tool_invocations` with `success = false`.
 

--- a/website/docs/tool.md
+++ b/website/docs/tool.md
@@ -180,6 +180,22 @@ http:
 
 The three whitelists are also **manageable at runtime** via the `/api/v1/sandbox/whitelist` API and the admin console — add or remove entries under the `FILE`, `SHELL`, or `HTTP` categories without a restart.
 
+### Enabling web search for IM / business agents
+
+`web_search`, `http_get`, and `fetch_webpage` are registered globally at runtime, but **only tools listed in that agent’s `AGENT.md` `tools:` frontmatter are exposed to the model** (see “Tool registry” filtering below). A common pitfall: the channel is `CONNECTED`, the user asks to “search the web”, and no tool is ever called — usually because the profile only lists `read_file` / `shell` / `notify`.
+
+```yaml
+tools:
+  - read_file
+  - shell
+  - notify
+  - web_search
+  - http_get
+  - fetch_webpage
+```
+
+In the agent body, require calling `web_search` first for live facts. The core-stage provider is DuckDuckGo Instant Answer; **Chinese or time-sensitive queries often return empty**. Fall back to `fetch_webpage` (for example `https://html.duckduckgo.com/html/?q=` + a URL-encoded query) or `http_get` against a public API (weather via `api.open-meteo.com` is already in the default write-whitelist examples; reads do not need that whitelist).
+
 If a tool call fails the sandbox check, `ToolExecutor` returns a non-retryable `ToolResult` with a clear error message describing which whitelist was violated. The call is still recorded in `tool_invocations` with `success = false`.
 
 `SecurityManager` is not used. It was deprecated in JDK 17 and removed in JDK 21. The sandbox is purely application-level: whitelists are enforced in `SandboxChecker` before the tool code runs.

--- a/website/zh/docs/profile.md
+++ b/website/zh/docs/profile.md
@@ -146,9 +146,13 @@ export DEEPSEEK_API_KEY=sk-...
 | `shell` | 执行 shell 命令（命令白名单） |
 | `http_get` | HTTP GET（默认放行 + SSRF 黑名单） |
 | `http_post` | HTTP POST（域名白名单） |
+| `fetch_webpage` | 抓取网页并抽取可读正文（默认放行 + SSRF） |
+| `web_search` | 网络搜索（默认放行 + SSRF；须显式列入 `tools:`） |
 | `save_memory` | 向 `MEMORY.md` 追加记忆 |
 | `recall_memory` | 关键词检索 `MEMORY.md` |
 | `notify` | 向按名引用的通知渠道推送消息 |
+
+> 飞书 / 企微 / 钉钉入站绑定的 Agent 若要「搜一下 / 查最新」，必须在 `tools:` 中加入 `web_search`（建议同时加 `http_get`、`fetch_webpage`）。仅渠道 `CONNECTED` 不够——未列入的工具不会出现在模型侧。详见 [Tool 体系](/zh/docs/tool)（「给 IM / 业务 Agent 开联网检索」一节）。
 
 来自 `mcp_servers` 的 MCP 工具以 server 声明的名称暴露（如 `github_create_pr`）。运行 `oryxos tool list` 查看所有已注册名称。详见 [Tool 体系](/zh/docs/tool)，包括 `notify` 如何按名解析渠道。
 

--- a/website/zh/docs/tool.md
+++ b/website/zh/docs/tool.md
@@ -184,6 +184,8 @@ http:
 
 `web_search` / `http_get` / `fetch_webpage` 虽已在运行时全局注册，但 **只有写进该 Agent `AGENT.md` 的 `tools:` 才会出现在模型可调用列表**（见下方「工具注册表」过滤）。常见踩坑：渠道已 `CONNECTED`，用户说「搜一下」却从不调工具——多半是 frontmatter 里只有 `read_file` / `shell` / `notify`。
 
+管理台 / API **新建 Agent** 的脚手架默认已包含下列工具；存量 Agent 仍需手工补上：
+
 ```yaml
 tools:
   - read_file

--- a/website/zh/docs/tool.md
+++ b/website/zh/docs/tool.md
@@ -180,6 +180,22 @@ http:
 
 这三个白名单也可在**运行期管理**——通过 `/api/v1/sandbox/whitelist` 接口和管理台，在 `FILE`、`SHELL`、`HTTP` 三类下增删条目，无需重启。
 
+### 给 IM / 业务 Agent 开联网检索
+
+`web_search` / `http_get` / `fetch_webpage` 虽已在运行时全局注册，但 **只有写进该 Agent `AGENT.md` 的 `tools:` 才会出现在模型可调用列表**（见下方「工具注册表」过滤）。常见踩坑：渠道已 `CONNECTED`，用户说「搜一下」却从不调工具——多半是 frontmatter 里只有 `read_file` / `shell` / `notify`。
+
+```yaml
+tools:
+  - read_file
+  - shell
+  - notify
+  - web_search
+  - http_get
+  - fetch_webpage
+```
+
+建议在正文里写明：需要实时信息时先调 `web_search`；核心阶段搜索走 DuckDuckGo Instant Answer，**中文或时效查询常返回空**——此时再用 `fetch_webpage`（如 `https://html.duckduckgo.com/html/?q=` + URL 编码关键词）或对公开 API 使用 `http_get`（例如天气用 `api.open-meteo.com`，该主机已在默认写白名单示例中，读路径本就不依赖白名单）。
+
 工具调用未通过沙箱校验时，`ToolExecutor` 返回不可重试的 `ToolResult`，并带有清晰的错误信息说明违反了哪条白名单。该调用仍会记录在 `tool_invocations` 里，`success = false`。
 
 不使用 `SecurityManager`。它从 JDK 17 起废弃，在 JDK 21 上已不可用。沙箱完全在应用层实现：工具代码运行前，`SandboxChecker` 已完成白名单校验。

--- a/website/zh/docs/tool.md
+++ b/website/zh/docs/tool.md
@@ -196,7 +196,7 @@ tools:
   - fetch_webpage
 ```
 
-建议在正文里写明：需要实时信息时先调 `web_search`；核心阶段搜索走 DuckDuckGo Instant Answer，**中文或时效查询常返回空**——此时再用 `fetch_webpage`（如 `https://html.duckduckgo.com/html/?q=` + URL 编码关键词）或对公开 API 使用 `http_get`（例如天气用 `api.open-meteo.com`，该主机已在默认写白名单示例中，读路径本就不依赖白名单）。
+建议在正文里写明：需要实时信息时先调 `web_search`。核心阶段搜索走 DuckDuckGo：**Instant Answer JSON 为空时（中文/时效查询常见）会自动再请求 HTML 轻量结果页**；若仍为空，再用 `fetch_webpage` 或对公开 API 使用 `http_get`（例如天气用 `api.open-meteo.com`）。
 
 工具调用未通过沙箱校验时，`ToolExecutor` 返回不可重试的 `ToolResult`，并带有清晰的错误信息说明违反了哪条白名单。该调用仍会记录在 `tool_invocations` 里，`success = false`。
 


### PR DESCRIPTION
## Summary
- Docs: IM agents must list `web_search` / `http_get` / `fetch_webpage` (zh/en Tool + Profile + channel guides).
- Scaffold / agency import defaults now include those tools for **new** agents.
- `DuckDuckGoSearchProvider`: when Instant Answer is empty, automatically retry HTML lite results (SSRF-safe, no redirect follow); also harvest Abstract when RelatedTopics is empty.
- Persona golden snapshots updated for the expanded default tool set.

## Test plan
- [x] `DuckDuckGoSearchProviderTest` / `WebSearchToolsTest`
- [x] `AgentLifecycleCreateScaffoldTest`
- [x] `PersonaPresetsGoldenTest`
- [ ] CI green