### PR TITLE
feat(channel-discord): inbound image/file download via CDN

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -104,6 +104,10 @@ http:
     - "*.slack.com"             # Slack Socket Mode WSS（wss-primary / wss-backup 等）
     - discord.com               # Discord REST API（发消息）
     - gateway.discord.gg        # Discord Gateway WSS
+    - cdn.discordapp.com        # Discord 入站附件 CDN
+    - media.discordapp.net      # Discord 入站媒体代理
+    - "*.discordapp.com"        # Discord CDN 子域
+    - "*.discordapp.net"        # Discord 媒体子域
     - api.open-meteo.com        # 天气 Agent 免 key 天气源（31 节 Demo 一）
     - hn.algolia.com            # 科技日报 Agent 新闻源（31 节 Demo 二）
     - api.github.com            # GitHub 日报脚本子进程网络（31 节 Demo 三）

--- a/docs/DiscordChannelSetup.md
+++ b/docs/DiscordChannelSetup.md
@@ -2,7 +2,7 @@
 
 本文是 OryxOS Discord 入站渠道的部署操作手册。架构对称飞书/企微/钉钉/Slack：以 **Gateway WebSocket** 主动连接 Discord（免公网回调 URL）；回复经 REST `POST /channels/{id}/messages`。
 
-> 范围：Discord Bot **Gateway v10**。MVP 仅文本私聊与公会频道 `@Bot`。附件/图片/语音后续单独 PR。
+> 范围：Discord Bot **Gateway v10**。文本私聊与公会频道 `@Bot`；入站图片/文件经 CDN 下载落盘。
 
 ## 一、Discord 侧：创建 Application 并启用 Intents
 
@@ -15,7 +15,7 @@
 5. 左侧 **General Information** 复制 **Application ID**（对应 `DISCORD_APPLICATION_ID`；Bot 的 User ID 通常与此相同，用于 `@` 匹配）。
 6. **OAuth2 → URL Generator**：
    - Scopes：`bot`
-   - Bot Permissions：至少 `Send Messages`、`Read Message History`、`View Channels`；私聊还需能接收 DM（默认 Bot 可开 DM）
+   - Bot Permissions：至少 `Send Messages`、`Read Message History`、`View Channels`、`Attach Files`（附件入站/出站体验）；私聊还需能接收 DM（默认 Bot 可开 DM）
    - 生成 URL，用浏览器邀请 Bot 进目标服务器。
 7. 用户需在 Discord **用户设置 → 隐私与安全** 允许来自服务器成员的私信（若测 DM）。
 
@@ -45,13 +45,15 @@
 3. **出站域名白名单**：确保 `http.allowed_domains` 包含：
    - `discord.com` — REST API
    - `gateway.discord.gg` — Gateway WSS
+   - `cdn.discordapp.com` / `media.discordapp.net` / `*.discordapp.com` / `*.discordapp.net` — 入站附件 CDN
 
 4. 启动后查渠道状态：`GET /api/v1/channels/status`，期望 `CONNECTED`。
 
 ## 三、使用方式
 
-- **私聊**：在 Discord 中打开该 Bot 的 DM，直接发文本。
-- **公会频道**：将 Bot 拉入服务器/频道后 `@Bot + 问题`（平台推送 `MESSAGE_CREATE` 且含提及）。
+- **私聊**：在 Discord 中打开该 Bot 的 DM，直接发文本、图片或文件。
+- **公会频道**：将 Bot 拉入服务器/频道后 `@Bot + 问题`（可带附件；平台推送 `MESSAGE_CREATE` 且含提及）。
+- **图片 / 文件**：经 `attachments[].url`（CDN）带 Bot Token 落盘到 `.oryxos/inbound-media/`；图片可供 Vision，文件路径写入 Agent 提示。
 - **联网检索**：须在绑定 Agent 的 `AGENT.md` `tools:` 中加入 `web_search` 等，见 Tool 文档。
 
 ## 四、与其它渠道的差异
@@ -61,11 +63,11 @@
 | 凭证 | App ID/Secret 等 | Bot Token + App-Level Token | Bot Token + Application ID |
 | 连接 | 各家长连接 | Socket Mode WSS | Gateway WSS v10 |
 | 回复 | 各平台 API | chat.postMessage | channels/{id}/messages |
-| MVP 媒体 | 图/文件/音视频 | 图片+文件 | **仅文本**（媒体后续） |
+| MVP 媒体 | 图/文件/音视频 | 图片+文件 | **图片 + 文件**（语音/视频后续） |
 
 ## 五、非目标（本期不做）
 
-- 图片 / 文件 / 语音 / 视频入站
+- 语音 / 视频入站
 - Slash Commands / Interactions / Components
 - HTTP Interactions 公网回调
 - Notify `type=discord`

--- a/oryxos-boot/src/main/resources/application.yml
+++ b/oryxos-boot/src/main/resources/application.yml
@@ -73,6 +73,10 @@ http:
     - "*.slack.com"         # Slack Socket Mode WSS（wss-primary / wss-backup 等）
     - discord.com           # Discord REST API（发消息）
     - gateway.discord.gg    # Discord Gateway WSS
+    - cdn.discordapp.com    # Discord 入站附件 CDN
+    - media.discordapp.net  # Discord 入站媒体代理
+    - "*.discordapp.com"    # Discord CDN 子域
+    - "*.discordapp.net"    # Discord 媒体子域
     - api.open-meteo.com    # 天气 Agent（免 key 天气源，31 节 Demo 一）
     - hn.algolia.com        # 科技日报 Agent 新闻源（免 key JSON，31 节 Demo 二）
     - api.github.com        # GitHub 日报脚本走子进程网络；列此便于审计与将来收口（31 节 Demo 三 §信任边界）

--- a/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordChannelAdapter.java
+++ b/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordChannelAdapter.java
@@ -36,6 +36,7 @@ public class DiscordChannelAdapter implements InboundChannelAdapter {
   private static final long RECONNECT_BASE_MS = 2_000L;
   private static final long RECONNECT_MAX_MS = 60_000L;
   private static final int RECONNECT_MAX_SHIFT = 5;
+  private static final String MEDIA_DIR_PREFIX = "oryxos-discord-media-";
 
   private final ChannelConfig config;
   private final ProfileRegistry profileRegistry;
@@ -45,6 +46,7 @@ public class DiscordChannelAdapter implements InboundChannelAdapter {
   private final AtomicReference<DiscordGatewayClient> gatewayRef = new AtomicReference<>();
   private volatile DiscordMessageSender sender;
   private volatile DiscordEventNormalizer normalizer;
+  private volatile DiscordInboundMediaResolver mediaResolver;
   private volatile DiscordDisconnectKind lastDisconnectKind = DiscordDisconnectKind.ABRUPT;
   private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
   private volatile String lastError;
@@ -123,6 +125,7 @@ public class DiscordChannelAdapter implements InboundChannelAdapter {
     }
     sender = null;
     normalizer = null;
+    mediaResolver = null;
     state = ChannelStatus.State.DISCONNECTED;
   }
 
@@ -183,6 +186,13 @@ public class DiscordChannelAdapter implements InboundChannelAdapter {
     if (sender == null) {
       sender =
           new DiscordMessageSender(guard, config.appId(), DiscordMessageSender.DEFAULT_CHUNK_SIZE);
+    }
+    if (mediaResolver == null) {
+      mediaResolver =
+          new DiscordInboundMediaResolver(
+              config.appId(),
+              io.oryxos.core.channel.InboundMediaRoots.forChannel(config.name(), MEDIA_DIR_PREFIX),
+              config.name());
     }
   }
 
@@ -309,7 +319,25 @@ public class DiscordChannelAdapter implements InboundChannelAdapter {
       LOG.info("渠道 {} 重复事件已忽略: {}", sanitize(m.channelName()), sanitize(m.messageId()));
       return;
     }
-    inboundMessageService.onClaimedMessage(m, this);
+    String replyTo = m.chatKind() == io.oryxos.core.channel.ChatKind.GROUP ? m.messageId() : null;
+    java.util.concurrent.CountDownLatch slowWork = null;
+    if (DiscordInboundMediaResolver.hasDownloadableMedia(m)) {
+      slowWork = inboundMessageService.beginSlowWork(this, m.chatId(), replyTo);
+    }
+    try {
+      DiscordInboundMediaResolver resolver = mediaResolver;
+      InboundMessage enriched = resolver == null ? m : resolver.resolve(m);
+      if (slowWork != null) {
+        inboundMessageService.onClaimedMessage(enriched, this, slowWork);
+      } else {
+        inboundMessageService.onClaimedMessage(enriched, this);
+      }
+    } catch (RuntimeException e) {
+      if (slowWork != null) {
+        slowWork.countDown();
+      }
+      throw e;
+    }
   }
 
   private static String sanitize(String value) {

--- a/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordEventNormalizer.java
+++ b/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordEventNormalizer.java
@@ -2,7 +2,9 @@ package io.oryxos.channel.discord;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -12,7 +14,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Discord Gateway {@code MESSAGE_CREATE} → 归一化 {@link InboundMessage}。
  *
- * <p>私聊（无 {@code guild_id}）直接收文本；公会频道仅当提及本 Bot（Application ID）时接受。
+ * <p>私聊（无 {@code guild_id}）收文本/附件；公会频道仅当提及本 Bot（Application ID）时接受。
  */
 public class DiscordEventNormalizer {
 
@@ -23,6 +25,8 @@ public class DiscordEventNormalizer {
   private static final String FIELD_AUTHOR = "author";
   private static final String FIELD_BOT = "bot";
   private static final String FIELD_WEBHOOK_ID = "webhook_id";
+  private static final String FIELD_ATTACHMENTS = "attachments";
+  private static final String MIME_IMAGE_PREFIX = "image/";
   private static final Pattern MENTION = Pattern.compile("<@!?([0-9]+)>\\s*");
 
   private final String channelName;
@@ -56,13 +60,14 @@ public class DiscordEventNormalizer {
       return Optional.empty();
     }
     String content = data.path("content").asText("").strip();
+    List<InboundAttachment> attachments = extractAttachments(data.path(FIELD_ATTACHMENTS));
     boolean inGuild = data.hasNonNull("guild_id") && !data.path("guild_id").asText("").isBlank();
     if (inGuild) {
       if (!mentionsBot(data, content)) {
         return Optional.empty();
       }
       content = stripMentions(content).strip();
-      if (content.isBlank()) {
+      if (content.isBlank() && attachments.isEmpty()) {
         return Optional.empty();
       }
       return Optional.of(
@@ -74,11 +79,11 @@ public class DiscordEventNormalizer {
               userId,
               chatId,
               content,
+              !content.isBlank(),
               true,
-              true,
-              List.of()));
+              attachments));
     }
-    if (content.isBlank()) {
+    if (content.isBlank() && attachments.isEmpty()) {
       return Optional.empty();
     }
     return Optional.of(
@@ -90,9 +95,47 @@ public class DiscordEventNormalizer {
             userId,
             chatId,
             content,
-            true,
+            !content.isBlank(),
             false,
-            List.of()));
+            attachments));
+  }
+
+  static List<InboundAttachment> extractAttachments(JsonNode attachments) {
+    List<InboundAttachment> out = new ArrayList<>();
+    if (attachments == null || !attachments.isArray()) {
+      return out;
+    }
+    for (JsonNode file : attachments) {
+      if (file == null || !file.isObject()) {
+        continue;
+      }
+      String url = text(file, "url");
+      if (url == null) {
+        url = text(file, "proxy_url");
+      }
+      if (url == null) {
+        continue;
+      }
+      String fileName = text(file, "filename");
+      String contentType = text(file, "content_type");
+      if (contentType != null && asciiLower(contentType).startsWith(MIME_IMAGE_PREFIX)) {
+        out.add(new InboundAttachment(InboundAttachment.TYPE_IMAGE, url, null, fileName));
+      } else {
+        out.add(InboundAttachment.fileUrl(url, fileName));
+      }
+    }
+    return out;
+  }
+
+  private static String asciiLower(String value) {
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
   }
 
   private boolean mentionsBot(JsonNode data, String content) {

--- a/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordInboundMediaResolver.java
+++ b/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordInboundMediaResolver.java
@@ -1,0 +1,282 @@
+package io.oryxos.channel.discord;
+
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMediaHttp;
+import io.oryxos.core.channel.InboundMediaJanitor;
+import io.oryxos.core.channel.InboundMediaLimits;
+import io.oryxos.core.channel.InboundMediaPaths;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.LimitedMediaWriter;
+import io.oryxos.core.session.ImageMime;
+import io.oryxos.core.session.InboundMediaExt;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Discord 入站图片/文件：{@code attachments[].url} 下载后落盘，再交给 enricher / Vision。
+ *
+ * <p>失败保留原远程 URL（降级，不阻断编排）。
+ */
+final class DiscordInboundMediaResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DiscordInboundMediaResolver.class);
+
+  private static final String DEFAULT_EXTENSION = ".bin";
+  private static final String EXT_DOT = ".";
+  private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
+  private static final int DOWNLOAD_ATTEMPTS = 2;
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(20);
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(120);
+  private static final String HEADER_AUTHORIZATION = "Authorization";
+  private static final String SCHEME_HTTPS = "https";
+  private static final String HOST_CDN = "cdn.discordapp.com";
+  private static final String HOST_MEDIA = "media.discordapp.net";
+  private static final String HOST_SUFFIX_DISCORDAPP = ".discordapp.com";
+  private static final String HOST_SUFFIX_DISCORDAPP_NET = ".discordapp.net";
+
+  private final String botToken;
+  private final Path mediaRoot;
+  private final String channelName;
+  private final InboundMediaJanitor janitor;
+
+  DiscordInboundMediaResolver(String botToken, Path mediaRoot, String channelName) {
+    this(botToken, mediaRoot, channelName, InboundMediaJanitor.fromEnv());
+  }
+
+  DiscordInboundMediaResolver(
+      String botToken, Path mediaRoot, String channelName, InboundMediaJanitor janitor) {
+    this.botToken = botToken;
+    this.mediaRoot = mediaRoot;
+    this.channelName = channelName;
+    this.janitor = janitor == null ? InboundMediaJanitor.fromEnv() : janitor;
+  }
+
+  InboundMessage resolve(InboundMessage message) {
+    if (message == null || message.attachments().isEmpty()) {
+      return message;
+    }
+    janitor.sweepIfDue(mediaRoot);
+    List<InboundAttachment> resolved = new ArrayList<>(message.attachments().size());
+    boolean changed = false;
+    for (InboundAttachment attachment : message.attachments()) {
+      if (!needsDownload(attachment)) {
+        resolved.add(attachment);
+        continue;
+      }
+      InboundAttachment next = downloadOrKeep(message.messageId(), attachment);
+      changed |= next != attachment;
+      resolved.add(next);
+    }
+    if (!changed) {
+      return message;
+    }
+    return new InboundMessage(
+        message.channelType(),
+        message.channelName(),
+        message.messageId(),
+        message.chatKind(),
+        message.userId(),
+        message.chatId(),
+        message.content(),
+        message.textual(),
+        message.mentionedBot(),
+        resolved);
+  }
+
+  static boolean needsDownload(InboundAttachment attachment) {
+    if (attachment == null || attachment.url() == null || attachment.url().isBlank()) {
+      return false;
+    }
+    String type = attachment.type();
+    return InboundAttachment.TYPE_IMAGE.equals(type) || InboundAttachment.TYPE_FILE.equals(type);
+  }
+
+  static boolean hasDownloadableMedia(InboundMessage message) {
+    if (message == null) {
+      return false;
+    }
+    for (InboundAttachment attachment : message.attachments()) {
+      if (needsDownload(attachment)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private InboundAttachment downloadOrKeep(String messageId, InboundAttachment attachment) {
+    String remoteUrl = attachment.url().strip();
+    Exception last = null;
+    for (int attempt = 1; attempt <= DOWNLOAD_ATTEMPTS; attempt++) {
+      long started = System.nanoTime();
+      try {
+        Path path = writeToMediaRoot(messageId, remoteUrl, attachment);
+        LOG.info(
+            "Discord 渠道 {} 媒体已落盘（messageId={}, type={}, {}ms）",
+            sanitize(channelName),
+            sanitize(messageId),
+            sanitize(attachment.type()),
+            (System.nanoTime() - started) / 1_000_000L);
+        return new InboundAttachment(
+            attachment.type(), path.toAbsolutePath().toString(), remoteUrl, attachment.fileName());
+      } catch (Exception e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
+        last = e;
+        LOG.warn(
+            "Discord 渠道 {} 下载媒体失败尝试 {}/{}（messageId={}, host={}, {}ms）：{}",
+            sanitize(channelName),
+            attempt,
+            DOWNLOAD_ATTEMPTS,
+            sanitize(messageId),
+            sanitize(hostOf(remoteUrl)),
+            (System.nanoTime() - started) / 1_000_000L,
+            sanitize(e.getMessage()));
+      }
+    }
+    LOG.warn(
+        "Discord 渠道 {} 下载媒体最终失败（messageId={}）：{}，保留远程 URL",
+        sanitize(channelName),
+        sanitize(messageId),
+        sanitize(last == null ? null : last.getMessage()));
+    return attachment;
+  }
+
+  private Path writeToMediaRoot(String messageId, String remoteUrl, InboundAttachment attachment)
+      throws Exception {
+    URI uri = URI.create(remoteUrl);
+    if (!isAllowedMediaUri(uri)) {
+      throw new IllegalStateException("拒绝非 Discord CDN 临时下载地址: " + sanitize(uri.getHost()));
+    }
+    Map<String, String> headers = Map.of(HEADER_AUTHORIZATION, "Bot " + botToken);
+    byte[] bytes =
+        InboundMediaHttp.getBytesFollowingAllowlist(
+            uri,
+            CONNECT_TIMEOUT,
+            READ_TIMEOUT,
+            InboundMediaLimits.MAX_FILE_BYTES,
+            this::isAllowedMediaUri,
+            headers);
+    if (bytes == null || bytes.length == 0) {
+      throw new IllegalStateException("下载临时文件为空");
+    }
+    String ext = extensionFor(attachment, remoteUrl);
+    Path dir = mediaRoot.resolve(safeSegment(messageId));
+    Files.createDirectories(dir);
+    String stem = "discord-media";
+    Path target = dir.resolve(stem + ext);
+    janitor.ensureQuotaOrThrow(mediaRoot);
+    LimitedMediaWriter.writeLimited(bytes, target, InboundMediaLimits.MAX_FILE_BYTES);
+    if (InboundAttachment.TYPE_IMAGE.equals(attachment.type())
+        && DEFAULT_EXTENSION.equals(ext)
+        && ImageMime.hasRecognizedMagic(target)) {
+      String betterExt = ImageMime.extensionFor(ImageMime.probeFile(target));
+      if (betterExt != null && !DEFAULT_EXTENSION.equals(betterExt) && !betterExt.equals(ext)) {
+        Path renamed = dir.resolve(stem + betterExt);
+        try {
+          Files.move(target, renamed);
+          return renamed;
+        } catch (Exception ignored) {
+          // 保留原扩展名
+        }
+      }
+    }
+    String better = InboundMediaExt.betterFileExtension(target, ext);
+    if (better != null && !better.equals(ext)) {
+      Path renamed = dir.resolve(stem + better);
+      try {
+        Files.move(target, renamed);
+        return renamed;
+      } catch (Exception ignored) {
+        // 保留原扩展名
+      }
+    }
+    return target;
+  }
+
+  private static String extensionFor(InboundAttachment attachment, String remoteUrl) {
+    if (attachment.fileName() != null && attachment.fileName().contains(EXT_DOT)) {
+      String fromName = extensionOf(attachment.fileName());
+      if (fromName != null) {
+        return fromName;
+      }
+    }
+    String fromUrl = extensionOf(remoteUrl);
+    return fromUrl == null ? DEFAULT_EXTENSION : fromUrl;
+  }
+
+  private static String extensionOf(String nameOrUrl) {
+    if (nameOrUrl == null || nameOrUrl.isBlank()) {
+      return null;
+    }
+    String path = nameOrUrl;
+    int q = path.indexOf('?');
+    if (q >= 0) {
+      path = path.substring(0, q);
+    }
+    int slash = path.lastIndexOf('/');
+    if (slash >= 0) {
+      path = path.substring(slash + 1);
+    }
+    int dot = path.lastIndexOf(EXT_DOT);
+    if (dot < 0 || dot == path.length() - 1) {
+      return null;
+    }
+    String ext = asciiLower(path.substring(dot));
+    if (!ext.matches(SAFE_EXTENSION_PATTERN)) {
+      return null;
+    }
+    return ext;
+  }
+
+  private boolean isAllowedMediaUri(URI uri) {
+    if (uri == null || uri.getScheme() == null || uri.getHost() == null) {
+      return false;
+    }
+    String scheme = asciiLower(uri.getScheme());
+    if (!SCHEME_HTTPS.equals(scheme)) {
+      return false;
+    }
+    String host = asciiLower(uri.getHost());
+    return HOST_CDN.equals(host)
+        || HOST_MEDIA.equals(host)
+        || host.endsWith(HOST_SUFFIX_DISCORDAPP)
+        || host.endsWith(HOST_SUFFIX_DISCORDAPP_NET);
+  }
+
+  /** ASCII-only 小写，避免 SpotBugs IMPROPER_UNICODE。 */
+  private static String asciiLower(String value) {
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
+  }
+
+  private static String safeSegment(String messageId) {
+    return InboundMediaPaths.safeSegment(messageId);
+  }
+
+  private static String hostOf(String url) {
+    try {
+      String host = URI.create(url).getHost();
+      return host == null ? "" : host;
+    } catch (IllegalArgumentException e) {
+      return "";
+    }
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-discord/src/test/java/io/oryxos/channel/discord/DiscordEventNormalizerTest.java
+++ b/oryxos-channel-discord/src/test/java/io/oryxos/channel/discord/DiscordEventNormalizerTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,6 +78,55 @@ class DiscordEventNormalizerTest {
   void otherEventsIgnored() {
     ObjectNode data = baseMessage("x", null);
     assertTrue(normalizer.normalize("MESSAGE_UPDATE", data).isEmpty());
+  }
+
+  @Test
+  @DisplayName("私聊图片附件 → TYPE_IMAGE")
+  void dmImageAttachment() {
+    ObjectNode data = baseMessage("", null);
+    var attachments = data.putArray("attachments");
+    ObjectNode file = attachments.addObject();
+    file.put("id", "att-1");
+    file.put("filename", "shot.png");
+    file.put("content_type", "image/png");
+    file.put("url", "https://cdn.discordapp.com/attachments/1/2/shot.png");
+    file.put("proxy_url", "https://media.discordapp.net/attachments/1/2/shot.png");
+    Optional<InboundMessage> msg = normalizer.normalize("MESSAGE_CREATE", data);
+    assertTrue(msg.isPresent());
+    InboundMessage m = msg.get();
+    assertEquals(1, m.attachments().size());
+    assertEquals(InboundAttachment.TYPE_IMAGE, m.attachments().get(0).type());
+    assertEquals("shot.png", m.attachments().get(0).fileName());
+    assertEquals(
+        "https://cdn.discordapp.com/attachments/1/2/shot.png", m.attachments().get(0).url());
+  }
+
+  @Test
+  @DisplayName("私聊非图片附件 → TYPE_FILE；公会仅附件+@Bot 可入站")
+  void fileAttachmentAndGuildMediaOnly() {
+    ObjectNode dm = baseMessage("", null);
+    dm.putArray("attachments")
+        .addObject()
+        .put("filename", "notes.pdf")
+        .put("content_type", "application/pdf")
+        .put("url", "https://cdn.discordapp.com/attachments/1/2/notes.pdf");
+    Optional<InboundMessage> dmMsg = normalizer.normalize("MESSAGE_CREATE", dm);
+    assertTrue(dmMsg.isPresent());
+    assertEquals(InboundAttachment.TYPE_FILE, dmMsg.get().attachments().get(0).type());
+
+    ObjectNode guild = baseMessage("<@" + APP_ID + ">", "guild-1");
+    guild.putArray("mentions").addObject().put("id", APP_ID).put("username", "oryxos");
+    guild
+        .putArray("attachments")
+        .addObject()
+        .put("filename", "a.jpg")
+        .put("content_type", "image/jpeg")
+        .put("url", "https://cdn.discordapp.com/attachments/9/8/a.jpg");
+    Optional<InboundMessage> guildMsg = normalizer.normalize("MESSAGE_CREATE", guild);
+    assertTrue(guildMsg.isPresent());
+    assertEquals(ChatKind.GROUP, guildMsg.get().chatKind());
+    assertEquals(1, guildMsg.get().attachments().size());
+    assertTrue(guildMsg.get().content().isBlank());
   }
 
   private static ObjectNode baseMessage(String content, String guildId) {


### PR DESCRIPTION
## Summary
- Parse Discord `MESSAGE_CREATE` `attachments[]` into image/file inbound attachments (blank text OK when media present)
- Download CDN URLs with Bot Token into `.oryxos/inbound-media/` (Slack-parity resolver + slow-work latch)
- Allowlist `cdn.discordapp.com` / `media.discordapp.net` / `*.discordapp.com|net`; update Discord setup docs

## Test plan
- [x] `mvn -pl oryxos-channel-discord verify` (local)
- [ ] CI green
- [ ] Local soak: DM image + file after rebuild on 8081