### PR TITLE
feat(channel-discord): inbound video via CDN with track ASR

### DIFF
--- a/docs/DiscordChannelSetup.md
+++ b/docs/DiscordChannelSetup.md
@@ -2,7 +2,7 @@
 
 本文是 OryxOS Discord 入站渠道的部署操作手册。架构对称飞书/企微/钉钉/Slack：以 **Gateway WebSocket** 主动连接 Discord（免公网回调 URL）；回复经 REST `POST /channels/{id}/messages`。
 
-> 范围：Discord Bot **Gateway v10**。文本私聊与公会频道 `@Bot`；入站图片/文件/语音经 CDN 下载落盘（语音走 Whisper ASR，对齐飞书/企微/钉钉）。
+> 范围：Discord Bot **Gateway v10**。文本私聊与公会频道 `@Bot`；入站图片/文件/语音/视频经 CDN 下载落盘（语音/视频音轨走 Whisper ASR，对齐飞书/企微/钉钉）。
 
 ## 一、Discord 侧：创建 Application 并启用 Intents
 
@@ -28,8 +28,10 @@
    ```bash
    export DISCORD_BOT_TOKEN=...
    export DISCORD_APPLICATION_ID=...
-   # 语音转写（与其它 IM 渠道共用）
+   # 语音 / 视频音轨转写（与其它 IM 渠道共用）
    export OPENAI_API_KEY=...   # 或 ORYXOS_ASR_API_KEY / ORYXOS_ASR_BASE_URL
+   # 视频抽轨 / 非原生音频格式常需 ffmpeg
+   export ORYXOS_FFMPEG=...    # 或确保 ffmpeg 在 PATH
    ```
 
 2. **渠道绑定** `.oryxos/channels.yaml`（模板见 `config/channels.yaml.example`）：
@@ -53,10 +55,11 @@
 
 ## 三、使用方式
 
-- **私聊**：在 Discord 中打开该 Bot 的 DM，直接发文本、图片、文件或语音气泡。
+- **私聊**：在 Discord 中打开该 Bot 的 DM，直接发文本、图片、文件、语音或视频。
 - **公会频道**：将 Bot 拉入服务器/频道后 `@Bot + 问题`（可带附件；平台推送 `MESSAGE_CREATE` 且含提及）。
 - **图片 / 文件**：经 `attachments[].url`（CDN）带 Bot Token 落盘到 `.oryxos/inbound-media/`；图片可供 Vision，文件路径写入 Agent 提示。
-- **语音**：`content_type` 为 `audio/*`、Voice Message（`flags` 含语音位）、或带 `waveform`/`duration_secs` 的附件 → 落盘后经 Whisper 转写注入正文（需配置 ASR Key；格式需 ffmpeg 时设置 `ORYXOS_FFMPEG` 或 PATH）。
+- **语音**：`content_type` 为 `audio/*`、Voice Message（`flags` 含语音位）、或带 `waveform`/`duration_secs` 的附件 → 落盘后经 Whisper 转写注入正文。
+- **视频**：`content_type` 为 `video/*` 或常见视频扩展名 → 落盘；默认尝试抽音轨 ASR（可用 `ORYXOS_VIDEO_ASR=0` 关闭）；**不自动理解画面**。
 - **联网检索**：须在绑定 Agent 的 `AGENT.md` `tools:` 中加入 `web_search` 等，见 Tool 文档。
 
 ## 四、与其它渠道的差异
@@ -66,11 +69,11 @@
 | 凭证 | App ID/Secret 等 | Bot Token + App-Level Token | Bot Token + Application ID |
 | 连接 | 各家长连接 | Socket Mode WSS | Gateway WSS v10 |
 | 回复 | 各平台 API | chat.postMessage | channels/{id}/messages |
-| MVP 媒体 | 图/文件/音视频 | 图片+文件 | **图片 + 文件 + 语音**（视频后续） |
+| MVP 媒体 | 图/文件/音视频 | 图片+文件 | **图片 + 文件 + 语音 + 视频** |
 
 ## 五、非目标（本期不做）
 
-- 视频入站
+- 视频画面理解 / 抽帧 Vision
 - Slash Commands / Interactions / Components
 - HTTP Interactions 公网回调
 - Notify `type=discord`

--- a/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordEventNormalizer.java
+++ b/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordEventNormalizer.java
@@ -14,8 +14,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Discord Gateway {@code MESSAGE_CREATE} → 归一化 {@link InboundMessage}。
  *
- * <p>私聊（无 {@code guild_id}）收文本/附件；公会频道仅当提及本 Bot（Application ID）时接受。 附件按 {@code content_type}
- * 分流：{@code image/*} → 图、{@code audio/*} → 语音、其余 → 文件。
+ * <p>私聊（无 {@code guild_id}）收文本/附件；公会频道仅当提及本 Bot（Application ID）时接受。附件按 {@code content_type}
+ * 分流：{@code image/*} → 图、{@code audio/*} → 语音、{@code video/*} → 视频、其余 → 文件。
  */
 public class DiscordEventNormalizer {
 
@@ -31,13 +31,16 @@ public class DiscordEventNormalizer {
   private static final String FIELD_DURATION_SECS = "duration_secs";
   private static final String MIME_IMAGE_PREFIX = "image/";
   private static final String MIME_AUDIO_PREFIX = "audio/";
+  private static final String MIME_VIDEO_PREFIX = "video/";
 
   /** Discord Voice Message 标志位（{@code 1 << 13}）。 */
   private static final int FLAG_IS_VOICE_MESSAGE = 8192;
 
   private static final Pattern MENTION = Pattern.compile("<@!?([0-9]+)>\\s*");
   private static final Pattern AUDIO_FILENAME =
-      Pattern.compile("(?i).*\\.(ogg|opus|mp3|wav|m4a|aac|flac|webm)$");
+      Pattern.compile("(?i).*\\.(ogg|opus|mp3|wav|m4a|aac|flac)$");
+  private static final Pattern VIDEO_FILENAME =
+      Pattern.compile("(?i).*\\.(mp4|mov|mkv|webm|avi|m4v)$");
 
   private final String channelName;
   private final String applicationId;
@@ -139,6 +142,8 @@ public class DiscordEventNormalizer {
         out.add(new InboundAttachment(InboundAttachment.TYPE_IMAGE, url, null, fileName));
       } else if (isAudioAttachment(mime, fileName, file, voiceMessage)) {
         out.add(new InboundAttachment(InboundAttachment.TYPE_AUDIO, url, null, fileName));
+      } else if (isVideoAttachment(mime, fileName)) {
+        out.add(new InboundAttachment(InboundAttachment.TYPE_VIDEO, url, null, fileName));
       } else {
         out.add(InboundAttachment.fileUrl(url, fileName));
       }
@@ -159,6 +164,14 @@ public class DiscordEventNormalizer {
       return true;
     }
     return fileName != null && AUDIO_FILENAME.matcher(fileName).matches();
+  }
+
+  /** 视频：MIME {@code video/*} 或常见视频扩展名。 */
+  private static boolean isVideoAttachment(String mime, String fileName) {
+    if (mime.startsWith(MIME_VIDEO_PREFIX)) {
+      return true;
+    }
+    return fileName != null && VIDEO_FILENAME.matcher(fileName).matches();
   }
 
   private static String asciiLower(String value) {

--- a/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordInboundMediaResolver.java
+++ b/oryxos-channel-discord/src/main/java/io/oryxos/channel/discord/DiscordInboundMediaResolver.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Discord 入站图片/文件/语音：{@code attachments[].url} 下载后落盘，再交给 enricher / Vision / Whisper。
+ * Discord 入站图片/文件/语音/视频：{@code attachments[].url} 下载后落盘，再交给 enricher / Vision / Whisper。
  *
  * <p>失败保留原远程 URL（降级，不阻断编排）。
  */
@@ -30,6 +30,7 @@ final class DiscordInboundMediaResolver {
 
   private static final String DEFAULT_EXTENSION = ".bin";
   private static final String DEFAULT_AUDIO_EXTENSION = ".ogg";
+  private static final String DEFAULT_VIDEO_EXTENSION = ".mp4";
   private static final String EXT_DOT = ".";
   private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
   private static final int DOWNLOAD_ATTEMPTS = 2;
@@ -98,7 +99,8 @@ final class DiscordInboundMediaResolver {
     String type = attachment.type();
     return InboundAttachment.TYPE_IMAGE.equals(type)
         || InboundAttachment.TYPE_FILE.equals(type)
-        || InboundAttachment.TYPE_AUDIO.equals(type);
+        || InboundAttachment.TYPE_AUDIO.equals(type)
+        || InboundAttachment.TYPE_VIDEO.equals(type);
   }
 
   static boolean hasDownloadableMedia(InboundMessage message) {
@@ -217,6 +219,9 @@ final class DiscordInboundMediaResolver {
     }
     if (InboundAttachment.TYPE_AUDIO.equals(attachment.type())) {
       return DEFAULT_AUDIO_EXTENSION;
+    }
+    if (InboundAttachment.TYPE_VIDEO.equals(attachment.type())) {
+      return DEFAULT_VIDEO_EXTENSION;
     }
     return DEFAULT_EXTENSION;
   }

--- a/oryxos-channel-discord/src/test/java/io/oryxos/channel/discord/DiscordEventNormalizerTest.java
+++ b/oryxos-channel-discord/src/test/java/io/oryxos/channel/discord/DiscordEventNormalizerTest.java
@@ -160,6 +160,21 @@ class DiscordEventNormalizerTest {
     assertEquals(InboundAttachment.TYPE_AUDIO, msg.get().attachments().get(0).type());
   }
 
+  @Test
+  @DisplayName("私聊 video/* 附件 → TYPE_VIDEO")
+  void dmVideoMime() {
+    ObjectNode data = baseMessage("", null);
+    data.putArray("attachments")
+        .addObject()
+        .put("filename", "clip.mp4")
+        .put("content_type", "video/mp4")
+        .put("url", "https://cdn.discordapp.com/attachments/1/2/clip.mp4");
+    Optional<InboundMessage> msg = normalizer.normalize("MESSAGE_CREATE", data);
+    assertTrue(msg.isPresent());
+    assertEquals(InboundAttachment.TYPE_VIDEO, msg.get().attachments().get(0).type());
+    assertEquals("clip.mp4", msg.get().attachments().get(0).fileName());
+  }
+
   private static ObjectNode baseMessage(String content, String guildId) {
     ObjectNode data = MAPPER.createObjectNode();
     data.put("id", "msg-1");


### PR DESCRIPTION
## Summary
- Soak: Discord video landed as `discord-media.mp4` but was typed as FILE (no track ASR)
- Add `video/*` / common video extensions → `TYPE_VIDEO`, CDN download (default `.mp4`)
- Docs: Discord MVP media parity with Feishu/WeCom/DingTalk (image+file+audio+video); note no frame Vision

## Test plan
- [x] `mvn -pl oryxos-channel-discord verify`
- [ ] CI green
- [ ] Re-send Discord DM video after restart; expect video path + optional track transcript (needs ffmpeg)