### PR TITLE
feat(channel): Slack Socket Mode inbound channel MVP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ WECOM_BOT_ID=
 WECOM_BOT_SECRET=
 DINGTALK_CLIENT_ID=
 DINGTALK_CLIENT_SECRET=
+SLACK_BOT_TOKEN=
+SLACK_APP_TOKEN=
+# SLACK_TEAM_ID=   # 可选，人工核对用；渠道启动走 auth 不必写入 channels.yaml
 # 飞书/钉钉入站语音转写（OpenAI 兼容 Whisper）；企微语音用平台 ASR，可不配
 OPENAI_API_KEY=
 # ORYXOS_ASR_API_KEY=

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -100,6 +100,8 @@ http:
     - qyapi.weixin.qq.com       # 企微群机器人 webhook 通知
     - api.dingtalk.com          # 钉钉 Stream 网关（开连接）
     - oapi.dingtalk.com         # 钉钉 webhook 通知 + sessionWebhook 回复
+    - slack.com                 # Slack Web API（connections.open / chat.postMessage）
+    - "*.slack.com"             # Slack Socket Mode WSS（wss-primary / wss-backup 等）
     - api.open-meteo.com        # 天气 Agent 免 key 天气源（31 节 Demo 一）
     - hn.algolia.com            # 科技日报 Agent 新闻源（31 节 Demo 二）
     - api.github.com            # GitHub 日报脚本子进程网络（31 节 Demo 三）

--- a/config/channels.yaml.example
+++ b/config/channels.yaml.example
@@ -25,3 +25,11 @@ channels:
   #   app_secret: ${DINGTALK_CLIENT_SECRET}
   #   agent: ops-agent
   #   enabled: true
+
+  # Slack Socket Mode 长连接（见 docs/SlackChannelSetup.md）
+  # - name: ops-slack
+  #   type: slack
+  #   app_id: ${SLACK_BOT_TOKEN}          # Bot User OAuth Token (xoxb-)
+  #   app_secret: ${SLACK_APP_TOKEN}      # App-Level Token (xapp-，需 connections:write)
+  #   agent: ops-agent
+  #   enabled: true

--- a/docs/SlackChannelSetup.md
+++ b/docs/SlackChannelSetup.md
@@ -1,0 +1,66 @@
+# Slack 机器人入站渠道接入指南
+
+本文是 OryxOS Slack 入站渠道的部署操作手册。架构对称飞书/企微/钉钉：以 **Socket Mode** WebSocket 主动连接 Slack（免公网回调 URL）；回复经 `chat.postMessage`。
+
+> 范围：Slack App **Socket Mode**。出站 Notify / MCP Slack 与本入站渠道分离。MVP 仅文本私聊与群 `@`。
+
+## 一、Slack 侧：创建 App 并启用 Socket Mode
+
+1. 打开 [api.slack.com/apps](https://api.slack.com/apps)，Create New App → From scratch，选目标 Workspace。
+2. **OAuth & Permissions** → Bot Token Scopes 至少：`chat:write`、`im:history`、`app_mentions:read`、`channels:history`（按需）。
+3. **Socket Mode** → Enable → 生成 **App-Level Token**（`xapp-…`），scope 勾 `connections:write`。
+4. **Event Subscriptions** → Enable → Subscribe to bot events：`message.im`、`app_mention`。
+5. **Install to Workspace**，复制 **Bot User OAuth Token**（`xoxb-…`）。
+6. 将 Bot 邀请进目标频道（群聊需 `@机器人`）。
+
+   - ⚠️ 凭证只经环境变量注入 OryxOS，禁止写入仓库或明文配置文件。
+
+## 二、OryxOS 侧：配置与启动
+
+1. **凭证走环境变量**：
+
+   ```bash
+   export SLACK_BOT_TOKEN=xoxb-...
+   export SLACK_APP_TOKEN=xapp-...
+   # 可选核对：export SLACK_TEAM_ID=T...
+   ```
+
+2. **渠道绑定** `.oryxos/channels.yaml`（模板见 `config/channels.yaml.example`）：
+
+   ```yaml
+   channels:
+     - name: ops-slack
+       type: slack
+       app_id: ${SLACK_BOT_TOKEN}       # Bot Token → chat.postMessage
+       app_secret: ${SLACK_APP_TOKEN}   # App-Level Token → Socket Mode
+       agent: ops-agent
+       enabled: true
+   ```
+
+3. **出站域名白名单**：确保 `http.allowed_domains` 包含：
+   - `slack.com` — Web API
+   - `*.slack.com` — Socket Mode WSS
+
+4. 启动后查渠道状态：`GET /api/v1/channels/status`，期望 `CONNECTED`。
+
+## 三、使用方式
+
+- **私聊**：在 Slack 中打开该 Bot 的 DM，直接发文本。
+- **群聊**：将 Bot 拉入频道后 `@Bot + 问题`（平台推送 `app_mention`）。
+- **联网检索**：须在绑定 Agent 的 `AGENT.md` `tools:` 中加入 `web_search` 等，见 Tool 文档。
+
+## 四、与飞书/企微/钉钉的差异
+
+| | 飞书 | 企微 | 钉钉 | Slack（本渠道） |
+|--|------|------|------|-----------------|
+| 凭证 | App ID / Secret | BotID / Secret | ClientId / Secret | Bot Token / App-Level Token |
+| 连接 | SDK 长连接 | 企微 WS | Stream WS | Socket Mode WSS |
+| 回复 | im API | 长连接发帧 | sessionWebhook | chat.postMessage |
+| MVP 媒体 | 图/文件/音视频 | 同 | 同 | **仅文本**（后续再补） |
+
+## 五、非目标（本期不做）
+
+- 图片 / 文件 / 语音 / 视频入站
+- Block Kit / 斜杠命令 / HTTP Events 公网回调
+- MCP `@modelcontextprotocol/server-slack`（可另配）
+- Notify `type=slack`

--- a/oryxos-boot/pom.xml
+++ b/oryxos-boot/pom.xml
@@ -58,6 +58,10 @@
         </dependency>
         <dependency>
             <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-channel-slack</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
             <artifactId>oryxos-web</artifactId>
         </dependency>
         <dependency>

--- a/oryxos-boot/src/main/resources/application.yml
+++ b/oryxos-boot/src/main/resources/application.yml
@@ -69,6 +69,8 @@ http:
     - qyapi.weixin.qq.com   # 企微群机器人 webhook 通知
     - api.dingtalk.com      # 钉钉 Stream 网关（开连接）
     - oapi.dingtalk.com     # 钉钉 webhook 通知 + sessionWebhook 回复
+    - slack.com             # Slack Web API（connections.open / chat.postMessage）
+    - "*.slack.com"         # Slack Socket Mode WSS（wss-primary / wss-backup 等）
     - api.open-meteo.com    # 天气 Agent（免 key 天气源，31 节 Demo 一）
     - hn.algolia.com        # 科技日报 Agent 新闻源（免 key JSON，31 节 Demo 二）
     - api.github.com        # GitHub 日报脚本走子进程网络；列此便于审计与将来收口（31 节 Demo 三 §信任边界）

--- a/oryxos-channel-slack/pom.xml
+++ b/oryxos-channel-slack/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.oryxos</groupId>
+        <artifactId>oryxos</artifactId>
+        <version>0.1.4-RELEASE</version>
+    </parent>
+
+    <artifactId>oryxos-channel-slack</artifactId>
+    <name>OryxOS Channel Slack</name>
+    <description>Slack bot inbound IM channel: Socket Mode long connection and chat.postMessage reply</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/ChannelSlackModule.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/ChannelSlackModule.java
@@ -1,0 +1,7 @@
+package io.oryxos.channel.slack;
+
+/** Marker for the Slack inbound channel module (not Spring-scanned; wired in OryxOsRuntime). */
+public final class ChannelSlackModule {
+
+  private ChannelSlackModule() {}
+}

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackChannelAdapter.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackChannelAdapter.java
@@ -1,0 +1,318 @@
+package io.oryxos.channel.slack;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.channel.ChannelConfig;
+import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.InboundChannelAdapter;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageService;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Slack 机器人入站适配器：一实例 = 一个 App 的一条 Socket Mode 长连接（对称飞书/企微/钉钉）。
+ *
+ * <p>凭证映射：{@code app_id} = Bot Token（{@code xoxb-}，Web API），{@code app_secret} = App-Level
+ * Token（{@code xapp-}，Socket Mode）。
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
+    justification = "socket/normalizer/sender 在 start() 内初始化；sendReply 有显式空判。")
+public class SlackChannelAdapter implements InboundChannelAdapter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SlackChannelAdapter.class);
+
+  public static final String TYPE = "slack";
+
+  private static final Duration START_TIMEOUT = Duration.ofSeconds(20);
+  private static final long RECONNECT_BASE_MS = 2_000L;
+  private static final long RECONNECT_MAX_MS = 60_000L;
+  private static final int RECONNECT_MAX_SHIFT = 5;
+
+  private final ChannelConfig config;
+  private final ProfileRegistry profileRegistry;
+  private final InboundMessageService inboundMessageService;
+  private final OutboundGuard guard;
+
+  private final AtomicReference<SlackSocketClient> socketRef = new AtomicReference<>();
+  private volatile SlackMessageSender sender;
+  private volatile SlackEventNormalizer normalizer;
+  private volatile SlackDisconnectKind lastDisconnectKind = SlackDisconnectKind.ABRUPT;
+  private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
+  private volatile String lastError;
+  private volatile boolean running;
+  private volatile ScheduledExecutorService reconnectScheduler;
+  private volatile ScheduledFuture<?> reconnectFuture;
+  private int reconnectAttempt;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "协作者均为 Runtime 装配的单例，共享引用正是意图")
+  public SlackChannelAdapter(
+      ChannelConfig config,
+      ProfileRegistry profileRegistry,
+      InboundMessageService inboundMessageService,
+      OutboundGuard guard) {
+    this.config = config;
+    this.profileRegistry = profileRegistry;
+    this.inboundMessageService = inboundMessageService;
+    this.guard = guard;
+  }
+
+  @Override
+  public String name() {
+    return config.name();
+  }
+
+  @Override
+  public String type() {
+    return TYPE;
+  }
+
+  @Override
+  public String boundAgent() {
+    return config.agent();
+  }
+
+  @Override
+  public synchronized void start() {
+    config.validateCredentialsResolved();
+    if (profileRegistry.get(config.agent()).isEmpty()) {
+      throw new IllegalArgumentException(
+          "渠道 " + config.name() + " 绑定的 Agent " + config.agent() + " 不存在");
+    }
+    guard.check(SlackSocketClient.API_BASE_URL);
+    guard.check(SlackMessageSender.API_BASE_URL);
+    running = true;
+    reconnectAttempt = 0;
+    cancelReconnectLocked();
+    try {
+      connectLocked();
+      state = ChannelStatus.State.CONNECTED;
+      lastError = null;
+      LOG.info(
+          "Slack 渠道 {} Socket Mode 已建立（Agent: {}）",
+          sanitize(config.name()),
+          sanitize(config.agent()));
+    } catch (Exception e) {
+      running = false;
+      shutdownReconnectSchedulerLocked();
+      state = ChannelStatus.State.ERROR;
+      lastError = "Socket Mode 连接失败: " + sanitize(e.getMessage());
+      throw new IllegalStateException("渠道 " + config.name() + " " + lastError, e);
+    }
+  }
+
+  @Override
+  public synchronized void stop() {
+    running = false;
+    cancelReconnectLocked();
+    shutdownReconnectSchedulerLocked();
+    SlackSocketClient socket = socketRef.getAndSet(null);
+    if (socket != null) {
+      socket.closeQuietly();
+    }
+    sender = null;
+    normalizer = null;
+    state = ChannelStatus.State.DISCONNECTED;
+  }
+
+  @Override
+  public ChannelStatus status() {
+    if (state == ChannelStatus.State.ERROR) {
+      return ChannelStatus.error(config.name(), TYPE, config.agent(), lastError);
+    }
+    SlackSocketClient socket = socketRef.get();
+    if (socket == null || !socket.isConnected()) {
+      return ChannelStatus.ok(
+          config.name(), TYPE, config.agent(), ChannelStatus.State.DISCONNECTED);
+    }
+    return ChannelStatus.ok(config.name(), TYPE, config.agent(), ChannelStatus.State.CONNECTED);
+  }
+
+  @Override
+  public void sendReply(String chatId, String text, String replyToMessageId) {
+    SlackMessageSender active = sender;
+    if (active == null) {
+      throw new IllegalStateException("渠道 " + config.name() + " 未启动，无法发送回复");
+    }
+    active.send(chatId, text, replyToMessageId);
+  }
+
+  @Override
+  public Optional<io.oryxos.core.channel.InboundProgressStream> openProgressStream(
+      String chatId, String replyToMessageId) {
+    SlackMessageSender active = sender;
+    if (active == null) {
+      return Optional.empty();
+    }
+    return Optional.of(new SlackProgressStream(active, chatId, replyToMessageId));
+  }
+
+  static long reconnectDelayMs(int attempt) {
+    return io.oryxos.core.channel.ReconnectBackoff.delayMs(
+        attempt, RECONNECT_BASE_MS, RECONNECT_MAX_MS, RECONNECT_MAX_SHIFT);
+  }
+
+  private void connectLocked() throws Exception {
+    socketRef.set(connect());
+  }
+
+  private SlackSocketClient connect() throws Exception {
+    ensureOutboundStack();
+    // app_id = bot token；app_secret = app-level token
+    SlackSocketClient client =
+        new SlackSocketClient(
+            config.appSecret(), guard, this::handleEvent, this::handleDisconnected);
+    client.connect(START_TIMEOUT);
+    return client;
+  }
+
+  private void ensureOutboundStack() {
+    if (normalizer == null) {
+      normalizer = new SlackEventNormalizer(config.name());
+    }
+    if (sender == null) {
+      sender = new SlackMessageSender(guard, config.appId(), SlackMessageSender.DEFAULT_CHUNK_SIZE);
+    }
+  }
+
+  private void handleDisconnected(SlackDisconnectKind kind) {
+    boolean shouldReconnect;
+    synchronized (this) {
+      if (!running || state == ChannelStatus.State.ERROR) {
+        return;
+      }
+      lastDisconnectKind = kind == null ? SlackDisconnectKind.ABRUPT : kind;
+      if (lastDisconnectKind == SlackDisconnectKind.GRACEFUL) {
+        reconnectAttempt = 0;
+      }
+      socketRef.set(null);
+      state = ChannelStatus.State.DISCONNECTED;
+      shouldReconnect = true;
+    }
+    if (shouldReconnect) {
+      if (lastDisconnectKind == SlackDisconnectKind.GRACEFUL) {
+        LOG.info("Slack 渠道 {} Socket Mode 服务端轮换断开，立即重连", sanitize(config.name()));
+      } else {
+        LOG.warn("Slack 渠道 {} Socket Mode 断开，将自动重连", sanitize(config.name()));
+      }
+      scheduleReconnect();
+    }
+  }
+
+  private void scheduleReconnect() {
+    synchronized (this) {
+      if (!running || reconnectFuture != null) {
+        return;
+      }
+      long delayMs =
+          lastDisconnectKind == SlackDisconnectKind.GRACEFUL
+              ? 0L
+              : reconnectDelayMs(reconnectAttempt);
+      reconnectFuture =
+          reconnectScheduler().schedule(this::attemptReconnect, delayMs, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private void attemptReconnect() {
+    synchronized (this) {
+      reconnectFuture = null;
+      if (!running) {
+        return;
+      }
+    }
+    SlackSocketClient client;
+    try {
+      client = connect();
+    } catch (Exception e) {
+      synchronized (this) {
+        reconnectAttempt++;
+        lastError = "Socket Mode 重连失败: " + sanitize(e.getMessage());
+        LOG.warn(
+            "Slack 渠道 {} 重连失败（第 {} 次）: {}",
+            sanitize(config.name()),
+            reconnectAttempt,
+            sanitize(lastError));
+      }
+      scheduleReconnect();
+      return;
+    }
+    synchronized (this) {
+      if (!running) {
+        client.closeQuietly();
+        return;
+      }
+      socketRef.set(client);
+      reconnectAttempt = 0;
+      state = ChannelStatus.State.CONNECTED;
+      lastError = null;
+      LOG.info("Slack 渠道 {} Socket Mode 已恢复", sanitize(config.name()));
+    }
+  }
+
+  private ScheduledExecutorService reconnectScheduler() {
+    ScheduledExecutorService scheduler = reconnectScheduler;
+    if (scheduler == null) {
+      ScheduledThreadPoolExecutor pool =
+          new ScheduledThreadPoolExecutor(
+              1,
+              r -> {
+                Thread t = new Thread(r, "slack-reconnect-" + sanitize(config.name()));
+                t.setDaemon(true);
+                return t;
+              });
+      pool.setRemoveOnCancelPolicy(true);
+      reconnectScheduler = pool;
+      return pool;
+    }
+    return scheduler;
+  }
+
+  private void cancelReconnectLocked() {
+    ScheduledFuture<?> pending = reconnectFuture;
+    if (pending != null) {
+      pending.cancel(false);
+      reconnectFuture = null;
+    }
+  }
+
+  private void shutdownReconnectSchedulerLocked() {
+    cancelReconnectLocked();
+    ScheduledExecutorService scheduler = reconnectScheduler;
+    if (scheduler != null) {
+      scheduler.shutdownNow();
+      reconnectScheduler = null;
+    }
+  }
+
+  private void handleEvent(JsonNode event) {
+    try {
+      Optional<InboundMessage> msg = normalizer.normalize(event);
+      msg.ifPresent(this::dispatchClaimed);
+    } catch (RuntimeException e) {
+      LOG.error("Slack 渠道 {} 事件处理异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
+    }
+  }
+
+  private void dispatchClaimed(InboundMessage m) {
+    if (!inboundMessageService.tryClaim(m.channelName(), m.messageId())) {
+      LOG.info("渠道 {} 重复事件已忽略: {}", sanitize(m.channelName()), sanitize(m.messageId()));
+      return;
+    }
+    inboundMessageService.onClaimedMessage(m, this);
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackDisconnectKind.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackDisconnectKind.java
@@ -1,0 +1,9 @@
+package io.oryxos.channel.slack;
+
+/** Slack Socket Mode 断线原因。 */
+enum SlackDisconnectKind {
+  /** 服务端 disconnect 帧（计划内，应立即重连）。 */
+  GRACEFUL,
+  /** 异常 / 对端关闭。 */
+  ABRUPT
+}

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackEventNormalizer.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackEventNormalizer.java
@@ -1,0 +1,138 @@
+package io.oryxos.channel.slack;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Slack Events API 事件 → 归一化 {@link InboundMessage}（MVP：仅文本私聊 / 群 {@code app_mention}）。
+ *
+ * <p>群聊只接受 {@code app_mention}；普通群消息丢弃。忽略 bot 自身消息与带 subtype 的系统编辑帧。
+ */
+public class SlackEventNormalizer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SlackEventNormalizer.class);
+
+  static final String CHANNEL_TYPE = "slack";
+  private static final String EVENT_MESSAGE = "message";
+  private static final String EVENT_APP_MENTION = "app_mention";
+  private static final String CHANNEL_TYPE_IM = "im";
+  private static final String CHANNEL_TYPE_MPIM = "mpim";
+  private static final Pattern MENTION = Pattern.compile("<@[A-Z0-9]+>\\s*");
+
+  private final String channelName;
+
+  public SlackEventNormalizer(String channelName) {
+    this.channelName = channelName;
+  }
+
+  /** 归一化一条 Events API {@code event} 对象；不支持或结构不完整返回 empty。 */
+  public Optional<InboundMessage> normalize(JsonNode event) {
+    if (event == null || !event.isObject()) {
+      return Optional.empty();
+    }
+    String type = text(event, "type");
+    if (type == null) {
+      return Optional.empty();
+    }
+    if (EVENT_APP_MENTION.equals(type)) {
+      return normalizeAppMention(event);
+    }
+    if (EVENT_MESSAGE.equals(type)) {
+      return normalizeMessage(event);
+    }
+    LOG.info("Slack 收到暂不支持的事件类型 type={}", sanitize(type));
+    return Optional.empty();
+  }
+
+  private Optional<InboundMessage> normalizeAppMention(JsonNode event) {
+    if (isBotOrEdited(event)) {
+      return Optional.empty();
+    }
+    String userId = text(event, "user");
+    String chatId = text(event, "channel");
+    String messageId = text(event, "ts");
+    if (userId == null || chatId == null || messageId == null) {
+      LOG.warn("Slack app_mention 缺关键字段（user/channel/ts），已丢弃");
+      return Optional.empty();
+    }
+    String content = stripMentions(event.path("text").asText("")).strip();
+    return Optional.of(
+        new InboundMessage(
+            CHANNEL_TYPE,
+            channelName,
+            messageId,
+            ChatKind.GROUP,
+            userId,
+            chatId,
+            content,
+            true,
+            true,
+            List.of()));
+  }
+
+  private Optional<InboundMessage> normalizeMessage(JsonNode event) {
+    if (isBotOrEdited(event)) {
+      return Optional.empty();
+    }
+    String channelType = text(event, "channel_type");
+    boolean dm = CHANNEL_TYPE_IM.equals(channelType) || CHANNEL_TYPE_MPIM.equals(channelType);
+    if (!dm) {
+      // 频道内普通 message 等 app_mention；避免重复处理
+      return Optional.empty();
+    }
+    String userId = text(event, "user");
+    String chatId = text(event, "channel");
+    String messageId = text(event, "ts");
+    if (userId == null || chatId == null || messageId == null) {
+      LOG.warn("Slack 私聊消息缺关键字段（user/channel/ts），已丢弃");
+      return Optional.empty();
+    }
+    String content = event.path("text").asText("").strip();
+    return Optional.of(
+        new InboundMessage(
+            CHANNEL_TYPE,
+            channelName,
+            messageId,
+            ChatKind.P2P,
+            userId,
+            chatId,
+            content,
+            true,
+            false,
+            List.of()));
+  }
+
+  private static boolean isBotOrEdited(JsonNode event) {
+    if (event.hasNonNull("bot_id")) {
+      return true;
+    }
+    String subtype = text(event, "subtype");
+    return subtype != null && !subtype.isBlank();
+  }
+
+  static String stripMentions(String text) {
+    if (text == null || text.isBlank()) {
+      return "";
+    }
+    return MENTION.matcher(text).replaceAll("").strip();
+  }
+
+  private static String text(JsonNode node, String field) {
+    JsonNode v = node.get(field);
+    if (v == null || v.isNull()) {
+      return null;
+    }
+    String s = v.asText();
+    return s == null || s.isBlank() ? null : s;
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackEventNormalizer.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackEventNormalizer.java
@@ -23,6 +23,7 @@ public class SlackEventNormalizer {
   private static final String EVENT_APP_MENTION = "app_mention";
   private static final String CHANNEL_TYPE_IM = "im";
   private static final String CHANNEL_TYPE_MPIM = "mpim";
+  private static final String FIELD_BOT_ID = "bot_id";
   private static final Pattern MENTION = Pattern.compile("<@[A-Z0-9]+>\\s*");
 
   private final String channelName;
@@ -109,7 +110,7 @@ public class SlackEventNormalizer {
   }
 
   private static boolean isBotOrEdited(JsonNode event) {
-    if (event.hasNonNull("bot_id")) {
+    if (event.hasNonNull(FIELD_BOT_ID)) {
       return true;
     }
     String subtype = text(event, "subtype");

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackMessageSender.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackMessageSender.java
@@ -27,6 +27,8 @@ public class SlackMessageSender {
   private static final int HTTP_STATUS_OK_MAX_EXCLUSIVE = 300;
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
   private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String FIELD_OK = "ok";
+  private static final String FIELD_ERROR = "error";
 
   private final HttpClient httpClient;
   private final OutboundGuard guard;
@@ -114,9 +116,9 @@ public class SlackMessageSender {
     if (root == null || !root.isObject()) {
       return;
     }
-    if (!root.path("ok").asBoolean(false)) {
+    if (!root.path(FIELD_OK).asBoolean(false)) {
       throw new IllegalStateException(
-          "Slack chat.postMessage 业务失败: " + sanitize(root.path("error").asText("unknown")));
+          "Slack chat.postMessage 业务失败: " + sanitize(root.path(FIELD_ERROR).asText("unknown")));
     }
   }
 

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackMessageSender.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackMessageSender.java
@@ -1,0 +1,126 @@
+package io.oryxos.channel.slack;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.OutboundGuard;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Slack 回复：{@code chat.postMessage}；出站前过 {@link OutboundGuard}。
+ *
+ * <p>凭证：Bot Token（{@code xoxb-}）。群聊 {@code replyToMessageId} 非空时作为 {@code thread_ts}。
+ */
+public class SlackMessageSender {
+
+  static final int DEFAULT_CHUNK_SIZE = 3500;
+  static final String API_BASE_URL = "https://slack.com";
+  static final String POST_MESSAGE_PATH = "/api/chat.postMessage";
+  private static final int HTTP_STATUS_OK_MIN = 200;
+  private static final int HTTP_STATUS_OK_MAX_EXCLUSIVE = 300;
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final HttpClient httpClient;
+  private final OutboundGuard guard;
+  private final String botToken;
+  private final int chunkSize;
+
+  public SlackMessageSender(OutboundGuard guard, String botToken, int chunkSize) {
+    this(
+        HttpClient.newBuilder().connectTimeout(REQUEST_TIMEOUT).build(),
+        guard,
+        botToken,
+        chunkSize);
+  }
+
+  SlackMessageSender(HttpClient httpClient, OutboundGuard guard, String botToken, int chunkSize) {
+    this.httpClient = httpClient;
+    this.guard = guard;
+    this.botToken = botToken;
+    this.chunkSize = chunkSize <= 0 ? DEFAULT_CHUNK_SIZE : chunkSize;
+  }
+
+  public void send(String channelId, String text, String replyToMessageId) {
+    guard.check(API_BASE_URL);
+    for (String chunk : segment(text == null ? "" : text, chunkSize)) {
+      postMessage(channelId, chunk, replyToMessageId);
+    }
+  }
+
+  private void postMessage(String channelId, String text, String threadTs) {
+    try {
+      ObjectNode body = MAPPER.createObjectNode();
+      body.put("channel", channelId);
+      body.put("text", text);
+      if (threadTs != null && !threadTs.isBlank()) {
+        body.put("thread_ts", threadTs);
+      }
+      String payload = MAPPER.writeValueAsString(body);
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(API_BASE_URL + POST_MESSAGE_PATH))
+              .timeout(REQUEST_TIMEOUT)
+              .header("Authorization", "Bearer " + botToken)
+              .header("Content-Type", "application/json; charset=utf-8")
+              .POST(HttpRequest.BodyPublishers.ofString(payload))
+              .build();
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() < HTTP_STATUS_OK_MIN
+          || response.statusCode() >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
+        throw new IllegalStateException(
+            "Slack chat.postMessage 失败 HTTP "
+                + response.statusCode()
+                + ": "
+                + sanitize(response.body()));
+      }
+      rejectBusinessError(response.body());
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("Slack chat.postMessage 失败: " + e.getMessage(), e);
+    }
+  }
+
+  static List<String> segment(String text, int chunkSize) {
+    if (text.isEmpty()) {
+      return List.of("");
+    }
+    List<String> parts = new ArrayList<>();
+    for (int i = 0; i < text.length(); i += chunkSize) {
+      parts.add(text.substring(i, Math.min(text.length(), i + chunkSize)));
+    }
+    return parts;
+  }
+
+  static void rejectBusinessError(String responseBody) {
+    if (responseBody == null || responseBody.isBlank()) {
+      return;
+    }
+    final JsonNode root;
+    try {
+      root = MAPPER.readTree(responseBody);
+    } catch (JacksonException ignored) {
+      return;
+    }
+    if (root == null || !root.isObject()) {
+      return;
+    }
+    if (!root.path("ok").asBoolean(false)) {
+      throw new IllegalStateException(
+          "Slack chat.postMessage 业务失败: " + sanitize(root.path("error").asText("unknown")));
+    }
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackProgressStream.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackProgressStream.java
@@ -1,0 +1,44 @@
+package io.oryxos.channel.slack;
+
+import io.oryxos.core.channel.InboundProgressStream;
+import io.oryxos.core.channel.PlaceholderProgressStream;
+
+/** Slack 进度流：chat.postMessage 无原地编辑，采用「占位 + 可选一次工具行 + 终态」。 */
+final class SlackProgressStream implements InboundProgressStream {
+
+  private final PlaceholderProgressStream delegate;
+
+  SlackProgressStream(SlackMessageSender sender, String chatId, String replyToMessageId) {
+    this.delegate = new PlaceholderProgressStream(sender::send, chatId, replyToMessageId, "Slack");
+  }
+
+  @Override
+  public void start() {
+    delegate.start();
+  }
+
+  @Override
+  public void onToken(String delta) {
+    delegate.onToken(delta);
+  }
+
+  @Override
+  public void onToolStart(String toolName) {
+    delegate.onToolStart(toolName);
+  }
+
+  @Override
+  public void onToolEnd(String toolName, boolean success) {
+    delegate.onToolEnd(toolName, success);
+  }
+
+  @Override
+  public void finish(String finalText) {
+    delegate.finish(finalText);
+  }
+
+  @Override
+  public void fail(String errorMessage) {
+    delegate.fail(errorMessage);
+  }
+}

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackSocketClient.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackSocketClient.java
@@ -41,6 +41,9 @@ final class SlackSocketClient implements WebSocket.Listener {
   private static final String TYPE_EVENTS_API = "events_api";
   private static final String TYPE_HELLO = "hello";
   private static final String TYPE_DISCONNECT = "disconnect";
+  private static final String FIELD_OK = "ok";
+  private static final String FIELD_ERROR = "error";
+  private static final String FIELD_URL = "url";
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private final String appToken;
@@ -255,11 +258,12 @@ final class SlackSocketClient implements WebSocket.Listener {
               + sanitize(response.body()));
     }
     JsonNode json = MAPPER.readTree(response.body());
-    if (!json.path("ok").asBoolean(false)) {
+    if (!json.path(FIELD_OK).asBoolean(false)) {
       throw new IllegalStateException(
-          "Slack apps.connections.open 业务失败: " + sanitize(json.path("error").asText("unknown")));
+          "Slack apps.connections.open 业务失败: "
+              + sanitize(json.path(FIELD_ERROR).asText("unknown")));
     }
-    String url = json.path("url").asText(null);
+    String url = json.path(FIELD_URL).asText(null);
     if (url == null || url.isBlank()) {
       throw new IllegalStateException("Slack apps.connections.open 响应缺少 url");
     }

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackSocketClient.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackSocketClient.java
@@ -1,0 +1,286 @@
+package io.oryxos.channel.slack;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.OutboundGuard;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Slack Socket Mode WebSocket：{@code apps.connections.open} 取 URL、收 envelope、ACK、事件回调。
+ *
+ * <p>凭证：App-Level Token（{@code xapp-}）开连接；事件载荷里的用户消息再交给上层。
+ */
+final class SlackSocketClient implements WebSocket.Listener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SlackSocketClient.class);
+
+  static final String API_BASE_URL = "https://slack.com";
+  static final String CONNECTIONS_OPEN_PATH = "/api/apps.connections.open";
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(20);
+  private static final long WS_CLOSE_TIMEOUT_MS = 2_000L;
+  private static final int HTTP_STATUS_OK_MIN = 200;
+  private static final int HTTP_STATUS_OK_MAX_EXCLUSIVE = 300;
+  private static final String TYPE_EVENTS_API = "events_api";
+  private static final String TYPE_HELLO = "hello";
+  private static final String TYPE_DISCONNECT = "disconnect";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final String appToken;
+  private final OutboundGuard guard;
+  private final Consumer<JsonNode> onEvent;
+  private final Consumer<SlackDisconnectKind> onDisconnected;
+
+  private final AtomicReference<WebSocket> socket = new AtomicReference<>();
+  private final AtomicBoolean connected = new AtomicBoolean(false);
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final StringBuilder textBuf = new StringBuilder();
+  private final CountDownLatch openLatch = new CountDownLatch(1);
+  private volatile String openError;
+  private final AtomicBoolean disconnectNotified = new AtomicBoolean(false);
+
+  SlackSocketClient(
+      String appToken,
+      OutboundGuard guard,
+      Consumer<JsonNode> onEvent,
+      Consumer<SlackDisconnectKind> onDisconnected) {
+    this.appToken = Objects.requireNonNull(appToken);
+    this.guard = Objects.requireNonNull(guard);
+    this.onEvent = Objects.requireNonNull(onEvent);
+    this.onDisconnected = onDisconnected == null ? kind -> {} : onDisconnected;
+  }
+
+  void connect(Duration timeout) throws Exception {
+    closed.set(false);
+    disconnectNotified.set(false);
+    guard.check(API_BASE_URL);
+    URI wsUri = openWebSocketUri();
+    // 沙箱只认 http/https；WSS 主机用 https 伪 URL 过白名单（对齐钉钉：开连接 HTTPS 过闸，WS 端点来自平台响应）
+    String host = wsUri.getHost();
+    if (host == null || host.isBlank()) {
+      throw new IllegalStateException("Slack Socket Mode URL 缺少主机名");
+    }
+    guard.check("https://" + host);
+    HttpClient client = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    CompletableFuture<WebSocket> future =
+        client.newWebSocketBuilder().connectTimeout(CONNECT_TIMEOUT).buildAsync(wsUri, this);
+    WebSocket ws;
+    try {
+      ws = future.get(timeout.toSeconds(), TimeUnit.SECONDS);
+    } catch (Exception e) {
+      future.cancel(true);
+      closeQuietly();
+      throw e;
+    }
+    socket.set(ws);
+    if (!openLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+      closeQuietly();
+      throw new IllegalStateException("Slack Socket Mode 连接超时（WebSocket 未就绪）");
+    }
+    if (openError != null) {
+      closeQuietly();
+      throw new IllegalStateException("Slack Socket Mode 连接失败: " + openError);
+    }
+    if (!connected.get()) {
+      closeQuietly();
+      throw new IllegalStateException("Slack Socket Mode 连接失败（未知原因）");
+    }
+  }
+
+  boolean isConnected() {
+    return connected.get() && !closed.get();
+  }
+
+  /** 限时关闭：{@code sendClose().join()} 偶发不返回时放弃等待（对齐飞书 #417），守护线程后台继续。 */
+  void closeQuietly() {
+    closed.set(true);
+    connected.set(false);
+    openLatch.countDown();
+    WebSocket ws = socket.getAndSet(null);
+    if (ws == null) {
+      return;
+    }
+    Thread closer =
+        Thread.ofPlatform()
+            .daemon(true)
+            .name("oryxos-slack-ws-close")
+            .unstarted(
+                () -> {
+                  try {
+                    ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").join();
+                  } catch (RuntimeException ignored) {
+                    // ignore
+                  }
+                });
+    closer.start();
+    try {
+      closer.join(WS_CLOSE_TIMEOUT_MS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    if (closer.isAlive()) {
+      LOG.warn("Slack WS close {}ms 未返回，放弃等待（守护线程后台继续）", WS_CLOSE_TIMEOUT_MS);
+    }
+  }
+
+  @Override
+  public void onOpen(WebSocket webSocket) {
+    connected.set(true);
+    disconnectNotified.set(false);
+    openLatch.countDown();
+    webSocket.request(1);
+  }
+
+  @Override
+  public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+    textBuf.append(data);
+    if (last) {
+      String raw = textBuf.toString();
+      textBuf.setLength(0);
+      handleText(webSocket, raw);
+    }
+    webSocket.request(1);
+    return null;
+  }
+
+  @Override
+  public CompletionStage<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
+    webSocket.request(1);
+    return null;
+  }
+
+  @Override
+  public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+    notifyDisconnected(SlackDisconnectKind.ABRUPT, "close " + statusCode + " " + reason);
+    return null;
+  }
+
+  @Override
+  public void onError(WebSocket webSocket, Throwable error) {
+    LOG.warn("Slack Socket Mode 连接错误: {}", sanitize(error == null ? null : error.getMessage()));
+    if (!connected.get()) {
+      openError = error == null ? "unknown" : error.getMessage();
+      openLatch.countDown();
+    }
+    notifyDisconnected(SlackDisconnectKind.ABRUPT, error == null ? null : error.getMessage());
+  }
+
+  /** 单测：注入原始 envelope JSON。 */
+  void dispatchFrameForTest(String raw, WebSocket webSocket) {
+    handleText(webSocket, raw);
+  }
+
+  private void handleText(WebSocket webSocket, String raw) {
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(raw);
+    } catch (JacksonException e) {
+      LOG.warn("Slack Socket Mode 帧 JSON 解析失败，已忽略");
+      return;
+    }
+    String type = root.path("type").asText("");
+    String envelopeId = root.path("envelope_id").asText("");
+    if (TYPE_HELLO.equals(type)) {
+      return;
+    }
+    if (TYPE_DISCONNECT.equals(type)) {
+      LOG.info("Slack Socket Mode 服务端请求断开: {}", sanitize(root.path("reason").asText("")));
+      ack(webSocket, envelopeId);
+      closeQuietly();
+      notifyDisconnected(SlackDisconnectKind.GRACEFUL, root.path("reason").asText(""));
+      return;
+    }
+    if (TYPE_EVENTS_API.equals(type)) {
+      ack(webSocket, envelopeId);
+      JsonNode payload = root.path("payload");
+      JsonNode event = payload.path("event");
+      if (event.isMissingNode() || !event.isObject()) {
+        return;
+      }
+      try {
+        onEvent.accept(event);
+      } catch (RuntimeException e) {
+        LOG.error("Slack 事件处理异常: {}", sanitize(e.getMessage()));
+      }
+    }
+  }
+
+  private void ack(WebSocket webSocket, String envelopeId) {
+    if (webSocket == null || envelopeId == null || envelopeId.isBlank()) {
+      return;
+    }
+    try {
+      ObjectNode ack = MAPPER.createObjectNode();
+      ack.put("envelope_id", envelopeId);
+      webSocket.sendText(MAPPER.writeValueAsString(ack), true);
+    } catch (Exception e) {
+      LOG.warn("Slack Socket Mode ACK 发送失败: {}", sanitize(e.getMessage()));
+    }
+  }
+
+  private URI openWebSocketUri() throws Exception {
+    HttpClient client = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(API_BASE_URL + CONNECTIONS_OPEN_PATH))
+            .timeout(CONNECT_TIMEOUT)
+            .header("Authorization", "Bearer " + appToken)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .POST(HttpRequest.BodyPublishers.noBody())
+            .build();
+    HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() < HTTP_STATUS_OK_MIN
+        || response.statusCode() >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
+      throw new IllegalStateException(
+          "Slack apps.connections.open 失败 HTTP "
+              + response.statusCode()
+              + ": "
+              + sanitize(response.body()));
+    }
+    JsonNode json = MAPPER.readTree(response.body());
+    if (!json.path("ok").asBoolean(false)) {
+      throw new IllegalStateException(
+          "Slack apps.connections.open 业务失败: " + sanitize(json.path("error").asText("unknown")));
+    }
+    String url = json.path("url").asText(null);
+    if (url == null || url.isBlank()) {
+      throw new IllegalStateException("Slack apps.connections.open 响应缺少 url");
+    }
+    return URI.create(url);
+  }
+
+  private void markDisconnected() {
+    closed.set(true);
+    connected.set(false);
+    openLatch.countDown();
+  }
+
+  private void notifyDisconnected(SlackDisconnectKind kind, String detail) {
+    if (!disconnectNotified.compareAndSet(false, true)) {
+      return;
+    }
+    markDisconnected();
+    onDisconnected.accept(kind);
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-slack/src/test/java/io/oryxos/channel/slack/SlackChannelAdapterStopTest.java
+++ b/oryxos-channel-slack/src/test/java/io/oryxos/channel/slack/SlackChannelAdapterStopTest.java
@@ -1,0 +1,49 @@
+package io.oryxos.channel.slack;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import io.oryxos.core.channel.ChannelConfig;
+import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.InboundMessageService;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.profile.ProfileRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SlackChannelAdapterStopTest {
+
+  private SlackChannelAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    ChannelConfig config =
+        new ChannelConfig("slack-test", "slack", "xoxb-test", "xapp-test", "demo-agent", true);
+    adapter =
+        new SlackChannelAdapter(
+            config,
+            mock(ProfileRegistry.class),
+            mock(InboundMessageService.class),
+            mock(OutboundGuard.class));
+  }
+
+  @Test
+  @DisplayName("未启动时 stop 安全")
+  void stopWithoutStartIsSafe() {
+    adapter.stop();
+    assertEquals(ChannelStatus.State.DISCONNECTED, adapter.status().state());
+  }
+
+  @Test
+  @DisplayName("重连退避随 attempt 增长且有上限")
+  void reconnectBackoffGrows() {
+    long d0 = SlackChannelAdapter.reconnectDelayMs(0);
+    long d3 = SlackChannelAdapter.reconnectDelayMs(3);
+    long d99 = SlackChannelAdapter.reconnectDelayMs(99);
+    assertTrue(d0 >= 2_000L);
+    assertTrue(d3 > d0);
+    assertTrue(d99 <= 60_000L);
+  }
+}

--- a/oryxos-channel-slack/src/test/java/io/oryxos/channel/slack/SlackEventNormalizerTest.java
+++ b/oryxos-channel-slack/src/test/java/io/oryxos/channel/slack/SlackEventNormalizerTest.java
@@ -1,0 +1,98 @@
+package io.oryxos.channel.slack;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SlackEventNormalizerTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private SlackEventNormalizer normalizer;
+
+  @BeforeEach
+  void setUp() {
+    normalizer = new SlackEventNormalizer("ops-slack");
+  }
+
+  @Test
+  @DisplayName("私聊 message + channel_type=im → P2P 文本")
+  void dmMessage() {
+    ObjectNode event = MAPPER.createObjectNode();
+    event.put("type", "message");
+    event.put("channel_type", "im");
+    event.put("user", "U111");
+    event.put("channel", "D222");
+    event.put("ts", "1710000000.000100");
+    event.put("text", "hello slack");
+    Optional<InboundMessage> msg = normalizer.normalize(event);
+    assertTrue(msg.isPresent());
+    InboundMessage m = msg.get();
+    assertEquals(ChatKind.P2P, m.chatKind());
+    assertEquals("hello slack", m.content());
+    assertEquals("D222", m.chatId());
+    assertEquals("U111", m.userId());
+    assertTrue(m.textual());
+  }
+
+  @Test
+  @DisplayName("app_mention → GROUP 且剥离 <@BOT>")
+  void appMention() {
+    ObjectNode event = MAPPER.createObjectNode();
+    event.put("type", "app_mention");
+    event.put("user", "U111");
+    event.put("channel", "C333");
+    event.put("ts", "1710000000.000200");
+    event.put("text", "<@B0BOT> 帮我查一下天气");
+    Optional<InboundMessage> msg = normalizer.normalize(event);
+    assertTrue(msg.isPresent());
+    InboundMessage m = msg.get();
+    assertEquals(ChatKind.GROUP, m.chatKind());
+    assertTrue(m.mentionedBot());
+    assertEquals("帮我查一下天气", m.content());
+  }
+
+  @Test
+  @DisplayName("频道普通 message（非 app_mention）丢弃")
+  void channelMessageWithoutMentionDropped() {
+    ObjectNode event = MAPPER.createObjectNode();
+    event.put("type", "message");
+    event.put("channel_type", "channel");
+    event.put("user", "U111");
+    event.put("channel", "C333");
+    event.put("ts", "1710000000.000300");
+    event.put("text", "noise");
+    assertTrue(normalizer.normalize(event).isEmpty());
+  }
+
+  @Test
+  @DisplayName("bot_id / subtype 消息丢弃")
+  void botAndSubtypeDropped() {
+    ObjectNode bot = MAPPER.createObjectNode();
+    bot.put("type", "message");
+    bot.put("channel_type", "im");
+    bot.put("bot_id", "B999");
+    bot.put("user", "U111");
+    bot.put("channel", "D222");
+    bot.put("ts", "1.1");
+    bot.put("text", "from bot");
+    assertTrue(normalizer.normalize(bot).isEmpty());
+
+    ObjectNode edited = MAPPER.createObjectNode();
+    edited.put("type", "message");
+    edited.put("channel_type", "im");
+    edited.put("subtype", "message_changed");
+    edited.put("user", "U111");
+    edited.put("channel", "D222");
+    edited.put("ts", "1.2");
+    edited.put("text", "edited");
+    assertTrue(normalizer.normalize(edited).isEmpty());
+  }
+}

--- a/oryxos-channel-slack/src/test/java/io/oryxos/channel/slack/SlackMessageSenderTest.java
+++ b/oryxos-channel-slack/src/test/java/io/oryxos/channel/slack/SlackMessageSenderTest.java
@@ -1,0 +1,39 @@
+package io.oryxos.channel.slack;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SlackMessageSenderTest {
+
+  @Test
+  @DisplayName("segment 按块切分")
+  void segmentChunks() {
+    List<String> parts = SlackMessageSender.segment("abcdefghij", 4);
+    assertEquals(List.of("abcd", "efgh", "ij"), parts);
+  }
+
+  @Test
+  @DisplayName("ok=true 不抛")
+  void okTrue() {
+    assertDoesNotThrow(
+        () -> SlackMessageSender.rejectBusinessError("{\"ok\":true,\"ts\":\"1.1\"}"));
+  }
+
+  @Test
+  @DisplayName("ok=false 抛业务失败")
+  void okFalse() {
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                SlackMessageSender.rejectBusinessError(
+                    "{\"ok\":false,\"error\":\"channel_not_found\"}"));
+    assertTrue(ex.getMessage().contains("channel_not_found"));
+  }
+}

--- a/oryxos-cli/pom.xml
+++ b/oryxos-cli/pom.xml
@@ -42,6 +42,10 @@
         </dependency>
         <dependency>
             <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-channel-slack</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
             <artifactId>oryxos-provider</artifactId>
         </dependency>
         <dependency>

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -1031,6 +1031,10 @@ public class OryxOsRuntime {
             io.oryxos.channel.dingtalk.DingTalkChannelAdapter.TYPE,
             resolved ->
                 new io.oryxos.channel.dingtalk.DingTalkChannelAdapter(
+                    resolved, profileRegistry, inboundMessageService, channelOutboundGuard),
+            io.oryxos.channel.slack.SlackChannelAdapter.TYPE,
+            resolved ->
+                new io.oryxos.channel.slack.SlackChannelAdapter(
                     resolved, profileRegistry, inboundMessageService, channelOutboundGuard)));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <module>oryxos-channel-feishu</module>
         <module>oryxos-channel-wecom</module>
         <module>oryxos-channel-dingtalk</module>
+        <module>oryxos-channel-slack</module>
         <module>oryxos-web</module>
         <module>oryxos-storage</module>
         <module>oryxos-cli</module>
@@ -139,6 +140,11 @@
             <dependency>
                 <groupId>io.oryxos</groupId>
                 <artifactId>oryxos-channel-dingtalk</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.oryxos</groupId>
+                <artifactId>oryxos-channel-slack</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary
- New `oryxos-channel-slack`: Socket Mode WS inbound, text DM + `app_mention`, `chat.postMessage` reply, reconnect, bounded WS close.
- Credential mapping: `app_id` = Bot Token (`xoxb-`), `app_secret` = App-Level Token (`xapp-`).
- Wire boot/cli factories; allowlist `slack.com` / `*.slack.com`; docs `SlackChannelSetup.md`.

## Test plan
- [x] Unit: SlackEventNormalizer / MessageSender / AdapterStop
- [x] Local serve: `ops-slack` CONNECTED
- [ ] Slack DM / channel `@OryxOS` text reply (manual)

Made with [Cursor](https://cursor.com)