### PR TITLE
feat(channel-slack): inbound image/file download with Bot Token

### DIFF
--- a/docs/SlackChannelSetup.md
+++ b/docs/SlackChannelSetup.md
@@ -7,10 +7,10 @@
 ## 一、Slack 侧：创建 App 并启用 Socket Mode
 
 1. 打开 [api.slack.com/apps](https://api.slack.com/apps)，Create New App → From scratch，选目标 Workspace。
-2. **OAuth & Permissions** → Bot Token Scopes 至少：`chat:write`、`im:history`、`app_mentions:read`、`channels:history`（按需）。
+2. **OAuth & Permissions** → Bot Token Scopes 至少：`chat:write`、`im:history`、`app_mentions:read`、`channels:history`、`files:read`（图片/文件入站）。
 3. **Socket Mode** → Enable → 生成 **App-Level Token**（`xapp-…`），scope 勾 `connections:write`。
-4. **Event Subscriptions** → Enable → Subscribe to bot events：`message.im`、`app_mention`。
-5. **Install to Workspace**，复制 **Bot User OAuth Token**（`xoxb-…`）。
+4. **Event Subscriptions** → Enable → Subscribe to bot events：`message.im`、`app_mention`（文件私聊走 `message.im` + `file_share`）。
+5. **Install to Workspace**（改 scopes 后需 **Reinstall**），复制 **Bot User OAuth Token**（`xoxb-…`）。
 6. 将 Bot 邀请进目标频道（群聊需 `@机器人`）。
 
    - ⚠️ 凭证只经环境变量注入 OryxOS，禁止写入仓库或明文配置文件。
@@ -45,8 +45,9 @@
 
 ## 三、使用方式
 
-- **私聊**：在 Slack 中打开该 Bot 的 DM，直接发文本。
+- **私聊**：在 Slack 中打开该 Bot 的 DM，直接发文本、图片或文件。
 - **群聊**：将 Bot 拉入频道后 `@Bot + 问题`（平台推送 `app_mention`）。
+- **图片 / 文件**：经 `url_private_download` 带 Bot Token 落盘到 `.oryxos/inbound-media/`（需 `files:read`）；图片可供 Vision，文件路径写入 Agent 提示。
 - **联网检索**：须在绑定 Agent 的 `AGENT.md` `tools:` 中加入 `web_search` 等，见 Tool 文档。
 
 ## 四、与飞书/企微/钉钉的差异
@@ -56,11 +57,11 @@
 | 凭证 | App ID / Secret | BotID / Secret | ClientId / Secret | Bot Token / App-Level Token |
 | 连接 | SDK 长连接 | 企微 WS | Stream WS | Socket Mode WSS |
 | 回复 | im API | 长连接发帧 | sessionWebhook | chat.postMessage |
-| MVP 媒体 | 图/文件/音视频 | 同 | 同 | **仅文本**（后续再补） |
+| MVP 媒体 | 图/文件/音视频 | 同 | 同 | **图片 + 文件**（语音/视频后续） |
 
 ## 五、非目标（本期不做）
 
-- 图片 / 文件 / 语音 / 视频入站
+- 语音 / 视频入站与 ASR
 - Block Kit / 斜杠命令 / HTTP Events 公网回调
 - MCP `@modelcontextprotocol/server-slack`（可另配）
 - Notify `type=slack`

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackChannelAdapter.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackChannelAdapter.java
@@ -37,6 +37,7 @@ public class SlackChannelAdapter implements InboundChannelAdapter {
   private static final long RECONNECT_BASE_MS = 2_000L;
   private static final long RECONNECT_MAX_MS = 60_000L;
   private static final int RECONNECT_MAX_SHIFT = 5;
+  private static final String MEDIA_DIR_PREFIX = "oryxos-slack-media-";
 
   private final ChannelConfig config;
   private final ProfileRegistry profileRegistry;
@@ -46,6 +47,7 @@ public class SlackChannelAdapter implements InboundChannelAdapter {
   private final AtomicReference<SlackSocketClient> socketRef = new AtomicReference<>();
   private volatile SlackMessageSender sender;
   private volatile SlackEventNormalizer normalizer;
+  private volatile SlackInboundMediaResolver mediaResolver;
   private volatile SlackDisconnectKind lastDisconnectKind = SlackDisconnectKind.ABRUPT;
   private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
   private volatile String lastError;
@@ -123,6 +125,7 @@ public class SlackChannelAdapter implements InboundChannelAdapter {
     }
     sender = null;
     normalizer = null;
+    mediaResolver = null;
     state = ChannelStatus.State.DISCONNECTED;
   }
 
@@ -183,6 +186,13 @@ public class SlackChannelAdapter implements InboundChannelAdapter {
     }
     if (sender == null) {
       sender = new SlackMessageSender(guard, config.appId(), SlackMessageSender.DEFAULT_CHUNK_SIZE);
+    }
+    if (mediaResolver == null) {
+      mediaResolver =
+          new SlackInboundMediaResolver(
+              config.appId(),
+              io.oryxos.core.channel.InboundMediaRoots.forChannel(config.name(), MEDIA_DIR_PREFIX),
+              config.name());
     }
   }
 
@@ -309,7 +319,25 @@ public class SlackChannelAdapter implements InboundChannelAdapter {
       LOG.info("渠道 {} 重复事件已忽略: {}", sanitize(m.channelName()), sanitize(m.messageId()));
       return;
     }
-    inboundMessageService.onClaimedMessage(m, this);
+    String replyTo = m.chatKind() == io.oryxos.core.channel.ChatKind.GROUP ? m.messageId() : null;
+    java.util.concurrent.CountDownLatch slowWork = null;
+    if (SlackInboundMediaResolver.hasDownloadableMedia(m)) {
+      slowWork = inboundMessageService.beginSlowWork(this, m.chatId(), replyTo);
+    }
+    try {
+      SlackInboundMediaResolver resolver = mediaResolver;
+      InboundMessage enriched = resolver == null ? m : resolver.resolve(m);
+      if (slowWork != null) {
+        inboundMessageService.onClaimedMessage(enriched, this, slowWork);
+      } else {
+        inboundMessageService.onClaimedMessage(enriched, this);
+      }
+    } catch (RuntimeException e) {
+      if (slowWork != null) {
+        slowWork.countDown();
+      }
+      throw e;
+    }
   }
 
   private static String sanitize(String value) {

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackEventNormalizer.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackEventNormalizer.java
@@ -2,17 +2,21 @@ package io.oryxos.channel.slack;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Slack Events API 事件 → 归一化 {@link InboundMessage}（MVP：仅文本私聊 / 群 {@code app_mention}）。
+ * Slack Events API 事件 → 归一化 {@link InboundMessage}。
  *
- * <p>群聊只接受 {@code app_mention}；普通群消息丢弃。忽略 bot 自身消息与带 subtype 的系统编辑帧。
+ * <p>私聊 {@code message}（含 {@code file_share}）与群 {@code app_mention}；忽略 bot 自身与编辑/删除等 subtype。
  */
 public class SlackEventNormalizer {
 
@@ -24,6 +28,10 @@ public class SlackEventNormalizer {
   private static final String CHANNEL_TYPE_IM = "im";
   private static final String CHANNEL_TYPE_MPIM = "mpim";
   private static final String FIELD_BOT_ID = "bot_id";
+  private static final String FIELD_FILES = "files";
+  private static final String SUBTYPE_FILE_SHARE = "file_share";
+  private static final String MIME_IMAGE_PREFIX = "image/";
+  private static final Set<String> ALLOWED_SUBTYPES = Set.of(SUBTYPE_FILE_SHARE);
   private static final Pattern MENTION = Pattern.compile("<@[A-Z0-9]+>\\s*");
 
   private final String channelName;
@@ -52,7 +60,7 @@ public class SlackEventNormalizer {
   }
 
   private Optional<InboundMessage> normalizeAppMention(JsonNode event) {
-    if (isBotOrEdited(event)) {
+    if (shouldDrop(event)) {
       return Optional.empty();
     }
     String userId = text(event, "user");
@@ -63,6 +71,10 @@ public class SlackEventNormalizer {
       return Optional.empty();
     }
     String content = stripMentions(event.path("text").asText("")).strip();
+    List<InboundAttachment> attachments = extractFiles(event.path(FIELD_FILES));
+    if (content.isBlank() && attachments.isEmpty()) {
+      return Optional.empty();
+    }
     return Optional.of(
         new InboundMessage(
             CHANNEL_TYPE,
@@ -72,19 +84,18 @@ public class SlackEventNormalizer {
             userId,
             chatId,
             content,
+            !content.isBlank(),
             true,
-            true,
-            List.of()));
+            attachments));
   }
 
   private Optional<InboundMessage> normalizeMessage(JsonNode event) {
-    if (isBotOrEdited(event)) {
+    if (shouldDrop(event)) {
       return Optional.empty();
     }
     String channelType = text(event, "channel_type");
     boolean dm = CHANNEL_TYPE_IM.equals(channelType) || CHANNEL_TYPE_MPIM.equals(channelType);
     if (!dm) {
-      // 频道内普通 message 等 app_mention；避免重复处理
       return Optional.empty();
     }
     String userId = text(event, "user");
@@ -95,6 +106,10 @@ public class SlackEventNormalizer {
       return Optional.empty();
     }
     String content = event.path("text").asText("").strip();
+    List<InboundAttachment> attachments = extractFiles(event.path(FIELD_FILES));
+    if (content.isBlank() && attachments.isEmpty()) {
+      return Optional.empty();
+    }
     return Optional.of(
         new InboundMessage(
             CHANNEL_TYPE,
@@ -104,17 +119,48 @@ public class SlackEventNormalizer {
             userId,
             chatId,
             content,
-            true,
+            !content.isBlank(),
             false,
-            List.of()));
+            attachments));
   }
 
-  private static boolean isBotOrEdited(JsonNode event) {
+  /** 丢弃 bot 消息与不可处理的 subtype；保留空 subtype 与 {@code file_share}（图片/文件入站）。 */
+  static boolean shouldDrop(JsonNode event) {
     if (event.hasNonNull(FIELD_BOT_ID)) {
       return true;
     }
     String subtype = text(event, "subtype");
-    return subtype != null && !subtype.isBlank();
+    if (subtype == null || subtype.isBlank()) {
+      return false;
+    }
+    return !ALLOWED_SUBTYPES.contains(subtype);
+  }
+
+  static List<InboundAttachment> extractFiles(JsonNode files) {
+    List<InboundAttachment> out = new ArrayList<>();
+    if (files == null || !files.isArray()) {
+      return out;
+    }
+    for (JsonNode file : files) {
+      if (file == null || !file.isObject()) {
+        continue;
+      }
+      String url = text(file, "url_private_download");
+      if (url == null) {
+        url = text(file, "url_private");
+      }
+      if (url == null) {
+        continue;
+      }
+      String fileName = text(file, "name");
+      String mime = text(file, "mimetype");
+      if (mime != null && mime.toLowerCase(Locale.ROOT).startsWith(MIME_IMAGE_PREFIX)) {
+        out.add(new InboundAttachment(InboundAttachment.TYPE_IMAGE, url, null, fileName));
+      } else {
+        out.add(InboundAttachment.fileUrl(url, fileName));
+      }
+    }
+    return out;
   }
 
   static String stripMentions(String text) {

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackInboundMediaResolver.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackInboundMediaResolver.java
@@ -227,7 +227,7 @@ final class SlackInboundMediaResolver {
     if (dot < 0 || dot == path.length() - 1) {
       return null;
     }
-    String ext = path.substring(dot).toLowerCase(Locale.ROOT);
+    String ext = asciiLower(path.substring(dot));
     if (!ext.matches(SAFE_EXTENSION_PATTERN)) {
       return null;
     }
@@ -238,12 +238,24 @@ final class SlackInboundMediaResolver {
     if (uri == null || uri.getScheme() == null || uri.getHost() == null) {
       return false;
     }
-    String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+    String scheme = asciiLower(uri.getScheme());
     if (!SCHEME_HTTPS.equals(scheme)) {
       return false;
     }
-    String host = uri.getHost().toLowerCase(Locale.ROOT);
+    String host = asciiLower(uri.getHost());
     return HOST_SLACK.equals(host) || host.endsWith(HOST_SUFFIX_SLACK);
+  }
+
+  /** ASCII-only 小写，避免 SpotBugs IMPROPER_UNICODE（scheme/host/ext 均为 ASCII）。 */
+  private static String asciiLower(String value) {
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
   }
 
   private static String safeSegment(String messageId) {

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackInboundMediaResolver.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackInboundMediaResolver.java
@@ -1,0 +1,266 @@
+package io.oryxos.channel.slack;
+
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMediaHttp;
+import io.oryxos.core.channel.InboundMediaJanitor;
+import io.oryxos.core.channel.InboundMediaLimits;
+import io.oryxos.core.channel.InboundMediaPaths;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.LimitedMediaWriter;
+import io.oryxos.core.session.ImageMime;
+import io.oryxos.core.session.InboundMediaExt;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Slack 入站图片/文件：事件里的 {@code url_private(_download)} 需带 Bot Token 下载后落盘，再交给 enricher / Vision。
+ *
+ * <p>失败保留原远程 URL（降级，不阻断编排）。
+ */
+final class SlackInboundMediaResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SlackInboundMediaResolver.class);
+
+  private static final String DEFAULT_EXTENSION = ".bin";
+  private static final String EXT_DOT = ".";
+  private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
+  private static final int DOWNLOAD_ATTEMPTS = 2;
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(20);
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(120);
+  private static final String HEADER_AUTHORIZATION = "Authorization";
+  private static final String SCHEME_HTTPS = "https";
+  private static final String HOST_SLACK = "slack.com";
+  private static final String HOST_SUFFIX_SLACK = ".slack.com";
+
+  private final String botToken;
+  private final Path mediaRoot;
+  private final String channelName;
+  private final InboundMediaJanitor janitor;
+
+  SlackInboundMediaResolver(String botToken, Path mediaRoot, String channelName) {
+    this(botToken, mediaRoot, channelName, InboundMediaJanitor.fromEnv());
+  }
+
+  SlackInboundMediaResolver(
+      String botToken, Path mediaRoot, String channelName, InboundMediaJanitor janitor) {
+    this.botToken = botToken;
+    this.mediaRoot = mediaRoot;
+    this.channelName = channelName;
+    this.janitor = janitor == null ? InboundMediaJanitor.fromEnv() : janitor;
+  }
+
+  InboundMessage resolve(InboundMessage message) {
+    if (message == null || message.attachments().isEmpty()) {
+      return message;
+    }
+    janitor.sweepIfDue(mediaRoot);
+    List<InboundAttachment> resolved = new ArrayList<>(message.attachments().size());
+    boolean changed = false;
+    for (InboundAttachment attachment : message.attachments()) {
+      if (!needsDownload(attachment)) {
+        resolved.add(attachment);
+        continue;
+      }
+      InboundAttachment next = downloadOrKeep(message.messageId(), attachment);
+      changed |= next != attachment;
+      resolved.add(next);
+    }
+    if (!changed) {
+      return message;
+    }
+    return new InboundMessage(
+        message.channelType(),
+        message.channelName(),
+        message.messageId(),
+        message.chatKind(),
+        message.userId(),
+        message.chatId(),
+        message.content(),
+        message.textual(),
+        message.mentionedBot(),
+        resolved);
+  }
+
+  static boolean needsDownload(InboundAttachment attachment) {
+    if (attachment == null || attachment.url() == null || attachment.url().isBlank()) {
+      return false;
+    }
+    String type = attachment.type();
+    return InboundAttachment.TYPE_IMAGE.equals(type) || InboundAttachment.TYPE_FILE.equals(type);
+  }
+
+  static boolean hasDownloadableMedia(InboundMessage message) {
+    if (message == null) {
+      return false;
+    }
+    for (InboundAttachment attachment : message.attachments()) {
+      if (needsDownload(attachment)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private InboundAttachment downloadOrKeep(String messageId, InboundAttachment attachment) {
+    String remoteUrl = attachment.url().strip();
+    Exception last = null;
+    for (int attempt = 1; attempt <= DOWNLOAD_ATTEMPTS; attempt++) {
+      long started = System.nanoTime();
+      try {
+        Path path = writeToMediaRoot(messageId, remoteUrl, attachment);
+        LOG.info(
+            "Slack 渠道 {} 媒体已落盘（messageId={}, type={}, {}ms）",
+            sanitize(channelName),
+            sanitize(messageId),
+            sanitize(attachment.type()),
+            (System.nanoTime() - started) / 1_000_000L);
+        return new InboundAttachment(
+            attachment.type(), path.toAbsolutePath().toString(), remoteUrl, attachment.fileName());
+      } catch (Exception e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
+        last = e;
+        LOG.warn(
+            "Slack 渠道 {} 下载媒体失败尝试 {}/{}（messageId={}, host={}, {}ms）：{}",
+            sanitize(channelName),
+            attempt,
+            DOWNLOAD_ATTEMPTS,
+            sanitize(messageId),
+            sanitize(hostOf(remoteUrl)),
+            (System.nanoTime() - started) / 1_000_000L,
+            sanitize(e.getMessage()));
+      }
+    }
+    LOG.warn(
+        "Slack 渠道 {} 下载媒体最终失败（messageId={}）：{}，保留远程 URL",
+        sanitize(channelName),
+        sanitize(messageId),
+        sanitize(last == null ? null : last.getMessage()));
+    return attachment;
+  }
+
+  private Path writeToMediaRoot(String messageId, String remoteUrl, InboundAttachment attachment)
+      throws Exception {
+    URI uri = URI.create(remoteUrl);
+    if (!isAllowedMediaUri(uri)) {
+      throw new IllegalStateException("拒绝非 Slack 文件域临时下载地址: " + sanitize(uri.getHost()));
+    }
+    Map<String, String> headers = Map.of(HEADER_AUTHORIZATION, "Bearer " + botToken);
+    byte[] bytes =
+        InboundMediaHttp.getBytesFollowingAllowlist(
+            uri,
+            CONNECT_TIMEOUT,
+            READ_TIMEOUT,
+            InboundMediaLimits.MAX_FILE_BYTES,
+            this::isAllowedMediaUri,
+            headers);
+    if (bytes == null || bytes.length == 0) {
+      throw new IllegalStateException("下载临时文件为空");
+    }
+    String ext = extensionFor(attachment, remoteUrl);
+    Path dir = mediaRoot.resolve(safeSegment(messageId));
+    Files.createDirectories(dir);
+    String stem = "slack-media";
+    Path target = dir.resolve(stem + ext);
+    janitor.ensureQuotaOrThrow(mediaRoot);
+    LimitedMediaWriter.writeLimited(bytes, target, InboundMediaLimits.MAX_FILE_BYTES);
+    if (InboundAttachment.TYPE_IMAGE.equals(attachment.type())
+        && DEFAULT_EXTENSION.equals(ext)
+        && ImageMime.hasRecognizedMagic(target)) {
+      String betterExt = ImageMime.extensionFor(ImageMime.probeFile(target));
+      if (betterExt != null && !DEFAULT_EXTENSION.equals(betterExt) && !betterExt.equals(ext)) {
+        Path renamed = dir.resolve(stem + betterExt);
+        try {
+          Files.move(target, renamed);
+          return renamed;
+        } catch (Exception ignored) {
+          // 保留原扩展名
+        }
+      }
+    }
+    String better = InboundMediaExt.betterFileExtension(target, ext);
+    if (better != null && !better.equals(ext)) {
+      Path renamed = dir.resolve(stem + better);
+      try {
+        Files.move(target, renamed);
+        return renamed;
+      } catch (Exception ignored) {
+        // 保留原扩展名
+      }
+    }
+    return target;
+  }
+
+  private static String extensionFor(InboundAttachment attachment, String remoteUrl) {
+    if (attachment.fileName() != null && attachment.fileName().contains(EXT_DOT)) {
+      String fromName = extensionOf(attachment.fileName());
+      if (fromName != null) {
+        return fromName;
+      }
+    }
+    String fromUrl = extensionOf(remoteUrl);
+    return fromUrl == null ? DEFAULT_EXTENSION : fromUrl;
+  }
+
+  private static String extensionOf(String nameOrUrl) {
+    if (nameOrUrl == null || nameOrUrl.isBlank()) {
+      return null;
+    }
+    String path = nameOrUrl;
+    int q = path.indexOf('?');
+    if (q >= 0) {
+      path = path.substring(0, q);
+    }
+    int slash = path.lastIndexOf('/');
+    if (slash >= 0) {
+      path = path.substring(slash + 1);
+    }
+    int dot = path.lastIndexOf(EXT_DOT);
+    if (dot < 0 || dot == path.length() - 1) {
+      return null;
+    }
+    String ext = path.substring(dot).toLowerCase(Locale.ROOT);
+    if (!ext.matches(SAFE_EXTENSION_PATTERN)) {
+      return null;
+    }
+    return ext;
+  }
+
+  private boolean isAllowedMediaUri(URI uri) {
+    if (uri == null || uri.getScheme() == null || uri.getHost() == null) {
+      return false;
+    }
+    String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+    if (!SCHEME_HTTPS.equals(scheme)) {
+      return false;
+    }
+    String host = uri.getHost().toLowerCase(Locale.ROOT);
+    return HOST_SLACK.equals(host) || host.endsWith(HOST_SUFFIX_SLACK);
+  }
+
+  private static String safeSegment(String messageId) {
+    return InboundMediaPaths.safeSegment(messageId);
+  }
+
+  private static String hostOf(String url) {
+    try {
+      String host = URI.create(url).getHost();
+      return host == null ? "" : host;
+    } catch (IllegalArgumentException e) {
+      return "";
+    }
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackInboundMediaResolver.java
+++ b/oryxos-channel-slack/src/main/java/io/oryxos/channel/slack/SlackInboundMediaResolver.java
@@ -15,7 +15,6 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/oryxos-channel-slack/src/test/java/io/oryxos/channel/slack/SlackEventNormalizerTest.java
+++ b/oryxos-channel-slack/src/test/java/io/oryxos/channel/slack/SlackEventNormalizerTest.java
@@ -1,11 +1,13 @@
 package io.oryxos.channel.slack;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,8 +75,8 @@ class SlackEventNormalizerTest {
   }
 
   @Test
-  @DisplayName("bot_id / subtype 消息丢弃")
-  void botAndSubtypeDropped() {
+  @DisplayName("bot_id / 编辑 subtype 丢弃；file_share 保留")
+  void botAndSubtypeHandling() {
     ObjectNode bot = MAPPER.createObjectNode();
     bot.put("type", "message");
     bot.put("channel_type", "im");
@@ -94,5 +96,30 @@ class SlackEventNormalizerTest {
     edited.put("ts", "1.2");
     edited.put("text", "edited");
     assertTrue(normalizer.normalize(edited).isEmpty());
+  }
+
+  @Test
+  @DisplayName("file_share 私聊：解析图片附件")
+  void fileShareDm() {
+    ObjectNode event = MAPPER.createObjectNode();
+    event.put("type", "message");
+    event.put("subtype", "file_share");
+    event.put("channel_type", "im");
+    event.put("user", "U111");
+    event.put("channel", "D222");
+    event.put("ts", "1710000000.000400");
+    event.put("text", "");
+    var files = event.putArray("files");
+    var file = files.addObject();
+    file.put("name", "shot.png");
+    file.put("mimetype", "image/png");
+    file.put("url_private_download", "https://files.slack.com/files-pri/T-F/download/shot.png");
+    Optional<InboundMessage> msg = normalizer.normalize(event);
+    assertTrue(msg.isPresent());
+    InboundMessage m = msg.get();
+    assertEquals(1, m.attachments().size());
+    assertEquals(InboundAttachment.TYPE_IMAGE, m.attachments().get(0).type());
+    assertEquals("shot.png", m.attachments().get(0).fileName());
+    assertFalse(m.textual());
   }
 }

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaHttp.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaHttp.java
@@ -164,10 +164,6 @@ public final class InboundMediaHttp {
     throw new IOException("媒体下载重定向超过上限 " + MAX_REDIRECTS);
   }
 
-  private static HttpURLConnection openGet(URI uri, int connectMs, int readMs) throws IOException {
-    return openGet(uri, connectMs, readMs, null);
-  }
-
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "URLCONNECTION_SSRF_FD",
       justification =

--- a/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaHttp.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/InboundMediaHttp.java
@@ -97,9 +97,20 @@ public final class InboundMediaHttp {
     throw new IllegalStateException("媒体下载重定向超过上限 " + MAX_REDIRECTS);
   }
 
+  public static byte[] getBytesFollowingAllowlist(
+      URI start,
+      Duration connectTimeout,
+      Duration readTimeout,
+      long maxBytes,
+      Predicate<URI> uriAllowed)
+      throws IOException {
+    return getBytesFollowingAllowlist(
+        start, connectTimeout, readTimeout, maxBytes, uriAllowed, null);
+  }
+
   /**
-   * 用 {@link HttpURLConnection} 下载（硬 connect/read 超时），最多跟随 {@value #MAX_REDIRECTS} 次且每跳校验
-   * allowlist；响应体超过 {@code maxBytes} 则失败。
+   * 同 {@link #getBytesFollowingAllowlist(URI, Duration, Duration, long, Predicate)}，可附带请求头（如 Slack
+   * {@code Authorization: Bearer xoxb-}）。
    */
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "URLCONNECTION_SSRF_FD",
@@ -111,7 +122,8 @@ public final class InboundMediaHttp {
       Duration connectTimeout,
       Duration readTimeout,
       long maxBytes,
-      Predicate<URI> uriAllowed)
+      Predicate<URI> uriAllowed,
+      java.util.Map<String, String> requestHeaders)
       throws IOException {
     if (start == null || uriAllowed == null) {
       throw new IllegalArgumentException("uri/allowlist 不可空");
@@ -126,7 +138,7 @@ public final class InboundMediaHttp {
       if (!uriAllowed.test(current)) {
         throw new IOException("拒绝非允许域临时下载地址: " + InboundMediaPaths.sanitizeLog(hostOf(current)));
       }
-      HttpURLConnection conn = openGet(current, connectMs, readMs);
+      HttpURLConnection conn = openGet(current, connectMs, readMs, requestHeaders);
       try {
         int code = conn.getResponseCode();
         if (code >= HTTP_STATUS_OK_MIN && code < HTTP_STATUS_OK_MAX_EXCLUSIVE) {
@@ -152,12 +164,18 @@ public final class InboundMediaHttp {
     throw new IOException("媒体下载重定向超过上限 " + MAX_REDIRECTS);
   }
 
+  private static HttpURLConnection openGet(URI uri, int connectMs, int readMs) throws IOException {
+    return openGet(uri, connectMs, readMs, null);
+  }
+
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
       value = "URLCONNECTION_SSRF_FD",
       justification =
           "仅由 getBytesFollowingAllowlist 在 uriAllowed 通过后调用；禁自动重定向，"
               + "避免 SpotBugs 将已校验 URI 的 openConnection 判为未防护 SSRF。")
-  private static HttpURLConnection openGet(URI uri, int connectMs, int readMs) throws IOException {
+  private static HttpURLConnection openGet(
+      URI uri, int connectMs, int readMs, java.util.Map<String, String> requestHeaders)
+      throws IOException {
     URL url;
     try {
       url = uri.toURL();
@@ -170,6 +188,13 @@ public final class InboundMediaHttp {
     conn.setReadTimeout(readMs);
     conn.setRequestMethod("GET");
     conn.setRequestProperty(HEADER_USER_AGENT, USER_AGENT);
+    if (requestHeaders != null) {
+      for (var e : requestHeaders.entrySet()) {
+        if (e.getKey() != null && !e.getKey().isBlank() && e.getValue() != null) {
+          conn.setRequestProperty(e.getKey(), e.getValue());
+        }
+      }
+    }
     conn.setUseCaches(false);
     return conn;
   }


### PR DESCRIPTION
## Summary
- Accept Slack `file_share` (was dropped as subtype); parse `files[]` into image/file attachments.
- Download `url_private(_download)` with `Authorization: Bearer` bot token; land under `.oryxos/inbound-media/`.
- `InboundMediaHttp` gains optional request-header overload for authenticated downloads.
- Docs: require `files:read` + reinstall.

## Test plan
- [x] Unit: file_share normalize + existing Slack tests
- [ ] Local: add `files:read`, reinstall app, DM bot an image/file
- [ ] CI green

Made with [Cursor](https://cursor.com)