### PR TITLE
feat(channel-discord): inbound voice/audio via CDN + Whisper

### DIFF
--- a/docs/DiscordChannelSetup.md
+++ b/docs/DiscordChannelSetup.md
@@ -2,7 +2,7 @@
 
 本文是 OryxOS Discord 入站渠道的部署操作手册。架构对称飞书/企微/钉钉/Slack：以 **Gateway WebSocket** 主动连接 Discord（免公网回调 URL）；回复经 REST `POST /channels/{id}/messages`。
 
-> 范围：Discord Bot **Gateway v10**。文本私聊与公会频道 `@Bot`；入站图片/文件经 CDN 下载落盘。
+> 范围：Discord Bot **Gateway v10**。文本私聊与公会频道 `@Bot`；入站图片/文件/语音经 CDN 下载落盘（语音走 Whisper ASR，对齐飞书/企微/钉钉）。
 
 ## 一、Discord 侧：创建 Application 并启用 Intents
 
@@ -28,6 +28,8 @@
    ```bash
    export DISCORD_BOT_TOKEN=...
    export DISCORD_APPLICATION_ID=...
+   # 语音转写（与其它 IM 渠道共用）
+   export OPENAI_API_KEY=...   # 或 ORYXOS_ASR_API_KEY / ORYXOS_ASR_BASE_URL
    ```
 
 2. **渠道绑定** `.oryxos/channels.yaml`（模板见 `config/channels.yaml.example`）：
@@ -51,9 +53,10 @@
 
 ## 三、使用方式
 
-- **私聊**：在 Discord 中打开该 Bot 的 DM，直接发文本、图片或文件。
+- **私聊**：在 Discord 中打开该 Bot 的 DM，直接发文本、图片、文件或语音气泡。
 - **公会频道**：将 Bot 拉入服务器/频道后 `@Bot + 问题`（可带附件；平台推送 `MESSAGE_CREATE` 且含提及）。
 - **图片 / 文件**：经 `attachments[].url`（CDN）带 Bot Token 落盘到 `.oryxos/inbound-media/`；图片可供 Vision，文件路径写入 Agent 提示。
+- **语音**：`content_type` 为 `audio/*`、Voice Message（`flags` 含语音位）、或带 `waveform`/`duration_secs` 的附件 → 落盘后经 Whisper 转写注入正文（需配置 ASR Key；格式需 ffmpeg 时设置 `ORYXOS_FFMPEG` 或 PATH）。
 - **联网检索**：须在绑定 Agent 的 `AGENT.md` `tools:` 中加入 `web_search` 等，见 Tool 文档。
 
 ## 四、与其它渠道的差异
@@ -63,11 +66,11 @@
 | 凭证 | App ID/Secret 等 | Bot Token + App-Level Token | Bot Token + Application ID |
 | 连接 | 各家长连接 | Socket Mode WSS | Gateway WSS v10 |
 | 回复 | 各平台 API | chat.postMessage | channels/{id}/messages |
-| MVP 媒体 | 图/文件/音视频 | 图片+文件 | **图片 + 文件**（语音/视频后续） |
+| MVP 媒体 | 图/文件/音视频 | 图片+文件 | **图片 + 文件 + 语音**（视频后续） |
 
 ## 五、非目标（本期不做）
 
-- 语音 / 视频入站
+- 视频入站
 - Slash Commands / Interactions / Components
 - HTTP Interactions 公网回调
 - Notify `type=discord`

--- a/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordEventNormalizer.java
+++ b/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordEventNormalizer.java
@@ -14,7 +14,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Discord Gateway {@code MESSAGE_CREATE} → 归一化 {@link InboundMessage}。
  *
- * <p>私聊（无 {@code guild_id}）收文本/附件；公会频道仅当提及本 Bot（Application ID）时接受。
+ * <p>私聊（无 {@code guild_id}）收文本/附件；公会频道仅当提及本 Bot（Application ID）时接受。 附件按 {@code content_type}
+ * 分流：{@code image/*} → 图、{@code audio/*} → 语音、其余 → 文件。
  */
 public class DiscordEventNormalizer {
 
@@ -26,8 +27,17 @@ public class DiscordEventNormalizer {
   private static final String FIELD_BOT = "bot";
   private static final String FIELD_WEBHOOK_ID = "webhook_id";
   private static final String FIELD_ATTACHMENTS = "attachments";
+  private static final String FIELD_WAVEFORM = "waveform";
+  private static final String FIELD_DURATION_SECS = "duration_secs";
   private static final String MIME_IMAGE_PREFIX = "image/";
+  private static final String MIME_AUDIO_PREFIX = "audio/";
+
+  /** Discord Voice Message 标志位（{@code 1 << 13}）。 */
+  private static final int FLAG_IS_VOICE_MESSAGE = 8192;
+
   private static final Pattern MENTION = Pattern.compile("<@!?([0-9]+)>\\s*");
+  private static final Pattern AUDIO_FILENAME =
+      Pattern.compile("(?i).*\\.(ogg|opus|mp3|wav|m4a|aac|flac|webm)$");
 
   private final String channelName;
   private final String applicationId;
@@ -60,7 +70,9 @@ public class DiscordEventNormalizer {
       return Optional.empty();
     }
     String content = data.path("content").asText("").strip();
-    List<InboundAttachment> attachments = extractAttachments(data.path(FIELD_ATTACHMENTS));
+    boolean voiceMessage = (data.path("flags").asInt(0) & FLAG_IS_VOICE_MESSAGE) != 0;
+    List<InboundAttachment> attachments =
+        extractAttachments(data.path(FIELD_ATTACHMENTS), voiceMessage);
     boolean inGuild = data.hasNonNull("guild_id") && !data.path("guild_id").asText("").isBlank();
     if (inGuild) {
       if (!mentionsBot(data, content)) {
@@ -101,6 +113,10 @@ public class DiscordEventNormalizer {
   }
 
   static List<InboundAttachment> extractAttachments(JsonNode attachments) {
+    return extractAttachments(attachments, false);
+  }
+
+  static List<InboundAttachment> extractAttachments(JsonNode attachments, boolean voiceMessage) {
     List<InboundAttachment> out = new ArrayList<>();
     if (attachments == null || !attachments.isArray()) {
       return out;
@@ -118,13 +134,31 @@ public class DiscordEventNormalizer {
       }
       String fileName = text(file, "filename");
       String contentType = text(file, "content_type");
-      if (contentType != null && asciiLower(contentType).startsWith(MIME_IMAGE_PREFIX)) {
+      String mime = contentType == null ? "" : asciiLower(contentType);
+      if (mime.startsWith(MIME_IMAGE_PREFIX)) {
         out.add(new InboundAttachment(InboundAttachment.TYPE_IMAGE, url, null, fileName));
+      } else if (isAudioAttachment(mime, fileName, file, voiceMessage)) {
+        out.add(new InboundAttachment(InboundAttachment.TYPE_AUDIO, url, null, fileName));
       } else {
         out.add(InboundAttachment.fileUrl(url, fileName));
       }
     }
     return out;
+  }
+
+  /** 语音：MIME {@code audio/*}、语音气泡标志、附件带 {@code waveform}/{@code duration_secs}、或常见音频扩展名。 */
+  private static boolean isAudioAttachment(
+      String mime, String fileName, JsonNode file, boolean voiceMessage) {
+    if (mime.startsWith(MIME_AUDIO_PREFIX)) {
+      return true;
+    }
+    if (voiceMessage) {
+      return true;
+    }
+    if (file.hasNonNull(FIELD_WAVEFORM) || file.hasNonNull(FIELD_DURATION_SECS)) {
+      return true;
+    }
+    return fileName != null && AUDIO_FILENAME.matcher(fileName).matches();
   }
 
   private static String asciiLower(String value) {

--- a/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordInboundMediaResolver.java
+++ b/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordInboundMediaResolver.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Discord 入站图片/文件：{@code attachments[].url} 下载后落盘，再交给 enricher / Vision。
+ * Discord 入站图片/文件/语音：{@code attachments[].url} 下载后落盘，再交给 enricher / Vision / Whisper。
  *
  * <p>失败保留原远程 URL（降级，不阻断编排）。
  */
@@ -29,6 +29,7 @@ final class DiscordInboundMediaResolver {
   private static final Logger LOG = LoggerFactory.getLogger(DiscordInboundMediaResolver.class);
 
   private static final String DEFAULT_EXTENSION = ".bin";
+  private static final String DEFAULT_AUDIO_EXTENSION = ".ogg";
   private static final String EXT_DOT = ".";
   private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
   private static final int DOWNLOAD_ATTEMPTS = 2;
@@ -95,7 +96,9 @@ final class DiscordInboundMediaResolver {
       return false;
     }
     String type = attachment.type();
-    return InboundAttachment.TYPE_IMAGE.equals(type) || InboundAttachment.TYPE_FILE.equals(type);
+    return InboundAttachment.TYPE_IMAGE.equals(type)
+        || InboundAttachment.TYPE_FILE.equals(type)
+        || InboundAttachment.TYPE_AUDIO.equals(type);
   }
 
   static boolean hasDownloadableMedia(InboundMessage message) {
@@ -209,7 +212,13 @@ final class DiscordInboundMediaResolver {
       }
     }
     String fromUrl = extensionOf(remoteUrl);
-    return fromUrl == null ? DEFAULT_EXTENSION : fromUrl;
+    if (fromUrl != null) {
+      return fromUrl;
+    }
+    if (InboundAttachment.TYPE_AUDIO.equals(attachment.type())) {
+      return DEFAULT_AUDIO_EXTENSION;
+    }
+    return DEFAULT_EXTENSION;
   }
 
   private static String extensionOf(String nameOrUrl) {

--- a/oryxos-channel-discord/src/test/java/io/oryxos/channel/discord/DiscordEventNormalizerTest.java
+++ b/oryxos-channel-discord/src/test/java/io/oryxos/channel/discord/DiscordEventNormalizerTest.java
@@ -129,6 +129,37 @@ class DiscordEventNormalizerTest {
     assertTrue(guildMsg.get().content().isBlank());
   }
 
+  @Test
+  @DisplayName("私聊 audio/* 附件 → TYPE_AUDIO")
+  void dmAudioMime() {
+    ObjectNode data = baseMessage("", null);
+    data.putArray("attachments")
+        .addObject()
+        .put("filename", "voice-message.ogg")
+        .put("content_type", "audio/ogg")
+        .put("url", "https://cdn.discordapp.com/attachments/1/2/voice-message.ogg")
+        .put("waveform", "AAAA")
+        .put("duration_secs", 2.5);
+    Optional<InboundMessage> msg = normalizer.normalize("MESSAGE_CREATE", data);
+    assertTrue(msg.isPresent());
+    assertEquals(InboundAttachment.TYPE_AUDIO, msg.get().attachments().get(0).type());
+    assertEquals("voice-message.ogg", msg.get().attachments().get(0).fileName());
+  }
+
+  @Test
+  @DisplayName("Discord Voice Message flags → TYPE_AUDIO")
+  void voiceMessageFlag() {
+    ObjectNode data = baseMessage("", null);
+    data.put("flags", 8192);
+    data.putArray("attachments")
+        .addObject()
+        .put("filename", "voice-message.ogg")
+        .put("url", "https://cdn.discordapp.com/attachments/1/2/voice-message.ogg");
+    Optional<InboundMessage> msg = normalizer.normalize("MESSAGE_CREATE", data);
+    assertTrue(msg.isPresent());
+    assertEquals(InboundAttachment.TYPE_AUDIO, msg.get().attachments().get(0).type());
+  }
+
   private static ObjectNode baseMessage(String content, String guildId) {
     ObjectNode data = MAPPER.createObjectNode();
     data.put("id", "msg-1");


### PR DESCRIPTION
## Summary
- Parse `audio/*`, Voice Message `flags`, `waveform`/`duration_secs`, and common audio filenames as `TYPE_AUDIO`
- Download via existing Discord CDN resolver (default `.ogg`); enricher/Whisper path unchanged (core ASR)
- Docs: Discord MVP media = image + file + voice; ASR env notes

## Test plan
- [x] `mvn -pl oryxos-channel-discord verify`
- [ ] CI green
- [ ] Local soak: Discord DM voice bubble → ASR transcript reply