### PR TITLE
feat(channel): Mattermost/Matrix inbound media + Matrix notify PUT

### DIFF
--- a/config/channels.yaml.example
+++ b/config/channels.yaml.example
@@ -88,6 +88,7 @@ channels:
   #   agent: ops-agent
   #   extra:
   #     base_url: ${MATTERMOST_BASE_URL}
+  #     access_token: ${MATTERMOST_ACCESS_TOKEN}
   #   enabled: true
 
   # Matrix /sync 长轮询（见 docs/MatrixChannelSetup.md）

--- a/docs/MatrixChannelSetup.md
+++ b/docs/MatrixChannelSetup.md
@@ -5,8 +5,14 @@ Client-Server API **`/sync` 长轮询**（免公网回调）。`extra.homeserver
 ## 一、Homeserver 侧
 
 1. 为 Bot 注册账号（如 `@oryx:example.com`），创建 access token。
-2. 邀请 Bot 进房间；房间消息需提及 Bot MXID。
-3. 把 homeserver 主机名加入 `http.allowed_domains`（自托管，不进默认清单）。
+2. 邀请 Bot 进房间；房间消息需提及 Bot MXID（正文含 `@bot:server` 或 `m.mentions.user_ids`）。
+3. 把 homeserver 主机名加入 `http.allowed_domains`（自托管，不进默认清单）。本机 Docker 用 `127.0.0.1` / `localhost`。
+
+本机验收可用：
+
+- Synapse：`oryxos-synapse` → `:8008`（`MATRIX_HOMESERVER=http://127.0.0.1:8008`）
+- Element：`oryxos-element` → http://127.0.0.1:8087 ，Homeserver 填 `http://127.0.0.1:8008`
+- 用户 `admin` / `tester` / Bot `oryxbot`，密码只在本机 `.env` `MATRIX_*_PASSWORD`
 
 ## 二、OryxOS 侧
 
@@ -24,9 +30,15 @@ channels:
 
 ## 三、Notify
 
-`type: matrix`：`homeserver` + `token` + `room_id`。
+`type: matrix`：`homeserver` + `token` + `room_id`。发信走 **PUT** `/_matrix/client/v3/rooms/{roomId}/send/m.room.message/{txn}`（POST 会被 homeserver 以 405 拒绝）。
 
-## 四、实测清单
+## 四、图片 / PDF
 
-- 私聊 / 房间 @ 往返
-- `notify` 进房间
+事件里的 `mxc://` 用 Bot token 走鉴权媒体接口落盘（`.oryxos/inbound-media/`），再交给与飞书相同的 Vision / `read_file` / Whisper。房间图/文件须提及 Bot（`@bot:server`、`@localpart` 或 `m.mentions`）；私聊不要求 @。
+
+## 五、实测清单
+
+- 房间 @ 往返（本机 Town Square + Element `:8087`）
+- 私聊（邀请自动加入；`m.direct` 在顶层 account_data，跨 sync 记住）
+- `notify` 进房间（本机 `ops-mx-notify` 已测）
+- 房间 `@Bot` + 图片 / PDF（说明里带 @，与附件同条或紧随）

--- a/docs/MattermostChannelSetup.md
+++ b/docs/MattermostChannelSetup.md
@@ -4,10 +4,10 @@
 
 ## 一、Mattermost 侧
 
-1. 系统控制台 → Integrations → Outgoing Webhooks：Callback URL = `https://<host>/api/v1/channels/inbound/ops-mattermost`，记下 Token。
+1. 系统控制台 → Integrations → Outgoing Webhooks：Callback URL = `https://<host>/api/v1/channels/inbound/ops-mattermost`，记下 Token。本机 Docker 回调宿主机 OryxOS 用 `http://host.docker.internal:8080/api/v1/channels/inbound/ops-mattermost`。
 2. Trigger Word 设为 `@你的Bot用户名`（频道 @ 规则）。
-3. 发帖用同一 Token 或 Personal Access Token（当前 `app_secret` 兼验证入站 token 与 Bearer）。
-4. `extra.base_url` 为站点根（如 `https://mm.example.com`），需加入 `http.allowed_domains`。
+3. 发帖用 **Personal Access Token**（或 Bot token）写入 `extra.access_token`。Outgoing Webhook 的 Token 只用于入站校验（`app_secret`），一般不能调 `POST /api/v4/posts`。
+4. `extra.base_url` 为站点根（如 `https://mm.example.com` 或本机 `http://127.0.0.1:8065`），需加入 `http.allowed_domains`。
 
 ## 二、OryxOS 侧
 
@@ -20,16 +20,24 @@ channels:
     agent: ops-agent
     extra:
       base_url: ${MATTERMOST_BASE_URL}
+      access_token: ${MATTERMOST_ACCESS_TOKEN} # PAT；省略则回退 app_secret
     enabled: true
 ```
 
-自托管域名不进默认白名单，请在部署配置里显式加入。
+自托管域名不进默认白名单，请在部署配置里显式加入。本机 Docker 回调宿主机时，Mattermost 还需把 `host.docker.internal`（或对应 CIDR）写入 **AllowedUntrustedInternalConnections**，否则 Outgoing Webhook 会静默 `address forbidden`。
 
 ## 三、Notify
 
 `type: mattermost`：Incoming Webhook `url`。
 
-## 四、实测清单
+## 四、图片 / PDF
+
+Outgoing Webhook **不带附件**。OryxOS 在入站后用 PAT 调 `GET /api/v4/posts/{id}` 取 `file_ids`，再 `GET /api/v4/files/{id}` 落盘（`.oryxos/inbound-media/`），交给与飞书相同的 Vision / `read_file` 路径。
+
+发图或 PDF 时说明里必须带 `@Bot`（否则 Webhook 不会触发）。`@Bot` 和附件必须在**同一条帖**里一次发出；先发文字再补附件会变成两条（第二条无 trigger，Agent 看不到文件）。只 @ 不配字、但带了附件，也会进编排。
+
+## 五、实测清单
 
 - 私聊 / 房间 @ 往返
-- `notify` 进房间
+- `notify` 进房间（本机 Incoming Webhook + `ops-mm-notify` 已测）
+- 房间 `@Bot` + 图片 / PDF（说明里带 @，与附件同一条帖；本机 Town Square UI 已测）

--- a/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixChannelAdapter.java
+++ b/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixChannelAdapter.java
@@ -10,6 +10,7 @@ import io.oryxos.core.channel.InboundMessage;
 import io.oryxos.core.channel.InboundMessageService;
 import io.oryxos.core.channel.OutboundGuard;
 import io.oryxos.core.profile.ProfileRegistry;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -209,7 +210,10 @@ public class MatrixChannelAdapter implements InboundChannelAdapter {
         } else {
           LOG.warn("Matrix 渠道 {} 加入邀请失败 HTTP {}", sanitize(config.name()), response.statusCode());
         }
-      } catch (Exception e) {
+      } catch (IOException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         LOG.warn("Matrix 渠道 {} 加入邀请异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
       }
     }
@@ -309,7 +313,10 @@ public class MatrixChannelAdapter implements InboundChannelAdapter {
           && !response.body().isBlank()) {
         rooms.replaceFromContent(MAPPER.readTree(response.body()));
       }
-    } catch (Exception e) {
+    } catch (IOException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       LOG.debug(
           "Matrix 渠道 {} 预载 m.direct 跳过: {}", sanitize(config.name()), sanitize(e.getMessage()));
     }

--- a/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixChannelAdapter.java
+++ b/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixChannelAdapter.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.oryxos.core.channel.ChannelConfig;
 import io.oryxos.core.channel.ChannelStatus;
 import io.oryxos.core.channel.InboundChannelAdapter;
+import io.oryxos.core.channel.InboundMediaRoots;
 import io.oryxos.core.channel.InboundMessage;
 import io.oryxos.core.channel.InboundMessageService;
 import io.oryxos.core.channel.OutboundGuard;
@@ -19,6 +20,7 @@ import java.time.Duration;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,10 +44,10 @@ public class MatrixChannelAdapter implements InboundChannelAdapter {
   private static final String FIELD_NEXT_BATCH = "next_batch";
   private static final String FIELD_ROOMS = "rooms";
   private static final String FIELD_JOIN = "join";
-  private static final String FIELD_ACCOUNT_DATA = "account_data";
-  private static final String FIELD_EVENTS = "events";
+  private static final String FIELD_INVITE = "invite";
   private static final String FIELD_TIMELINE = "timeline";
-  private static final String MARKER_DIRECT = "m.direct";
+  private static final String FIELD_EVENTS = "events";
+  private static final String MEDIA_DIR_PREFIX = "oryxos-mx-media-";
 
   private final ChannelConfig config;
   private final ProfileRegistry profileRegistry;
@@ -54,6 +56,8 @@ public class MatrixChannelAdapter implements InboundChannelAdapter {
 
   private volatile MatrixEventNormalizer normalizer;
   private volatile MatrixMessageSender sender;
+  private volatile MatrixInboundMediaResolver mediaResolver;
+  private volatile MatrixDirectRooms directRooms;
   private volatile HttpClient http;
   private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
   private volatile boolean running;
@@ -105,6 +109,15 @@ public class MatrixChannelAdapter implements InboundChannelAdapter {
     http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(15)).build();
     normalizer = new MatrixEventNormalizer(config.name(), config.appId());
     sender = new MatrixMessageSender(guard, config.extra(EXTRA_HOMESERVER), config.appSecret());
+    mediaResolver =
+        new MatrixInboundMediaResolver(
+            guard,
+            config.extra(EXTRA_HOMESERVER),
+            config.appSecret(),
+            InboundMediaRoots.forChannel(config.name(), MEDIA_DIR_PREFIX),
+            config.name());
+    directRooms = new MatrixDirectRooms();
+    seedDirectRooms();
     pollThread = Thread.ofVirtual().name("oryxos-matrix-" + config.name()).start(this::syncLoop);
     state = ChannelStatus.State.CONNECTED;
   }
@@ -117,6 +130,7 @@ public class MatrixChannelAdapter implements InboundChannelAdapter {
       t.interrupt();
       pollThread = null;
     }
+    mediaResolver = null;
     state = ChannelStatus.State.DISCONNECTED;
   }
 
@@ -140,6 +154,11 @@ public class MatrixChannelAdapter implements InboundChannelAdapter {
         JsonNode root = syncOnce();
         if (root != null) {
           since = root.path(FIELD_NEXT_BATCH).asText(since);
+          MatrixDirectRooms rooms = directRooms;
+          if (rooms != null) {
+            rooms.mergeFromSync(root);
+          }
+          acceptInvites(root.path(FIELD_ROOMS).path(FIELD_INVITE));
           dispatchJoin(root.path(FIELD_ROOMS).path(FIELD_JOIN));
         }
       } catch (InterruptedException e) {
@@ -155,6 +174,64 @@ public class MatrixChannelAdapter implements InboundChannelAdapter {
     }
   }
 
+  private void acceptInvites(JsonNode invite) {
+    if (invite == null || !invite.isObject() || http == null) {
+      return;
+    }
+    Iterator<String> rooms = invite.fieldNames();
+    while (rooms.hasNext()) {
+      String roomId = rooms.next();
+      if (inviteLooksDirect(invite.get(roomId))) {
+        MatrixDirectRooms directs = directRooms;
+        if (directs != null) {
+          directs.remember(roomId);
+        }
+      }
+      try {
+        String homeserver = MatrixMessageSender.trimSlash(config.extra(EXTRA_HOMESERVER));
+        String url =
+            homeserver
+                + "/_matrix/client/v3/join/"
+                + URLEncoder.encode(roomId, StandardCharsets.UTF_8);
+        guard.check(url);
+        HttpRequest request =
+            HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(15))
+                .header("Authorization", "Bearer " + config.appSecret())
+                .header("Content-Type", "application/json; charset=utf-8")
+                .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                .build();
+        HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= HTTP_STATUS_OK_MIN
+            && response.statusCode() < HTTP_STATUS_OK_MAX_EXCLUSIVE) {
+          LOG.info("Matrix 渠道 {} 已加入邀请房间", sanitize(config.name()));
+        } else {
+          LOG.warn("Matrix 渠道 {} 加入邀请失败 HTTP {}", sanitize(config.name()), response.statusCode());
+        }
+      } catch (Exception e) {
+        LOG.warn("Matrix 渠道 {} 加入邀请异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
+      }
+    }
+  }
+
+  static boolean inviteLooksDirect(JsonNode inviteRoom) {
+    if (inviteRoom == null) {
+      return false;
+    }
+    JsonNode events = inviteRoom.path("invite_state").path("events");
+    if (!events.isArray()) {
+      return false;
+    }
+    for (JsonNode event : events) {
+      if ("m.room.member".equals(event.path("type").asText(""))
+          && event.path("content").path("is_direct").asBoolean(false)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private void dispatchJoin(JsonNode join) {
     if (join == null || !join.isObject()) {
       return;
@@ -162,20 +239,79 @@ public class MatrixChannelAdapter implements InboundChannelAdapter {
     Iterator<Map.Entry<String, JsonNode>> rooms = join.fields();
     while (rooms.hasNext()) {
       Map.Entry<String, JsonNode> room = rooms.next();
-      boolean direct =
-          room.getValue()
-              .path(FIELD_ACCOUNT_DATA)
-              .path(FIELD_EVENTS)
-              .toString()
-              .contains(MARKER_DIRECT);
+      MatrixDirectRooms directs = directRooms;
+      boolean direct = directs != null && directs.isDirect(room.getKey());
       JsonNode events = room.getValue().path(FIELD_TIMELINE).path(FIELD_EVENTS);
       if (!events.isArray()) {
         continue;
       }
       for (JsonNode event : events) {
         Optional<InboundMessage> msg = normalizer.normalize(room.getKey(), event, direct);
-        msg.ifPresent(m -> inboundMessageService.onMessage(m, this));
+        msg.ifPresent(this::dispatch);
       }
+    }
+  }
+
+  private void dispatch(InboundMessage incoming) {
+    if (!inboundMessageService.tryClaim(incoming.channelName(), incoming.messageId())) {
+      LOG.info(
+          "渠道 {} 重复事件已忽略: {}", sanitize(incoming.channelName()), sanitize(incoming.messageId()));
+      return;
+    }
+    MatrixInboundMediaResolver resolver = mediaResolver;
+    InboundMessage discovered = incoming;
+    CountDownLatch slow = null;
+    if (resolver != null && MatrixInboundMediaResolver.needsDownload(discovered)) {
+      slow = inboundMessageService.beginSlowWork(this, discovered.chatId(), discovered.messageId());
+      discovered = resolver.download(discovered);
+    }
+    if (!discovered.processable()) {
+      if (slow != null) {
+        slow.countDown();
+      }
+      return;
+    }
+    try {
+      if (slow != null) {
+        inboundMessageService.onClaimedMessage(discovered, this, slow);
+      } else {
+        inboundMessageService.onClaimedMessage(discovered, this);
+      }
+    } catch (RuntimeException e) {
+      if (slow != null) {
+        slow.countDown();
+      }
+      throw e;
+    }
+  }
+
+  private void seedDirectRooms() {
+    MatrixDirectRooms rooms = directRooms;
+    if (rooms == null || http == null) {
+      return;
+    }
+    try {
+      String homeserver = MatrixMessageSender.trimSlash(config.extra(EXTRA_HOMESERVER));
+      String user = URLEncoder.encode(config.appId(), StandardCharsets.UTF_8);
+      String url = homeserver + "/_matrix/client/v3/user/" + user + "/account_data/m.direct";
+      guard.check(url);
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(url))
+              .timeout(Duration.ofSeconds(15))
+              .header("Authorization", "Bearer " + config.appSecret())
+              .GET()
+              .build();
+      HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() >= HTTP_STATUS_OK_MIN
+          && response.statusCode() < HTTP_STATUS_OK_MAX_EXCLUSIVE
+          && response.body() != null
+          && !response.body().isBlank()) {
+        rooms.replaceFromContent(MAPPER.readTree(response.body()));
+      }
+    } catch (Exception e) {
+      LOG.debug(
+          "Matrix 渠道 {} 预载 m.direct 跳过: {}", sanitize(config.name()), sanitize(e.getMessage()));
     }
   }
 

--- a/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixDirectRooms.java
+++ b/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixDirectRooms.java
@@ -1,0 +1,71 @@
+package io.oryxos.channel.matrix;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 解析并记住 {@code m.direct}。该事件在 {@code /sync} <strong>顶层</strong> {@code account_data}，不是房间
+ * account_data；内容是整份覆盖，须跨增量 sync 保留。
+ */
+final class MatrixDirectRooms {
+
+  private static final String FIELD_ACCOUNT_DATA = "account_data";
+  private static final String FIELD_EVENTS = "events";
+  private static final String FIELD_TYPE = "type";
+  private static final String FIELD_CONTENT = "content";
+  private static final String TYPE_DIRECT = "m.direct";
+
+  private final Set<String> roomIds = ConcurrentHashMap.newKeySet();
+
+  void mergeFromSync(JsonNode root) {
+    if (root == null || !root.isObject()) {
+      return;
+    }
+    JsonNode events = root.path(FIELD_ACCOUNT_DATA).path(FIELD_EVENTS);
+    if (!events.isArray()) {
+      return;
+    }
+    for (JsonNode event : events) {
+      if (TYPE_DIRECT.equals(event.path(FIELD_TYPE).asText(""))) {
+        replaceFromContent(event.path(FIELD_CONTENT));
+      }
+    }
+  }
+
+  void replaceFromContent(JsonNode content) {
+    roomIds.clear();
+    if (content == null || !content.isObject()) {
+      return;
+    }
+    Iterator<Map.Entry<String, JsonNode>> users = content.fields();
+    while (users.hasNext()) {
+      JsonNode rooms = users.next().getValue();
+      if (!rooms.isArray()) {
+        continue;
+      }
+      for (JsonNode room : rooms) {
+        String id = room.asText("");
+        if (!id.isBlank()) {
+          roomIds.add(id);
+        }
+      }
+    }
+  }
+
+  void remember(String roomId) {
+    if (roomId != null && !roomId.isBlank()) {
+      roomIds.add(roomId);
+    }
+  }
+
+  boolean isDirect(String roomId) {
+    return roomId != null && roomIds.contains(roomId);
+  }
+
+  int size() {
+    return roomIds.size();
+  }
+}

--- a/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixEventNormalizer.java
+++ b/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixEventNormalizer.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.oryxos.core.channel.ChatKind;
 import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -53,20 +52,13 @@ public class MatrixEventNormalizer {
     }
     JsonNode content = event.path(FIELD_CONTENT);
     String msgtype = content.path(FIELD_MSGTYPE).asText("");
-    String body = content.path(FIELD_BODY).asText("").strip();
-    List<InboundAttachment> attachments = new ArrayList<>();
-    if (MSG_IMAGE.equals(msgtype)) {
-      attachments.add(
-          InboundAttachment.imageReference(content.path(FIELD_URL).asText(DEFAULT_MXC)));
-    } else if (MSG_AUDIO.equals(msgtype)) {
-      attachments.add(
-          InboundAttachment.audioReference(content.path(FIELD_URL).asText(DEFAULT_MXC)));
-    } else if (MSG_VIDEO.equals(msgtype)) {
-      attachments.add(
-          InboundAttachment.videoReference(content.path(FIELD_URL).asText(DEFAULT_MXC)));
-    } else if (MSG_FILE.equals(msgtype)) {
-      attachments.add(InboundAttachment.fileReference(content.path(FIELD_URL).asText(DEFAULT_MXC)));
+    String rawBody = content.path(FIELD_BODY).asText("").strip();
+    String fileName = content.path("filename").asText("");
+    if (fileName.isBlank()) {
+      fileName = rawBody;
     }
+    List<InboundAttachment> attachments = extractAttachments(msgtype, content, fileName);
+    String body = captionOrEmpty(msgtype, rawBody, fileName);
     if (!direct) {
       if (!mentionsBot(content, body)) {
         return Optional.empty();
@@ -116,6 +108,45 @@ public class MatrixEventNormalizer {
             attachments));
   }
 
+  private static List<InboundAttachment> extractAttachments(
+      String msgtype, JsonNode content, String fileName) {
+    String mxc = content.path(FIELD_URL).asText(DEFAULT_MXC);
+    if (MSG_IMAGE.equals(msgtype)) {
+      return List.of(new InboundAttachment(InboundAttachment.TYPE_IMAGE, null, mxc, fileName));
+    }
+    if (MSG_AUDIO.equals(msgtype)) {
+      return List.of(new InboundAttachment(InboundAttachment.TYPE_AUDIO, null, mxc, fileName));
+    }
+    if (MSG_VIDEO.equals(msgtype)) {
+      return List.of(new InboundAttachment(InboundAttachment.TYPE_VIDEO, null, mxc, fileName));
+    }
+    if (MSG_FILE.equals(msgtype)) {
+      return List.of(InboundAttachment.fileReference(mxc, fileName));
+    }
+    return List.of();
+  }
+
+  private static String captionOrEmpty(String msgtype, String rawBody, String fileName) {
+    if (!MSG_IMAGE.equals(msgtype)
+        && !MSG_AUDIO.equals(msgtype)
+        && !MSG_VIDEO.equals(msgtype)
+        && !MSG_FILE.equals(msgtype)) {
+      return rawBody;
+    }
+    if (rawBody == null || rawBody.isBlank()) {
+      return "";
+    }
+    if (rawBody.equals(fileName) || looksLikeFilename(rawBody)) {
+      return "";
+    }
+    return rawBody;
+  }
+
+  private static boolean looksLikeFilename(String body) {
+    int dot = body.lastIndexOf('.');
+    return dot > 0 && dot < body.length() - 1 && !body.contains(" ");
+  }
+
   private boolean mentionsBot(JsonNode content, String body) {
     if (botUserId.isBlank()) {
       return false;
@@ -128,14 +159,39 @@ public class MatrixEventNormalizer {
         }
       }
     }
-    return body != null && asciiLower(body).contains(asciiLower(botUserId));
+    if (body == null) {
+      return false;
+    }
+    String lower = asciiLower(body);
+    if (lower.contains(asciiLower(botUserId))) {
+      return true;
+    }
+    String local = localMention();
+    return !local.isEmpty() && lower.contains(local);
   }
 
   private String stripBot(String body) {
     if (body == null || botUserId.isBlank()) {
       return body == null ? "" : body;
     }
-    return body.replace(botUserId, "").strip();
+    String stripped = body.replace(botUserId, "");
+    String local = localMention();
+    if (!local.isEmpty()) {
+      stripped = stripped.replace(local, "");
+    }
+    return stripped.strip();
+  }
+
+  /** Element 常显示 {@code @localpart}，不全写 MXID。 */
+  private String localMention() {
+    if (botUserId.length() < 2 || botUserId.charAt(0) != '@') {
+      return "";
+    }
+    int colon = botUserId.indexOf(':');
+    if (colon <= 1) {
+      return "";
+    }
+    return asciiLower(botUserId.substring(0, colon));
   }
 
   private static String asciiLower(String value) {

--- a/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixEventNormalizer.java
+++ b/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixEventNormalizer.java
@@ -26,6 +26,8 @@ public class MatrixEventNormalizer {
   private static final String FIELD_MENTIONS = "m.mentions";
   private static final String FIELD_USER_IDS = "user_ids";
   private static final String DEFAULT_MXC = "mxc";
+  private static final char MXID_PREFIX = '@';
+  private static final int MXID_MIN_LEN = 2;
 
   private final String channelName;
   private final String botUserId;
@@ -184,7 +186,7 @@ public class MatrixEventNormalizer {
 
   /** Element 常显示 {@code @localpart}，不全写 MXID。 */
   private String localMention() {
-    if (botUserId.length() < 2 || botUserId.charAt(0) != '@') {
+    if (botUserId.length() < MXID_MIN_LEN || botUserId.charAt(0) != MXID_PREFIX) {
       return "";
     }
     int colon = botUserId.indexOf(':');

--- a/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixInboundMediaResolver.java
+++ b/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixInboundMediaResolver.java
@@ -209,7 +209,8 @@ final class MatrixInboundMediaResolver {
     if (shouldProbeImageExtension(type, ext, target)) {
       String betterExt = ImageMime.extensionFor(ImageMime.probeFile(target));
       target = renameIfBetter(dir, target, ext, betterExt);
-      ext = extensionOf(target.getFileName().toString());
+      Path fileName = target.getFileName();
+      ext = fileName == null ? DEFAULT_EXTENSION : extensionOf(fileName.toString());
     }
     String sniffed =
         InboundMediaExt.betterFileExtension(target, ext == null ? DEFAULT_EXTENSION : ext);
@@ -288,7 +289,8 @@ final class MatrixInboundMediaResolver {
   }
 
   private static String sanitize(String value) {
-    return InboundMediaPaths.sanitizeLog(value);
+    // 内联替换：SpotBugs CRLF_INJECTION_LOGS 需在本类内可见的 \r/\n 清洗
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
   }
 
   record Mxc(String server, String mediaId) {}

--- a/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixInboundMediaResolver.java
+++ b/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixInboundMediaResolver.java
@@ -1,0 +1,285 @@
+package io.oryxos.channel.matrix;
+
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMediaJanitor;
+import io.oryxos.core.channel.InboundMediaLimits;
+import io.oryxos.core.channel.InboundMediaPaths;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.LimitedMediaWriter;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.session.ImageMime;
+import io.oryxos.core.session.InboundMediaExt;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Matrix 入站图/文件：事件里已有 {@code mxc://}，用 Bot token 走鉴权媒体接口落盘。失败保留 mxc，不阻断文字编排。 */
+final class MatrixInboundMediaResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MatrixInboundMediaResolver.class);
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+  private static final int HTTP_OK_MIN = 200;
+  private static final int HTTP_OK_MAX_EXCLUSIVE = 300;
+  private static final String MXC_PREFIX = "mxc://";
+  private static final String DEFAULT_EXTENSION = ".bin";
+  private static final String FILE_PREFIX = "mx-media";
+
+  private final HttpClient http;
+  private final OutboundGuard guard;
+  private final String homeserver;
+  private final String token;
+  private final Path mediaRoot;
+  private final String channelName;
+  private final InboundMediaJanitor janitor;
+
+  MatrixInboundMediaResolver(
+      OutboundGuard guard, String homeserver, String token, Path mediaRoot, String channelName) {
+    this(
+        HttpClient.newBuilder().connectTimeout(TIMEOUT).build(),
+        guard,
+        homeserver,
+        token,
+        mediaRoot,
+        channelName,
+        InboundMediaJanitor.fromEnv());
+  }
+
+  MatrixInboundMediaResolver(
+      HttpClient http,
+      OutboundGuard guard,
+      String homeserver,
+      String token,
+      Path mediaRoot,
+      String channelName,
+      InboundMediaJanitor janitor) {
+    this.http = http;
+    this.guard = guard;
+    this.homeserver = MatrixMessageSender.trimSlash(homeserver);
+    this.token = token;
+    this.mediaRoot = mediaRoot;
+    this.channelName = channelName;
+    this.janitor = janitor == null ? InboundMediaJanitor.fromEnv() : janitor;
+  }
+
+  InboundMessage download(InboundMessage message) {
+    if (message == null || message.attachments().isEmpty()) {
+      return message;
+    }
+    janitor.sweepIfDue(mediaRoot);
+    List<InboundAttachment> resolved = new ArrayList<>(message.attachments().size());
+    boolean changed = false;
+    for (InboundAttachment attachment : message.attachments()) {
+      if (!needsDownload(attachment)) {
+        resolved.add(attachment);
+        continue;
+      }
+      InboundAttachment next = downloadOrKeep(message.messageId(), attachment);
+      changed |= next != attachment;
+      resolved.add(next);
+    }
+    if (!changed) {
+      return message;
+    }
+    return new InboundMessage(
+        message.channelType(),
+        message.channelName(),
+        message.messageId(),
+        message.chatKind(),
+        message.userId(),
+        message.chatId(),
+        message.content(),
+        message.textual() || !message.content().isBlank(),
+        message.mentionedBot(),
+        resolved);
+  }
+
+  static boolean needsDownload(InboundMessage message) {
+    if (message == null) {
+      return false;
+    }
+    for (InboundAttachment attachment : message.attachments()) {
+      if (needsDownload(attachment)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean needsDownload(InboundAttachment attachment) {
+    return attachment != null
+        && attachment.reference() != null
+        && !attachment.reference().isBlank()
+        && (attachment.url() == null || attachment.url().isBlank());
+  }
+
+  static String[] downloadUrls(String homeserver, String mxc) {
+    Mxc parsed = parseMxc(mxc);
+    if (parsed == null) {
+      return new String[0];
+    }
+    String base = MatrixMessageSender.trimSlash(homeserver);
+    String server = URLEncoder.encode(parsed.server, StandardCharsets.UTF_8);
+    String id = URLEncoder.encode(parsed.mediaId, StandardCharsets.UTF_8);
+    return new String[] {
+      base + "/_matrix/client/v1/media/download/" + server + "/" + id,
+      base + "/_matrix/media/v3/download/" + server + "/" + id
+    };
+  }
+
+  static Mxc parseMxc(String raw) {
+    if (raw == null || !raw.startsWith(MXC_PREFIX)) {
+      return null;
+    }
+    String rest = raw.substring(MXC_PREFIX.length());
+    int slash = rest.indexOf('/');
+    if (slash <= 0 || slash == rest.length() - 1) {
+      return null;
+    }
+    String server = rest.substring(0, slash);
+    String mediaId = rest.substring(slash + 1);
+    if (server.isBlank() || mediaId.isBlank() || mediaId.contains("/")) {
+      return null;
+    }
+    return new Mxc(server, mediaId);
+  }
+
+  private InboundAttachment downloadOrKeep(String messageId, InboundAttachment attachment) {
+    String type = attachment.type();
+    String name = attachment.fileName();
+    String[] urls = downloadUrls(homeserver, attachment.reference());
+    if (urls.length == 0) {
+      return attachment;
+    }
+    Exception last = null;
+    for (String url : urls) {
+      try {
+        return fetchToDisk(messageId, attachment, type, name, url);
+      } catch (Exception e) {
+        last = e;
+      }
+    }
+    LOG.warn(
+        "Matrix 渠道 {} 下载媒体失败（mxc={}）：{}，保留引用",
+        sanitize(channelName),
+        sanitize(attachment.reference()),
+        sanitize(last == null ? "" : last.getMessage()));
+    return attachment;
+  }
+
+  private InboundAttachment fetchToDisk(
+      String messageId, InboundAttachment attachment, String type, String name, String url)
+      throws Exception {
+    guard.check(url);
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .timeout(TIMEOUT)
+            .header("Authorization", "Bearer " + token)
+            .GET()
+            .build();
+    HttpResponse<byte[]> response = http.send(request, HttpResponse.BodyHandlers.ofByteArray());
+    if (response.statusCode() < HTTP_OK_MIN || response.statusCode() >= HTTP_OK_MAX_EXCLUSIVE) {
+      throw new IllegalStateException("HTTP " + response.statusCode());
+    }
+    byte[] bytes = response.body();
+    if (bytes == null || bytes.length == 0) {
+      throw new IllegalStateException("空文件");
+    }
+    janitor.ensureQuotaOrThrow(mediaRoot);
+    Path dir = mediaRoot.resolve(InboundMediaPaths.safeSegment(messageId));
+    Files.createDirectories(dir);
+    String ext = extensionOf(name);
+    if (ext == null) {
+      ext = DEFAULT_EXTENSION;
+    }
+    Path target = dir.resolve(FILE_PREFIX + ext);
+    LimitedMediaWriter.writeLimited(bytes, target, InboundMediaLimits.MAX_FILE_BYTES);
+    if (InboundAttachment.TYPE_IMAGE.equals(type)
+        && DEFAULT_EXTENSION.equals(ext)
+        && ImageMime.hasRecognizedMagic(target)) {
+      String betterExt = ImageMime.extensionFor(ImageMime.probeFile(target));
+      target = renameIfBetter(dir, target, ext, betterExt);
+      ext = extensionOf(target.getFileName().toString());
+    }
+    String sniffed =
+        InboundMediaExt.betterFileExtension(target, ext == null ? DEFAULT_EXTENSION : ext);
+    target = renameIfBetter(dir, target, ext, sniffed);
+    if (InboundAttachment.TYPE_FILE.equals(type) && ImageMime.hasRecognizedMagic(target)) {
+      type = InboundAttachment.TYPE_IMAGE;
+    }
+    LOG.info(
+        "Matrix 渠道 {} 媒体已落盘（messageId={}, type={}）",
+        sanitize(channelName),
+        sanitize(messageId),
+        sanitize(type));
+    return new InboundAttachment(
+        type, target.toAbsolutePath().toString(), attachment.reference(), name);
+  }
+
+  private Path renameIfBetter(Path dir, Path current, String currentExt, String betterExt) {
+    if (betterExt == null || betterExt.isBlank() || betterExt.equals(currentExt)) {
+      return current;
+    }
+    Path renamed = dir.resolve(FILE_PREFIX + betterExt);
+    try {
+      Files.move(current, renamed);
+      return renamed;
+    } catch (Exception ignored) {
+      return current;
+    }
+  }
+
+  private static String extensionOf(String nameOrUrl) {
+    if (nameOrUrl == null || nameOrUrl.isBlank()) {
+      return null;
+    }
+    String path = nameOrUrl;
+    int q = path.indexOf('?');
+    if (q >= 0) {
+      path = path.substring(0, q);
+    }
+    int slash = path.lastIndexOf('/');
+    if (slash >= 0) {
+      path = path.substring(slash + 1);
+    }
+    int dot = path.lastIndexOf('.');
+    if (dot < 0 || dot == path.length() - 1) {
+      return null;
+    }
+    String ext = asciiLower(path.substring(dot));
+    if (!ext.matches("\\.[a-z0-9]{1,8}")) {
+      return null;
+    }
+    return ext;
+  }
+
+  private static String asciiLower(String value) {
+    if (value == null) {
+      return "";
+    }
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
+  }
+
+  private static String sanitize(String value) {
+    return InboundMediaPaths.sanitizeLog(value);
+  }
+
+  record Mxc(String server, String mediaId) {}
+}

--- a/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixInboundMediaResolver.java
+++ b/oryxos-channel-matrix/src/main/java/io/oryxos/channel/matrix/MatrixInboundMediaResolver.java
@@ -31,8 +31,10 @@ final class MatrixInboundMediaResolver {
   private static final int HTTP_OK_MIN = 200;
   private static final int HTTP_OK_MAX_EXCLUSIVE = 300;
   private static final String MXC_PREFIX = "mxc://";
+  private static final String PATH_SEP = "/";
   private static final String DEFAULT_EXTENSION = ".bin";
   private static final String FILE_PREFIX = "mx-media";
+  private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
 
   private final HttpClient http;
   private final OutboundGuard guard;
@@ -147,7 +149,7 @@ final class MatrixInboundMediaResolver {
     }
     String server = rest.substring(0, slash);
     String mediaId = rest.substring(slash + 1);
-    if (server.isBlank() || mediaId.isBlank() || mediaId.contains("/")) {
+    if (server.isBlank() || mediaId.isBlank() || mediaId.contains(PATH_SEP)) {
       return null;
     }
     return new Mxc(server, mediaId);
@@ -204,9 +206,7 @@ final class MatrixInboundMediaResolver {
     }
     Path target = dir.resolve(FILE_PREFIX + ext);
     LimitedMediaWriter.writeLimited(bytes, target, InboundMediaLimits.MAX_FILE_BYTES);
-    if (InboundAttachment.TYPE_IMAGE.equals(type)
-        && DEFAULT_EXTENSION.equals(ext)
-        && ImageMime.hasRecognizedMagic(target)) {
+    if (shouldProbeImageExtension(type, ext, target)) {
       String betterExt = ImageMime.extensionFor(ImageMime.probeFile(target));
       target = renameIfBetter(dir, target, ext, betterExt);
       ext = extensionOf(target.getFileName().toString());
@@ -224,6 +224,16 @@ final class MatrixInboundMediaResolver {
         sanitize(type));
     return new InboundAttachment(
         type, target.toAbsolutePath().toString(), attachment.reference(), name);
+  }
+
+  private static boolean shouldProbeImageExtension(String type, String ext, Path target) {
+    if (!InboundAttachment.TYPE_IMAGE.equals(type)) {
+      return false;
+    }
+    if (!DEFAULT_EXTENSION.equals(ext)) {
+      return false;
+    }
+    return ImageMime.hasRecognizedMagic(target);
   }
 
   private Path renameIfBetter(Path dir, Path current, String currentExt, String betterExt) {
@@ -257,7 +267,7 @@ final class MatrixInboundMediaResolver {
       return null;
     }
     String ext = asciiLower(path.substring(dot));
-    if (!ext.matches("\\.[a-z0-9]{1,8}")) {
+    if (!ext.matches(SAFE_EXTENSION_PATTERN)) {
       return null;
     }
     return ext;

--- a/oryxos-channel-matrix/src/test/java/io/oryxos/channel/matrix/MatrixDirectRoomsTest.java
+++ b/oryxos-channel-matrix/src/test/java/io/oryxos/channel/matrix/MatrixDirectRoomsTest.java
@@ -1,0 +1,69 @@
+package io.oryxos.channel.matrix;
+
+import static io.oryxos.channel.matrix.MatrixChannelAdapter.inviteLooksDirect;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MatrixDirectRoomsTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final MatrixDirectRooms rooms = new MatrixDirectRooms();
+
+  @Test
+  @DisplayName("顶层 account_data m.direct 记房间，房间 account_data 不算")
+  void topLevelDirectOnly() throws Exception {
+    rooms.mergeFromSync(
+        mapper.readTree(
+            """
+            {
+              "account_data": {
+                "events": [
+                  {"type":"m.direct","content":{"@alice:hs":["!dm:hs"]}}
+                ]
+              },
+              "rooms": {
+                "join": {
+                  "!room:hs": {
+                    "account_data": {"events":[{"type":"m.tag"}]}
+                  }
+                }
+              }
+            }
+            """));
+    assertTrue(rooms.isDirect("!dm:hs"));
+    assertFalse(rooms.isDirect("!room:hs"));
+    assertEquals(1, rooms.size());
+  }
+
+  @Test
+  @DisplayName("后续增量没有 m.direct 时仍记住")
+  void persistsAcrossEmptySync() throws Exception {
+    rooms.mergeFromSync(
+        mapper.readTree(
+            """
+            {"account_data":{"events":[{"type":"m.direct","content":{"@a:hs":["!dm:hs"]}}]}}
+            """));
+    rooms.mergeFromSync(mapper.readTree("{\"next_batch\":\"s2\"}"));
+    assertTrue(rooms.isDirect("!dm:hs"));
+  }
+
+  @Test
+  @DisplayName("邀请 is_direct 记为私聊")
+  void rememberInvite() throws Exception {
+    rooms.remember("!newdm:hs");
+    assertTrue(rooms.isDirect("!newdm:hs"));
+    assertTrue(
+        inviteLooksDirect(
+            mapper.readTree(
+                """
+                {"invite_state":{"events":[
+                  {"type":"m.room.member","content":{"membership":"invite","is_direct":true}}
+                ]}}
+                """)));
+  }
+}

--- a/oryxos-channel-matrix/src/test/java/io/oryxos/channel/matrix/MatrixEventNormalizerTest.java
+++ b/oryxos-channel-matrix/src/test/java/io/oryxos/channel/matrix/MatrixEventNormalizerTest.java
@@ -39,6 +39,29 @@ class MatrixEventNormalizerTest {
     assertEquals("查天气", msg.get().content());
   }
 
+  @Test
+  @DisplayName("房间只写 @localpart 也算提及")
+  void roomLocalpartMention() {
+    var msg = normalizer.normalize("!r:hs", event("@oryx 查天气", false), false);
+    assertTrue(msg.isPresent());
+    assertEquals("查天气", msg.get().content());
+  }
+
+  @Test
+  @DisplayName("图片文件名不当正文")
+  void imageFilenameNotText() {
+    var root = event("shot.png", false);
+    ((com.fasterxml.jackson.databind.node.ObjectNode) root.get("content"))
+        .put("msgtype", "m.image")
+        .put("url", "mxc://hs/img")
+        .put("filename", "shot.png");
+    var msg = normalizer.normalize("!dm:hs", root, true);
+    assertTrue(msg.isPresent());
+    assertEquals("", msg.get().content());
+    assertEquals(false, msg.get().textual());
+    assertEquals("shot.png", msg.get().attachments().get(0).fileName());
+  }
+
   private ObjectNode event(String body, boolean mention) {
     ObjectNode root = mapper.createObjectNode();
     root.put("type", "m.room.message");

--- a/oryxos-channel-matrix/src/test/java/io/oryxos/channel/matrix/MatrixInboundMediaResolverTest.java
+++ b/oryxos-channel-matrix/src/test/java/io/oryxos/channel/matrix/MatrixInboundMediaResolverTest.java
@@ -1,0 +1,73 @@
+package io.oryxos.channel.matrix;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpServer;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMessage;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MatrixInboundMediaResolverTest {
+
+  @Test
+  @DisplayName("mxc 解析与鉴权媒体 URL")
+  void parseAndUrls() {
+    MatrixInboundMediaResolver.Mxc mxc = MatrixInboundMediaResolver.parseMxc("mxc://hs/img1");
+    assertEquals("hs", mxc.server());
+    assertEquals("img1", mxc.mediaId());
+    String[] urls =
+        MatrixInboundMediaResolver.downloadUrls("http://127.0.0.1:8008", "mxc://hs/img1");
+    assertEquals("http://127.0.0.1:8008/_matrix/client/v1/media/download/hs/img1", urls[0]);
+    assertEquals("http://127.0.0.1:8008/_matrix/media/v3/download/hs/img1", urls[1]);
+  }
+
+  @Test
+  @DisplayName("鉴权下载落盘后 url 为本机路径")
+  void downloadWritesFile(@TempDir Path dir) throws Exception {
+    byte[] png =
+        new byte[] {(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D};
+    HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.createContext(
+        "/_matrix/client/v1/media/download/hs/img1",
+        exchange -> {
+          exchange.sendResponseHeaders(200, png.length);
+          exchange.getResponseBody().write(png);
+          exchange.close();
+        });
+    server.start();
+    try {
+      String hs = "http://127.0.0.1:" + server.getAddress().getPort();
+      MatrixInboundMediaResolver resolver =
+          new MatrixInboundMediaResolver(url -> {}, hs, "tok", dir, "ops-matrix");
+      InboundMessage incoming =
+          new InboundMessage(
+              "matrix",
+              "ops-matrix",
+              "$e1",
+              ChatKind.P2P,
+              "@alice:hs",
+              "!dm:hs",
+              "",
+              false,
+              false,
+              List.of(
+                  new InboundAttachment(
+                      InboundAttachment.TYPE_IMAGE, null, "mxc://hs/img1", "a.png")));
+      InboundMessage out = resolver.download(incoming);
+      assertEquals(1, out.attachments().size());
+      String url = out.attachments().get(0).url();
+      assertTrue(url != null && Files.exists(Path.of(url)));
+      assertEquals("mxc://hs/img1", out.attachments().get(0).reference());
+    } finally {
+      server.stop(0);
+    }
+  }
+}

--- a/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostChannelAdapter.java
+++ b/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostChannelAdapter.java
@@ -3,6 +3,7 @@ package io.oryxos.channel.mattermost;
 import io.oryxos.core.channel.ChannelConfig;
 import io.oryxos.core.channel.ChannelStatus;
 import io.oryxos.core.channel.InboundChannelAdapter;
+import io.oryxos.core.channel.InboundMediaRoots;
 import io.oryxos.core.channel.InboundMessage;
 import io.oryxos.core.channel.InboundMessageService;
 import io.oryxos.core.channel.InboundWebhookHandler;
@@ -11,15 +12,24 @@ import io.oryxos.core.channel.WebhookRequest;
 import io.oryxos.core.channel.WebhookResponse;
 import io.oryxos.core.profile.ProfileRegistry;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Mattermost 入站：Outgoing Webhook。{@code app_id}=Bot 用户名，{@code app_secret}=webhook token + 发贴
- * token，{@code extra.base_url}。
+ * Mattermost 入站：Outgoing Webhook。{@code app_id}=Bot 用户名，{@code app_secret}=webhook token，{@code
+ * extra.base_url}；发帖 Bearer 优先 {@code extra.access_token}（PAT），否则回退 {@code app_secret}。
  */
 public class MattermostChannelAdapter implements InboundChannelAdapter, InboundWebhookHandler {
 
+  private static final Logger LOG = LoggerFactory.getLogger(MattermostChannelAdapter.class);
   public static final String TYPE = "mattermost";
   private static final String EXTRA_BASE_URL = "base_url";
+  private static final String MEDIA_DIR_PREFIX = "oryxos-mm-media-";
+
+  /** 发帖 PAT；缺省则复用 {@code app_secret}（Outgoing Webhook token 通常不能调 {@code /api/v4/posts}）。 */
+  private static final String EXTRA_ACCESS_TOKEN = "access_token";
+
   private static final int HTTP_UNAUTHORIZED = 401;
 
   private final ChannelConfig config;
@@ -29,6 +39,7 @@ public class MattermostChannelAdapter implements InboundChannelAdapter, InboundW
 
   private volatile MattermostEventNormalizer normalizer;
   private volatile MattermostMessageSender sender;
+  private volatile MattermostInboundMediaResolver mediaResolver;
   private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
@@ -71,13 +82,23 @@ public class MattermostChannelAdapter implements InboundChannelAdapter, InboundW
           "渠道 " + config.name() + " 绑定的 Agent " + config.agent() + " 不存在");
     }
     guard.check(config.extra(EXTRA_BASE_URL));
+    String token = postToken(config);
+    String baseUrl = config.extra(EXTRA_BASE_URL);
     normalizer = new MattermostEventNormalizer(config.name(), config.appId());
-    sender = new MattermostMessageSender(guard, config.extra(EXTRA_BASE_URL), config.appSecret());
+    sender = new MattermostMessageSender(guard, baseUrl, token);
+    mediaResolver =
+        new MattermostInboundMediaResolver(
+            guard,
+            baseUrl,
+            token,
+            InboundMediaRoots.forChannel(config.name(), MEDIA_DIR_PREFIX),
+            config.name());
     state = ChannelStatus.State.CONNECTED;
   }
 
   @Override
   public synchronized void stop() {
+    mediaResolver = null;
     state = ChannelStatus.State.DISCONNECTED;
   }
 
@@ -100,8 +121,53 @@ public class MattermostChannelAdapter implements InboundChannelAdapter, InboundW
     if (normalizer == null || !normalizer.tokenMatches(request.body(), config.appSecret())) {
       return WebhookResponse.text(HTTP_UNAUTHORIZED, "invalid token");
     }
-    Optional<InboundMessage> msg = normalizer.normalize(request.body());
-    msg.ifPresent(m -> inboundMessageService.onMessage(m, this));
+    Optional<InboundMessage> raw = normalizer.normalize(request.body());
+    if (raw.isEmpty()) {
+      return WebhookResponse.ok();
+    }
+    dispatch(raw.get());
     return WebhookResponse.ok();
+  }
+
+  private void dispatch(InboundMessage incoming) {
+    if (!inboundMessageService.tryClaim(incoming.channelName(), incoming.messageId())) {
+      LOG.info(
+          "渠道 {} 重复事件已忽略: {}", sanitize(incoming.channelName()), sanitize(incoming.messageId()));
+      return;
+    }
+    MattermostInboundMediaResolver resolver = mediaResolver;
+    InboundMessage discovered = resolver == null ? incoming : resolver.discover(incoming);
+    if (!discovered.processable()) {
+      return;
+    }
+    CountDownLatch slow = null;
+    if (resolver != null && MattermostInboundMediaResolver.needsDownload(discovered)) {
+      slow = inboundMessageService.beginSlowWork(this, discovered.chatId(), discovered.messageId());
+      discovered = resolver.download(discovered);
+    }
+    try {
+      if (slow != null) {
+        inboundMessageService.onClaimedMessage(discovered, this, slow);
+      } else {
+        inboundMessageService.onClaimedMessage(discovered, this);
+      }
+    } catch (RuntimeException e) {
+      if (slow != null) {
+        slow.countDown();
+      }
+      throw e;
+    }
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+
+  static String postToken(ChannelConfig config) {
+    String extra = config.extra(EXTRA_ACCESS_TOKEN);
+    if (extra != null && !extra.isBlank()) {
+      return extra;
+    }
+    return config.appSecret();
   }
 }

--- a/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostEventNormalizer.java
+++ b/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostEventNormalizer.java
@@ -58,7 +58,19 @@ public class MattermostEventNormalizer {
       }
       text = stripMention(text);
       if (text.isBlank()) {
-        return Optional.empty();
+        // 只 @Bot / 配图无说明：先放行，适配器再按 post 拉 file_ids；无附件则不进编排
+        return Optional.of(
+            new InboundMessage(
+                CHANNEL_TYPE,
+                channelName,
+                messageId,
+                ChatKind.GROUP,
+                userId,
+                chatId,
+                "",
+                false,
+                true,
+                List.of()));
       }
       return Optional.of(
           new InboundMessage(

--- a/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostInboundMediaResolver.java
+++ b/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostInboundMediaResolver.java
@@ -293,7 +293,8 @@ final class MattermostInboundMediaResolver {
       if (shouldProbeImageExtension(type, ext, target)) {
         String betterExt = ImageMime.extensionFor(ImageMime.probeFile(target));
         target = renameIfBetter(dir, target, ext, betterExt);
-        ext = extensionOf(target.getFileName().toString());
+        Path fileName = target.getFileName();
+        ext = fileName == null ? DEFAULT_EXTENSION : extensionOf(fileName.toString());
       }
       String sniffed =
           InboundMediaExt.betterFileExtension(target, ext == null ? DEFAULT_EXTENSION : ext);
@@ -436,7 +437,8 @@ final class MattermostInboundMediaResolver {
   }
 
   private static String sanitize(String value) {
-    return InboundMediaPaths.sanitizeLog(value);
+    // 内联替换：SpotBugs CRLF_INJECTION_LOGS 需在本类内可见的 \r/\n 清洗
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
   }
 
   record FileSpec(String id, String name, String mimeType, String extension) {}

--- a/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostInboundMediaResolver.java
+++ b/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostInboundMediaResolver.java
@@ -209,16 +209,38 @@ final class MattermostInboundMediaResolver {
     if (ext == null) {
       ext = extensionOf(fileName);
     }
-    if (mime.startsWith(MIME_IMAGE_PREFIX) || (ext != null && IMAGE_EXT.contains(ext))) {
+    if (matchesMimeOrExt(mime, MIME_IMAGE_PREFIX, ext, IMAGE_EXT)) {
       return InboundAttachment.TYPE_IMAGE;
     }
-    if (mime.startsWith(MIME_AUDIO_PREFIX) || (ext != null && AUDIO_EXT.contains(ext))) {
+    if (matchesMimeOrExt(mime, MIME_AUDIO_PREFIX, ext, AUDIO_EXT)) {
       return InboundAttachment.TYPE_AUDIO;
     }
-    if (mime.startsWith(MIME_VIDEO_PREFIX) || (ext != null && VIDEO_EXT.contains(ext))) {
+    if (matchesMimeOrExt(mime, MIME_VIDEO_PREFIX, ext, VIDEO_EXT)) {
       return InboundAttachment.TYPE_VIDEO;
     }
     return InboundAttachment.TYPE_FILE;
+  }
+
+  private static boolean matchesMimeOrExt(
+      String mime, String mimePrefix, String ext, Set<String> extensions) {
+    if (mime.startsWith(mimePrefix)) {
+      return true;
+    }
+    return ext != null && extensions.contains(ext);
+  }
+
+  /** Webhook 无 mime 时，用事件侧已推断的 type 补齐。 */
+  private static String applyFallbackType(String type, String mimeType, String fallbackType) {
+    if (mimeType != null && !mimeType.isBlank()) {
+      return type;
+    }
+    if (fallbackType == null || fallbackType.isBlank()) {
+      return type;
+    }
+    if (!InboundAttachment.TYPE_FILE.equals(type)) {
+      return type;
+    }
+    return fallbackType;
   }
 
   private List<FileSpec> fetchFileSpecs(String postId) {
@@ -250,12 +272,7 @@ final class MattermostInboundMediaResolver {
 
   private InboundAttachment downloadOrKeep(String messageId, FileSpec spec, String fallbackType) {
     String type = classifyType(spec.mimeType(), spec.name(), spec.extension());
-    if ((spec.mimeType() == null || spec.mimeType().isBlank())
-        && fallbackType != null
-        && !fallbackType.isBlank()
-        && InboundAttachment.TYPE_FILE.equals(type)) {
-      type = fallbackType;
-    }
+    type = applyFallbackType(type, spec.mimeType(), fallbackType);
     String url = baseUrl + "/api/v4/files/" + spec.id();
     guard.check(url);
     try {
@@ -273,9 +290,7 @@ final class MattermostInboundMediaResolver {
       String ext = extensionFor(spec, type);
       Path target = dir.resolve("mm-media" + ext);
       LimitedMediaWriter.writeLimited(bytes, target, InboundMediaLimits.MAX_FILE_BYTES);
-      if (InboundAttachment.TYPE_IMAGE.equals(type)
-          && DEFAULT_EXTENSION.equals(ext)
-          && ImageMime.hasRecognizedMagic(target)) {
+      if (shouldProbeImageExtension(type, ext, target)) {
         String betterExt = ImageMime.extensionFor(ImageMime.probeFile(target));
         target = renameIfBetter(dir, target, ext, betterExt);
         ext = extensionOf(target.getFileName().toString());
@@ -305,6 +320,16 @@ final class MattermostInboundMediaResolver {
       }
       return InboundAttachment.fileReference(spec.id(), spec.name());
     }
+  }
+
+  private static boolean shouldProbeImageExtension(String type, String ext, Path target) {
+    if (!InboundAttachment.TYPE_IMAGE.equals(type)) {
+      return false;
+    }
+    if (!DEFAULT_EXTENSION.equals(ext)) {
+      return false;
+    }
+    return ImageMime.hasRecognizedMagic(target);
   }
 
   private Path renameIfBetter(Path dir, Path current, String currentExt, String betterExt) {

--- a/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostInboundMediaResolver.java
+++ b/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostInboundMediaResolver.java
@@ -1,0 +1,418 @@
+package io.oryxos.channel.mattermost;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMediaJanitor;
+import io.oryxos.core.channel.InboundMediaLimits;
+import io.oryxos.core.channel.InboundMediaPaths;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.LimitedMediaWriter;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.session.ImageMime;
+import io.oryxos.core.session.InboundMediaExt;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Mattermost 入站图/文件：Outgoing Webhook 无附件字段，用 PAT 调 {@code GET /api/v4/posts/{id}} 取 {@code
+ * file_ids}，再 {@code GET /api/v4/files/{id}} 落盘。失败保留 file_id 引用，不阻断文字编排。
+ */
+final class MattermostInboundMediaResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MattermostInboundMediaResolver.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+  private static final int HTTP_OK_MIN = 200;
+  private static final int HTTP_OK_MAX_EXCLUSIVE = 300;
+  private static final String DEFAULT_EXTENSION = ".bin";
+  private static final String EXT_DOT = ".";
+  private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
+  private static final Set<String> IMAGE_EXT =
+      Set.of(".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".heic");
+  private static final Set<String> AUDIO_EXT =
+      Set.of(".mp3", ".wav", ".ogg", ".m4a", ".aac", ".amr");
+  private static final Set<String> VIDEO_EXT = Set.of(".mp4", ".mov", ".webm", ".mkv");
+  private static final String MIME_IMAGE_PREFIX = "image/";
+  private static final String MIME_AUDIO_PREFIX = "audio/";
+  private static final String MIME_VIDEO_PREFIX = "video/";
+  private static final String SAFE_FILE_ID = "[A-Za-z0-9_-]+";
+
+  private final HttpClient http;
+  private final OutboundGuard guard;
+  private final String baseUrl;
+  private final String token;
+  private final Path mediaRoot;
+  private final String channelName;
+  private final InboundMediaJanitor janitor;
+
+  MattermostInboundMediaResolver(
+      OutboundGuard guard, String baseUrl, String token, Path mediaRoot, String channelName) {
+    this(
+        HttpClient.newBuilder().connectTimeout(TIMEOUT).build(),
+        guard,
+        baseUrl,
+        token,
+        mediaRoot,
+        channelName,
+        InboundMediaJanitor.fromEnv());
+  }
+
+  MattermostInboundMediaResolver(
+      HttpClient http,
+      OutboundGuard guard,
+      String baseUrl,
+      String token,
+      Path mediaRoot,
+      String channelName,
+      InboundMediaJanitor janitor) {
+    this.http = http;
+    this.guard = guard;
+    this.baseUrl = MattermostMessageSender.trimSlash(baseUrl);
+    this.token = token;
+    this.mediaRoot = mediaRoot;
+    this.channelName = channelName;
+    this.janitor = janitor == null ? InboundMediaJanitor.fromEnv() : janitor;
+  }
+
+  InboundMessage resolve(InboundMessage message) {
+    return download(discover(message));
+  }
+
+  InboundMessage discover(InboundMessage message) {
+    if (message == null || message.messageId() == null || message.messageId().isBlank()) {
+      return message;
+    }
+    List<FileSpec> specs = fetchFileSpecs(message.messageId());
+    if (specs.isEmpty()) {
+      return message;
+    }
+    List<InboundAttachment> attachments = new ArrayList<>(specs.size());
+    for (FileSpec spec : specs) {
+      String type = classifyType(spec.mimeType(), spec.name(), spec.extension());
+      attachments.add(new InboundAttachment(type, null, spec.id(), spec.name()));
+    }
+    boolean textual = message.textual() || !message.content().isBlank();
+    return withAttachments(message, attachments, textual);
+  }
+
+  InboundMessage download(InboundMessage message) {
+    if (message == null || message.attachments().isEmpty()) {
+      return message;
+    }
+    janitor.sweepIfDue(mediaRoot);
+    List<InboundAttachment> resolved = new ArrayList<>(message.attachments().size());
+    boolean changed = false;
+    for (InboundAttachment attachment : message.attachments()) {
+      if (!needsDownload(attachment)) {
+        resolved.add(attachment);
+        continue;
+      }
+      FileSpec spec =
+          new FileSpec(
+              attachment.reference(),
+              attachment.fileName() == null ? "" : attachment.fileName(),
+              "",
+              "");
+      InboundAttachment next = downloadOrKeep(message.messageId(), spec, attachment.type());
+      changed |= next != attachment;
+      resolved.add(next);
+    }
+    if (!changed) {
+      return message;
+    }
+    return withAttachments(message, resolved, message.textual() || !message.content().isBlank());
+  }
+
+  private static InboundMessage withAttachments(
+      InboundMessage message, List<InboundAttachment> attachments, boolean textual) {
+    return new InboundMessage(
+        message.channelType(),
+        message.channelName(),
+        message.messageId(),
+        message.chatKind(),
+        message.userId(),
+        message.chatId(),
+        message.content(),
+        textual,
+        message.mentionedBot(),
+        attachments);
+  }
+
+  private static boolean needsDownload(InboundAttachment attachment) {
+    return attachment != null
+        && attachment.reference() != null
+        && !attachment.reference().isBlank()
+        && (attachment.url() == null || attachment.url().isBlank());
+  }
+
+  static boolean needsDownload(InboundMessage message) {
+    if (message == null) {
+      return false;
+    }
+    for (InboundAttachment attachment : message.attachments()) {
+      if (needsDownload(attachment)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static List<FileSpec> filesFromPost(JsonNode post) {
+    List<FileSpec> out = new ArrayList<>();
+    if (post == null) {
+      return out;
+    }
+    JsonNode files = post.path("metadata").path("files");
+    if (files.isArray()) {
+      for (JsonNode file : files) {
+        String id = file.path("id").asText("");
+        if (id.isBlank() || !id.matches(SAFE_FILE_ID)) {
+          continue;
+        }
+        out.add(
+            new FileSpec(
+                id,
+                file.path("name").asText(""),
+                file.path("mime_type").asText(""),
+                file.path("extension").asText("")));
+      }
+    }
+    if (!out.isEmpty()) {
+      return out;
+    }
+    JsonNode ids = post.path("file_ids");
+    if (ids.isArray()) {
+      for (JsonNode idNode : ids) {
+        String id = idNode.asText("");
+        if (!id.isBlank() && id.matches(SAFE_FILE_ID)) {
+          out.add(new FileSpec(id, "", "", ""));
+        }
+      }
+    }
+    return out;
+  }
+
+  static String classifyType(String mimeType, String fileName, String extension) {
+    String mime = asciiLower(mimeType);
+    String ext = normalizeExt(extension);
+    if (ext == null) {
+      ext = extensionOf(fileName);
+    }
+    if (mime.startsWith(MIME_IMAGE_PREFIX) || (ext != null && IMAGE_EXT.contains(ext))) {
+      return InboundAttachment.TYPE_IMAGE;
+    }
+    if (mime.startsWith(MIME_AUDIO_PREFIX) || (ext != null && AUDIO_EXT.contains(ext))) {
+      return InboundAttachment.TYPE_AUDIO;
+    }
+    if (mime.startsWith(MIME_VIDEO_PREFIX) || (ext != null && VIDEO_EXT.contains(ext))) {
+      return InboundAttachment.TYPE_VIDEO;
+    }
+    return InboundAttachment.TYPE_FILE;
+  }
+
+  private List<FileSpec> fetchFileSpecs(String postId) {
+    if (!postId.matches(SAFE_FILE_ID)) {
+      return List.of();
+    }
+    String url = baseUrl + "/api/v4/posts/" + postId;
+    guard.check(url);
+    try {
+      HttpResponse<String> response = sendGet(url);
+      if (response.statusCode() < HTTP_OK_MIN || response.statusCode() >= HTTP_OK_MAX_EXCLUSIVE) {
+        LOG.warn(
+            "Mattermost 渠道 {} 读帖失败 HTTP {}（postId={}）",
+            sanitize(channelName),
+            response.statusCode(),
+            sanitize(postId));
+        return List.of();
+      }
+      return filesFromPost(MAPPER.readTree(response.body()));
+    } catch (Exception e) {
+      LOG.warn(
+          "Mattermost 渠道 {} 读帖异常（postId={}）：{}",
+          sanitize(channelName),
+          sanitize(postId),
+          sanitize(e.getMessage()));
+      return List.of();
+    }
+  }
+
+  private InboundAttachment downloadOrKeep(String messageId, FileSpec spec, String fallbackType) {
+    String type = classifyType(spec.mimeType(), spec.name(), spec.extension());
+    if ((spec.mimeType() == null || spec.mimeType().isBlank())
+        && fallbackType != null
+        && !fallbackType.isBlank()
+        && InboundAttachment.TYPE_FILE.equals(type)) {
+      type = fallbackType;
+    }
+    String url = baseUrl + "/api/v4/files/" + spec.id();
+    guard.check(url);
+    try {
+      HttpResponse<byte[]> response = sendGetBytes(url);
+      if (response.statusCode() < HTTP_OK_MIN || response.statusCode() >= HTTP_OK_MAX_EXCLUSIVE) {
+        throw new IllegalStateException("HTTP " + response.statusCode());
+      }
+      byte[] bytes = response.body();
+      if (bytes == null || bytes.length == 0) {
+        throw new IllegalStateException("空文件");
+      }
+      janitor.ensureQuotaOrThrow(mediaRoot);
+      Path dir = mediaRoot.resolve(InboundMediaPaths.safeSegment(messageId));
+      Files.createDirectories(dir);
+      String ext = extensionFor(spec, type);
+      Path target = dir.resolve("mm-media" + ext);
+      LimitedMediaWriter.writeLimited(bytes, target, InboundMediaLimits.MAX_FILE_BYTES);
+      if (InboundAttachment.TYPE_IMAGE.equals(type)
+          && DEFAULT_EXTENSION.equals(ext)
+          && ImageMime.hasRecognizedMagic(target)) {
+        String betterExt = ImageMime.extensionFor(ImageMime.probeFile(target));
+        target = renameIfBetter(dir, target, ext, betterExt);
+        ext = extensionOf(target.getFileName().toString());
+      }
+      String sniffed =
+          InboundMediaExt.betterFileExtension(target, ext == null ? DEFAULT_EXTENSION : ext);
+      target = renameIfBetter(dir, target, ext, sniffed);
+      if (InboundAttachment.TYPE_FILE.equals(type) && ImageMime.hasRecognizedMagic(target)) {
+        type = InboundAttachment.TYPE_IMAGE;
+      }
+      LOG.info(
+          "Mattermost 渠道 {} 媒体已落盘（messageId={}, type={}, fileId={}）",
+          sanitize(channelName),
+          sanitize(messageId),
+          sanitize(type),
+          sanitize(spec.id()));
+      return new InboundAttachment(
+          type, target.toAbsolutePath().toString(), spec.id(), spec.name());
+    } catch (Exception e) {
+      LOG.warn(
+          "Mattermost 渠道 {} 下载媒体失败（fileId={}）：{}，保留 file_id",
+          sanitize(channelName),
+          sanitize(spec.id()),
+          sanitize(e.getMessage()));
+      if (InboundAttachment.TYPE_IMAGE.equals(type)) {
+        return new InboundAttachment(type, null, spec.id(), spec.name());
+      }
+      return InboundAttachment.fileReference(spec.id(), spec.name());
+    }
+  }
+
+  private Path renameIfBetter(Path dir, Path current, String currentExt, String betterExt) {
+    if (betterExt == null || betterExt.isBlank() || betterExt.equals(currentExt)) {
+      return current;
+    }
+    Path renamed = dir.resolve("mm-media" + betterExt);
+    try {
+      Files.move(current, renamed);
+      return renamed;
+    } catch (Exception ignored) {
+      return current;
+    }
+  }
+
+  private HttpResponse<String> sendGet(String url) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .timeout(TIMEOUT)
+            .header("Authorization", "Bearer " + token)
+            .GET()
+            .build();
+    return http.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  private HttpResponse<byte[]> sendGetBytes(String url) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .timeout(TIMEOUT)
+            .header("Authorization", "Bearer " + token)
+            .GET()
+            .build();
+    return http.send(request, HttpResponse.BodyHandlers.ofByteArray());
+  }
+
+  private static String extensionFor(FileSpec spec, String type) {
+    String fromName = extensionOf(spec.name());
+    if (fromName != null) {
+      return fromName;
+    }
+    String fromExt = normalizeExt(spec.extension());
+    if (fromExt != null) {
+      return fromExt;
+    }
+    if (InboundAttachment.TYPE_IMAGE.equals(type)) {
+      return DEFAULT_EXTENSION;
+    }
+    return DEFAULT_EXTENSION;
+  }
+
+  private static String normalizeExt(String extension) {
+    if (extension == null || extension.isBlank()) {
+      return null;
+    }
+    String ext = extension.strip();
+    if (!ext.startsWith(EXT_DOT)) {
+      ext = EXT_DOT + ext;
+    }
+    ext = asciiLower(ext);
+    if (!ext.matches(SAFE_EXTENSION_PATTERN)) {
+      return null;
+    }
+    return ext;
+  }
+
+  private static String extensionOf(String nameOrUrl) {
+    if (nameOrUrl == null || nameOrUrl.isBlank()) {
+      return null;
+    }
+    String path = nameOrUrl;
+    int q = path.indexOf('?');
+    if (q >= 0) {
+      path = path.substring(0, q);
+    }
+    int slash = path.lastIndexOf('/');
+    if (slash >= 0) {
+      path = path.substring(slash + 1);
+    }
+    int dot = path.lastIndexOf(EXT_DOT);
+    if (dot < 0 || dot == path.length() - 1) {
+      return null;
+    }
+    String ext = asciiLower(path.substring(dot));
+    if (!ext.matches(SAFE_EXTENSION_PATTERN)) {
+      return null;
+    }
+    return ext;
+  }
+
+  private static String asciiLower(String value) {
+    if (value == null) {
+      return "";
+    }
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
+  }
+
+  private static String sanitize(String value) {
+    return InboundMediaPaths.sanitizeLog(value);
+  }
+
+  record FileSpec(String id, String name, String mimeType, String extension) {}
+}

--- a/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostMessageSender.java
+++ b/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostMessageSender.java
@@ -15,6 +15,7 @@ public class MattermostMessageSender {
 
   private static final int HTTP_STATUS_OK_MIN = 200;
   private static final int HTTP_STATUS_OK_MAX_EXCLUSIVE = 300;
+  private static final int ERROR_BODY_MAX_LEN = 200;
   private static final Duration TIMEOUT = Duration.ofSeconds(20);
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -57,8 +58,8 @@ public class MattermostMessageSender {
       if (response.statusCode() < HTTP_STATUS_OK_MIN
           || response.statusCode() >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
         String errorBody = response.body() == null ? "" : response.body().strip();
-        if (errorBody.length() > 200) {
-          errorBody = errorBody.substring(0, 200);
+        if (errorBody.length() > ERROR_BODY_MAX_LEN) {
+          errorBody = errorBody.substring(0, ERROR_BODY_MAX_LEN);
         }
         throw new IllegalStateException(
             "Mattermost 发消息失败 HTTP "

--- a/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostMessageSender.java
+++ b/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostMessageSender.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.oryxos.core.channel.OutboundGuard;
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -99,7 +100,10 @@ public class MattermostMessageSender {
       JsonNode node = MAPPER.readTree(response.body());
       String root = node.path("root_id").asText("");
       return root.isBlank() ? postId : root;
-    } catch (Exception e) {
+    } catch (IOException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       return null;
     }
   }

--- a/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostMessageSender.java
+++ b/oryxos-channel-mattermost/src/main/java/io/oryxos/channel/mattermost/MattermostMessageSender.java
@@ -1,5 +1,6 @@
 package io.oryxos.channel.mattermost;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.oryxos.core.channel.OutboundGuard;
@@ -40,8 +41,9 @@ public class MattermostMessageSender {
       ObjectNode body = MAPPER.createObjectNode();
       body.put("channel_id", channelId);
       body.put("message", text == null ? "" : text);
-      if (replyToMessageId != null && !replyToMessageId.isBlank()) {
-        body.put("root_id", replyToMessageId);
+      String rootId = resolveThreadRootId(replyToMessageId);
+      if (rootId != null && !rootId.isBlank()) {
+        body.put("root_id", rootId);
       }
       HttpRequest request =
           HttpRequest.newBuilder()
@@ -54,12 +56,50 @@ public class MattermostMessageSender {
       HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
       if (response.statusCode() < HTTP_STATUS_OK_MIN
           || response.statusCode() >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
-        throw new IllegalStateException("Mattermost 发消息失败 HTTP " + response.statusCode());
+        String errorBody = response.body() == null ? "" : response.body().strip();
+        if (errorBody.length() > 200) {
+          errorBody = errorBody.substring(0, 200);
+        }
+        throw new IllegalStateException(
+            "Mattermost 发消息失败 HTTP "
+                + response.statusCode()
+                + (errorBody.isEmpty() ? "" : ": " + errorBody));
       }
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {
       throw new IllegalStateException("Mattermost 发消息失败: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Outgoing Webhook 只给当前帖 {@code post_id}。线程里回帖的 id 不能当 {@code root_id}，须解析到根帖；查不到则不跟帖，避免 HTTP
+   * 400。
+   */
+  private String resolveThreadRootId(String postId) {
+    if (postId == null || postId.isBlank()) {
+      return null;
+    }
+    String url = baseUrl + "/api/v4/posts/" + postId;
+    guard.check(url);
+    try {
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(url))
+              .timeout(TIMEOUT)
+              .header("Authorization", "Bearer " + token)
+              .GET()
+              .build();
+      HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() < HTTP_STATUS_OK_MIN
+          || response.statusCode() >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
+        return null;
+      }
+      JsonNode node = MAPPER.readTree(response.body());
+      String root = node.path("root_id").asText("");
+      return root.isBlank() ? postId : root;
+    } catch (Exception e) {
+      return null;
     }
   }
 

--- a/oryxos-channel-mattermost/src/test/java/io/oryxos/channel/mattermost/MattermostChannelAdapterTest.java
+++ b/oryxos-channel-mattermost/src/test/java/io/oryxos/channel/mattermost/MattermostChannelAdapterTest.java
@@ -1,0 +1,41 @@
+package io.oryxos.channel.mattermost;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.oryxos.core.channel.ChannelConfig;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MattermostChannelAdapterTest {
+
+  @Test
+  @DisplayName("extra.access_token 优先于 app_secret 发帖")
+  void extraAccessTokenWins() {
+    ChannelConfig config =
+        new ChannelConfig(
+            "ops-mattermost",
+            "mattermost",
+            "oryxbot",
+            "hook-token",
+            "demo-agent",
+            true,
+            Map.of("base_url", "http://127.0.0.1:8065", "access_token", "pat-token"));
+    assertEquals("pat-token", MattermostChannelAdapter.postToken(config));
+  }
+
+  @Test
+  @DisplayName("无 extra.access_token 时回退 app_secret")
+  void fallbackAppSecret() {
+    ChannelConfig config =
+        new ChannelConfig(
+            "ops-mattermost",
+            "mattermost",
+            "oryxbot",
+            "hook-token",
+            "demo-agent",
+            true,
+            Map.of("base_url", "http://127.0.0.1:8065"));
+    assertEquals("hook-token", MattermostChannelAdapter.postToken(config));
+  }
+}

--- a/oryxos-channel-mattermost/src/test/java/io/oryxos/channel/mattermost/MattermostEventNormalizerTest.java
+++ b/oryxos-channel-mattermost/src/test/java/io/oryxos/channel/mattermost/MattermostEventNormalizerTest.java
@@ -33,6 +33,19 @@ class MattermostEventNormalizerTest {
   }
 
   @Test
+  @DisplayName("频道只 @bot 无正文 → 非文本 GROUP，留给媒体解析")
+  void channelMentionOnly() {
+    var msg =
+        normalizer.normalize(
+            "token=t&user_id=u1&channel_id=c1&post_id=p1&channel_type=O&text=@oryxbot&trigger_word=@oryxbot");
+    assertTrue(msg.isPresent());
+    assertEquals(ChatKind.GROUP, msg.get().chatKind());
+    assertEquals("", msg.get().content());
+    assertTrue(msg.get().mentionedBot());
+    assertTrue(msg.get().attachments().isEmpty());
+  }
+
+  @Test
   @DisplayName("频道 @bot → GROUP")
   void channelMention() {
     var msg =

--- a/oryxos-channel-mattermost/src/test/java/io/oryxos/channel/mattermost/MattermostInboundMediaResolverTest.java
+++ b/oryxos-channel-mattermost/src/test/java/io/oryxos/channel/mattermost/MattermostInboundMediaResolverTest.java
@@ -1,0 +1,64 @@
+package io.oryxos.channel.mattermost;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.core.channel.InboundAttachment;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MattermostInboundMediaResolverTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  @DisplayName("metadata.files 解析 id / 文件名 / mime")
+  void filesFromMetadata() throws Exception {
+    var post =
+        MAPPER.readTree(
+            """
+            {
+              "file_ids": ["abc"],
+              "metadata": {
+                "files": [
+                  {"id": "img1", "name": "a.png", "mime_type": "image/png", "extension": "png"},
+                  {"id": "doc1", "name": "b.pdf", "mime_type": "application/pdf", "extension": "pdf"}
+                ]
+              }
+            }
+            """);
+    List<MattermostInboundMediaResolver.FileSpec> files =
+        MattermostInboundMediaResolver.filesFromPost(post);
+    assertEquals(2, files.size());
+    assertEquals("img1", files.get(0).id());
+    assertEquals("b.pdf", files.get(1).name());
+  }
+
+  @Test
+  @DisplayName("无 metadata 时回退 file_ids")
+  void filesFromIds() throws Exception {
+    var post = MAPPER.readTree("{\"file_ids\":[\"only1\",\"bad id\"]}");
+    List<MattermostInboundMediaResolver.FileSpec> files =
+        MattermostInboundMediaResolver.filesFromPost(post);
+    assertEquals(1, files.size());
+    assertEquals("only1", files.get(0).id());
+  }
+
+  @Test
+  @DisplayName("按 mime / 扩展名分类图与 PDF")
+  void classify() {
+    assertEquals(
+        InboundAttachment.TYPE_IMAGE,
+        MattermostInboundMediaResolver.classifyType("image/jpeg", "x", "jpg"));
+    assertEquals(
+        InboundAttachment.TYPE_FILE,
+        MattermostInboundMediaResolver.classifyType("application/pdf", "x.pdf", "pdf"));
+    assertEquals(
+        InboundAttachment.TYPE_IMAGE,
+        MattermostInboundMediaResolver.classifyType("", "shot.PNG", ""));
+    assertEquals(
+        InboundAttachment.TYPE_VIDEO,
+        MattermostInboundMediaResolver.classifyType("video/mp4", "a.mp4", "mp4"));
+  }
+}

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/DingTalkNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/DingTalkNotifyAdapter.java
@@ -42,6 +42,10 @@ public class DingTalkNotifyAdapter implements NotifyChannelAdapter {
 
   private final NotifyPoster poster;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "NotifyPoster is a Spring singleton shared by notify adapters; storing the reference is intentional.")
   public DingTalkNotifyAdapter(NotifyPoster poster) {
     this.poster = poster;
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/DiscordNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/DiscordNotifyAdapter.java
@@ -14,6 +14,10 @@ public class DiscordNotifyAdapter implements NotifyChannelAdapter {
 
   private final NotifyPoster poster;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "NotifyPoster is a Spring singleton shared by notify adapters; storing the reference is intentional.")
   public DiscordNotifyAdapter(NotifyPoster poster) {
     this.poster = poster;
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/FeishuNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/FeishuNotifyAdapter.java
@@ -40,6 +40,10 @@ public class FeishuNotifyAdapter implements NotifyChannelAdapter {
 
   private final NotifyPoster poster;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "NotifyPoster is a Spring singleton shared by notify adapters; storing the reference is intentional.")
   public FeishuNotifyAdapter(NotifyPoster poster) {
     this.poster = poster;
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/GoogleChatNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/GoogleChatNotifyAdapter.java
@@ -7,6 +7,10 @@ public class GoogleChatNotifyAdapter implements NotifyChannelAdapter {
 
   private final NotifyPoster poster;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "NotifyPoster is a Spring singleton shared by notify adapters; storing the reference is intentional.")
   public GoogleChatNotifyAdapter(NotifyPoster poster) {
     this.poster = poster;
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/MatrixNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/MatrixNotifyAdapter.java
@@ -13,6 +13,10 @@ public class MatrixNotifyAdapter implements NotifyChannelAdapter {
 
   private final NotifyPoster poster;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "NotifyPoster is a Spring singleton shared by notify adapters; storing the reference is intentional.")
   public MatrixNotifyAdapter(NotifyPoster poster) {
     this.poster = poster;
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/MatrixNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/MatrixNotifyAdapter.java
@@ -47,7 +47,7 @@ public class MatrixNotifyAdapter implements NotifyChannelAdapter {
     if (token != null && !token.isBlank()) {
       headers.put("Authorization", "Bearer " + token);
     }
-    poster.postJson(url, body, headers);
+    poster.putJson(url, body, headers);
   }
 
   private static String trimSlash(String homeserver) {

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/MattermostNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/MattermostNotifyAdapter.java
@@ -7,6 +7,10 @@ public class MattermostNotifyAdapter implements NotifyChannelAdapter {
 
   private final NotifyPoster poster;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "NotifyPoster is a Spring singleton shared by notify adapters; storing the reference is intentional.")
   public MattermostNotifyAdapter(NotifyPoster poster) {
     this.poster = poster;
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyPoster.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/NotifyPoster.java
@@ -60,13 +60,24 @@ public final class NotifyPoster {
 
   /** 同 {@link #postJson(String, Object)}，可带额外请求头（Bot Token 等）。 */
   public void postJson(String url, Object body, Map<String, String> headers) {
+    sendJson(HttpMethod.POST, url, body, headers);
+  }
+
+  /**
+   * PUT JSON。Matrix Client-Server {@code /send/m.room.message/{txn}} 必须用 PUT，POST 会被 homeserver 拒绝。
+   */
+  public void putJson(String url, Object body, Map<String, String> headers) {
+    sendJson(HttpMethod.PUT, url, body, headers);
+  }
+
+  private void sendJson(HttpMethod method, String url, Object body, Map<String, String> headers) {
     String current = url;
-    HttpMethod hopMethod = HttpMethod.POST;
+    HttpMethod hopMethod = method;
     Object hopBody = body;
     Map<String, String> hopHeaders = headers == null ? Map.of() : headers;
     for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
       sandbox.enforce(new SandboxAction(ActionType.HTTP_REQUEST, current));
-      RestClient.RequestBodySpec spec = hopClient.method(hopMethod).uri(current);
+      RestClient.RequestBodySpec spec = hopClient.method(hopMethod).uri(URI.create(current));
       hopHeaders.forEach(spec::header);
       if (hopBody != null) {
         spec.contentType(MediaType.APPLICATION_JSON).body(hopBody);

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/SlackNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/SlackNotifyAdapter.java
@@ -15,6 +15,10 @@ public class SlackNotifyAdapter implements NotifyChannelAdapter {
 
   private final NotifyPoster poster;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "NotifyPoster is a Spring singleton shared by notify adapters; storing the reference is intentional.")
   public SlackNotifyAdapter(NotifyPoster poster) {
     this.poster = poster;
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/TeamsNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/TeamsNotifyAdapter.java
@@ -7,6 +7,10 @@ public class TeamsNotifyAdapter implements NotifyChannelAdapter {
 
   private final NotifyPoster poster;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "NotifyPoster is a Spring singleton shared by notify adapters; storing the reference is intentional.")
   public TeamsNotifyAdapter(NotifyPoster poster) {
     this.poster = poster;
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/TelegramNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/TelegramNotifyAdapter.java
@@ -15,6 +15,10 @@ public class TelegramNotifyAdapter implements NotifyChannelAdapter {
 
   private final NotifyPoster poster;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "NotifyPoster is a Spring singleton shared by notify adapters; storing the reference is intentional.")
   public TelegramNotifyAdapter(NotifyPoster poster) {
     this.poster = poster;
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/WeComNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/WeComNotifyAdapter.java
@@ -24,6 +24,10 @@ public class WeComNotifyAdapter implements NotifyChannelAdapter {
 
   private final NotifyPoster poster;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "NotifyPoster is a Spring singleton shared by notify adapters; storing the reference is intentional.")
   public WeComNotifyAdapter(NotifyPoster poster) {
     this.poster = poster;
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/WebhookNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/WebhookNotifyAdapter.java
@@ -13,6 +13,10 @@ public class WebhookNotifyAdapter implements NotifyChannelAdapter {
 
   private final NotifyPoster poster;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "NotifyPoster is a Spring singleton shared by notify adapters; storing the reference is intentional.")
   public WebhookNotifyAdapter(NotifyPoster poster) {
     this.poster = poster;
   }

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/WhatsAppNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/WhatsAppNotifyAdapter.java
@@ -14,6 +14,10 @@ public class WhatsAppNotifyAdapter implements NotifyChannelAdapter {
 
   private final NotifyPoster poster;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "NotifyPoster is a Spring singleton shared by notify adapters; storing the reference is intentional.")
   public WhatsAppNotifyAdapter(NotifyPoster poster) {
     this.poster = poster;
   }

--- a/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
@@ -28,7 +28,7 @@ import org.springframework.web.client.RestClientResponseException;
  */
 class VendorNotifyAdapterTest {
 
-  private record ReceivedRequest(String query, String body) {}
+  private record ReceivedRequest(String method, String path, String query, String body) {}
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -57,7 +57,12 @@ class VendorNotifyAdapterTest {
 
   private void record(HttpExchange exchange) throws IOException {
     String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
-    received.add(new ReceivedRequest(exchange.getRequestURI().getQuery(), body));
+    received.add(
+        new ReceivedRequest(
+            exchange.getRequestMethod(),
+            exchange.getRequestURI().getRawPath(),
+            exchange.getRequestURI().getQuery(),
+            body));
     byte[] payload = responseBody.getBytes(StandardCharsets.UTF_8);
     if (!responseBody.isEmpty()) {
       exchange.getResponseHeaders().add("Content-Type", "application/json; charset=utf-8");
@@ -446,5 +451,29 @@ class VendorNotifyAdapterTest {
         IllegalArgumentException.class,
         () -> new MatrixNotifyAdapter(poster).send(new NotifyTarget("matrix", Map.of()), "hi"));
     assertEquals(0, received.size());
+  }
+
+  @Test
+  @DisplayName("Matrix：homeserver + token + room_id 走 PUT m.room.message")
+  void matrixHomeserverPutBody() throws IOException {
+    new MatrixNotifyAdapter(poster)
+        .send(
+            new NotifyTarget(
+                "matrix",
+                Map.of(
+                    "homeserver",
+                    "http://127.0.0.1:" + server.getAddress().getPort(),
+                    "token",
+                    "tok",
+                    "room_id",
+                    "!r:hs")),
+            "日报来了");
+    JsonNode body = lastBody();
+    assertEquals("m.text", body.get("msgtype").asText());
+    assertEquals("日报来了", body.get("body").asText());
+    ReceivedRequest last = received.get(received.size() - 1);
+    assertEquals("PUT", last.method());
+    assertTrue(last.path().contains("%21r%3Ahs"));
+    assertTrue(!last.path().contains("%2521"), "房间 ID 不得二次编码");
   }
 }

--- a/specs/026-im-channel-roadmap/acceptance.md
+++ b/specs/026-im-channel-roadmap/acceptance.md
@@ -1,6 +1,6 @@
 # 026 验收记录
 
-**日期**: 2026-09-08  
+**日期**: 2026-09-08（WhatsApp 接线 / Mattermost 本机往返 / Matrix 本机往返补记 2026-09-09）  
 **范围**: 波次 0–5 代码 + 契约/归一化单测。真平台按已有凭证推进。
 
 ## 单测（本机 JDK 21）
@@ -29,6 +29,20 @@
 | Slack 入站 | 主仓已测并合入：[PR #420](https://github.com/oryx-labs/oryxos/pull/420) Socket Mode `CONNECTED` + 文本往返；[PR #421](https://github.com/oryx-labs/oryxos/pull/421) 图片/文件入站。本机 `ops-slack` 仍为 `CONNECTED`，既有 Slack 会话可回放 |
 | Discord 入站 | 主仓已测并合入：[PR #422](https://github.com/oryx-labs/oryxos/pull/422) Gateway 文本 DM / 公会 `@Bot`；[#423](https://github.com/oryx-labs/oryxos/pull/423)/[#425](https://github.com/oryx-labs/oryxos/pull/425)/[#426](https://github.com/oryx-labs/oryxos/pull/426)/[#427](https://github.com/oryx-labs/oryxos/pull/427) 图/文件/语音/视频 soak。本机 `ops-discord` 仍为 `CONNECTED`，既有 Discord 会话可回放 |
 | Slack / Discord `notify` | 026 [PR #429](https://github.com/oryx-labs/oryxos/pull/429) 已补适配器；出站路径与入站回复同源（Slack `chat.postMessage` / Discord REST）。不要把后续 `conversations.list` / 列频道探测当成「未打真实频道」 |
-| WhatsApp / Teams / GChat / Mattermost / Matrix | 无可用凭证，未宣称 COMPLETE |
+| WhatsApp 入站接线 | 本机 `.env` 已有 `WHATSAPP_*`（不入库）。`cs-whatsapp` 绑 `demo-agent` 后 `GET /api/v1/channels/status` 为 `CONNECTED`。本机与 Cloudflare quick tunnel 的 GET 订阅挑战均回写 `hub.challenge`（200）。未宣称 COMPLETE |
+| WhatsApp Graph 凭证 | 通过（2026-09-09）：系统用户令牌（`whatsapp_business_messaging` + `whatsapp_business_management`）后 Graph `/{phone-number-id}` HTTP 200，`code_verification_status=VERIFIED` |
+| WhatsApp 24h 真机往返 | **挂起，不标 COMPLETE**：Cloud API 号 `+86 138 0199 6162`（显示名 OryxOS）同时是提交者日常 WhatsApp。自己发给自己无效；朋友搜该号只会进已有私聊，消息不进 webhook。关手机 App 不能改路由。要另备专用号或 Meta API Setup 测试号（From / `+1`）再测 |
+| Mattermost 入站接线 | 本机 Docker `oryxos-mattermost`（`mattermost/mattermost-preview` `:8065`）。`.env` 已有 `MATTERMOST_*`（不入库）。`ops-mattermost` 绑 `demo-agent` 后 `GET /api/v1/channels/status` 为 `CONNECTED`。Outgoing Webhook 回调 `http://host.docker.internal:8080/api/v1/channels/inbound/ops-mattermost`；站点 `AllowedUntrustedInternalConnections` 含 `host.docker.internal`（否则静默 address forbidden）。`http.allowed_domains` 含 `127.0.0.1` / `localhost` |
+| Mattermost 房间 `@Bot` 往返 | 通过（2026-09-09）：Town Square `@oryxbot` → DeepSeek 推理 → `POST /api/v4/posts` 回帖（约 23 字）。入站 token 与发帖 PAT 分开（`app_secret` vs `extra.access_token`） |
+| Mattermost `notify` | 通过（2026-09-09）：Incoming Webhook 进 Town Square；管理台渠道 `ops-mm-notify`（`type: mattermost`）；`demo-agent` `notify` 工具推送后房间可见（marker 命中，约 48 字）。webhook URL 只在本机 `.env` `MATTERMOST_INCOMING_WEBHOOK_URL` |
+| Mattermost 图 / PDF | 通过（2026-09-09）：Webhook 后 PAT 拉 `file_ids` 落盘。API 小 PNG + 文本 PDF 回帖约 168 字。Town Square UI 真机：`@oryxbot` 与图 / PDF **同一条帖**发出后落盘并分别说明。只贴图不 @、或先发 @ 再另贴附件，都不会进媒体路径 |
+| Matrix 入站接线 | 本机 Docker `oryxos-synapse`（`matrixdotorg/synapse` `:8008`）。`.env` 已有 `MATRIX_*`（不入库）。`ops-matrix` 绑 `demo-agent` 后 `GET /api/v1/channels/status` 为 `CONNECTED`。`/sync` 长轮询，无需公网回调。`http.allowed_domains` 含 `127.0.0.1` / `localhost` |
+| Matrix 房间 `@Bot` 往返 | 通过（2026-09-09）：Town Square `@oryxbot:localhost` / `@oryxbot` / `m.mentions` → 回帖。Element Web：`oryxos-element` `:8087` |
+| Matrix Element UI（Chrome） | 通过（2026-09-09）：本机 Google Chrome + Playwright `channel=chrome` 打开 `:8087`，homeserver 选 `localhost`，`admin` 登录（首次需重置数字身份），Town Square `@oryxbot` 可见 Bot 回帖 |
+| Matrix 对齐飞书/企微/钉钉（Chrome） | 通过（2026-09-10）：房间 `@oryxbot`+图、`@oryxbot`+PDF 同条发出并回帖；私聊无 @ 往返；`ops-mx-notify` 进房间。媒体落盘 / 慢路径「处理中」/ 私聊不要求 @，口径对齐国内三家 |
+| Matrix 私聊 | 通过（2026-09-09）：邀请自动加入；`m.direct` 读顶层 account_data 并跨 sync 记住；`is_direct` 邀请记入私聊集合。私聊不要求 @，已有往返 |
+| Matrix 图 / PDF | 通过（2026-09-09）：`mxc://` 鉴权下载落盘（日志「媒体已落盘」）。与飞书相同 Vision / `read_file`。极小/残缺 PNG 会被 Vision 拒后降级纯文本（与 Mattermost 小图实测相同） |
+| Matrix `notify` | 通过（2026-09-09）：管理台渠道 `ops-mx-notify`（`type: matrix`，`homeserver` + `token` + `room_id`）。Client-Server 发信必须 **PUT**（POST 为 405）。`NotifyPoster` 对完整 URL 用 `URI.create`，避免房间 ID 二次编码（否则 403 not in room）。`demo-agent` `notify` 后房间可见 marker |
+| Teams / GChat | 无可用凭证，未宣称 COMPLETE |
 
 管理台 Notify 已补齐 026 类型（原先 API 只允许飞书/企微/钉钉/webhook/email，适配器注册了也建不了渠道）。

--- a/specs/026-im-channel-roadmap/plan.md
+++ b/specs/026-im-channel-roadmap/plan.md
@@ -172,8 +172,8 @@ website/zh/docs/tool.md / profile.md   # 渠道表同步
 - [ ] B2 WhatsApp 入站 + notify + 会话窗错误 + Setup  
 - [ ] B3 Teams 入站 + notify + Setup  
 - [ ] B4 Google Chat 入站 + notify + Setup  
-- [ ] B5 Mattermost 入站 + notify + Setup  
-- [ ] B6 Matrix 入站 + notify + Setup  
+- [x] B5 Mattermost 入站 + notify + Setup（本机 Docker 2026-09-09）  
+- [x] B6 Matrix 入站 + notify + Setup（本机 Synapse + Element 2026-09-09）  
 - [ ] 网站文档渠道表与 `channels.yaml.example` 与上表一致  
 - [ ] 不把「未过 Meta/Azure 审核的演示」写成生产就绪  
 


### PR DESCRIPTION
## Summary
- Mattermost: Outgoing Webhook 后用 PAT 拉 `file_ids` 落盘；房间 @ 与附件同帖；线程 `root_id` 修复。
- Matrix: `mxc://` 鉴权媒体落盘；顶层 `m.direct` + 邀请自动加入；房间支持 `@localpart`；notify 改为 PUT，并用 `URI.create` 避免房间 ID 二次编码。
- 本机 Docker（Mattermost / Synapse+Element Chrome）真机验收已记入 `specs/026-im-channel-roadmap/acceptance.md`。

## Test plan
- [x] `mvn -pl oryxos-channel-matrix,oryxos-channel-mattermost,oryxos-tool -am` 相关单测
- [x] Mattermost Town Square `@oryxbot` 文字 / 图+PDF / notify
- [x] Matrix Element Chrome：房间 @、图、PDF、私聊无 @、`ops-mx-notify`