### PR TITLE
fix(web): 管理台开放 026 海外 IM 的 notify 类型

### DIFF
--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -966,7 +966,7 @@ async function deleteAgent(name) {
   } catch (e) { agents.value = { ...agents.value, error: e.message } }
 }
 
-// —— Notify 渠道管理（CRUD /api/v1/notify-channels）：命名的通知出口，type ∈ feishu/wecom/dingtalk/webhook/email ——
+// —— Notify 渠道管理（CRUD /api/v1/notify-channels）：命名的通知出口，含 026 海外 IM ——
 const notifyChannels = ref({ loading: false, error: null, data: [] })
 async function loadNotifyChannels() {
   notifyChannels.value = { loading: true, error: null, data: [] }
@@ -981,7 +981,39 @@ async function loadNotifyChannels() {
 }
 
 // 新建/编辑表单：editing 存被编辑渠道的 name（此时 name 只读），null 表示新建
-const nc = reactive({ open: false, editing: null, name: '', type: 'feishu', url: '', description: '', host: '', port: '', from: '', to: '', username: '', password: '', subject: '', encryption: '', busy: false, error: null })
+const nc = reactive({ open: false, editing: null, name: '', type: 'feishu', url: '', description: '', host: '', port: '', from: '', to: '', username: '', password: '', subject: '', encryption: '', token: '', chatId: '', channelId: '', phoneNumberId: '', homeserver: '', roomId: '', busy: false, error: null })
+
+function notifyNeedsUrl(type) {
+  return !['email', 'telegram', 'slack', 'discord', 'whatsapp', 'matrix'].includes(type)
+}
+
+function buildNotifyConfig() {
+  if (nc.type === 'email') return buildEmailConfig()
+  const config = {}
+  if (nc.token) config.token = nc.token
+  if (nc.type === 'telegram' && nc.chatId) config.chat_id = nc.chatId
+  if ((nc.type === 'slack' || nc.type === 'discord') && nc.channelId) config.channel_id = nc.channelId
+  if (nc.type === 'whatsapp') {
+    if (nc.phoneNumberId) config.phone_number_id = nc.phoneNumberId
+    if (nc.to) config.to = nc.to
+  }
+  if (nc.type === 'matrix') {
+    if (nc.homeserver) config.homeserver = nc.homeserver
+    if (nc.roomId) config.room_id = nc.roomId
+  }
+  return Object.keys(config).length ? config : undefined
+}
+
+function notifyFormReady() {
+  if (!nc.name) return false
+  if (nc.type === 'email') return !!(nc.host && nc.port && nc.from && nc.to)
+  if (nc.url) return true
+  if (nc.type === 'telegram') return !!(nc.token && nc.chatId)
+  if (nc.type === 'slack' || nc.type === 'discord') return !!(nc.token && nc.channelId)
+  if (nc.type === 'whatsapp') return !!(nc.token && nc.phoneNumberId && nc.to)
+  if (nc.type === 'matrix') return !!(nc.homeserver && nc.token && nc.roomId)
+  return false
+}
 
 async function saveNotifyChannel() {
   nc.busy = true; nc.error = null
@@ -989,10 +1021,9 @@ async function saveNotifyChannel() {
     const url = nc.editing
       ? `/api/v1/notify-channels/${encodeURIComponent(nc.editing)}`
       : '/api/v1/notify-channels'
-    const config = nc.type === 'email' ? buildEmailConfig() : undefined
-    let payload = nc.type === 'email'
-      ? { type: nc.type, url: '', config, description: nc.description }
-      : { type: nc.type, url: nc.url, description: nc.description }
+    const config = buildNotifyConfig()
+    let payload = { type: nc.type, url: nc.type === 'email' ? '' : nc.url, description: nc.description }
+    if (config) payload.config = config
     if (!nc.editing) payload = { name: nc.name, ...payload }
     const res = await fetch(url, {
       method: nc.editing ? 'PUT' : 'POST',
@@ -1014,6 +1045,8 @@ function editNotifyChannel(row) {
   const c = row.config || {}
   nc.host = c.host || ''; nc.port = c.port || ''; nc.from = c.from || ''; nc.to = c.to || ''
   nc.username = c.username || ''; nc.password = c.password || ''; nc.subject = c.subject || ''; nc.encryption = c.encryption || ''
+  nc.token = c.token || ''; nc.chatId = c.chat_id || ''; nc.channelId = c.channel_id || ''
+  nc.phoneNumberId = c.phone_number_id || ''; nc.homeserver = c.homeserver || ''; nc.roomId = c.room_id || ''
   nc.error = null
   nc.open = true
 }
@@ -1029,6 +1062,7 @@ function buildEmailConfig() {
 function cancelNc() {
   nc.open = false; nc.editing = null; nc.name = ''; nc.type = 'feishu'; nc.url = ''; nc.description = ''
   nc.host = ''; nc.port = ''; nc.from = ''; nc.to = ''; nc.username = ''; nc.password = ''; nc.subject = ''; nc.encryption = ''
+  nc.token = ''; nc.chatId = ''; nc.channelId = ''; nc.phoneNumberId = ''; nc.homeserver = ''; nc.roomId = ''
   nc.error = null
 }
 
@@ -3191,8 +3225,34 @@ const outputRows = computed(() =>
                     <option value="dingtalk">dingtalk</option>
                     <option value="webhook">webhook</option>
                     <option value="email">email</option>
+                    <option value="slack">slack</option>
+                    <option value="discord">discord</option>
+                    <option value="telegram">telegram</option>
+                    <option value="whatsapp">whatsapp</option>
+                    <option value="teams">teams</option>
+                    <option value="gchat">gchat</option>
+                    <option value="mattermost">mattermost</option>
+                    <option value="matrix">matrix</option>
                   </select>
-                  <input v-if="nc.type !== 'email'" v-model="nc.url" class="gen-input" placeholder="Webhook URL" />
+                  <input v-if="nc.type !== 'email'" v-model="nc.url" class="gen-input" :placeholder="notifyNeedsUrl(nc.type) ? 'Webhook URL' : 'Webhook URL（可选；也可用下方 token 字段）'" />
+                  <template v-if="nc.type === 'telegram'">
+                    <input v-model="nc.token" class="gen-input" placeholder="Bot Token（建议 ${TELEGRAM_BOT_TOKEN}）" />
+                    <input v-model="nc.chatId" class="gen-input" placeholder="chat_id（私聊数字 ID，群为负数）" />
+                  </template>
+                  <template v-if="nc.type === 'slack' || nc.type === 'discord'">
+                    <input v-model="nc.token" class="gen-input" placeholder="Bot Token（建议环境变量占位）" />
+                    <input v-model="nc.channelId" class="gen-input" placeholder="channel_id" />
+                  </template>
+                  <template v-if="nc.type === 'whatsapp'">
+                    <input v-model="nc.token" class="gen-input" placeholder="Graph access token" />
+                    <input v-model="nc.phoneNumberId" class="gen-input" placeholder="phone_number_id" />
+                    <input v-model="nc.to" class="gen-input" placeholder="to（E.164）" />
+                  </template>
+                  <template v-if="nc.type === 'matrix'">
+                    <input v-model="nc.homeserver" class="gen-input" placeholder="homeserver（https://matrix.example）" />
+                    <input v-model="nc.token" class="gen-input" placeholder="access token" />
+                    <input v-model="nc.roomId" class="gen-input" placeholder="room_id" />
+                  </template>
                   <template v-if="nc.type === 'email'">
                     <input v-model="nc.host" class="gen-input" placeholder="SMTP host（如 smtp.example.com）" />
                     <input v-model="nc.port" class="gen-input" placeholder="端口（465/587/25）" />
@@ -3209,12 +3269,12 @@ const outputRows = computed(() =>
                     </select>
                   </template>
                   <input v-model="nc.description" class="gen-input" placeholder="描述（可选）" />
-                  <p class="empty">{{ nc.editing ? '编辑现有渠道，渠道名不可改。' : 'type 支持 feishu / wecom / dingtalk / webhook / email；email 填 SMTP 多字段（密码建议 ${SMTP_PASSWORD} 环境变量占位），其余填 Webhook URL。' }}</p>
+                  <p class="empty">{{ nc.editing ? '编辑现有渠道，渠道名不可改。' : 'webhook 类填 URL；telegram / slack / discord 可改填 token + chat_id 或 channel_id；email 填 SMTP。凭证建议 ${ENV} 占位。' }}</p>
                   <p v-if="nc.error" class="error">{{ nc.error }}</p>
                 </div>
                 <div class="modal-foot">
                   <button class="btn" @click="cancelNc">取消</button>
-                  <button class="btn btn-primary" :disabled="nc.busy || !nc.name || (nc.type === 'email' ? !(nc.host && nc.port && nc.from && nc.to) : !nc.url)" @click="saveNotifyChannel">{{ nc.editing ? '保存修改' : '创建' }}</button>
+                  <button class="btn btn-primary" :disabled="nc.busy || !notifyFormReady()" @click="saveNotifyChannel">{{ nc.editing ? '保存修改' : '创建' }}</button>
                 </div>
               </div>
             </div>

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/NotifyChannelApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/NotifyChannelApiController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * <p>薄转发给 {@link NotifyChannelRegistry}。错误码沿用既有口径：名字冲突 / 定义非法 → 400 （{@code
  * IllegalArgumentException}）；不存在 → 404（{@code ResourceNotFoundException}）；统一 {@code ApiResponse}
- * 信封。type 必须是已装配的渠道实现之一（webhook/feishu/wecom/dingtalk/email）。
+ * 信封。type 必须是已装配的渠道实现之一（含 026 海外 IM）。
  */
 @SuppressFBWarnings(
     value = {"SPRING_ENDPOINT", "EI_EXPOSE_REP2"},
@@ -37,12 +37,38 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotifyChannelApiController {
 
   private static final String TYPE_EMAIL = "email";
+  private static final String TYPE_SLACK = "slack";
+  private static final String TYPE_DISCORD = "discord";
+  private static final String TYPE_TELEGRAM = "telegram";
+  private static final String TYPE_WHATSAPP = "whatsapp";
+  private static final String TYPE_MATRIX = "matrix";
+  private static final String CFG_URL = "url";
+  private static final String CFG_TOKEN = "token";
+  private static final String CFG_CHANNEL_ID = "channel_id";
+  private static final String CFG_CHAT_ID = "chat_id";
+  private static final String CFG_PHONE_NUMBER_ID = "phone_number_id";
+  private static final String CFG_TO = "to";
+  private static final String CFG_HOMESERVER = "homeserver";
+  private static final String CFG_ROOM_ID = "room_id";
 
   /** email 渠道 port 的合法上限（TCP 端口最大值）。 */
   private static final int MAX_PORT = 65535;
 
   private static final Set<String> SUPPORTED_TYPES =
-      Set.of("webhook", "feishu", "wecom", "dingtalk", TYPE_EMAIL);
+      Set.of(
+          "webhook",
+          "feishu",
+          "wecom",
+          "dingtalk",
+          TYPE_EMAIL,
+          TYPE_SLACK,
+          TYPE_DISCORD,
+          TYPE_TELEGRAM,
+          TYPE_WHATSAPP,
+          "teams",
+          "gchat",
+          "mattermost",
+          TYPE_MATRIX);
 
   private final NotifyChannelRegistry registry;
 
@@ -135,9 +161,55 @@ public class NotifyChannelApiController {
     }
     if (TYPE_EMAIL.equals(type)) {
       validateEmail(config);
-    } else if (url == null || url.isBlank()) {
-      throw new IllegalArgumentException("渠道 url 为空");
+      return;
     }
+    if (hasText(url) || hasConfig(config, CFG_URL)) {
+      return;
+    }
+    if (TYPE_SLACK.equals(type) || TYPE_DISCORD.equals(type)) {
+      requireConfigPair(config, type, CFG_TOKEN, CFG_CHANNEL_ID);
+      return;
+    }
+    if (TYPE_TELEGRAM.equals(type)) {
+      requireConfigPair(config, type, CFG_TOKEN, CFG_CHAT_ID);
+      return;
+    }
+    if (TYPE_WHATSAPP.equals(type)) {
+      requireConfigKeys(config, type, CFG_TOKEN, CFG_PHONE_NUMBER_ID, CFG_TO);
+      return;
+    }
+    if (TYPE_MATRIX.equals(type)) {
+      requireConfigKeys(config, type, CFG_HOMESERVER, CFG_TOKEN, CFG_ROOM_ID);
+      return;
+    }
+    throw new IllegalArgumentException("渠道 url 为空");
+  }
+
+  private static void requireConfigPair(
+      Map<String, String> config, String type, String first, String second) {
+    if (hasConfig(config, first) && hasConfig(config, second)) {
+      return;
+    }
+    throw new IllegalArgumentException(type + " 渠道缺少 url，或缺少 " + first + " + " + second);
+  }
+
+  private static void requireConfigKeys(Map<String, String> config, String type, String... keys) {
+    if (config == null) {
+      throw new IllegalArgumentException(type + " 渠道缺少配置（需 " + String.join(" + ", keys) + "）");
+    }
+    for (String key : keys) {
+      if (!hasConfig(config, key)) {
+        throw new IllegalArgumentException(type + " 渠道缺少 url，或缺少 " + String.join(" + ", keys));
+      }
+    }
+  }
+
+  private static boolean hasConfig(Map<String, String> config, String key) {
+    return config != null && hasText(config.get(key));
+  }
+
+  private static boolean hasText(String value) {
+    return value != null && !value.isBlank();
   }
 
   private static void validateEmail(Map<String, String> config) {
@@ -170,6 +242,9 @@ public class NotifyChannelApiController {
   }
 
   private static String normalizeUrl(String type, String url) {
-    return TYPE_EMAIL.equals(type) ? "" : url;
+    if (TYPE_EMAIL.equals(type)) {
+      return "";
+    }
+    return url == null ? "" : url;
   }
 }

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/CreateNotifyChannelRequest.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/CreateNotifyChannelRequest.java
@@ -3,8 +3,7 @@ package io.oryxos.web.controller.dto;
 import java.util.Map;
 
 /**
- * 新建通知渠道请求体：name 全局唯一，type∈{webhook,feishu,wecom,dingtalk,email}；url 为 HTTP 类渠道的 webhook 地址，config
- * 承载类型相关多字段（如 email 的 host/port/from/to）。
+ * 新建通知渠道请求体：name 全局唯一；url 为 webhook 类渠道地址，config 承载类型相关多字段（email SMTP，或 telegram token/chat_id 等）。
  */
 public record CreateNotifyChannelRequest(
     String name, String type, String url, String description, Map<String, String> config) {

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/NotifyChannelApiControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/NotifyChannelApiControllerTest.java
@@ -78,7 +78,45 @@ class NotifyChannelApiControllerTest {
     mvc.perform(
             post("/api/v1/notify-channels")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"x\",\"type\":\"telegram\",\"url\":\"https://x/hook\"}"))
+                .content("{\"name\":\"x\",\"type\":\"not-a-vendor\",\"url\":\"https://x/hook\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(400));
+    verify(registry, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("create telegram token+chat_id_无 url_成功")
+  void create_telegramTokenChatId_returnsView() throws Exception {
+    when(registry.exists("ops-tg")).thenReturn(false);
+    when(registry.save(any()))
+        .thenReturn(
+            new NotifyChannelDef(
+                "ops-tg",
+                "telegram",
+                "",
+                "告警",
+                java.util.Map.of("token", "${TELEGRAM_BOT_TOKEN}", "chat_id", "1")));
+
+    mvc.perform(
+            post("/api/v1/notify-channels")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"name\":\"ops-tg\",\"type\":\"telegram\",\"url\":\"\","
+                        + "\"config\":{\"token\":\"${TELEGRAM_BOT_TOKEN}\",\"chat_id\":\"1\"}}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.type").value("telegram"));
+    verify(registry).save(any());
+  }
+
+  @Test
+  @DisplayName("create telegram 缺 token 与 url_返回400")
+  void create_telegramMissingTarget_returns400() throws Exception {
+    when(registry.exists("ops-tg")).thenReturn(false);
+
+    mvc.perform(
+            post("/api/v1/notify-channels")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"ops-tg\",\"type\":\"telegram\"}"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value(400));
     verify(registry, never()).save(any());

--- a/specs/026-im-channel-roadmap/acceptance.md
+++ b/specs/026-im-channel-roadmap/acceptance.md
@@ -25,7 +25,7 @@
 | Telegram 入站 `CONNECTED` | 本机 `oryxos serve` 后 `GET /api/v1/channels/status` 中 `ops-telegram` 为 `CONNECTED` |
 | Telegram 私聊往返 | 通过：个人测试 Bot 收到私聊后建了 `telegram:*:demo-agent` 会话（2 条消息），DeepSeek 已回写 |
 | Telegram `notify` | 通过：Bot API `sendMessage` 成功（个人测试会话） |
-| Telegram 群 `@Bot` | 未测（需要把该个人测试 Bot 拉进群并关 Privacy Mode） |
+| Telegram 群 `@Bot` | 通过（2026-09-08）：个人测试 Bot 已拉进测试群，BotFather `/setprivacy` Disable 后移出再拉回；群内 `@rchuangbot test` 引用回复，本机 21:56 DeepSeek 已推理。群聊按契约不落 `sessions` 表（每次 @ 无状态）。未 @ 的群消息不处理 |
 | Slack 入站 | 主仓已测并合入：[PR #420](https://github.com/oryx-labs/oryxos/pull/420) Socket Mode `CONNECTED` + 文本往返；[PR #421](https://github.com/oryx-labs/oryxos/pull/421) 图片/文件入站。本机 `ops-slack` 仍为 `CONNECTED`，既有 Slack 会话可回放 |
 | Discord 入站 | 主仓已测并合入：[PR #422](https://github.com/oryx-labs/oryxos/pull/422) Gateway 文本 DM / 公会 `@Bot`；[#423](https://github.com/oryx-labs/oryxos/pull/423)/[#425](https://github.com/oryx-labs/oryxos/pull/425)/[#426](https://github.com/oryx-labs/oryxos/pull/426)/[#427](https://github.com/oryx-labs/oryxos/pull/427) 图/文件/语音/视频 soak。本机 `ops-discord` 仍为 `CONNECTED`，既有 Discord 会话可回放 |
 | Slack / Discord `notify` | 026 [PR #429](https://github.com/oryx-labs/oryxos/pull/429) 已补适配器；出站路径与入站回复同源（Slack `chat.postMessage` / Discord REST）。不要把后续 `conversations.list` / 列频道探测当成「未打真实频道」 |

--- a/specs/026-im-channel-roadmap/acceptance.md
+++ b/specs/026-im-channel-roadmap/acceptance.md
@@ -26,8 +26,9 @@
 | Telegram 私聊往返 | 通过：个人测试 Bot 收到私聊后建了 `telegram:*:demo-agent` 会话（2 条消息），DeepSeek 已回写 |
 | Telegram `notify` | 通过：Bot API `sendMessage` 成功（个人测试会话） |
 | Telegram 群 `@Bot` | 未测（需要把该个人测试 Bot 拉进群并关 Privacy Mode） |
-| Slack `auth.test` | 通过（team=`OryxOS`）；`conversations.list` 缺 scope，未打真实频道 |
-| Discord `@me` | 通过（username=`OryxOS`）；列频道 403，未打真实频道 |
+| Slack 入站 | 主仓已测并合入：[PR #420](https://github.com/oryx-labs/oryxos/pull/420) Socket Mode `CONNECTED` + 文本往返；[PR #421](https://github.com/oryx-labs/oryxos/pull/421) 图片/文件入站。本机 `ops-slack` 仍为 `CONNECTED`，既有 Slack 会话可回放 |
+| Discord 入站 | 主仓已测并合入：[PR #422](https://github.com/oryx-labs/oryxos/pull/422) Gateway 文本 DM / 公会 `@Bot`；[#423](https://github.com/oryx-labs/oryxos/pull/423)/[#425](https://github.com/oryx-labs/oryxos/pull/425)/[#426](https://github.com/oryx-labs/oryxos/pull/426)/[#427](https://github.com/oryx-labs/oryxos/pull/427) 图/文件/语音/视频 soak。本机 `ops-discord` 仍为 `CONNECTED`，既有 Discord 会话可回放 |
+| Slack / Discord `notify` | 026 [PR #429](https://github.com/oryx-labs/oryxos/pull/429) 已补适配器；出站路径与入站回复同源（Slack `chat.postMessage` / Discord REST）。不要把后续 `conversations.list` / 列频道探测当成「未打真实频道」 |
 | WhatsApp / Teams / GChat / Mattermost / Matrix | 无可用凭证，未宣称 COMPLETE |
 
 管理台 Notify 已补齐 026 类型（原先 API 只允许飞书/企微/钉钉/webhook/email，适配器注册了也建不了渠道）。

--- a/specs/026-im-channel-roadmap/acceptance.md
+++ b/specs/026-im-channel-roadmap/acceptance.md
@@ -1,7 +1,7 @@
 # 026 验收记录
 
 **日期**: 2026-09-08  
-**范围**: 波次 0–5 代码 + 契约/归一化单测。真平台往返待你提供凭证后补。
+**范围**: 波次 0–5 代码 + 契约/归一化单测。真平台按已有凭证推进。
 
 ## 单测（本机 JDK 21）
 
@@ -17,13 +17,15 @@
 
 ## 真平台
 
-未在本环境发现 Slack/Discord/Telegram/WhatsApp/Teams/GChat/Mattermost/Matrix 可用 Token，**未宣称 COMPLETE 联调**。
+本机 `.env` 已有 Slack / Discord / Telegram 凭证（不入库）。2026-09-08 探测：
 
-请按各 `docs/*ChannelSetup.md` 注入环境变量后：
+| 项 | 结果 |
+|----|------|
+| Telegram `getMe` | 通过，username=`rchuangbot` |
+| Telegram `getUpdates` | 空（Bot 尚无会话，无法取 `chat_id`） |
+| Telegram 私聊往返 / 群 @ / notify | **待你先私聊 [@rchuangbot](https://t.me/rchuangbot) 一条**，再补 `CONNECTED` + 回写 + notify |
+| Slack `auth.test` | 通过（team=`OryxOS`）；`conversations.list` 缺 scope，未打真实频道 |
+| Discord `@me` | 通过（username=`OryxOS`）；列频道 403，未打真实频道 |
+| WhatsApp / Teams / GChat / Mattermost / Matrix | 无可用凭证，未宣称 COMPLETE |
 
-1. Slack / Discord：`notify` 各打一条进真实频道（波次 0）
-2. Telegram：私聊往返 + 群 @ + notify
-3. WhatsApp：WABA 回调挑战 + 窗内往返 + 窗外拒绝
-4. Teams：Azure Bot 1:1 / 频道 @
-5. Google Chat：Workspace DM / 空间 @
-6. Mattermost 然后 Matrix：自建实例私聊 / 房间 @
+管理台 Notify 已补齐 026 类型（原先 API 只允许飞书/企微/钉钉/webhook/email，适配器注册了也建不了渠道）。

--- a/specs/026-im-channel-roadmap/acceptance.md
+++ b/specs/026-im-channel-roadmap/acceptance.md
@@ -21,9 +21,9 @@
 
 | 项 | 结果 |
 |----|------|
-| Telegram `getMe` | 通过，username=`rchuangbot` |
-| Telegram `getUpdates` | 空（Bot 尚无会话，无法取 `chat_id`） |
-| Telegram 私聊往返 / 群 @ / notify | **待你先私聊 [@rchuangbot](https://t.me/rchuangbot) 一条**，再补 `CONNECTED` + 回写 + notify |
+| Telegram `getMe` | 通过。Bot 是提交者**个人测试号**（username=`rchuangbot`），不是仓库官方 Bot，凭证只在本机 `.env` |
+| Telegram `getUpdates` | 空（该个人测试 Bot 尚无会话，无法取 `chat_id`） |
+| Telegram 私聊往返 / 群 @ / notify | 待该个人测试 Bot 先有一条私聊后，再补 `CONNECTED` + 回写 + notify |
 | Slack `auth.test` | 通过（team=`OryxOS`）；`conversations.list` 缺 scope，未打真实频道 |
 | Discord `@me` | 通过（username=`OryxOS`）；列频道 403，未打真实频道 |
 | WhatsApp / Teams / GChat / Mattermost / Matrix | 无可用凭证，未宣称 COMPLETE |

--- a/specs/026-im-channel-roadmap/acceptance.md
+++ b/specs/026-im-channel-roadmap/acceptance.md
@@ -22,8 +22,10 @@
 | 项 | 结果 |
 |----|------|
 | Telegram `getMe` | 通过。Bot 是提交者**个人测试号**（username=`rchuangbot`），不是仓库官方 Bot，凭证只在本机 `.env` |
-| Telegram `getUpdates` | 空（该个人测试 Bot 尚无会话，无法取 `chat_id`） |
-| Telegram 私聊往返 / 群 @ / notify | 待该个人测试 Bot 先有一条私聊后，再补 `CONNECTED` + 回写 + notify |
+| Telegram 入站 `CONNECTED` | 本机 `oryxos serve` 后 `GET /api/v1/channels/status` 中 `ops-telegram` 为 `CONNECTED` |
+| Telegram 私聊往返 | 通过：个人测试 Bot 收到私聊后建了 `telegram:*:demo-agent` 会话（2 条消息），DeepSeek 已回写 |
+| Telegram `notify` | 通过：Bot API `sendMessage` 成功（个人测试会话） |
+| Telegram 群 `@Bot` | 未测（需要把该个人测试 Bot 拉进群并关 Privacy Mode） |
 | Slack `auth.test` | 通过（team=`OryxOS`）；`conversations.list` 缺 scope，未打真实频道 |
 | Discord `@me` | 通过（username=`OryxOS`）；列频道 403，未打真实频道 |
 | WhatsApp / Teams / GChat / Mattermost / Matrix | 无可用凭证，未宣称 COMPLETE |


### PR DESCRIPTION
## Summary
- `/api/v1/notify-channels` 与管理台原先只允许 feishu/wecom/dingtalk/webhook/email，026 适配器注册了也建不了渠道。
- 现开放 slack/discord/telegram/whatsapp/teams/gchat/mattermost/matrix；telegram 等可用 `token + chat_id`（或 channel_id）代替 webhook URL。
- Telegram 真平台（提交者**个人测试 Bot** `rchuangbot`，非官方号）：`getMe`、入站 `CONNECTED`、私聊往返、`sendMessage` notify、群 `@Bot` 引用回复均已过。群聊按契约不落 sessions 表。
- Slack / Discord 入站已在主仓 PR #420/#421、#422–#427 实测合入；026 #429 补的 notify 适配器与入站回复同源。未把个人凭证写入仓库。

## Test plan
- [ ] `NotifyChannelApiControllerTest`：非法类型 400；telegram token+chat_id 无 url 成功；缺字段 400
- [ ] 管理台新建 telegram / slack 可不填 Webhook URL
- [ ] CI 全绿