### PR TITLE
fix(tool,channel): surface scanned-PDF cause in read_file errors

### DIFF
--- a/oryxos-core/src/main/java/io/oryxos/core/channel/DefaultInboundMediaEnricher.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/channel/DefaultInboundMediaEnricher.java
@@ -20,6 +20,10 @@ public final class DefaultInboundMediaEnricher implements InboundMediaEnricher {
   private static final String FILE_WITH_REF = "[用户发送了一个文件]\n文件资源: ";
   private static final String FILE_NAME_LINE = "\n文件名: ";
   private static final String FILE_HINT = "\n可用 read_file 读取该路径（文本或文本型 PDF；须在 FILE 沙箱白名单内）。";
+  private static final String FILE_HINT_PDF =
+      "\n可用 read_file 读取该路径（仅文本型 PDF 可抽取正文；扫描件/纯图片 PDF 无文本层会失败——请改发可复制文字的 PDF，或把页面截图当图片发送走 Vision）。"
+          + "\n请使用上方「本地路径」原样调用 read_file，勿改文件名。";
+  private static final String PDF_SUFFIX = ".pdf";
   private static final String AUDIO_PREFIX = "[用户发送了一段语音]\n转写: ";
   private static final String AUDIO_PATH = "[用户发送了一段语音]\n本地路径: ";
   private static final String AUDIO_NO_ASR =
@@ -100,9 +104,29 @@ public final class DefaultInboundMediaEnricher implements InboundMediaEnricher {
       sb.append(FILE_NAME_LINE).append(attachment.fileName().strip());
     }
     if (attachment.url() != null && !attachment.url().isBlank()) {
-      sb.append(FILE_HINT);
+      sb.append(looksLikePdf(attachment) ? FILE_HINT_PDF : FILE_HINT);
     }
     return sb.toString();
+  }
+
+  private static boolean looksLikePdf(InboundAttachment attachment) {
+    String url = attachment.url();
+    if (url != null && asciiLower(url).contains(PDF_SUFFIX)) {
+      return true;
+    }
+    String name = attachment.fileName();
+    return name != null && asciiLower(name).endsWith(PDF_SUFFIX);
+  }
+
+  private static String asciiLower(String value) {
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
   }
 
   private String enrichAudio(InboundAttachment attachment, String channel) {

--- a/oryxos-core/src/test/java/io/oryxos/core/channel/DefaultInboundMediaEnricherTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/channel/DefaultInboundMediaEnricherTest.java
@@ -78,6 +78,8 @@ class DefaultInboundMediaEnricherTest {
     assertTrue(input.contains("季度报告.pdf"));
     assertTrue(input.contains("文件"));
     assertTrue(input.contains("read_file"));
+    assertTrue(input.contains("扫描件") || input.contains("文本型 PDF"));
+    assertTrue(input.contains("勿改文件名"));
   }
 
   @Test

--- a/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/builtin/FileTools.java
@@ -69,7 +69,12 @@ public class FileTools {
       }
       return Files.readString(file);
     } catch (IOException e) {
-      throw new UncheckedIOException("读取文件失败: " + path, e);
+      String detail = e.getMessage();
+      if (detail == null || detail.isBlank()) {
+        throw new UncheckedIOException("读取文件失败: " + path, e);
+      }
+      // 把根因（如「PDF 无文本层」）透出给 Agent，避免只看到笼统的「读取文件失败」后乱猜路径
+      throw new UncheckedIOException("读取文件失败: " + path + " — " + detail.strip(), e);
     }
   }
 

--- a/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/builtin/FileToolsTest.java
@@ -17,6 +17,7 @@ import io.oryxos.tool.sandbox.SandboxViolationException;
 import io.oryxos.tool.sandbox.ShellSandboxProperties;
 import io.oryxos.tool.sandbox.WhitelistSandbox;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -739,6 +740,20 @@ class FileToolsTest {
     }
     String text = tools.readFile(pdf.toString());
     assertTrue(text.contains("OryxOS PDF inbound ok"), text);
+  }
+
+  @Test
+  @DisplayName("read_file 扫描件 PDF 错误信息包含无文本层根因")
+  void readFileScannedPdfSurfacesCause() throws IOException {
+    Path pdf = dir.resolve("scan.pdf");
+    try (var doc = new org.apache.pdfbox.pdmodel.PDDocument()) {
+      doc.addPage(new org.apache.pdfbox.pdmodel.PDPage());
+      doc.save(pdf.toFile());
+    }
+    UncheckedIOException ex =
+        assertThrows(UncheckedIOException.class, () -> tools.readFile(pdf.toString()));
+    assertTrue(ex.getMessage().contains("无文本层"), ex.getMessage());
+    assertTrue(ex.getMessage().contains(pdf.toString()), ex.getMessage());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Discord media soak: image Vision OK; scanned PDF `read_file` failed with opaque「读取文件失败」, agent then guessed wrong filenames
- Propagate PdfTextExtractor cause (e.g. 无文本层) in `read_file` errors
- Enricher PDF hint: tell agent not to rename path; scanned PDF → text PDF or Vision screenshot

## Test plan
- [x] DefaultInboundMediaEnricherTest + FileToolsTest (scanned PDF case)
- [ ] CI green