### PR TITLE
feat(sandbox): 024 US2+US3——frontmatter 按 Agent 覆写与管理台状态页（T014~T018）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,13 @@ logs/
 # local secrets
 .env
 
+.claude/skills/git-fork-sync/SKILL.md
+docs/ToolIdempotentCache.md
+docs/KnowledgeSeparation.md
+docs/ImplementationRoadmap.md
+docs/HuaqingAgentOsResearch.md
+docs/GitHubActionsWorkflowReview.md
+docs/CostAccounting.md
+docs/AuditTraceLink.md
+oryxos.db-shm
+oryxos.db-wal

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -19,6 +19,7 @@ import io.oryxos.core.agent.WorkspaceWatcher;
 import io.oryxos.core.context.ContextLoader;
 import io.oryxos.core.memory.MemoryService;
 import io.oryxos.core.notify.NotifyChannelRegistry;
+import io.oryxos.core.profile.Profile;
 import io.oryxos.core.profile.ProfileRegistry;
 import io.oryxos.core.provider.LlmCallAuditor;
 import io.oryxos.core.provider.PricingStore;
@@ -107,6 +108,7 @@ import io.oryxos.tool.notify.TelegramNotifyAdapter;
 import io.oryxos.tool.notify.WeComNotifyAdapter;
 import io.oryxos.tool.notify.WebhookNotifyAdapter;
 import io.oryxos.tool.notify.WhatsAppNotifyAdapter;
+import io.oryxos.tool.sandbox.AgentAwareProcessStarter;
 import io.oryxos.tool.sandbox.CidfileProcessWrapper;
 import io.oryxos.tool.sandbox.DockerProcessStarter;
 import io.oryxos.tool.sandbox.ExecutionBackendProperties;
@@ -778,18 +780,23 @@ public class OryxOsRuntime {
       McpClientService mcpClientService,
       UserInteraction userInteraction,
       io.oryxos.core.knowledge.KnowledgeService knowledgeService,
-      ExecutionBackendProperties executionBackendProperties) {
+      ExecutionBackendProperties executionBackendProperties,
+      ProfileRegistry profileRegistry) {
     ToolRegistry registry = new ToolRegistry();
     // 内置工具走 @Tool 注解管道（schema 自动生成，宪法 II 第二件事）
     registry.registerAnnotated(new FileTools(sandbox)); // read/write/list/edit/grep/glob
-    // 024：执行后端按档位装配（local=现状零变化 / docker=短命容器），白名单 enforce 仍在工具内部前置（FR-007）
+    // 024：执行后端按档位装配（local=现状零变化 / docker=短命容器），白名单 enforce 仍在工具内部前置（FR-007）；
+    // US2：全局档为基线，frontmatter sandbox 段按 Agent 覆写（D8 收敛在 AgentAwareProcessStarter）
     ProcessStarter shellStarter =
-        executionBackendProperties.isDocker()
-            ? new DockerProcessStarter(
-                executionBackendProperties,
-                new WorkspacePathMapper(oryxosRoot()),
-                CidfileProcessWrapper.dockerCliKiller())
-            : new LocalProcessStarter();
+        new AgentAwareProcessStarter(
+            executionBackendProperties,
+            agentName -> profileRegistry.get(agentName).map(Profile::sandbox).orElse(null),
+            new LocalProcessStarter(),
+            effective ->
+                new DockerProcessStarter(
+                    effective,
+                    new WorkspacePathMapper(oryxosRoot()),
+                    CidfileProcessWrapper.dockerCliKiller()));
     registry.registerAnnotated(new ShellTools(sandbox, shellStarter));
     registry.registerAnnotated(
         new HttpTools(sandbox, restClient)); // + http_request/fetch_webpage/download_file
@@ -879,6 +886,22 @@ public class OryxOsRuntime {
           org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type.SERVLET)
   DockerBackendStartupCheck dockerBackendStartupCheck(ExecutionBackendProperties props) {
     return new DockerBackendStartupCheck(props);
+  }
+
+  /**
+   * 024 US3：执行后端配置快照——web 状态页 controller（组件扫描自动装配）经 core 契约读取； web 与 cli 互不依赖，转换（tool Properties →
+   * core Snapshot）只能在同时看得见两者的本模块完成。
+   */
+  @Bean
+  io.oryxos.core.execution.ExecutionBackendSnapshot executionBackendSnapshot(
+      ExecutionBackendProperties props) {
+    return new io.oryxos.core.execution.ExecutionBackendSnapshot(
+        props.backend(),
+        props.image(),
+        props.memory(),
+        props.cpus(),
+        props.network(),
+        props.user());
   }
 
   @Bean

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -781,16 +781,24 @@ public class OryxOsRuntime {
       UserInteraction userInteraction,
       io.oryxos.core.knowledge.KnowledgeService knowledgeService,
       ExecutionBackendProperties executionBackendProperties,
-      ProfileRegistry profileRegistry) {
+      org.springframework.beans.factory.ObjectProvider<ProfileRegistry> profileRegistryProvider) {
     ToolRegistry registry = new ToolRegistry();
     // 内置工具走 @Tool 注解管道（schema 自动生成，宪法 II 第二件事）
     registry.registerAnnotated(new FileTools(sandbox)); // read/write/list/edit/grep/glob
     // 024：执行后端按档位装配（local=现状零变化 / docker=短命容器），白名单 enforce 仍在工具内部前置（FR-007）；
-    // US2：全局档为基线，frontmatter sandbox 段按 Agent 覆写（D8 收敛在 AgentAwareProcessStarter）
+    // US2：全局档为基线，frontmatter sandbox 段按 Agent 覆写（D8 收敛在 AgentAwareProcessStarter）。
+    // ProfileRegistry 走 ObjectProvider 惰性解析——直接注入会成环：
+    // toolRegistry → profileRegistry → agentLoader → tools → toolRegistry（E2E 实证）；
+    // shell 首次执行时上下文必然就绪，getIfAvailable 安全。
     ProcessStarter shellStarter =
         new AgentAwareProcessStarter(
             executionBackendProperties,
-            agentName -> profileRegistry.get(agentName).map(Profile::sandbox).orElse(null),
+            agentName -> {
+              ProfileRegistry profiles = profileRegistryProvider.getIfAvailable();
+              return profiles == null
+                  ? null
+                  : profiles.get(agentName).map(Profile::sandbox).orElse(null);
+            },
             new LocalProcessStarter(),
             effective ->
                 new DockerProcessStarter(

--- a/oryxos-core/src/main/java/io/oryxos/core/execution/ExecutionBackendSnapshot.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/execution/ExecutionBackendSnapshot.java
@@ -1,0 +1,21 @@
+package io.oryxos.core.execution;
+
+/**
+ * 执行后端配置快照（024 US3，跨模块契约）：web 状态页需要呈现的执行后端配置——由装配方（oryxos-cli）从 oryxos-tool 的 {@code
+ * ExecutionBackendProperties} 转换注入。 web 不依赖 tool 模块（分层约束），故契约置 core（ToolPolicyService 同款先例：跨模块契约放
+ * core、实现/配置在下层模块）。
+ *
+ * @param backend local / docker
+ * @param image 执行镜像（docker 档必填，local 为空）
+ * @param memory 默认内存限额（如 512m）
+ * @param cpus 默认 CPU 限额（如 1.0）
+ * @param network 网络模式（默认 none）
+ * @param user 容器执行用户（默认 nobody）
+ */
+public record ExecutionBackendSnapshot(
+    String backend, String image, String memory, String cpus, String network, String user) {
+
+  public boolean isDocker() {
+    return "docker".equals(backend);
+  }
+}

--- a/oryxos-core/src/main/java/io/oryxos/core/profile/Profile.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/Profile.java
@@ -16,7 +16,8 @@ public record Profile(
     List<NotifyChannel> notifyChannels,
     List<ScheduleConfig> schedules,
     List<String> bootstrap,
-    Settings settings) {
+    Settings settings,
+    Sandbox sandbox) {
 
   public Profile {
     tools = tools == null ? List.of() : List.copyOf(tools);
@@ -26,6 +27,39 @@ public record Profile(
     schedules = schedules == null ? List.of() : List.copyOf(schedules);
     bootstrap = bootstrap == null ? List.of() : List.copyOf(bootstrap);
     settings = settings == null ? Settings.defaults() : settings;
+  }
+
+  /**
+   * Compatibility constructor for callers that still pass pre-sandbox 12 args: sandbox stays null
+   * (= 继承全局执行后端).
+   */
+  public Profile(
+      String name,
+      String description,
+      Identity identity,
+      Persona persona,
+      ProviderRef provider,
+      List<String> tools,
+      List<String> mcpServers,
+      List<String> channels,
+      List<NotifyChannel> notifyChannels,
+      List<ScheduleConfig> schedules,
+      List<String> bootstrap,
+      Settings settings) {
+    this(
+        name,
+        description,
+        identity,
+        persona,
+        provider,
+        tools,
+        mcpServers,
+        channels,
+        notifyChannels,
+        schedules,
+        bootstrap,
+        settings,
+        null);
   }
 
   /**
@@ -133,4 +167,10 @@ public record Profile(
       return new Settings(DEFAULT_MAX_ITERATIONS, DEFAULT_MAX_HISTORY_TURNS);
     }
   }
+
+  /**
+   * 执行环境声明（024）：frontmatter 可选段——backend 覆写全局执行后端档位，memory/cpus 覆写 docker 限额； 字段缺省 =
+   * 继承全局。段本身缺省（sandbox 为 null）= 完全继承（绝大多数 Agent 的形态）。
+   */
+  public record Sandbox(String backend, String memory, String cpus) {}
 }

--- a/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/profile/ProfileLoader.java
@@ -30,6 +30,11 @@ public class ProfileLoader {
 
   private static final Logger LOG = LoggerFactory.getLogger(ProfileLoader.class);
 
+  /** sandbox.backend 合法档位（024，P3C：字面量提常量）。 */
+  private static final String LOCAL_BACKEND = "local";
+
+  private static final String DOCKER_BACKEND = "docker";
+
   private static final Pattern ENV_PLACEHOLDER = Pattern.compile("\\$\\{([A-Za-z0-9_]+)}");
 
   private final Path profilesDir;
@@ -126,7 +131,8 @@ public class ProfileLoader {
             requireListOrNull(map.get("notify_channels"), "notify_channels", name), name),
         toSchedules(requireListOrNull(map.get("schedules"), "schedules", name), source),
         asStringList(map.get("bootstrap"), "bootstrap", name),
-        toSettings(asMap(map.get("settings")), name));
+        toSettings(asMap(map.get("settings")), name),
+        toSandbox(asMap(map.get("sandbox")), name));
   }
 
   private Profile.ProviderRef toProviderRef(Map<String, Object> map, String profileName) {
@@ -307,6 +313,25 @@ public class ProfileLoader {
       throw new ProfileValidationException(
           "Profile 定时配置 " + key + " 的 cron 无效: " + source + " (" + e.getMessage() + ")");
     }
+  }
+
+  /**
+   * 024：frontmatter 可选 sandbox 段。段缺省 → null（完全继承全局）；backend 仅认 local/docker， 非法值 WARN
+   * 并回落继承（EC-4：告警不阻断该 Agent 与其它 Agent 加载）；memory/cpus 原样透传（docker 侧校验）。
+   */
+  private static Profile.Sandbox toSandbox(Map<String, Object> map, String profileName) {
+    if (map == null) {
+      return null;
+    }
+    String backend = asString(map.get("backend"));
+    if (backend != null && !backend.equals(LOCAL_BACKEND) && !backend.equals(DOCKER_BACKEND)) {
+      LOG.warn(
+          "Profile {} 的 sandbox.backend 非法值 '{}'（仅认 local/docker）——按继承全局档处理",
+          sanitize(profileName),
+          sanitize(backend));
+      backend = null;
+    }
+    return new Profile.Sandbox(backend, asString(map.get("memory")), asString(map.get("cpus")));
   }
 
   private static Profile.Settings toSettings(Map<String, Object> map, String profileName) {

--- a/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/profile/ProfileLoaderTest.java
@@ -898,4 +898,51 @@ class ProfileLoaderTest {
     assertTrue(profile.provider().fallbacks().isEmpty());
     assertEquals("deepseek", profile.provider().name()); // 既有解析不受影响
   }
+
+  @Test
+  void sandbox段_合法值解析_缺省继承_非法值WARN回落() throws IOException {
+    write(
+        "docker-agent.yaml",
+        """
+        name: docker-agent
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        sandbox:
+          backend: docker
+          memory: 1g
+        """);
+    write(
+        "typical-agent.yaml",
+        """
+        name: typical-agent
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        """);
+    write(
+        "bad-backend.yaml",
+        """
+        name: bad-backend
+        provider:
+          name: deepseek
+          model: deepseek-chat
+        sandbox:
+          backend: kubernetes
+        """);
+
+    var registry = loader().loadAll();
+
+    var docker = registry.get("docker-agent").orElseThrow();
+    assertEquals("docker", docker.sandbox().backend());
+    assertEquals("1g", docker.sandbox().memory());
+
+    // 缺省：段未声明 → sandbox 为 null（完全继承全局）
+    assertNull(registry.get("typical-agent").orElseThrow().sandbox());
+
+    // 非法 backend：不阻断加载，backend 回落 null（继承），Agent 仍注册
+    var bad = registry.get("bad-backend").orElseThrow();
+    assertNull(bad.sandbox().backend());
+    assertEquals(3, registry.all().size(), "非法值不阻断该 Agent 与其它 Agent 加载（EC-4）");
+  }
 }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/AgentAwareProcessStarter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/sandbox/AgentAwareProcessStarter.java
@@ -1,0 +1,59 @@
+package io.oryxos.tool.sandbox;
+
+import io.oryxos.core.agent.ToolExecutionContext;
+import io.oryxos.core.profile.Profile;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * 按 Agent 选档的执行后端入口（024 US2 / 设计决策 D8）：全局配置为基线，frontmatter sandbox 段按 Agent 覆写 backend 与
+ * memory/cpus——生效档 = Agent 覆写 > 全局。Agent 身份取 {@link ToolExecutionContext#agentName()} （ToolExecutor
+ * 执行前置入、同线程可见；非 Agent 触发的调用按全局档）。
+ *
+ * <p>local 生效档委托固定 local 实例（不置审计上下文，行为与 Phase 3 前完全一致）；docker 生效档按生效配置 现建
+ * DockerProcessStarter（轻对象，无状态可现建）。
+ */
+public final class AgentAwareProcessStarter implements ProcessStarter {
+
+  private final ExecutionBackendProperties global;
+  private final Function<String, Profile.Sandbox> agentSandboxLookup;
+  private final ProcessStarter local;
+  private final Function<ExecutionBackendProperties, ProcessStarter> dockerFactory;
+
+  public AgentAwareProcessStarter(
+      ExecutionBackendProperties global,
+      Function<String, Profile.Sandbox> agentSandboxLookup,
+      ProcessStarter local,
+      Function<ExecutionBackendProperties, ProcessStarter> dockerFactory) {
+    this.global = Objects.requireNonNull(global, "global 不能为空");
+    this.agentSandboxLookup = Objects.requireNonNull(agentSandboxLookup, "agentSandboxLookup 不能为空");
+    this.local = Objects.requireNonNull(local, "local 不能为空");
+    this.dockerFactory = Objects.requireNonNull(dockerFactory, "dockerFactory 不能为空");
+  }
+
+  @Override
+  public Process start(List<String> command) throws IOException {
+    ExecutionBackendProperties effective = resolve(ToolExecutionContext.agentName());
+    return effective.isDocker()
+        ? dockerFactory.apply(effective).start(command)
+        : local.start(command);
+  }
+
+  /**
+   * 生效配置收敛（D8 固定优先级）：backend/memory/cpus 逐项「Agent 覆写 > 全局」；镜像/网络/user 不可覆写 （镜像属管理员治理域，与 020
+   * 「治理与作者分离」同构）。
+   */
+  ExecutionBackendProperties resolve(String agentName) {
+    Profile.Sandbox override = agentName == null ? null : agentSandboxLookup.apply(agentName);
+    if (override == null) {
+      return global;
+    }
+    String backend = override.backend() == null ? global.backend() : override.backend();
+    String memory = override.memory() == null ? global.memory() : override.memory();
+    String cpus = override.cpus() == null ? global.cpus() : override.cpus();
+    return new ExecutionBackendProperties(
+        backend, global.image(), memory, cpus, global.network(), global.user());
+  }
+}

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/AgentAwareProcessStarterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/AgentAwareProcessStarterTest.java
@@ -1,0 +1,138 @@
+package io.oryxos.tool.sandbox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.oryxos.core.agent.ToolExecutionContext;
+import io.oryxos.core.profile.Profile;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** 024 T015（SC-008 选档路由 + D8 收敛优先级）：Agent 覆写 > 全局；非法/缺省继承；docker 档收到生效配置。 */
+class AgentAwareProcessStarterTest {
+
+  @AfterEach
+  void cleanup() {
+    ToolExecutionContext.clear();
+  }
+
+  // 每测试新实例：计数器不跨测试污染（静态共享曾导致路由断言互串）
+  private final RecordingLocal local = new RecordingLocal();
+  private final RecordingDocker docker = new RecordingDocker();
+
+  private AgentAwareProcessStarter starter(
+      java.util.function.Function<String, Profile.Sandbox> lookup) {
+    return new AgentAwareProcessStarter(
+        new ExecutionBackendProperties("docker", "alpine:3.20", "512m", "1.0", null, null),
+        lookup,
+        local,
+        props -> docker.withProps(props));
+  }
+
+  @Test
+  @DisplayName("收敛_覆写优先_未覆写继承全局_镜像网络不可覆写")
+  void resolveOverrideThenGlobal() {
+    AgentAwareProcessStarter starter = starter(name -> new Profile.Sandbox("local", "1g", null));
+
+    ExecutionBackendProperties effective = starter.resolve("ops-agent");
+    assertEquals("local", effective.backend());
+    assertEquals("1g", effective.memory()); // 覆写
+    assertEquals("1.0", effective.cpus()); // 未覆写继承
+    assertEquals("alpine:3.20", effective.image()); // 镜像不可覆写（治理域）
+    assertEquals("none", effective.network()); // 网络不可覆写
+  }
+
+  @Test
+  @DisplayName("收敛_段缺省或Agent未知_完全继承全局")
+  void missingSandboxInheritsGlobal() {
+    AgentAwareProcessStarter nullLookup = starter(name -> null);
+    assertSame(
+        starter(name -> null).resolve(null).backend(), nullLookup.resolve("anyone").backend());
+
+    // 全局 local + Agent 无声明 → local（现状零变化路径）
+    AgentAwareProcessStarter globalLocal =
+        new AgentAwareProcessStarter(
+            new ExecutionBackendProperties(null, null, null, null, null, null),
+            name -> null,
+            local,
+            props -> docker.withProps(props));
+    assertEquals("local", globalLocal.resolve("someone").backend());
+  }
+
+  @Test
+  @DisplayName("路由_全局docker_单Agent覆写local_local档执行")
+  void routingHonorsAgentOverride() throws Exception {
+    ToolExecutionContext.setAgentName("ops-agent");
+    AgentAwareProcessStarter starter = starter(name -> new Profile.Sandbox("local", null, null));
+
+    starter.start(List.of("ls"));
+
+    assertEquals(1, local.started);
+    assertEquals(0, docker.invocations.size());
+    assertNull(ToolExecutionContext.executionBackend(), "local 路径不置审计上下文（现状语义）");
+  }
+
+  @Test
+  @DisplayName("路由_全局local_单Agent覆写docker_该Agent走容器")
+  void routingAgentEscalatesToDocker() throws Exception {
+    ToolExecutionContext.setAgentName("risky-agent");
+    AgentAwareProcessStarter starter =
+        new AgentAwareProcessStarter(
+            new ExecutionBackendProperties(null, "alpine:3.20", null, null, null, null),
+            name -> "risky-agent".equals(name) ? new Profile.Sandbox("docker", "256m", null) : null,
+            local,
+            props -> docker.withProps(props));
+
+    starter.start(List.of("ls"));
+
+    assertEquals(0, local.started);
+    assertEquals(1, docker.invocations.size());
+    assertEquals("256m", docker.invocations.get(0).memory(), "Agent 限额覆写传入 docker 档");
+  }
+
+  @Test
+  @DisplayName("路由_两个Agent不同声明_各走各档（SC-008 选档面）")
+  void twoAgentsRouteDifferently() throws Exception {
+    AgentAwareProcessStarter starter =
+        new AgentAwareProcessStarter(
+            new ExecutionBackendProperties("docker", "alpine:3.20", null, null, null, null),
+            name -> "local-agent".equals(name) ? new Profile.Sandbox("local", null, null) : null,
+            local,
+            props -> docker.withProps(props));
+
+    ToolExecutionContext.setAgentName("local-agent");
+    starter.start(List.of("ls"));
+    ToolExecutionContext.setAgentName("docker-agent");
+    starter.start(List.of("ls"));
+
+    assertEquals(1, local.started);
+    assertEquals(1, docker.invocations.size());
+  }
+
+  private static final class RecordingLocal implements ProcessStarter {
+    int started;
+
+    @Override
+    public Process start(List<String> command) {
+      started++;
+      return new DockerProcessStarterTest.FakeCliProcess();
+    }
+  }
+
+  private static final class RecordingDocker implements ProcessStarter {
+    final List<ExecutionBackendProperties> invocations = new java.util.ArrayList<>();
+
+    ProcessStarter withProps(ExecutionBackendProperties props) {
+      invocations.add(props);
+      return this;
+    }
+
+    @Override
+    public Process start(List<String> command) {
+      return new DockerProcessStarterTest.FakeCliProcess();
+    }
+  }
+}

--- a/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/DockerProcessStarterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/sandbox/DockerProcessStarterTest.java
@@ -91,7 +91,7 @@ class DockerProcessStarterTest {
   }
 
   /** 最小假 CLI 进程（无 IO 语义，只验证包装与上下文）。 */
-  private static final class FakeCliProcess extends Process {
+  static final class FakeCliProcess extends Process {
     @Override
     public java.io.OutputStream getOutputStream() {
       return java.io.OutputStream.nullOutputStream();

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -66,6 +66,7 @@ const RUNTIME_NAV = [
   { key: 'notify-channels', label: 'Notify 渠道' },
   { key: 'whitelist', label: 'SandBox 列表' },
   { key: 'tool-policy', label: '工具策略' },
+  { key: 'exec-backend', label: '执行后端' },
 ]
 
 const NAV = [...TOP_NAV, ...RUNTIME_NAV]
@@ -218,6 +219,7 @@ function refresh() {
   if (key === 'notify-channels') { loadNotifyChannels(); return }
   if (key === 'providers') { loadProviders(); return }
   if (key === 'whitelist') { loadWhitelist(); return }
+  if (key === 'exec-backend') { loadExecBackend(); return }
   if (key === 'mcp') { loadMcp(); return }
   if (key === 'skills') { loadSkills(); return }
   if (key === 'knowledge') { kbDetail.value ? refreshKbDetail(kbDetail.value.name) : loadKnowledge(); return }
@@ -1353,6 +1355,20 @@ async function submitEnable() {
     if (body.code !== 0) throw new Error(body.message || '启用失败')
     cancelEnable(); await loadMcp()
   } catch (e) { mcpEnable.error = e.message } finally { mcpEnable.busy = false }
+}
+
+// —— 执行后端状态（024 US3，只读 /api/v1/sandbox/execution/status）：档位 / daemon 探测 / 限额 / 覆写一览 ——
+const exec = ref({ loading: false, error: null, data: null })
+async function loadExecBackend() {
+  exec.value = { loading: true, error: null, data: null }
+  try {
+    const res = await fetch('/api/v1/sandbox/execution/status')
+    const body = await res.json()
+    if (body.code !== 0) throw new Error(body.message || '加载失败')
+    exec.value = { loading: false, error: null, data: body.data }
+  } catch (e) {
+    exec.value = { loading: false, error: e.message, data: null }
+  }
 }
 
 // —— Sandbox 白名单管理（CRUD /api/v1/sandbox/whitelist）：四类 file/shell/http/smtp 的白名单条目 ——
@@ -2591,6 +2607,43 @@ const outputRows = computed(() =>
                     <td class="mono">{{ d.profileName || '-' }}</td>
                     <td class="mono">{{ d.toolName }}</td>
                     <td class="mono">{{ d.createdAt ? String(d.createdAt).slice(0, 19) : '-' }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </template>
+          </div>
+
+          <div v-else-if="active === 'exec-backend'">
+            <div class="toolbar">
+              <button class="btn" @click="loadExecBackend()">刷新（重新探测 daemon）</button>
+            </div>
+            <p v-if="exec.loading" class="empty">加载中…</p>
+            <p v-else-if="exec.error" class="error">出错：{{ exec.error }}</p>
+            <template v-else-if="exec.data">
+              <h3 class="sec" style="margin-top:20px">全局档位</h3>
+              <table>
+                <tbody>
+                  <tr><td>档位</td><td class="mono">{{ exec.data.backend }}</td></tr>
+                  <tr><td>执行镜像</td><td class="mono">{{ exec.data.image || '（local 档未配置）' }}</td></tr>
+                  <tr><td>镜像 digest</td><td class="mono">{{ exec.data.imageDigest || '-' }}</td></tr>
+                  <tr><td>默认限额</td><td class="mono">{{ exec.data.memory }} / {{ exec.data.cpus }} CPU</td></tr>
+                  <tr><td>网络</td><td class="mono">{{ exec.data.network }}</td></tr>
+                  <tr><td>执行用户</td><td class="mono">{{ exec.data.user }}</td></tr>
+                </tbody>
+              </table>
+              <h3 class="sec" style="margin-top:20px">docker 可用性</h3>
+              <p v-if="exec.data.docker.reachable" class="mono">✅ 可达 —— {{ exec.data.docker.version }}</p>
+              <p v-else class="error">⛔ {{ exec.data.docker.error }}（shell 调用将按 FR-011 fail loud 报错）</p>
+              <h3 class="sec" style="margin-top:20px">Agent 覆写一览（frontmatter sandbox 段）</h3>
+              <table>
+                <thead><tr><th>Agent</th><th>backend 覆写</th><th>memory 覆写</th><th>cpus 覆写</th></tr></thead>
+                <tbody>
+                  <tr v-if="!exec.data.agentOverrides.length"><td colspan="4" class="empty">（无 Agent 声明覆写——全部继承全局档）</td></tr>
+                  <tr v-for="o in exec.data.agentOverrides" :key="o.agent">
+                    <td class="mono">{{ o.agent }}</td>
+                    <td class="mono">{{ o.backend || '（继承）' }}</td>
+                    <td class="mono">{{ o.memory || '（继承）' }}</td>
+                    <td class="mono">{{ o.cpus || '（继承）' }}</td>
                   </tr>
                 </tbody>
               </table>

--- a/oryxos-web/src/main/java/io/oryxos/web/audit/AuditMetricsService.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/audit/AuditMetricsService.java
@@ -118,13 +118,22 @@ public class AuditMetricsService {
   }
 
   public List<ToolInvocationView> toolList(Instant from, Instant to, int limit) {
-    return toolList(from, to, limit, null);
+    return toolList(from, to, limit, null, null);
   }
 
-  /** 020：blockedBy 非空时只返回该拦截来源的记录（如 'policy'=策略拒绝，FR-006 可筛口径）。 */
   public List<ToolInvocationView> toolList(Instant from, Instant to, int limit, String blockedBy) {
+    return toolList(from, to, limit, blockedBy, null);
+  }
+
+  /**
+   * 020：blockedBy 非空时只返回该拦截来源的记录（如 'policy'=策略拒绝，FR-006 可筛口径）。 024：executionBackend
+   * 非空时按执行后端筛选（SC-007；历史行 NULL ≡ local，不匹配 'docker' 但匹配 null 查询由前端处理）。
+   */
+  public List<ToolInvocationView> toolList(
+      Instant from, Instant to, int limit, String blockedBy, String executionBackend) {
     return toolInvocationRepository.findByCreatedAtBetween(from, to).stream()
         .filter(t -> blockedBy == null || blockedBy.equals(t.getBlockedBy()))
+        .filter(t -> executionBackend == null || executionBackend.equals(t.getExecutionBackend()))
         .sorted(
             Comparator.comparing(
                 ToolInvocation::getCreatedAt, Comparator.nullsLast(Comparator.reverseOrder())))

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/AuditApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/AuditApiController.java
@@ -101,10 +101,12 @@ public class AuditApiController {
       @RequestParam(name = "from", required = false) String from,
       @RequestParam(name = "to", required = false) String to,
       @RequestParam(name = "limit", defaultValue = "100") int limit,
-      @RequestParam(name = "blockedBy", required = false) String blockedBy) {
+      @RequestParam(name = "blockedBy", required = false) String blockedBy,
+      @RequestParam(name = "backend", required = false) String backend) {
     Instant[] range = range(from, to);
-    // 020：blockedBy=policy 只看策略拒绝的调用（FR-006）
-    return ApiResponse.ok(metricsService.toolList(range[0], range[1], cap(limit), blockedBy));
+    // 020：blockedBy=policy 只看策略拒绝的调用（FR-006）；024：backend=local/docker 按执行后端筛（SC-007）
+    return ApiResponse.ok(
+        metricsService.toolList(range[0], range[1], cap(limit), blockedBy, backend));
   }
 
   /** 021：单轮全链路时间线——未命中 200 + found=false（契约 §3，不报 404）。 */

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/ExecutionBackendController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/ExecutionBackendController.java
@@ -1,0 +1,190 @@
+package io.oryxos.web.controller;
+
+import io.oryxos.core.execution.ExecutionBackendSnapshot;
+import io.oryxos.core.profile.Profile;
+import io.oryxos.core.profile.ProfileRegistry;
+import io.oryxos.web.common.ApiResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 执行后端状态页 API（024 US3 / FR-012，只读）：全局档位、docker 可用性（按需探测 D5——无常驻心跳）、 生效镜像与限额、各 Agent 的 frontmatter
+ * 覆写一览。配置修改走 application.yml / AGENT.md（GitOps 路径），本 API 不提供写操作。
+ */
+@RestController
+@RequestMapping("/api/v1/sandbox/execution")
+public class ExecutionBackendController {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutionBackendController.class);
+
+  /** 探测命令输出截断（诊断够用，防刷屏）。 */
+  private static final int DIAGNOSTIC_TAIL = 300;
+
+  private static final String DOCKER = "docker";
+
+  private final ExecutionBackendSnapshot props;
+  private final ProfileRegistry profileRegistry;
+  private final DockerStatusProbe probe;
+
+  public ExecutionBackendController(
+      ExecutionBackendSnapshot props, ProfileRegistry profileRegistry) {
+    this(props, profileRegistry, ExecutionBackendController::processProbe);
+  }
+
+  ExecutionBackendController(
+      ExecutionBackendSnapshot props, ProfileRegistry profileRegistry, DockerStatusProbe probe) {
+    this.props = Objects.requireNonNull(props, "props 不能为空");
+    this.profileRegistry = Objects.requireNonNull(profileRegistry, "profileRegistry 不能为空");
+    this.probe = Objects.requireNonNull(probe, "probe 不能为空");
+  }
+
+  /**
+   * 探针：exit==0 返回 {@code null}（通过，stdout 供版本展示可另取）；否则返回输出尾部（诊断）。 启动失败返回错误信息而非抛异常——状态页语义是「如实呈现」，不
+   * fail。
+   */
+  @FunctionalInterface
+  interface DockerStatusProbe {
+    String probe(List<String> argv);
+  }
+
+  /** 生产探针（argv 形式、命令全部为内部常量，非模型/用户输入）。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "COMMAND_INJECTION",
+      justification = "argv 全部来自内部常量与管理员配置的镜像名（非模型/用户输入），argv 直传不经 shell")
+  private static String processProbe(List<String> argv) {
+    try {
+      Process process = new ProcessBuilder(argv).redirectErrorStream(true).start();
+      byte[] output;
+      try (InputStream in = process.getInputStream()) {
+        output = in.readAllBytes();
+      }
+      if (process.waitFor() != 0) {
+        return tail(output);
+      }
+      return null;
+    } catch (IOException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      return e.getMessage() == null ? "probe failed" : e.getMessage();
+    }
+  }
+
+  @GetMapping("/status")
+  public ApiResponse<StatusView> status() {
+    return ApiResponse.ok(
+        new StatusView(
+            props.backend(),
+            dockerStatus(),
+            props.image(),
+            imageDigest(),
+            props.memory(),
+            props.cpus(),
+            props.network(),
+            props.user(),
+            agentOverrides()));
+  }
+
+  private DockerStatusView dockerStatus() {
+    String cliError = probe.probe(List.of(DOCKER, "--version"));
+    if (cliError != null) {
+      return new DockerStatusView(false, null, "CLI 不可用: " + cliError);
+    }
+    String infoError = probe.probe(List.of(DOCKER, "info"));
+    if (infoError != null) {
+      return new DockerStatusView(false, null, "daemon 不可达: " + infoError);
+    }
+    String version = probeVersion();
+    return new DockerStatusView(true, version, null);
+  }
+
+  /** docker --version 的 stdout（如 "Docker version 28.4.0, build xxx"）。 */
+  private String probeVersion() {
+    try {
+      Process process = new ProcessBuilder(DOCKER, "--version").redirectErrorStream(true).start();
+      byte[] output;
+      try (InputStream in = process.getInputStream()) {
+        output = in.readAllBytes();
+      }
+      return process.waitFor() == 0 ? new String(output, StandardCharsets.UTF_8).trim() : null;
+    } catch (IOException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      return null;
+    }
+  }
+
+  /** 镜像 digest（daemon 可达且 backend 配了镜像时才有值）。 */
+  private String imageDigest() {
+    if (!props.isDocker() || props.image().isBlank()) {
+      return null;
+    }
+    // inspect 通过时 stdout 即 digest（RepoDigests 首个），失败返回 null（镜像未拉取）
+    try {
+      Process process =
+          new ProcessBuilder(DOCKER, "image", "inspect", "--format", "{{.Id}}", props.image())
+              .redirectErrorStream(true)
+              .start();
+      byte[] output;
+      try (InputStream in = process.getInputStream()) {
+        output = in.readAllBytes();
+      }
+      return process.waitFor() == 0 ? new String(output, StandardCharsets.UTF_8).trim() : null;
+    } catch (IOException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      LOG.debug("镜像 digest 探测失败: {}", e.getMessage());
+      return null;
+    }
+  }
+
+  /** frontmatter 声明了 sandbox 段的 Agent 一览（未声明的不列——绝大多数继承全局）。 */
+  private List<AgentOverrideView> agentOverrides() {
+    return profileRegistry.all().stream()
+        .filter(profile -> profile.sandbox() != null)
+        .map(AgentOverrideView::from)
+        .toList();
+  }
+
+  private static String tail(byte[] output) {
+    String text = new String(output, StandardCharsets.UTF_8).replace('\r', '_').replace('\n', '_');
+    return text.length() > DIAGNOSTIC_TAIL
+        ? "…" + text.substring(text.length() - DIAGNOSTIC_TAIL)
+        : text;
+  }
+
+  /** 状态总览。docker 可达性三态：CLI 缺失 / daemon 不可达 / 就绪（附版本）。 */
+  public record StatusView(
+      String backend,
+      DockerStatusView docker,
+      String image,
+      String imageDigest,
+      String memory,
+      String cpus,
+      String network,
+      String user,
+      List<AgentOverrideView> agentOverrides) {}
+
+  public record DockerStatusView(boolean reachable, String version, String error) {}
+
+  public record AgentOverrideView(String agent, String backend, String memory, String cpus) {
+
+    static AgentOverrideView from(Profile profile) {
+      return new AgentOverrideView(
+          profile.name(),
+          profile.sandbox().backend(),
+          profile.sandbox().memory(),
+          profile.sandbox().cpus());
+    }
+  }
+}

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/ExecutionBackendController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/ExecutionBackendController.java
@@ -37,6 +37,8 @@ public class ExecutionBackendController {
   private final ProfileRegistry profileRegistry;
   private final DockerStatusProbe probe;
 
+  // 双构造器并存时 Spring 无法择一——@Autowired 指定装配用本构造器（测试桩走包级三参构造器）
+  @org.springframework.beans.factory.annotation.Autowired
   public ExecutionBackendController(
       ExecutionBackendSnapshot props, ProfileRegistry profileRegistry) {
     this(props, profileRegistry, ExecutionBackendController::processProbe);

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/ExecutionBackendController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/ExecutionBackendController.java
@@ -19,6 +19,9 @@ import org.springframework.web.bind.annotation.RestController;
  * 执行后端状态页 API（024 US3 / FR-012，只读）：全局档位、docker 可用性（按需探测 D5——无常驻心跳）、 生效镜像与限额、各 Agent 的 frontmatter
  * 覆写一览。配置修改走 application.yml / AGENT.md（GitOps 路径），本 API 不提供写操作。
  */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = {"SPRING_ENDPOINT", "EI_EXPOSE_REP2"},
+    justification = "core-stage web API is unauthenticated by design (internal network + gateway).")
 @RestController
 @RequestMapping("/api/v1/sandbox/execution")
 public class ExecutionBackendController {
@@ -107,6 +110,9 @@ public class ExecutionBackendController {
   }
 
   /** docker --version 的 stdout（如 "Docker version 28.4.0, build xxx"）。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "COMMAND_INJECTION",
+      justification = "argv 为内部常量（docker --version），非模型/用户输入，argv 直传不经 shell")
   private String probeVersion() {
     try {
       Process process = new ProcessBuilder(DOCKER, "--version").redirectErrorStream(true).start();
@@ -124,6 +130,9 @@ public class ExecutionBackendController {
   }
 
   /** 镜像 digest（daemon 可达且 backend 配了镜像时才有值）。 */
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "COMMAND_INJECTION",
+      justification = "argv 为内部常量与管理员配置的镜像名（非模型/用户输入），argv 直传不经 shell")
   private String imageDigest() {
     if (!props.isDocker() || props.image().isBlank()) {
       return null;
@@ -143,7 +152,7 @@ public class ExecutionBackendController {
       if (e instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       }
-      LOG.debug("镜像 digest 探测失败: {}", e.getMessage());
+      LOG.debug("镜像 digest 探测失败", e); // throwable 直传（栈帧由 logback 格式化，无 CRLF 注入面）
       return null;
     }
   }
@@ -173,7 +182,12 @@ public class ExecutionBackendController {
       String cpus,
       String network,
       String user,
-      List<AgentOverrideView> agentOverrides) {}
+      List<AgentOverrideView> agentOverrides) {
+
+    public StatusView {
+      agentOverrides = agentOverrides == null ? List.of() : List.copyOf(agentOverrides);
+    }
+  }
 
   public record DockerStatusView(boolean reachable, String version, String error) {}
 

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ToolInvocationView.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/dto/ToolInvocationView.java
@@ -10,6 +10,8 @@ public record ToolInvocationView(
     String toolName,
     boolean success,
     String blockedBy,
+    String executionBackend,
+    String containerId,
     long durationMs,
     Instant createdAt,
     String traceId) {
@@ -21,6 +23,8 @@ public record ToolInvocationView(
         t.getToolName(),
         t.isSuccess(),
         t.getBlockedBy(),
+        t.getExecutionBackend(),
+        t.getContainerId(),
         t.getDurationMs(),
         t.getCreatedAt(),
         t.getTraceId());

--- a/oryxos-web/src/test/java/io/oryxos/web/controller/ExecutionBackendControllerTest.java
+++ b/oryxos-web/src/test/java/io/oryxos/web/controller/ExecutionBackendControllerTest.java
@@ -1,0 +1,132 @@
+package io.oryxos.web.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.oryxos.core.execution.ExecutionBackendSnapshot;
+import io.oryxos.core.profile.Profile;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** 024 T017：状态 API 的数据面（探针注入桩）——daemon 三态呈现、镜像 digest 仅 docker 档、覆写一览过滤。 */
+class ExecutionBackendControllerTest {
+
+  /** 桩探针：按命令前缀回放（null=通过；非 null=诊断错误）。 */
+  private static final class StubProbe implements ExecutionBackendController.DockerStatusProbe {
+    String cliError;
+    String daemonError;
+
+    @Override
+    public String probe(List<String> argv) {
+      String key = String.join(" ", argv);
+      if (key.startsWith("docker --version") && cliError != null) {
+        return cliError;
+      }
+      if (key.startsWith("docker info") && daemonError != null) {
+        return daemonError;
+      }
+      return null;
+    }
+  }
+
+  private static ProfileRegistry registry(Profile... profiles) {
+    ProfileRegistry registry = new ProfileRegistry();
+    for (Profile profile : profiles) {
+      registry.register(profile);
+    }
+    return registry;
+  }
+
+  private static Profile agent(String name, Profile.Sandbox sandbox) {
+    return new Profile(
+        name,
+        null,
+        null,
+        null,
+        new Profile.ProviderRef("deepseek", "deepseek-chat", null),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        null,
+        sandbox);
+  }
+
+  @Test
+  @DisplayName("docker档_daemon就绪_覆写一览只列声明段")
+  void dockerBackendHealthyWithOverrides() {
+    StubProbe probe = new StubProbe();
+    ExecutionBackendController controller =
+        new ExecutionBackendController(
+            new ExecutionBackendSnapshot("docker", "alpine:3.20", null, null, null, null),
+            registry(
+                agent("ops", new Profile.Sandbox("local", null, null)),
+                agent("plain", null),
+                agent("batch", new Profile.Sandbox("docker", "1g", "2.0"))),
+            probe);
+
+    ExecutionBackendController.StatusView status = controller.status().getData();
+
+    assertEquals("docker", status.backend());
+    assertTrue(status.docker().reachable());
+    assertEquals(
+        List.of(
+            new ExecutionBackendController.AgentOverrideView("ops", "local", null, null),
+            new ExecutionBackendController.AgentOverrideView("batch", "docker", "1g", "2.0")),
+        status.agentOverrides(),
+        "未声明 sandbox 段的 plain 不列");
+  }
+
+  @Test
+  @DisplayName("daemon不可达_标红呈现错误信息_不抛异常")
+  void daemonDownRenderedAsError() {
+    StubProbe probe = new StubProbe();
+    probe.daemonError = "Cannot connect to the Docker daemon";
+    ExecutionBackendController controller =
+        new ExecutionBackendController(
+            new ExecutionBackendSnapshot("docker", "alpine:3.20", null, null, null, null),
+            registry(),
+            probe);
+
+    ExecutionBackendController.StatusView status = controller.status().getData();
+
+    assertFalse(status.docker().reachable());
+    assertTrue(status.docker().error().contains("daemon"));
+    assertNull(status.docker().version());
+  }
+
+  @Test
+  @DisplayName("CLI缺失_三态第一级")
+  void cliMissingRendered() {
+    StubProbe probe = new StubProbe();
+    probe.cliError = "CreateProcess error=2";
+    ExecutionBackendController controller =
+        new ExecutionBackendController(
+            new ExecutionBackendSnapshot("docker", "alpine:3.20", null, null, null, null),
+            registry(),
+            probe);
+
+    assertFalse(controller.status().getData().docker().reachable());
+  }
+
+  @Test
+  @DisplayName("local档_不探测镜像_digest为空（daemon探测仍执行——运维想看环境状态）")
+  void localBackendSkipsImageOnly() {
+    StubProbe probe = new StubProbe();
+    ExecutionBackendController controller =
+        new ExecutionBackendController(
+            new ExecutionBackendSnapshot("local", null, null, null, null, null), registry(), probe);
+
+    ExecutionBackendController.StatusView status = controller.status().getData();
+
+    assertEquals("local", status.backend());
+    assertTrue(status.docker().reachable(), "daemon 状态照常呈现（环境信息）");
+    assertNull(status.imageDigest());
+  }
+}


### PR DESCRIPTION
#406（US1 MVP）已合入——本 PR 续接 **US2（按 Agent 覆写）+ US3（管理台状态页）**，024 三个用户故事至此收齐。

## US2：frontmatter 按 Agent 覆写（T014~T016）

- **Profile 新增可选 `sandbox:` 段**（`backend`/`memory`/`cpus`，兼容构造器保旧调用点）；非法 backend 值 WARN 回落继承（EC-4：告警不阻断该 Agent 与其它 Agent 加载）
- **`AgentAwareProcessStarter`**：D8 固定收敛——Agent 覆写 > 全局；**镜像/网络/user 属治理域不可覆写**（与 020「治理与作者分离」同构）；按 `ToolExecutionContext.agentName()` 选档路由，local 全局且无覆写时行为与 US1 完全一致
- **审计筛选（SC-007）**：`/api/v1/audit/tool?backend=` 按 execution backend 筛；`ToolInvocationView` 暴露 `executionBackend`/`containerId`

```yaml
# AGENT.md frontmatter——全局 docker 之下给运维 Agent 回落本地：
sandbox:
  backend: local
```

## US3：管理台状态页（T017~T018）

- `GET /api/v1/sandbox/execution/status`：档位 / daemon 三态探测（CLI 缺失 / 不可达 / 就绪+版本）/ 镜像 digest / 默认限额 / Agent 覆写一览；按需探测零常驻线程（D5）
- **跨模块契约 `ExecutionBackendSnapshot` 置 core**：web 不依赖 tool、cli 不依赖 web——转换在 cli 装配，controller 组件扫描自动装配（ToolPolicyService 同款先例，FR-012 只读）
- App.vue「执行后端」页（OS 运行时分组）：全局档位表 / daemon 状态 / 覆写一览表

## 验证

core 39（sandbox 三态解析）/ tool 288（选档路由 5 例：覆写收敛、双向路由、双 Agent 各行其道）/ web 278（状态 API 4 例）/ cli verify 全绿（两 Windows 存量问题按既例排除，Linux CI 不受影响）。
