### PR TITLE
feat(channel-discord): Gateway text DM and guild mention MVP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ DINGTALK_CLIENT_SECRET=
 SLACK_BOT_TOKEN=
 SLACK_APP_TOKEN=
 # SLACK_TEAM_ID=   # 可选，人工核对用；渠道启动走 auth 不必写入 channels.yaml
+DISCORD_BOT_TOKEN=
+DISCORD_APPLICATION_ID=
 # 飞书/钉钉入站语音转写（OpenAI 兼容 Whisper）；企微语音用平台 ASR，可不配
 OPENAI_API_KEY=
 # ORYXOS_ASR_API_KEY=

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -102,6 +102,8 @@ http:
     - oapi.dingtalk.com         # 钉钉 webhook 通知 + sessionWebhook 回复
     - slack.com                 # Slack Web API（connections.open / chat.postMessage）
     - "*.slack.com"             # Slack Socket Mode WSS（wss-primary / wss-backup 等）
+    - discord.com               # Discord REST API（发消息）
+    - gateway.discord.gg        # Discord Gateway WSS
     - api.open-meteo.com        # 天气 Agent 免 key 天气源（31 节 Demo 一）
     - hn.algolia.com            # 科技日报 Agent 新闻源（31 节 Demo 二）
     - api.github.com            # GitHub 日报脚本子进程网络（31 节 Demo 三）

--- a/config/channels.yaml.example
+++ b/config/channels.yaml.example
@@ -33,3 +33,19 @@ channels:
   #   app_secret: ${SLACK_APP_TOKEN}      # App-Level Token (xapp-，需 connections:write)
   #   agent: ops-agent
   #   enabled: true
+
+  # Discord Gateway 长连接（见 docs/DiscordChannelSetup.md）
+  # - name: ops-discord
+  #   type: discord
+  #   app_id: ${DISCORD_BOT_TOKEN}            # Bot Token
+  #   app_secret: ${DISCORD_APPLICATION_ID}   # Application ID（@提及匹配）
+  #   agent: ops-agent
+  #   enabled: true
+
+  # Discord Gateway 长连接（见 docs/DiscordChannelSetup.md）
+  # - name: ops-discord
+  #   type: discord
+  #   app_id: ${DISCORD_BOT_TOKEN}            # Bot Token
+  #   app_secret: ${DISCORD_APPLICATION_ID}   # Application ID（频道 @Bot 匹配）
+  #   agent: ops-agent
+  #   enabled: true

--- a/docs/DiscordChannelSetup.md
+++ b/docs/DiscordChannelSetup.md
@@ -1,0 +1,71 @@
+# Discord 机器人入站渠道接入指南
+
+本文是 OryxOS Discord 入站渠道的部署操作手册。架构对称飞书/企微/钉钉/Slack：以 **Gateway WebSocket** 主动连接 Discord（免公网回调 URL）；回复经 REST `POST /channels/{id}/messages`。
+
+> 范围：Discord Bot **Gateway v10**。MVP 仅文本私聊与公会频道 `@Bot`。附件/图片/语音后续单独 PR。
+
+## 一、Discord 侧：创建 Application 并启用 Intents
+
+1. 打开 [Discord Developer Portal](https://discord.com/developers/applications) → **New Application**，命名后创建。
+2. 左侧 **Bot** → **Add Bot**（若尚未创建）。
+3. **Privileged Gateway Intents** 打开：
+   - **Message Content Intent**（必开，否则收不到消息正文）
+   - （可选）Server Members Intent — MVP 不需要
+4. Bot 页 **Reset Token** / 复制 **Bot Token**（保密，对应 OryxOS `DISCORD_BOT_TOKEN`）。
+5. 左侧 **General Information** 复制 **Application ID**（对应 `DISCORD_APPLICATION_ID`；Bot 的 User ID 通常与此相同，用于 `@` 匹配）。
+6. **OAuth2 → URL Generator**：
+   - Scopes：`bot`
+   - Bot Permissions：至少 `Send Messages`、`Read Message History`、`View Channels`；私聊还需能接收 DM（默认 Bot 可开 DM）
+   - 生成 URL，用浏览器邀请 Bot 进目标服务器。
+7. 用户需在 Discord **用户设置 → 隐私与安全** 允许来自服务器成员的私信（若测 DM）。
+
+   - ⚠️ 凭证只经环境变量注入 OryxOS，禁止写入仓库或明文配置文件。
+
+## 二、OryxOS 侧：配置与启动
+
+1. **凭证走环境变量**：
+
+   ```bash
+   export DISCORD_BOT_TOKEN=...
+   export DISCORD_APPLICATION_ID=...
+   ```
+
+2. **渠道绑定** `.oryxos/channels.yaml`（模板见 `config/channels.yaml.example`）：
+
+   ```yaml
+   channels:
+     - name: ops-discord
+       type: discord
+       app_id: ${DISCORD_BOT_TOKEN}            # Bot Token → Gateway Identify + REST
+       app_secret: ${DISCORD_APPLICATION_ID}   # Application ID → @提及匹配
+       agent: ops-agent
+       enabled: true
+   ```
+
+3. **出站域名白名单**：确保 `http.allowed_domains` 包含：
+   - `discord.com` — REST API
+   - `gateway.discord.gg` — Gateway WSS
+
+4. 启动后查渠道状态：`GET /api/v1/channels/status`，期望 `CONNECTED`。
+
+## 三、使用方式
+
+- **私聊**：在 Discord 中打开该 Bot 的 DM，直接发文本。
+- **公会频道**：将 Bot 拉入服务器/频道后 `@Bot + 问题`（平台推送 `MESSAGE_CREATE` 且含提及）。
+- **联网检索**：须在绑定 Agent 的 `AGENT.md` `tools:` 中加入 `web_search` 等，见 Tool 文档。
+
+## 四、与其它渠道的差异
+
+| | 飞书/企微/钉钉 | Slack | Discord（本渠道） |
+|--|----------------|-------|-------------------|
+| 凭证 | App ID/Secret 等 | Bot Token + App-Level Token | Bot Token + Application ID |
+| 连接 | 各家长连接 | Socket Mode WSS | Gateway WSS v10 |
+| 回复 | 各平台 API | chat.postMessage | channels/{id}/messages |
+| MVP 媒体 | 图/文件/音视频 | 图片+文件 | **仅文本**（媒体后续） |
+
+## 五、非目标（本期不做）
+
+- 图片 / 文件 / 语音 / 视频入站
+- Slash Commands / Interactions / Components
+- HTTP Interactions 公网回调
+- Notify `type=discord`

--- a/oryxos-boot/pom.xml
+++ b/oryxos-boot/pom.xml
@@ -62,6 +62,10 @@
         </dependency>
         <dependency>
             <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-channel-discord</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
             <artifactId>oryxos-web</artifactId>
         </dependency>
         <dependency>

--- a/oryxos-boot/src/main/resources/application.yml
+++ b/oryxos-boot/src/main/resources/application.yml
@@ -71,6 +71,8 @@ http:
     - oapi.dingtalk.com     # 钉钉 webhook 通知 + sessionWebhook 回复
     - slack.com             # Slack Web API（connections.open / chat.postMessage）
     - "*.slack.com"         # Slack Socket Mode WSS（wss-primary / wss-backup 等）
+    - discord.com           # Discord REST API（发消息）
+    - gateway.discord.gg    # Discord Gateway WSS
     - api.open-meteo.com    # 天气 Agent（免 key 天气源，31 节 Demo 一）
     - hn.algolia.com        # 科技日报 Agent 新闻源（免 key JSON，31 节 Demo 二）
     - api.github.com        # GitHub 日报脚本走子进程网络；列此便于审计与将来收口（31 节 Demo 三 §信任边界）

--- a/oryxos-channel-discord/pom.xml
+++ b/oryxos-channel-discord/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.oryxos</groupId>
+        <artifactId>oryxos</artifactId>
+        <version>0.1.4-RELEASE</version>
+    </parent>
+
+    <artifactId>oryxos-channel-discord</artifactId>
+    <name>OryxOS Channel Discord</name>
+    <description>Discord bot inbound IM channel: Gateway long connection and REST reply</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/ChannelDiscordModule.java
+++ b/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/ChannelDiscordModule.java
@@ -1,0 +1,7 @@
+package io.oryxos.channel.discord;
+
+/** Marker for the Discord inbound channel module (not Spring-scanned; wired in OryxOsRuntime). */
+public final class ChannelDiscordModule {
+
+  private ChannelDiscordModule() {}
+}

--- a/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordChannelAdapter.java
+++ b/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordChannelAdapter.java
@@ -1,0 +1,318 @@
+package io.oryxos.channel.discord;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.channel.ChannelConfig;
+import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.InboundChannelAdapter;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageService;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Discord 机器人入站适配器：一实例 = 一个 Bot 的一条 Gateway 长连接（对称 Slack/飞书）。
+ *
+ * <p>凭证映射：{@code app_id} = Bot Token，{@code app_secret} = Application ID（提及匹配）。
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
+    justification = "gateway/normalizer/sender 在 start() 内初始化；sendReply 有显式空判。")
+public class DiscordChannelAdapter implements InboundChannelAdapter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DiscordChannelAdapter.class);
+
+  public static final String TYPE = "discord";
+
+  private static final Duration START_TIMEOUT = Duration.ofSeconds(25);
+  private static final long RECONNECT_BASE_MS = 2_000L;
+  private static final long RECONNECT_MAX_MS = 60_000L;
+  private static final int RECONNECT_MAX_SHIFT = 5;
+
+  private final ChannelConfig config;
+  private final ProfileRegistry profileRegistry;
+  private final InboundMessageService inboundMessageService;
+  private final OutboundGuard guard;
+
+  private final AtomicReference<DiscordGatewayClient> gatewayRef = new AtomicReference<>();
+  private volatile DiscordMessageSender sender;
+  private volatile DiscordEventNormalizer normalizer;
+  private volatile DiscordDisconnectKind lastDisconnectKind = DiscordDisconnectKind.ABRUPT;
+  private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
+  private volatile String lastError;
+  private volatile boolean running;
+  private volatile ScheduledExecutorService reconnectScheduler;
+  private volatile ScheduledFuture<?> reconnectFuture;
+  private int reconnectAttempt;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "协作者均为 Runtime 装配的单例，共享引用正是意图")
+  public DiscordChannelAdapter(
+      ChannelConfig config,
+      ProfileRegistry profileRegistry,
+      InboundMessageService inboundMessageService,
+      OutboundGuard guard) {
+    this.config = config;
+    this.profileRegistry = profileRegistry;
+    this.inboundMessageService = inboundMessageService;
+    this.guard = guard;
+  }
+
+  @Override
+  public String name() {
+    return config.name();
+  }
+
+  @Override
+  public String type() {
+    return TYPE;
+  }
+
+  @Override
+  public String boundAgent() {
+    return config.agent();
+  }
+
+  @Override
+  public synchronized void start() {
+    config.validateCredentialsResolved();
+    if (profileRegistry.get(config.agent()).isEmpty()) {
+      throw new IllegalArgumentException(
+          "渠道 " + config.name() + " 绑定的 Agent " + config.agent() + " 不存在");
+    }
+    guard.check(DiscordGatewayClient.API_BASE_URL);
+    guard.check(DiscordGatewayClient.GATEWAY_ORIGIN_FOR_GUARD);
+    guard.check(DiscordMessageSender.API_BASE_URL);
+    running = true;
+    reconnectAttempt = 0;
+    cancelReconnectLocked();
+    try {
+      connectLocked();
+      state = ChannelStatus.State.CONNECTED;
+      lastError = null;
+      LOG.info(
+          "Discord 渠道 {} Gateway 已建立（Agent: {}）",
+          sanitize(config.name()),
+          sanitize(config.agent()));
+    } catch (Exception e) {
+      running = false;
+      shutdownReconnectSchedulerLocked();
+      state = ChannelStatus.State.ERROR;
+      lastError = "Gateway 连接失败: " + sanitize(e.getMessage());
+      throw new IllegalStateException("渠道 " + config.name() + " " + lastError, e);
+    }
+  }
+
+  @Override
+  public synchronized void stop() {
+    running = false;
+    cancelReconnectLocked();
+    shutdownReconnectSchedulerLocked();
+    DiscordGatewayClient gateway = gatewayRef.getAndSet(null);
+    if (gateway != null) {
+      gateway.closeQuietly();
+    }
+    sender = null;
+    normalizer = null;
+    state = ChannelStatus.State.DISCONNECTED;
+  }
+
+  @Override
+  public ChannelStatus status() {
+    if (state == ChannelStatus.State.ERROR) {
+      return ChannelStatus.error(config.name(), TYPE, config.agent(), lastError);
+    }
+    DiscordGatewayClient gateway = gatewayRef.get();
+    if (gateway == null || !gateway.isConnected()) {
+      return ChannelStatus.ok(
+          config.name(), TYPE, config.agent(), ChannelStatus.State.DISCONNECTED);
+    }
+    return ChannelStatus.ok(config.name(), TYPE, config.agent(), ChannelStatus.State.CONNECTED);
+  }
+
+  @Override
+  public void sendReply(String chatId, String text, String replyToMessageId) {
+    DiscordMessageSender active = sender;
+    if (active == null) {
+      throw new IllegalStateException("渠道 " + config.name() + " 未启动，无法发送回复");
+    }
+    active.send(chatId, text, replyToMessageId);
+  }
+
+  @Override
+  public Optional<io.oryxos.core.channel.InboundProgressStream> openProgressStream(
+      String chatId, String replyToMessageId) {
+    DiscordMessageSender active = sender;
+    if (active == null) {
+      return Optional.empty();
+    }
+    return Optional.of(new DiscordProgressStream(active, chatId, replyToMessageId));
+  }
+
+  static long reconnectDelayMs(int attempt) {
+    return io.oryxos.core.channel.ReconnectBackoff.delayMs(
+        attempt, RECONNECT_BASE_MS, RECONNECT_MAX_MS, RECONNECT_MAX_SHIFT);
+  }
+
+  private void connectLocked() throws Exception {
+    gatewayRef.set(connect());
+  }
+
+  private DiscordGatewayClient connect() throws Exception {
+    ensureOutboundStack();
+    DiscordGatewayClient client =
+        new DiscordGatewayClient(
+            config.appId(), guard, this::handleDispatch, this::handleDisconnected);
+    client.connect(START_TIMEOUT);
+    return client;
+  }
+
+  private void ensureOutboundStack() {
+    if (normalizer == null) {
+      normalizer = new DiscordEventNormalizer(config.name(), config.appSecret());
+    }
+    if (sender == null) {
+      sender =
+          new DiscordMessageSender(guard, config.appId(), DiscordMessageSender.DEFAULT_CHUNK_SIZE);
+    }
+  }
+
+  private void handleDisconnected(DiscordDisconnectKind kind) {
+    boolean shouldReconnect;
+    synchronized (this) {
+      if (!running || state == ChannelStatus.State.ERROR) {
+        return;
+      }
+      lastDisconnectKind = kind == null ? DiscordDisconnectKind.ABRUPT : kind;
+      if (lastDisconnectKind == DiscordDisconnectKind.GRACEFUL) {
+        reconnectAttempt = 0;
+      }
+      gatewayRef.set(null);
+      state = ChannelStatus.State.DISCONNECTED;
+      shouldReconnect = true;
+    }
+    if (shouldReconnect) {
+      if (lastDisconnectKind == DiscordDisconnectKind.GRACEFUL) {
+        LOG.info("Discord 渠道 {} Gateway 服务端要求重连，立即重连", sanitize(config.name()));
+      } else {
+        LOG.warn("Discord 渠道 {} Gateway 断开，将自动重连", sanitize(config.name()));
+      }
+      scheduleReconnect();
+    }
+  }
+
+  private void scheduleReconnect() {
+    synchronized (this) {
+      if (!running || reconnectFuture != null) {
+        return;
+      }
+      long delayMs =
+          lastDisconnectKind == DiscordDisconnectKind.GRACEFUL
+              ? 0L
+              : reconnectDelayMs(reconnectAttempt);
+      reconnectFuture =
+          reconnectScheduler().schedule(this::attemptReconnect, delayMs, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private void attemptReconnect() {
+    synchronized (this) {
+      reconnectFuture = null;
+      if (!running) {
+        return;
+      }
+    }
+    DiscordGatewayClient client;
+    try {
+      client = connect();
+    } catch (Exception e) {
+      synchronized (this) {
+        reconnectAttempt++;
+        lastError = "Gateway 重连失败: " + sanitize(e.getMessage());
+        LOG.warn(
+            "Discord 渠道 {} 重连失败（第 {} 次）: {}",
+            sanitize(config.name()),
+            reconnectAttempt,
+            sanitize(lastError));
+      }
+      scheduleReconnect();
+      return;
+    }
+    synchronized (this) {
+      if (!running) {
+        client.closeQuietly();
+        return;
+      }
+      gatewayRef.set(client);
+      reconnectAttempt = 0;
+      state = ChannelStatus.State.CONNECTED;
+      lastError = null;
+      LOG.info("Discord 渠道 {} Gateway 已恢复", sanitize(config.name()));
+    }
+  }
+
+  private ScheduledExecutorService reconnectScheduler() {
+    ScheduledExecutorService scheduler = reconnectScheduler;
+    if (scheduler == null) {
+      ScheduledThreadPoolExecutor pool =
+          new ScheduledThreadPoolExecutor(
+              1,
+              r -> {
+                Thread t = new Thread(r, "discord-reconnect-" + sanitize(config.name()));
+                t.setDaemon(true);
+                return t;
+              });
+      pool.setRemoveOnCancelPolicy(true);
+      reconnectScheduler = pool;
+      return pool;
+    }
+    return scheduler;
+  }
+
+  private void cancelReconnectLocked() {
+    ScheduledFuture<?> pending = reconnectFuture;
+    if (pending != null) {
+      pending.cancel(false);
+      reconnectFuture = null;
+    }
+  }
+
+  private void shutdownReconnectSchedulerLocked() {
+    cancelReconnectLocked();
+    ScheduledExecutorService scheduler = reconnectScheduler;
+    if (scheduler != null) {
+      scheduler.shutdownNow();
+      reconnectScheduler = null;
+    }
+  }
+
+  private void handleDispatch(String eventName, JsonNode data) {
+    try {
+      Optional<InboundMessage> msg = normalizer.normalize(eventName, data);
+      msg.ifPresent(this::dispatchClaimed);
+    } catch (RuntimeException e) {
+      LOG.error("Discord 渠道 {} 事件处理异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
+    }
+  }
+
+  private void dispatchClaimed(InboundMessage m) {
+    if (!inboundMessageService.tryClaim(m.channelName(), m.messageId())) {
+      LOG.info("渠道 {} 重复事件已忽略: {}", sanitize(m.channelName()), sanitize(m.messageId()));
+      return;
+    }
+    inboundMessageService.onClaimedMessage(m, this);
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordDisconnectKind.java
+++ b/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordDisconnectKind.java
@@ -1,0 +1,9 @@
+package io.oryxos.channel.discord;
+
+/** Discord Gateway 断线原因：服务端要求重连 vs 异常断开。 */
+enum DiscordDisconnectKind {
+  /** op=7 Reconnect 或可预期关闭，立即重连。 */
+  GRACEFUL,
+  /** 网络错误 / 异常 close，指数退避重连。 */
+  ABRUPT
+}

--- a/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordEventNormalizer.java
+++ b/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordEventNormalizer.java
@@ -1,0 +1,132 @@
+package io.oryxos.channel.discord;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Discord Gateway {@code MESSAGE_CREATE} → 归一化 {@link InboundMessage}。
+ *
+ * <p>私聊（无 {@code guild_id}）直接收文本；公会频道仅当提及本 Bot（Application ID）时接受。
+ */
+public class DiscordEventNormalizer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DiscordEventNormalizer.class);
+
+  static final String CHANNEL_TYPE = "discord";
+  private static final String EVENT_MESSAGE_CREATE = "MESSAGE_CREATE";
+  private static final String FIELD_AUTHOR = "author";
+  private static final String FIELD_BOT = "bot";
+  private static final String FIELD_WEBHOOK_ID = "webhook_id";
+  private static final Pattern MENTION = Pattern.compile("<@!?([0-9]+)>\\s*");
+
+  private final String channelName;
+  private final String applicationId;
+
+  public DiscordEventNormalizer(String channelName, String applicationId) {
+    this.channelName = channelName;
+    this.applicationId = applicationId == null ? "" : applicationId.strip();
+  }
+
+  /** 归一化一条 Gateway Dispatch 的 {@code d} 载荷；{@code t} 非 MESSAGE_CREATE 时返回 empty。 */
+  public Optional<InboundMessage> normalize(String eventName, JsonNode data) {
+    if (eventName == null || data == null || !data.isObject()) {
+      return Optional.empty();
+    }
+    if (!EVENT_MESSAGE_CREATE.equals(eventName)) {
+      return Optional.empty();
+    }
+    JsonNode author = data.path(FIELD_AUTHOR);
+    if (author.path(FIELD_BOT).asBoolean(false)) {
+      return Optional.empty();
+    }
+    if (data.hasNonNull(FIELD_WEBHOOK_ID)) {
+      return Optional.empty();
+    }
+    String userId = text(author, "id");
+    String chatId = text(data, "channel_id");
+    String messageId = text(data, "id");
+    if (userId == null || chatId == null || messageId == null) {
+      LOG.warn("Discord MESSAGE_CREATE 缺关键字段（author.id/channel_id/id），已丢弃");
+      return Optional.empty();
+    }
+    String content = data.path("content").asText("").strip();
+    boolean inGuild = data.hasNonNull("guild_id") && !data.path("guild_id").asText("").isBlank();
+    if (inGuild) {
+      if (!mentionsBot(data, content)) {
+        return Optional.empty();
+      }
+      content = stripMentions(content).strip();
+      if (content.isBlank()) {
+        return Optional.empty();
+      }
+      return Optional.of(
+          new InboundMessage(
+              CHANNEL_TYPE,
+              channelName,
+              messageId,
+              ChatKind.GROUP,
+              userId,
+              chatId,
+              content,
+              true,
+              true,
+              List.of()));
+    }
+    if (content.isBlank()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new InboundMessage(
+            CHANNEL_TYPE,
+            channelName,
+            messageId,
+            ChatKind.P2P,
+            userId,
+            chatId,
+            content,
+            true,
+            false,
+            List.of()));
+  }
+
+  private boolean mentionsBot(JsonNode data, String content) {
+    if (applicationId.isBlank()) {
+      return false;
+    }
+    JsonNode mentions = data.path("mentions");
+    if (mentions.isArray()) {
+      for (JsonNode m : mentions) {
+        if (applicationId.equals(text(m, "id"))) {
+          return true;
+        }
+      }
+    }
+    if (content == null) {
+      return false;
+    }
+    return content.contains("<@" + applicationId + ">")
+        || content.contains("<@!" + applicationId + ">");
+  }
+
+  static String stripMentions(String text) {
+    if (text == null || text.isBlank()) {
+      return "";
+    }
+    return MENTION.matcher(text).replaceAll("").strip();
+  }
+
+  private static String text(JsonNode node, String field) {
+    JsonNode v = node.get(field);
+    if (v == null || v.isNull()) {
+      return null;
+    }
+    String s = v.asText();
+    return s == null || s.isBlank() ? null : s;
+  }
+}

--- a/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordGatewayClient.java
+++ b/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordGatewayClient.java
@@ -1,0 +1,355 @@
+package io.oryxos.channel.discord;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.OutboundGuard;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Discord Gateway WebSocket（v10）：Hello → Identify → Heartbeat；Dispatch {@code MESSAGE_CREATE}。
+ *
+ * <p>凭证：Bot Token。出站主机过 {@link OutboundGuard}。
+ */
+final class DiscordGatewayClient implements WebSocket.Listener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DiscordGatewayClient.class);
+
+  static final String API_BASE_URL = "https://discord.com";
+  static final String GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json";
+  static final String GATEWAY_ORIGIN_FOR_GUARD = "https://gateway.discord.gg";
+
+  /** GUILDS | GUILD_MESSAGES | DIRECT_MESSAGES | MESSAGE_CONTENT */
+  static final int INTENTS = (1 << 0) | (1 << 9) | (1 << 12) | (1 << 15);
+
+  private static final int OP_DISPATCH = 0;
+  private static final int OP_HEARTBEAT = 1;
+  private static final int OP_IDENTIFY = 2;
+  private static final int OP_RECONNECT = 7;
+  private static final int OP_INVALID_SESSION = 9;
+  private static final int OP_HELLO = 10;
+  private static final int OP_HEARTBEAT_ACK = 11;
+
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(20);
+  private static final long WS_CLOSE_TIMEOUT_MS = 2_000L;
+  private static final long READY_TIMEOUT_MS = 20_000L;
+  private static final String FIELD_OP = "op";
+  private static final String FIELD_D = "d";
+  private static final String FIELD_S = "s";
+  private static final String FIELD_T = "t";
+  private static final String EVENT_READY = "READY";
+  private static final long DEFAULT_HEARTBEAT_MS = 41_250L;
+  private static final long MIN_HEARTBEAT_MS = 1_000L;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final String botToken;
+  private final OutboundGuard guard;
+  private final BiConsumer<String, JsonNode> onDispatch;
+  private final Consumer<DiscordDisconnectKind> onDisconnected;
+
+  private final AtomicReference<WebSocket> socket = new AtomicReference<>();
+  private final AtomicBoolean connected = new AtomicBoolean(false);
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final AtomicBoolean identified = new AtomicBoolean(false);
+  private final StringBuilder textBuf = new StringBuilder();
+  private final CountDownLatch readyLatch = new CountDownLatch(1);
+  private volatile String openError;
+  private final AtomicBoolean disconnectNotified = new AtomicBoolean(false);
+  private final AtomicLong lastSeq = new AtomicLong(-1);
+  private volatile ScheduledExecutorService heartbeatScheduler;
+  private volatile ScheduledFuture<?> heartbeatFuture;
+
+  DiscordGatewayClient(
+      String botToken,
+      OutboundGuard guard,
+      BiConsumer<String, JsonNode> onDispatch,
+      Consumer<DiscordDisconnectKind> onDisconnected) {
+    this.botToken = Objects.requireNonNull(botToken);
+    this.guard = Objects.requireNonNull(guard);
+    this.onDispatch = Objects.requireNonNull(onDispatch);
+    this.onDisconnected = onDisconnected == null ? kind -> {} : onDisconnected;
+  }
+
+  void connect(Duration timeout) throws Exception {
+    closed.set(false);
+    disconnectNotified.set(false);
+    identified.set(false);
+    lastSeq.set(-1);
+    openError = null;
+    guard.check(API_BASE_URL);
+    guard.check(GATEWAY_ORIGIN_FOR_GUARD);
+    URI wsUri = URI.create(GATEWAY_URL);
+    HttpClient client = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    CompletableFuture<WebSocket> future =
+        client.newWebSocketBuilder().connectTimeout(CONNECT_TIMEOUT).buildAsync(wsUri, this);
+    WebSocket ws;
+    try {
+      ws = future.get(timeout.toSeconds(), TimeUnit.SECONDS);
+    } catch (Exception e) {
+      future.cancel(true);
+      closeQuietly();
+      throw e;
+    }
+    socket.set(ws);
+    long waitMs = Math.max(timeout.toMillis(), READY_TIMEOUT_MS);
+    if (!readyLatch.await(waitMs, TimeUnit.MILLISECONDS)) {
+      closeQuietly();
+      throw new IllegalStateException("Discord Gateway 连接超时（未收到 READY）");
+    }
+    if (openError != null) {
+      closeQuietly();
+      throw new IllegalStateException("Discord Gateway 连接失败: " + openError);
+    }
+    if (!connected.get() || !identified.get()) {
+      closeQuietly();
+      throw new IllegalStateException("Discord Gateway 连接失败（未知原因）");
+    }
+  }
+
+  boolean isConnected() {
+    return connected.get() && identified.get() && !closed.get();
+  }
+
+  void closeQuietly() {
+    closed.set(true);
+    connected.set(false);
+    identified.set(false);
+    stopHeartbeat();
+    readyLatch.countDown();
+    WebSocket ws = socket.getAndSet(null);
+    if (ws == null) {
+      return;
+    }
+    Thread closer =
+        Thread.ofPlatform()
+            .daemon(true)
+            .name("oryxos-discord-ws-close")
+            .unstarted(
+                () -> {
+                  try {
+                    ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").join();
+                  } catch (RuntimeException ignored) {
+                    // ignore
+                  }
+                });
+    closer.start();
+    try {
+      closer.join(WS_CLOSE_TIMEOUT_MS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    if (closer.isAlive()) {
+      LOG.warn("Discord WS close {}ms 未返回，放弃等待（守护线程后台继续）", WS_CLOSE_TIMEOUT_MS);
+    }
+  }
+
+  @Override
+  public void onOpen(WebSocket webSocket) {
+    connected.set(true);
+    disconnectNotified.set(false);
+    webSocket.request(1);
+  }
+
+  @Override
+  public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+    textBuf.append(data);
+    if (last) {
+      String raw = textBuf.toString();
+      textBuf.setLength(0);
+      handleText(webSocket, raw);
+    }
+    webSocket.request(1);
+    return null;
+  }
+
+  @Override
+  public CompletionStage<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
+    webSocket.request(1);
+    return null;
+  }
+
+  @Override
+  public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+    notifyDisconnected(DiscordDisconnectKind.ABRUPT, "close " + statusCode + " " + reason);
+    return null;
+  }
+
+  @Override
+  public void onError(WebSocket webSocket, Throwable error) {
+    LOG.warn("Discord Gateway 连接错误: {}", sanitize(error == null ? null : error.getMessage()));
+    if (!identified.get()) {
+      openError = error == null ? "unknown" : error.getMessage();
+      readyLatch.countDown();
+    }
+    notifyDisconnected(DiscordDisconnectKind.ABRUPT, error == null ? null : error.getMessage());
+  }
+
+  /** 单测：注入原始 Gateway JSON。 */
+  void dispatchFrameForTest(String raw) {
+    handleText(socket.get(), raw);
+  }
+
+  private void handleText(WebSocket webSocket, String raw) {
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(raw);
+    } catch (JacksonException e) {
+      LOG.warn("Discord Gateway 帧 JSON 解析失败，已忽略");
+      return;
+    }
+    int op = root.path(FIELD_OP).asInt(-1);
+    JsonNode d = root.get(FIELD_D);
+    if (!root.path(FIELD_S).isNull() && root.has(FIELD_S) && root.get(FIELD_S).canConvertToLong()) {
+      lastSeq.set(root.get(FIELD_S).asLong());
+    }
+    if (op == OP_HELLO) {
+      onHello(webSocket, d);
+    } else if (op == OP_HEARTBEAT_ACK) {
+      // ok
+    } else if (op == OP_HEARTBEAT) {
+      sendHeartbeat(webSocket);
+    } else if (op == OP_RECONNECT) {
+      LOG.info("Discord Gateway 服务端要求重连 (op=7)");
+      closeQuietly();
+      notifyDisconnected(DiscordDisconnectKind.GRACEFUL, "reconnect");
+    } else if (op == OP_INVALID_SESSION) {
+      boolean resumable = d != null && d.asBoolean(false);
+      LOG.warn("Discord Gateway Invalid Session resumable={}", resumable);
+      closeQuietly();
+      notifyDisconnected(DiscordDisconnectKind.ABRUPT, "invalid_session");
+    } else if (op == OP_DISPATCH) {
+      String t = root.path(FIELD_T).asText("");
+      if (EVENT_READY.equals(t)) {
+        identified.set(true);
+        readyLatch.countDown();
+        LOG.info("Discord Gateway READY");
+        return;
+      }
+      if (d != null && d.isObject()) {
+        try {
+          onDispatch.accept(t, d);
+        } catch (RuntimeException e) {
+          LOG.error("Discord 事件处理异常: {}", sanitize(e.getMessage()));
+        }
+      }
+    }
+  }
+
+  private void onHello(WebSocket webSocket, JsonNode d) {
+    long intervalMs =
+        d == null
+            ? DEFAULT_HEARTBEAT_MS
+            : d.path("heartbeat_interval").asLong(DEFAULT_HEARTBEAT_MS);
+    startHeartbeat(webSocket, intervalMs);
+    sendIdentify(webSocket);
+  }
+
+  private void sendIdentify(WebSocket webSocket) {
+    try {
+      ObjectNode root = MAPPER.createObjectNode();
+      root.put(FIELD_OP, OP_IDENTIFY);
+      ObjectNode data = root.putObject(FIELD_D);
+      data.put("token", botToken);
+      data.put("intents", INTENTS);
+      ObjectNode props = data.putObject("properties");
+      props.put("os", System.getProperty("os.name", "unknown"));
+      props.put("browser", "oryxos");
+      props.put("device", "oryxos");
+      webSocket.sendText(MAPPER.writeValueAsString(root), true);
+    } catch (Exception e) {
+      openError = e.getMessage();
+      readyLatch.countDown();
+      LOG.warn("Discord Identify 发送失败: {}", sanitize(e.getMessage()));
+    }
+  }
+
+  private void startHeartbeat(WebSocket webSocket, long intervalMs) {
+    stopHeartbeat();
+    ScheduledThreadPoolExecutor pool =
+        new ScheduledThreadPoolExecutor(
+            1,
+            r -> {
+              Thread t = new Thread(r, "oryxos-discord-heartbeat");
+              t.setDaemon(true);
+              return t;
+            });
+    pool.setRemoveOnCancelPolicy(true);
+    heartbeatScheduler = pool;
+    long delay = Math.max(MIN_HEARTBEAT_MS, intervalMs);
+    heartbeatFuture =
+        pool.scheduleAtFixedRate(
+            () -> sendHeartbeat(webSocket), delay, delay, TimeUnit.MILLISECONDS);
+  }
+
+  private void sendHeartbeat(WebSocket webSocket) {
+    if (webSocket == null || closed.get()) {
+      return;
+    }
+    try {
+      ObjectNode root = MAPPER.createObjectNode();
+      root.put(FIELD_OP, OP_HEARTBEAT);
+      long seq = lastSeq.get();
+      if (seq >= 0) {
+        root.put(FIELD_D, seq);
+      } else {
+        root.putNull(FIELD_D);
+      }
+      webSocket.sendText(MAPPER.writeValueAsString(root), true);
+    } catch (Exception e) {
+      LOG.warn("Discord Heartbeat 发送失败: {}", sanitize(e.getMessage()));
+    }
+  }
+
+  private void stopHeartbeat() {
+    ScheduledFuture<?> future = heartbeatFuture;
+    if (future != null) {
+      future.cancel(false);
+      heartbeatFuture = null;
+    }
+    ScheduledExecutorService scheduler = heartbeatScheduler;
+    if (scheduler != null) {
+      scheduler.shutdownNow();
+      heartbeatScheduler = null;
+    }
+  }
+
+  private void markDisconnected() {
+    closed.set(true);
+    connected.set(false);
+    identified.set(false);
+    stopHeartbeat();
+    readyLatch.countDown();
+  }
+
+  private void notifyDisconnected(DiscordDisconnectKind kind, String detail) {
+    if (!disconnectNotified.compareAndSet(false, true)) {
+      return;
+    }
+    markDisconnected();
+    onDisconnected.accept(kind);
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordMessageSender.java
+++ b/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordMessageSender.java
@@ -1,0 +1,124 @@
+package io.oryxos.channel.discord;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.OutboundGuard;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Discord 回复：{@code POST /channels/{id}/messages}；出站前过 {@link OutboundGuard}。
+ *
+ * <p>凭证：Bot Token。群聊 {@code replyToMessageId} 非空时写入 {@code message_reference}。
+ */
+public class DiscordMessageSender {
+
+  static final int DEFAULT_CHUNK_SIZE = 1900;
+  static final String API_BASE_URL = "https://discord.com";
+  static final String API_PREFIX = "/api/v10";
+  private static final int HTTP_STATUS_OK_MIN = 200;
+  private static final int HTTP_STATUS_OK_MAX_EXCLUSIVE = 300;
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String FIELD_CODE = "code";
+  private static final String FIELD_MESSAGE = "message";
+
+  private final HttpClient httpClient;
+  private final OutboundGuard guard;
+  private final String botToken;
+  private final int chunkSize;
+
+  public DiscordMessageSender(OutboundGuard guard, String botToken, int chunkSize) {
+    this(
+        HttpClient.newBuilder().connectTimeout(REQUEST_TIMEOUT).build(),
+        guard,
+        botToken,
+        chunkSize);
+  }
+
+  DiscordMessageSender(HttpClient httpClient, OutboundGuard guard, String botToken, int chunkSize) {
+    this.httpClient = httpClient;
+    this.guard = guard;
+    this.botToken = botToken;
+    this.chunkSize = chunkSize <= 0 ? DEFAULT_CHUNK_SIZE : chunkSize;
+  }
+
+  public void send(String channelId, String text, String replyToMessageId) {
+    guard.check(API_BASE_URL);
+    for (String chunk : segment(text == null ? "" : text, chunkSize)) {
+      postMessage(channelId, chunk, replyToMessageId);
+    }
+  }
+
+  private void postMessage(String channelId, String text, String replyToMessageId) {
+    try {
+      ObjectNode body = MAPPER.createObjectNode();
+      body.put("content", text);
+      if (replyToMessageId != null && !replyToMessageId.isBlank()) {
+        ObjectNode ref = body.putObject("message_reference");
+        ref.put("message_id", replyToMessageId);
+        ref.put("fail_if_not_exists", false);
+      }
+      String payload = MAPPER.writeValueAsString(body);
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(API_BASE_URL + API_PREFIX + "/channels/" + channelId + "/messages"))
+              .timeout(REQUEST_TIMEOUT)
+              .header("Authorization", "Bot " + botToken)
+              .header("Content-Type", "application/json; charset=utf-8")
+              .POST(HttpRequest.BodyPublishers.ofString(payload))
+              .build();
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() < HTTP_STATUS_OK_MIN
+          || response.statusCode() >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
+        rejectApiError(response.statusCode(), response.body());
+      }
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("Discord 发消息失败: " + e.getMessage(), e);
+    }
+  }
+
+  static List<String> segment(String text, int chunkSize) {
+    if (text.isEmpty()) {
+      return List.of("");
+    }
+    List<String> parts = new ArrayList<>();
+    for (int i = 0; i < text.length(); i += chunkSize) {
+      parts.add(text.substring(i, Math.min(text.length(), i + chunkSize)));
+    }
+    return parts;
+  }
+
+  static void rejectApiError(int statusCode, String responseBody) {
+    String detail = sanitize(responseBody);
+    if (responseBody != null && !responseBody.isBlank()) {
+      try {
+        JsonNode root = MAPPER.readTree(responseBody);
+        if (root != null && root.isObject()) {
+          String msg = root.path(FIELD_MESSAGE).asText(null);
+          int code = root.path(FIELD_CODE).asInt(0);
+          if (msg != null && !msg.isBlank()) {
+            detail = sanitize(msg) + (code > 0 ? " (code=" + code + ")" : "");
+          }
+        }
+      } catch (JacksonException ignored) {
+        // keep raw body
+      }
+    }
+    throw new IllegalStateException("Discord 发消息失败 HTTP " + statusCode + ": " + detail);
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordProgressStream.java
+++ b/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordProgressStream.java
@@ -1,0 +1,45 @@
+package io.oryxos.channel.discord;
+
+import io.oryxos.core.channel.InboundProgressStream;
+import io.oryxos.core.channel.PlaceholderProgressStream;
+
+/** Discord 进度流：REST 发消息无原地编辑，采用占位进度。 */
+final class DiscordProgressStream implements InboundProgressStream {
+
+  private final PlaceholderProgressStream delegate;
+
+  DiscordProgressStream(DiscordMessageSender sender, String chatId, String replyToMessageId) {
+    this.delegate =
+        new PlaceholderProgressStream(sender::send, chatId, replyToMessageId, "Discord");
+  }
+
+  @Override
+  public void start() {
+    delegate.start();
+  }
+
+  @Override
+  public void onToken(String delta) {
+    delegate.onToken(delta);
+  }
+
+  @Override
+  public void onToolStart(String toolName) {
+    delegate.onToolStart(toolName);
+  }
+
+  @Override
+  public void onToolEnd(String toolName, boolean success) {
+    delegate.onToolEnd(toolName, success);
+  }
+
+  @Override
+  public void finish(String finalText) {
+    delegate.finish(finalText);
+  }
+
+  @Override
+  public void fail(String errorMessage) {
+    delegate.fail(errorMessage);
+  }
+}

--- a/oryxos-channel-discord/src/test/java/io/oryxos/channel/discord/DiscordChannelAdapterStopTest.java
+++ b/oryxos-channel-discord/src/test/java/io/oryxos/channel/discord/DiscordChannelAdapterStopTest.java
@@ -1,0 +1,50 @@
+package io.oryxos.channel.discord;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import io.oryxos.core.channel.ChannelConfig;
+import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.InboundMessageService;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.profile.ProfileRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DiscordChannelAdapterStopTest {
+
+  private DiscordChannelAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    ChannelConfig config =
+        new ChannelConfig(
+            "discord-test", "discord", "bot-token-test", "app-id-test", "demo-agent", true);
+    adapter =
+        new DiscordChannelAdapter(
+            config,
+            mock(ProfileRegistry.class),
+            mock(InboundMessageService.class),
+            mock(OutboundGuard.class));
+  }
+
+  @Test
+  @DisplayName("未启动时 stop 安全")
+  void stopWithoutStartIsSafe() {
+    adapter.stop();
+    assertEquals(ChannelStatus.State.DISCONNECTED, adapter.status().state());
+  }
+
+  @Test
+  @DisplayName("重连退避随 attempt 增长且有上限")
+  void reconnectBackoffGrows() {
+    long d0 = DiscordChannelAdapter.reconnectDelayMs(0);
+    long d3 = DiscordChannelAdapter.reconnectDelayMs(3);
+    long d99 = DiscordChannelAdapter.reconnectDelayMs(99);
+    assertTrue(d0 >= 2_000L);
+    assertTrue(d3 > d0);
+    assertTrue(d99 <= 60_000L);
+  }
+}

--- a/oryxos-channel-discord/src/test/java/io/oryxos/channel/discord/DiscordEventNormalizerTest.java
+++ b/oryxos-channel-discord/src/test/java/io/oryxos/channel/discord/DiscordEventNormalizerTest.java
@@ -1,0 +1,96 @@
+package io.oryxos.channel.discord;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DiscordEventNormalizerTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String APP_ID = "123456789012345678";
+  private DiscordEventNormalizer normalizer;
+
+  @BeforeEach
+  void setUp() {
+    normalizer = new DiscordEventNormalizer("ops-discord", APP_ID);
+  }
+
+  @Test
+  @DisplayName("私聊 MESSAGE_CREATE（无 guild_id）→ P2P")
+  void dmMessage() {
+    ObjectNode data = baseMessage("hello discord", null);
+    Optional<InboundMessage> msg = normalizer.normalize("MESSAGE_CREATE", data);
+    assertTrue(msg.isPresent());
+    InboundMessage m = msg.get();
+    assertEquals(ChatKind.P2P, m.chatKind());
+    assertEquals("hello discord", m.content());
+    assertEquals("channel-1", m.chatId());
+    assertEquals("user-1", m.userId());
+    assertFalse(m.mentionedBot());
+  }
+
+  @Test
+  @DisplayName("公会 @Bot → GROUP 且剥离提及")
+  void guildMention() {
+    ObjectNode data = baseMessage("<@" + APP_ID + "> 帮我查天气", "guild-1");
+    var mentions = data.putArray("mentions");
+    mentions.addObject().put("id", APP_ID).put("username", "oryxos");
+    Optional<InboundMessage> msg = normalizer.normalize("MESSAGE_CREATE", data);
+    assertTrue(msg.isPresent());
+    InboundMessage m = msg.get();
+    assertEquals(ChatKind.GROUP, m.chatKind());
+    assertTrue(m.mentionedBot());
+    assertEquals("帮我查天气", m.content());
+  }
+
+  @Test
+  @DisplayName("公会无 @ 丢弃")
+  void guildWithoutMentionDropped() {
+    ObjectNode data = baseMessage("noise", "guild-1");
+    assertTrue(normalizer.normalize("MESSAGE_CREATE", data).isEmpty());
+  }
+
+  @Test
+  @DisplayName("bot / webhook 丢弃")
+  void botAndWebhookDropped() {
+    ObjectNode bot = baseMessage("from bot", null);
+    bot.path("author").path("bot"); // ensure author exists
+    ((ObjectNode) bot.get("author")).put("bot", true);
+    assertTrue(normalizer.normalize("MESSAGE_CREATE", bot).isEmpty());
+
+    ObjectNode webhook = baseMessage("hook", null);
+    webhook.put("webhook_id", "wh-1");
+    assertTrue(normalizer.normalize("MESSAGE_CREATE", webhook).isEmpty());
+  }
+
+  @Test
+  @DisplayName("非 MESSAGE_CREATE 忽略")
+  void otherEventsIgnored() {
+    ObjectNode data = baseMessage("x", null);
+    assertTrue(normalizer.normalize("MESSAGE_UPDATE", data).isEmpty());
+  }
+
+  private static ObjectNode baseMessage(String content, String guildId) {
+    ObjectNode data = MAPPER.createObjectNode();
+    data.put("id", "msg-1");
+    data.put("channel_id", "channel-1");
+    data.put("content", content);
+    if (guildId != null) {
+      data.put("guild_id", guildId);
+    }
+    ObjectNode author = data.putObject("author");
+    author.put("id", "user-1");
+    author.put("username", "richard");
+    author.put("bot", false);
+    return data;
+  }
+}

--- a/oryxos-channel-discord/src/test/java/io/oryxos/channel/discord/DiscordMessageSenderTest.java
+++ b/oryxos-channel-discord/src/test/java/io/oryxos/channel/discord/DiscordMessageSenderTest.java
@@ -1,0 +1,46 @@
+package io.oryxos.channel.discord;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DiscordMessageSenderTest {
+
+  @Test
+  @DisplayName("segment 按块切分")
+  void segmentChunks() {
+    List<String> parts = DiscordMessageSender.segment("abcdefghij", 4);
+    assertEquals(List.of("abcd", "efgh", "ij"), parts);
+  }
+
+  @Test
+  @DisplayName("HTTP 错误体解析 message/code")
+  void rejectApiError() {
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                DiscordMessageSender.rejectApiError(
+                    403, "{\"message\":\"Missing Access\",\"code\":50001}"));
+    assertTrue(ex.getMessage().contains("Missing Access"));
+    assertTrue(ex.getMessage().contains("50001"));
+  }
+
+  @Test
+  @DisplayName("空 body 仍抛 HTTP 状态")
+  void rejectEmptyBody() {
+    assertDoesNotThrow(
+        () -> {
+          try {
+            DiscordMessageSender.rejectApiError(500, "");
+          } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("500"));
+          }
+        });
+  }
+}

--- a/oryxos-cli/pom.xml
+++ b/oryxos-cli/pom.xml
@@ -46,6 +46,10 @@
         </dependency>
         <dependency>
             <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-channel-discord</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
             <artifactId>oryxos-provider</artifactId>
         </dependency>
         <dependency>

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -1035,6 +1035,10 @@ public class OryxOsRuntime {
             io.oryxos.channel.slack.SlackChannelAdapter.TYPE,
             resolved ->
                 new io.oryxos.channel.slack.SlackChannelAdapter(
+                    resolved, profileRegistry, inboundMessageService, channelOutboundGuard),
+            io.oryxos.channel.discord.DiscordChannelAdapter.TYPE,
+            resolved ->
+                new io.oryxos.channel.discord.DiscordChannelAdapter(
                     resolved, profileRegistry, inboundMessageService, channelOutboundGuard)));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <module>oryxos-channel-wecom</module>
         <module>oryxos-channel-dingtalk</module>
         <module>oryxos-channel-slack</module>
+        <module>oryxos-channel-discord</module>
         <module>oryxos-web</module>
         <module>oryxos-storage</module>
         <module>oryxos-cli</module>
@@ -145,6 +146,11 @@
             <dependency>
                 <groupId>io.oryxos</groupId>
                 <artifactId>oryxos-channel-slack</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.oryxos</groupId>
+                <artifactId>oryxos-channel-discord</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary
- New `oryxos-channel-discord`: Gateway v10 (Hello / Identify / Heartbeat), `MESSAGE_CREATE` for DM + guild `@Bot`, REST reply, reconnect, bounded WS close.
- Wire into boot/cli factories, `http.allowed_domains` (`discord.com`, `gateway.discord.gg`), channels/`.env` examples, `docs/DiscordChannelSetup.md`.
- Credentials: `app_id` = Bot Token, `app_secret` = Application ID. Media inbound deferred.

## Test plan
- [x] `mvn -pl oryxos-channel-discord verify` (10 unit tests, PMD/SpotBugs clean)
- [ ] Manual: create Discord app, enable Message Content Intent, set env, DM + guild @Bot
- [ ] CI green

Made with [Cursor](https://cursor.com)