### PR TITLE
feat(channel): QQ official Bot inbound and notify (029)

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -108,6 +108,7 @@ http:
     - media.discordapp.net      # Discord 入站媒体代理
     - "*.discordapp.com"        # Discord CDN 子域
     - "*.discordapp.net"        # Discord 媒体子域
+    - api.bot.qq.com            # QQ 官方 Bot OpenAPI + Gateway
     - api.open-meteo.com        # 天气 Agent 免 key 天气源（31 节 Demo 一）
     - hn.algolia.com            # 科技日报 Agent 新闻源（31 节 Demo 二）
     - api.github.com            # GitHub 日报脚本子进程网络（31 节 Demo 三）

--- a/config/channels.yaml.example
+++ b/config/channels.yaml.example
@@ -100,3 +100,11 @@ channels:
   #   extra:
   #     homeserver: ${MATRIX_HOMESERVER}
   #   enabled: true
+
+  # QQ 官方 Bot Gateway（见 docs/QqChannelSetup.md）
+  # - name: ops-qq
+  #   type: qq
+  #   app_id: ${QQ_APP_ID}
+  #   app_secret: ${QQ_APP_SECRET}
+  #   agent: demo-agent
+  #   enabled: true

--- a/docs/QqChannelSetup.md
+++ b/docs/QqChannelSetup.md
@@ -1,0 +1,66 @@
+# QQ 官方机器人入站渠道接入指南
+
+本文是 OryxOS QQ 入站渠道的部署手册。以 **Gateway WebSocket** 连接 QQ 开放平台（免公网回调）；回复经 REST `/v2/groups|users/.../messages`。出站告警另见 Notify `type: qq`。
+
+> 范围：QQ **群** `@Bot`（`GROUP_AT_MESSAGE_CREATE`）与 **单聊**（`C2C_MESSAGE_CREATE`）。频道 / 子频道为二期。不做个人号协议。
+
+## 一、开放平台侧
+
+1. 打开 [QQ 开放平台](https://q.qq.com/) / [机器人文档](https://bot.q.qq.com/wiki/) 创建机器人，记下 **AppID**、**AppSecret**。
+2. 管理端订阅事件：至少开启群与单聊相关能力（对应 Intent `GROUP_AND_C2C_EVENT`）。
+3. 将机器人拉入**沙箱/测试群**；群内通常需 **@Bot** 才会推送群消息事件。
+4. 若启用 IP 白名单：正式环境把本机/服务器出口 IP 加入白名单（沙箱一般不受限）。接口域：
+   - 换票 / OpenAPI：`https://api.bot.qq.com`
+   - Gateway：自 `GET /gateway` 返回的 `wss://…`（常见 `api.bot.qq.com` 同源）
+5. 凭证只走环境变量，禁止写入仓库。
+
+## 二、OryxOS 侧
+
+```bash
+export QQ_APP_ID=...
+export QQ_APP_SECRET=...
+```
+
+`.oryxos/channels.yaml`（模板见 `config/channels.yaml.example`）：
+
+```yaml
+channels:
+  - name: ops-qq
+    type: qq
+    app_id: ${QQ_APP_ID}
+    app_secret: ${QQ_APP_SECRET}
+    agent: demo-agent
+    enabled: true
+```
+
+`http.allowed_domains` 需包含 `api.bot.qq.com`（见 `config/application.yml.example`）。
+
+启动后 `GET /api/v1/channels/status` 期望 `CONNECTED`（Gateway READY）。
+
+## 三、行为约定
+
+| 场景 | 行为 |
+|------|------|
+| 群 `@Bot` 文本 | 进编排；回复带被动 `msg_id`（约 5 分钟窗） |
+| 单聊文本 | 进编排；无私聊 @ 要求；回复走 `/v2/users/{openid}/messages` |
+| 重复 `msg_id` | 去重，只答一次 |
+| 频道消息 | MVP 不处理 |
+
+内部 `chatId` 形如 `group:{group_openid}` / `user:{user_openid}`（发信路径编码，对用户不可见）。
+
+## 四、Notify
+
+管理台 `type: qq`：
+
+- `token`：已换好的 `access_token`（`QQBot` 鉴权值，不含前缀）
+- `group_openid` **或** `user_openid`
+- 联调可另给 `url` 打到假 HTTP，body 仍为 `{ "msg_type": 0, "content": "..." }`
+
+主动消息受官方限额与用户/群「允许主动消息」开关约束；群被动优先用入站 `msg_id`。
+
+## 五、实测清单
+
+- 群 `@Bot` 往返  
+- 单聊往返  
+- `notify` 进指定 openid  
+- 无凭证时以单测为准，不宣称生产联调完成

--- a/oryxos-boot/pom.xml
+++ b/oryxos-boot/pom.xml
@@ -90,6 +90,10 @@
         </dependency>
         <dependency>
             <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-channel-qq</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
             <artifactId>oryxos-web</artifactId>
         </dependency>
         <dependency>

--- a/oryxos-channel-qq/pom.xml
+++ b/oryxos-channel-qq/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.oryxos</groupId>
+        <artifactId>oryxos</artifactId>
+        <version>0.1.4-RELEASE</version>
+    </parent>
+
+    <artifactId>oryxos-channel-qq</artifactId>
+    <name>OryxOS Channel QQ</name>
+    <description>QQ official Bot API v2 inbound IM: Gateway WebSocket and REST reply</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqAccessTokenClient.java
+++ b/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqAccessTokenClient.java
@@ -1,0 +1,127 @@
+package io.oryxos.channel.qq;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.OutboundGuard;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * QQ Bot {@code access_token}：{@code POST /app/getAppAccessToken}，过期前刷新，不落盘。
+ *
+ * <p>鉴权头格式：{@code Authorization: QQBot {access_token}}。
+ */
+final class QqAccessTokenClient {
+
+  static final String API_BASE_URL = "https://api.bot.qq.com";
+  static final String TOKEN_PATH = "/app/getAppAccessToken";
+  private static final Duration TIMEOUT = Duration.ofSeconds(20);
+
+  /** 提前刷新余量，避免边界过期。 */
+  private static final long REFRESH_SKEW_MS = 60_000L;
+
+  private static final long DEFAULT_EXPIRES_MS = 7_200_000L;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String FIELD_ACCESS_TOKEN = "access_token";
+  private static final String FIELD_EXPIRES_IN = "expires_in";
+
+  private final HttpClient http;
+  private final OutboundGuard guard;
+  private final String appId;
+  private final String clientSecret;
+  private final AtomicReference<CachedToken> cached = new AtomicReference<>();
+
+  QqAccessTokenClient(OutboundGuard guard, String appId, String clientSecret) {
+    this(HttpClient.newBuilder().connectTimeout(TIMEOUT).build(), guard, appId, clientSecret);
+  }
+
+  QqAccessTokenClient(HttpClient http, OutboundGuard guard, String appId, String clientSecret) {
+    this.http = Objects.requireNonNull(http);
+    this.guard = Objects.requireNonNull(guard);
+    this.appId = Objects.requireNonNull(appId);
+    this.clientSecret = Objects.requireNonNull(clientSecret);
+  }
+
+  String authorizationHeader() {
+    return "QQBot " + accessToken();
+  }
+
+  String accessToken() {
+    CachedToken current = cached.get();
+    long now = System.currentTimeMillis();
+    if (current != null && now < current.expiresAtMs() - REFRESH_SKEW_MS) {
+      return current.token();
+    }
+    synchronized (this) {
+      current = cached.get();
+      now = System.currentTimeMillis();
+      if (current != null && now < current.expiresAtMs() - REFRESH_SKEW_MS) {
+        return current.token();
+      }
+      CachedToken refreshed = fetch();
+      cached.set(refreshed);
+      return refreshed.token();
+    }
+  }
+
+  private CachedToken fetch() {
+    String url = API_BASE_URL + TOKEN_PATH;
+    guard.check(url);
+    try {
+      ObjectNode body = MAPPER.createObjectNode();
+      body.put("appId", appId);
+      body.put("clientSecret", clientSecret);
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(url))
+              .timeout(TIMEOUT)
+              .header("Content-Type", "application/json; charset=utf-8")
+              .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body)))
+              .build();
+      HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+      JsonNode root = MAPPER.readTree(response.body() == null ? "{}" : response.body());
+      String token = root.path(FIELD_ACCESS_TOKEN).asText("");
+      if (token.isBlank()) {
+        throw new IllegalStateException(
+            "QQ getAppAccessToken 无 access_token: " + sanitize(response.body()));
+      }
+      long expiresInSec = parseExpiresIn(root.path(FIELD_EXPIRES_IN));
+      long expiresAt = System.currentTimeMillis() + Math.max(1_000L, expiresInSec * 1_000L);
+      return new CachedToken(token, expiresAt);
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("QQ getAppAccessToken 失败: " + e.getMessage(), e);
+    }
+  }
+
+  private static long parseExpiresIn(JsonNode node) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return DEFAULT_EXPIRES_MS / 1_000L;
+    }
+    if (node.isNumber()) {
+      return node.asLong(DEFAULT_EXPIRES_MS / 1_000L);
+    }
+    String text = node.asText("");
+    if (text.isBlank()) {
+      return DEFAULT_EXPIRES_MS / 1_000L;
+    }
+    try {
+      return Long.parseLong(text.strip());
+    } catch (NumberFormatException e) {
+      return DEFAULT_EXPIRES_MS / 1_000L;
+    }
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+
+  private record CachedToken(String token, long expiresAtMs) {}
+}

--- a/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqChannelAdapter.java
+++ b/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqChannelAdapter.java
@@ -1,0 +1,298 @@
+package io.oryxos.channel.qq;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.channel.ChannelConfig;
+import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.InboundChannelAdapter;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageService;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * QQ 官方机器人入站：一实例 = 一条 Gateway 长连接。
+ *
+ * <p>凭证：{@code app_id}=AppID，{@code app_secret}=AppSecret（换 access_token）。
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
+    justification = "gateway/normalizer/sender/tokens 在 start() 内初始化；sendReply 有显式空判。")
+public class QqChannelAdapter implements InboundChannelAdapter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(QqChannelAdapter.class);
+
+  public static final String TYPE = "qq";
+
+  private static final Duration START_TIMEOUT = Duration.ofSeconds(25);
+  private static final long RECONNECT_BASE_MS = 2_000L;
+  private static final long RECONNECT_MAX_MS = 60_000L;
+  private static final int RECONNECT_MAX_SHIFT = 5;
+
+  private final ChannelConfig config;
+  private final ProfileRegistry profileRegistry;
+  private final InboundMessageService inboundMessageService;
+  private final OutboundGuard guard;
+
+  private final AtomicReference<QqGatewayClient> gatewayRef = new AtomicReference<>();
+  private volatile QqAccessTokenClient tokens;
+  private volatile QqMessageSender sender;
+  private volatile QqEventNormalizer normalizer;
+  private volatile QqDisconnectKind lastDisconnectKind = QqDisconnectKind.ABRUPT;
+  private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
+  private volatile String lastError;
+  private volatile boolean running;
+  private volatile ScheduledExecutorService reconnectScheduler;
+  private volatile ScheduledFuture<?> reconnectFuture;
+  private int reconnectAttempt;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "协作者均为 Runtime 装配的单例，共享引用正是意图")
+  public QqChannelAdapter(
+      ChannelConfig config,
+      ProfileRegistry profileRegistry,
+      InboundMessageService inboundMessageService,
+      OutboundGuard guard) {
+    this.config = config;
+    this.profileRegistry = profileRegistry;
+    this.inboundMessageService = inboundMessageService;
+    this.guard = guard;
+  }
+
+  @Override
+  public String name() {
+    return config.name();
+  }
+
+  @Override
+  public String type() {
+    return TYPE;
+  }
+
+  @Override
+  public String boundAgent() {
+    return config.agent();
+  }
+
+  @Override
+  public synchronized void start() {
+    config.validateCredentialsResolved();
+    if (profileRegistry.get(config.agent()).isEmpty()) {
+      throw new IllegalArgumentException(
+          "渠道 " + config.name() + " 绑定的 Agent " + config.agent() + " 不存在");
+    }
+    guard.check(QqAccessTokenClient.API_BASE_URL);
+    guard.check(QqGatewayClient.GATEWAY_ORIGIN_FOR_GUARD);
+    running = true;
+    reconnectAttempt = 0;
+    cancelReconnectLocked();
+    try {
+      connectLocked();
+      state = ChannelStatus.State.CONNECTED;
+      lastError = null;
+      LOG.info(
+          "QQ 渠道 {} Gateway 已建立（Agent: {}）", sanitize(config.name()), sanitize(config.agent()));
+    } catch (Exception e) {
+      running = false;
+      shutdownReconnectSchedulerLocked();
+      state = ChannelStatus.State.ERROR;
+      lastError = "Gateway 连接失败: " + sanitize(e.getMessage());
+      throw new IllegalStateException("渠道 " + config.name() + " " + lastError, e);
+    }
+  }
+
+  @Override
+  public synchronized void stop() {
+    running = false;
+    cancelReconnectLocked();
+    shutdownReconnectSchedulerLocked();
+    QqGatewayClient gateway = gatewayRef.getAndSet(null);
+    if (gateway != null) {
+      gateway.closeQuietly();
+    }
+    sender = null;
+    normalizer = null;
+    tokens = null;
+    state = ChannelStatus.State.DISCONNECTED;
+  }
+
+  @Override
+  public ChannelStatus status() {
+    if (state == ChannelStatus.State.ERROR) {
+      return ChannelStatus.error(config.name(), TYPE, config.agent(), lastError);
+    }
+    QqGatewayClient gateway = gatewayRef.get();
+    if (gateway == null || !gateway.isConnected()) {
+      return ChannelStatus.ok(
+          config.name(), TYPE, config.agent(), ChannelStatus.State.DISCONNECTED);
+    }
+    return ChannelStatus.ok(config.name(), TYPE, config.agent(), ChannelStatus.State.CONNECTED);
+  }
+
+  @Override
+  public void sendReply(String chatId, String text, String replyToMessageId) {
+    QqMessageSender active = sender;
+    if (active == null) {
+      throw new IllegalStateException("渠道 " + config.name() + " 未启动，无法发送回复");
+    }
+    active.send(chatId, text, replyToMessageId);
+  }
+
+  static long reconnectDelayMs(int attempt) {
+    return io.oryxos.core.channel.ReconnectBackoff.delayMs(
+        attempt, RECONNECT_BASE_MS, RECONNECT_MAX_MS, RECONNECT_MAX_SHIFT);
+  }
+
+  private void connectLocked() throws Exception {
+    gatewayRef.set(connect());
+  }
+
+  private QqGatewayClient connect() throws Exception {
+    ensureOutboundStack();
+    QqGatewayClient client =
+        new QqGatewayClient(tokens, guard, this::handleDispatch, this::handleDisconnected);
+    client.connect(START_TIMEOUT);
+    return client;
+  }
+
+  private void ensureOutboundStack() {
+    if (tokens == null) {
+      tokens = new QqAccessTokenClient(guard, config.appId(), config.appSecret());
+    }
+    if (normalizer == null) {
+      normalizer = new QqEventNormalizer(config.name());
+    }
+    if (sender == null) {
+      sender = new QqMessageSender(guard, tokens);
+    }
+  }
+
+  private void handleDisconnected(QqDisconnectKind kind) {
+    boolean shouldReconnect;
+    synchronized (this) {
+      if (!running || state == ChannelStatus.State.ERROR) {
+        return;
+      }
+      lastDisconnectKind = kind == null ? QqDisconnectKind.ABRUPT : kind;
+      if (lastDisconnectKind == QqDisconnectKind.GRACEFUL) {
+        reconnectAttempt = 0;
+      }
+      gatewayRef.set(null);
+      state = ChannelStatus.State.DISCONNECTED;
+      shouldReconnect = true;
+    }
+    if (shouldReconnect) {
+      if (lastDisconnectKind == QqDisconnectKind.GRACEFUL) {
+        LOG.info("QQ 渠道 {} Gateway 服务端要求重连，立即重连", sanitize(config.name()));
+      } else {
+        LOG.warn("QQ 渠道 {} Gateway 断开，将自动重连", sanitize(config.name()));
+      }
+      scheduleReconnect();
+    }
+  }
+
+  private void scheduleReconnect() {
+    synchronized (this) {
+      if (!running || reconnectFuture != null) {
+        return;
+      }
+      long delayMs =
+          lastDisconnectKind == QqDisconnectKind.GRACEFUL ? 0L : reconnectDelayMs(reconnectAttempt);
+      reconnectFuture =
+          reconnectScheduler().schedule(this::attemptReconnect, delayMs, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private void attemptReconnect() {
+    synchronized (this) {
+      reconnectFuture = null;
+      if (!running) {
+        return;
+      }
+    }
+    QqGatewayClient client;
+    try {
+      client = connect();
+    } catch (Exception e) {
+      synchronized (this) {
+        reconnectAttempt++;
+        lastError = "Gateway 重连失败: " + sanitize(e.getMessage());
+        LOG.warn(
+            "QQ 渠道 {} 重连失败（第 {} 次）: {}",
+            sanitize(config.name()),
+            reconnectAttempt,
+            sanitize(lastError));
+      }
+      scheduleReconnect();
+      return;
+    }
+    synchronized (this) {
+      if (!running) {
+        client.closeQuietly();
+        return;
+      }
+      gatewayRef.set(client);
+      reconnectAttempt = 0;
+      state = ChannelStatus.State.CONNECTED;
+      lastError = null;
+      LOG.info("QQ 渠道 {} Gateway 已恢复", sanitize(config.name()));
+    }
+  }
+
+  private ScheduledExecutorService reconnectScheduler() {
+    ScheduledExecutorService scheduler = reconnectScheduler;
+    if (scheduler == null) {
+      ScheduledThreadPoolExecutor pool =
+          new ScheduledThreadPoolExecutor(
+              1,
+              r -> {
+                Thread t = new Thread(r, "qq-reconnect-" + sanitize(config.name()));
+                t.setDaemon(true);
+                return t;
+              });
+      pool.setRemoveOnCancelPolicy(true);
+      reconnectScheduler = pool;
+      return pool;
+    }
+    return scheduler;
+  }
+
+  private void cancelReconnectLocked() {
+    ScheduledFuture<?> pending = reconnectFuture;
+    if (pending != null) {
+      pending.cancel(false);
+      reconnectFuture = null;
+    }
+  }
+
+  private void shutdownReconnectSchedulerLocked() {
+    cancelReconnectLocked();
+    ScheduledExecutorService scheduler = reconnectScheduler;
+    if (scheduler != null) {
+      scheduler.shutdownNow();
+      reconnectScheduler = null;
+    }
+  }
+
+  private void handleDispatch(String eventName, JsonNode data) {
+    try {
+      Optional<InboundMessage> msg = normalizer.normalize(eventName, data);
+      msg.ifPresent(m -> inboundMessageService.onMessage(m, this));
+    } catch (RuntimeException e) {
+      LOG.error("QQ 渠道 {} 事件处理异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
+    }
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqChatTargets.java
+++ b/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqChatTargets.java
@@ -1,0 +1,36 @@
+package io.oryxos.channel.qq;
+
+/** chatId 编码：群 {@code group:{openid}}，单聊 {@code user:{openid}}。 */
+final class QqChatTargets {
+
+  static final String PREFIX_GROUP = "group:";
+  static final String PREFIX_USER = "user:";
+
+  private QqChatTargets() {}
+
+  static String group(String groupOpenid) {
+    return PREFIX_GROUP + groupOpenid;
+  }
+
+  static String user(String userOpenid) {
+    return PREFIX_USER + userOpenid;
+  }
+
+  static boolean isGroup(String chatId) {
+    return chatId != null && chatId.startsWith(PREFIX_GROUP);
+  }
+
+  static boolean isUser(String chatId) {
+    return chatId != null && chatId.startsWith(PREFIX_USER);
+  }
+
+  static String openid(String chatId) {
+    if (isGroup(chatId)) {
+      return chatId.substring(PREFIX_GROUP.length());
+    }
+    if (isUser(chatId)) {
+      return chatId.substring(PREFIX_USER.length());
+    }
+    throw new IllegalArgumentException("非法 QQ chatId（需 group: 或 user: 前缀）: " + chatId);
+  }
+}

--- a/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqDisconnectKind.java
+++ b/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqDisconnectKind.java
@@ -1,0 +1,7 @@
+package io.oryxos.channel.qq;
+
+/** Gateway 断开原因：优雅重连可立即重试，突发断开走退避。 */
+enum QqDisconnectKind {
+  GRACEFUL,
+  ABRUPT
+}

--- a/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqEventNormalizer.java
+++ b/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqEventNormalizer.java
@@ -1,0 +1,138 @@
+package io.oryxos.channel.qq;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * QQ Gateway Dispatch → {@link InboundMessage}。
+ *
+ * <p>MVP：{@code GROUP_AT_MESSAGE_CREATE}（事件即 @Bot）+ {@code C2C_MESSAGE_CREATE}。频道事件丢弃。
+ */
+public class QqEventNormalizer {
+
+  static final String CHANNEL_TYPE = "qq";
+  static final String EVENT_GROUP_AT = "GROUP_AT_MESSAGE_CREATE";
+  static final String EVENT_C2C = "C2C_MESSAGE_CREATE";
+
+  private static final Pattern MENTION = Pattern.compile("<@!?\\w+>");
+  private static final String FIELD_ID = "id";
+  private static final String FIELD_CONTENT = "content";
+  private static final String FIELD_AUTHOR = "author";
+  private static final String FIELD_GROUP_OPENID = "group_openid";
+  private static final String FIELD_MEMBER_OPENID = "member_openid";
+  private static final String FIELD_USER_OPENID = "user_openid";
+
+  private final String channelName;
+
+  public QqEventNormalizer(String channelName) {
+    this.channelName = channelName;
+  }
+
+  public Optional<InboundMessage> normalize(String eventName, JsonNode data) {
+    if (eventName == null || data == null || !data.isObject()) {
+      return Optional.empty();
+    }
+    if (EVENT_GROUP_AT.equals(eventName)) {
+      return normalizeGroup(data);
+    }
+    if (EVENT_C2C.equals(eventName)) {
+      return normalizeC2c(data);
+    }
+    return Optional.empty();
+  }
+
+  private Optional<InboundMessage> normalizeGroup(JsonNode data) {
+    String messageId = text(data, FIELD_ID);
+    String groupOpenid = text(data, FIELD_GROUP_OPENID);
+    JsonNode author = data.path(FIELD_AUTHOR);
+    String userId = firstNonBlank(text(author, FIELD_MEMBER_OPENID), text(author, FIELD_ID));
+    if (messageId == null || groupOpenid == null || userId == null) {
+      return Optional.empty();
+    }
+    String content = stripMentions(data.path(FIELD_CONTENT).asText("")).strip();
+    if (content.isBlank()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new InboundMessage(
+            CHANNEL_TYPE,
+            channelName,
+            messageId,
+            ChatKind.GROUP,
+            userId,
+            QqChatTargets.group(groupOpenid),
+            content,
+            true,
+            true,
+            List.of()));
+  }
+
+  private Optional<InboundMessage> normalizeC2c(JsonNode data) {
+    String messageId = text(data, FIELD_ID);
+    JsonNode author = data.path(FIELD_AUTHOR);
+    String userId = firstNonBlank(text(author, FIELD_USER_OPENID), text(author, FIELD_ID));
+    if (messageId == null || userId == null) {
+      return Optional.empty();
+    }
+    String content = stripMentions(data.path(FIELD_CONTENT).asText("")).strip();
+    if (content.isBlank()) {
+      return Optional.of(
+          new InboundMessage(
+              CHANNEL_TYPE,
+              channelName,
+              messageId,
+              ChatKind.P2P,
+              userId,
+              QqChatTargets.user(userId),
+              "",
+              false,
+              false,
+              List.of()));
+    }
+    return Optional.of(
+        new InboundMessage(
+            CHANNEL_TYPE,
+            channelName,
+            messageId,
+            ChatKind.P2P,
+            userId,
+            QqChatTargets.user(userId),
+            content,
+            true,
+            false,
+            List.of()));
+  }
+
+  static String stripMentions(String content) {
+    if (content == null || content.isBlank()) {
+      return content == null ? "" : content;
+    }
+    return MENTION.matcher(content).replaceAll("").strip();
+  }
+
+  private static String firstNonBlank(String a, String b) {
+    if (a != null && !a.isBlank()) {
+      return a;
+    }
+    if (b != null && !b.isBlank()) {
+      return b;
+    }
+    return null;
+  }
+
+  private static String text(JsonNode node, String field) {
+    if (node == null || !node.isObject()) {
+      return null;
+    }
+    JsonNode v = node.get(field);
+    if (v == null || v.isNull()) {
+      return null;
+    }
+    String s = v.asText();
+    return s == null || s.isBlank() ? null : s;
+  }
+}

--- a/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqGatewayClient.java
+++ b/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqGatewayClient.java
@@ -1,0 +1,383 @@
+package io.oryxos.channel.qq;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.OutboundGuard;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * QQ Gateway WebSocket：Hello → Identify → Heartbeat；Dispatch 群 @ / 单聊事件。
+ *
+ * <p>Intent：{@code GROUP_AND_C2C_EVENT}（{@code 1 << 25}）。Identify token = {@code QQBot
+ * {access_token}}。
+ */
+final class QqGatewayClient implements WebSocket.Listener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(QqGatewayClient.class);
+
+  static final String API_BASE_URL = QqAccessTokenClient.API_BASE_URL;
+
+  /** OutboundGuard 用；真实 WSS 主机以 {@code GET /gateway} 为准。 */
+  static final String GATEWAY_ORIGIN_FOR_GUARD = "https://api.bot.qq.com";
+
+  /** GROUP_AND_C2C_EVENT */
+  static final int INTENTS = 1 << 25;
+
+  private static final int OP_DISPATCH = 0;
+  private static final int OP_HEARTBEAT = 1;
+  private static final int OP_IDENTIFY = 2;
+  private static final int OP_RECONNECT = 7;
+  private static final int OP_INVALID_SESSION = 9;
+  private static final int OP_HELLO = 10;
+  private static final int OP_HEARTBEAT_ACK = 11;
+
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(20);
+  private static final long WS_CLOSE_TIMEOUT_MS = 2_000L;
+  private static final long READY_TIMEOUT_MS = 20_000L;
+  private static final long DEFAULT_HEARTBEAT_MS = 41_250L;
+  private static final long MIN_HEARTBEAT_MS = 1_000L;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String FIELD_OP = "op";
+  private static final String FIELD_D = "d";
+  private static final String FIELD_S = "s";
+  private static final String FIELD_T = "t";
+  private static final String FIELD_URL = "url";
+  private static final String EVENT_READY = "READY";
+
+  private final QqAccessTokenClient tokens;
+  private final OutboundGuard guard;
+  private final BiConsumer<String, JsonNode> onDispatch;
+  private final Consumer<QqDisconnectKind> onDisconnected;
+
+  private final AtomicReference<WebSocket> socket = new AtomicReference<>();
+  private final AtomicBoolean connected = new AtomicBoolean(false);
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final AtomicBoolean identified = new AtomicBoolean(false);
+  private final StringBuilder textBuf = new StringBuilder();
+  private final CountDownLatch readyLatch = new CountDownLatch(1);
+  private volatile String openError;
+  private final AtomicBoolean disconnectNotified = new AtomicBoolean(false);
+  private final AtomicLong lastSeq = new AtomicLong(-1);
+  private volatile ScheduledExecutorService heartbeatScheduler;
+  private volatile ScheduledFuture<?> heartbeatFuture;
+
+  QqGatewayClient(
+      QqAccessTokenClient tokens,
+      OutboundGuard guard,
+      BiConsumer<String, JsonNode> onDispatch,
+      Consumer<QqDisconnectKind> onDisconnected) {
+    this.tokens = Objects.requireNonNull(tokens);
+    this.guard = Objects.requireNonNull(guard);
+    this.onDispatch = Objects.requireNonNull(onDispatch);
+    this.onDisconnected = onDisconnected == null ? kind -> {} : onDisconnected;
+  }
+
+  void connect(Duration timeout) throws Exception {
+    closed.set(false);
+    disconnectNotified.set(false);
+    identified.set(false);
+    lastSeq.set(-1);
+    openError = null;
+    guard.check(API_BASE_URL);
+    guard.check(GATEWAY_ORIGIN_FOR_GUARD);
+    String gatewayUrl = fetchGatewayUrl();
+    URI wsUri = URI.create(gatewayUrl);
+    HttpClient client = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    CompletableFuture<WebSocket> future =
+        client.newWebSocketBuilder().connectTimeout(CONNECT_TIMEOUT).buildAsync(wsUri, this);
+    WebSocket ws;
+    try {
+      ws = future.get(timeout.toSeconds(), TimeUnit.SECONDS);
+    } catch (Exception e) {
+      future.cancel(true);
+      closeQuietly();
+      throw e;
+    }
+    socket.set(ws);
+    long waitMs = Math.max(timeout.toMillis(), READY_TIMEOUT_MS);
+    if (!readyLatch.await(waitMs, TimeUnit.MILLISECONDS)) {
+      closeQuietly();
+      throw new IllegalStateException("QQ Gateway 连接超时（未收到 READY）");
+    }
+    if (openError != null) {
+      closeQuietly();
+      throw new IllegalStateException("QQ Gateway 连接失败: " + openError);
+    }
+    if (!connected.get() || !identified.get()) {
+      closeQuietly();
+      throw new IllegalStateException("QQ Gateway 连接失败（未知原因）");
+    }
+  }
+
+  boolean isConnected() {
+    return connected.get() && identified.get() && !closed.get();
+  }
+
+  void closeQuietly() {
+    closed.set(true);
+    connected.set(false);
+    identified.set(false);
+    stopHeartbeat();
+    readyLatch.countDown();
+    WebSocket ws = socket.getAndSet(null);
+    if (ws == null) {
+      return;
+    }
+    Thread closer =
+        Thread.ofPlatform()
+            .daemon(true)
+            .name("oryxos-qq-ws-close")
+            .unstarted(
+                () -> {
+                  try {
+                    ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye").join();
+                  } catch (RuntimeException ignored) {
+                    // ignore
+                  }
+                });
+    closer.start();
+    try {
+      closer.join(WS_CLOSE_TIMEOUT_MS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    if (closer.isAlive()) {
+      LOG.warn("QQ WS close {}ms 未返回，放弃等待（守护线程后台继续）", WS_CLOSE_TIMEOUT_MS);
+    }
+  }
+
+  @Override
+  public void onOpen(WebSocket webSocket) {
+    connected.set(true);
+    disconnectNotified.set(false);
+    webSocket.request(1);
+  }
+
+  @Override
+  public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+    textBuf.append(data);
+    if (last) {
+      String raw = textBuf.toString();
+      textBuf.setLength(0);
+      handleText(webSocket, raw);
+    }
+    webSocket.request(1);
+    return null;
+  }
+
+  @Override
+  public CompletionStage<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
+    webSocket.request(1);
+    return null;
+  }
+
+  @Override
+  public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+    notifyDisconnected(QqDisconnectKind.ABRUPT, "close " + statusCode + " " + reason);
+    return null;
+  }
+
+  @Override
+  public void onError(WebSocket webSocket, Throwable error) {
+    LOG.warn("QQ Gateway 连接错误: {}", sanitize(error == null ? null : error.getMessage()));
+    if (!identified.get()) {
+      openError = error == null ? "unknown" : error.getMessage();
+      readyLatch.countDown();
+    }
+    notifyDisconnected(QqDisconnectKind.ABRUPT, error == null ? null : error.getMessage());
+  }
+
+  private String fetchGatewayUrl() throws Exception {
+    String url = API_BASE_URL + "/gateway";
+    guard.check(url);
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .timeout(CONNECT_TIMEOUT)
+            .header("Authorization", tokens.authorizationHeader())
+            .GET()
+            .build();
+    HttpClient client = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+    JsonNode root = MAPPER.readTree(response.body() == null ? "{}" : response.body());
+    String gateway = root.path(FIELD_URL).asText("");
+    if (gateway.isBlank()) {
+      throw new IllegalStateException("QQ GET /gateway 无 url: " + sanitize(response.body()));
+    }
+    return gateway;
+  }
+
+  private void handleText(WebSocket webSocket, String raw) {
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(raw);
+    } catch (JacksonException e) {
+      LOG.warn("QQ Gateway 帧 JSON 解析失败，已忽略");
+      return;
+    }
+    int op = root.path(FIELD_OP).asInt(-1);
+    JsonNode d = root.get(FIELD_D);
+    if (!root.path(FIELD_S).isNull() && root.has(FIELD_S) && root.get(FIELD_S).canConvertToLong()) {
+      lastSeq.set(root.get(FIELD_S).asLong());
+    }
+    if (op == OP_HELLO) {
+      onHello(webSocket, d);
+    } else if (op == OP_HEARTBEAT_ACK) {
+      // ok
+    } else if (op == OP_HEARTBEAT) {
+      sendHeartbeat(webSocket);
+    } else if (op == OP_RECONNECT) {
+      LOG.info("QQ Gateway 服务端要求重连 (op=7)");
+      closeQuietly();
+      notifyDisconnected(QqDisconnectKind.GRACEFUL, "reconnect");
+    } else if (op == OP_INVALID_SESSION) {
+      boolean resumable = d != null && d.asBoolean(false);
+      LOG.warn("QQ Gateway Invalid Session resumable={}", resumable);
+      closeQuietly();
+      notifyDisconnected(QqDisconnectKind.ABRUPT, "invalid_session");
+    } else if (op == OP_DISPATCH) {
+      String t = root.path(FIELD_T).asText("");
+      if (EVENT_READY.equals(t)) {
+        identified.set(true);
+        readyLatch.countDown();
+        LOG.info("QQ Gateway READY");
+        return;
+      }
+      if (d != null && d.isObject()) {
+        try {
+          onDispatch.accept(t, d);
+        } catch (RuntimeException e) {
+          LOG.error("QQ 事件处理异常: {}", sanitize(e.getMessage()));
+        }
+      }
+    }
+  }
+
+  private void onHello(WebSocket webSocket, JsonNode d) {
+    long intervalMs =
+        d == null
+            ? DEFAULT_HEARTBEAT_MS
+            : d.path("heartbeat_interval").asLong(DEFAULT_HEARTBEAT_MS);
+    startHeartbeat(webSocket, intervalMs);
+    sendIdentify(webSocket);
+  }
+
+  private void sendIdentify(WebSocket webSocket) {
+    try {
+      ObjectNode root = MAPPER.createObjectNode();
+      root.put(FIELD_OP, OP_IDENTIFY);
+      ObjectNode data = root.putObject(FIELD_D);
+      data.put("token", tokens.authorizationHeader());
+      data.put("intents", INTENTS);
+      ArrayNode shard = data.putArray("shard");
+      shard.add(0);
+      shard.add(1);
+      ObjectNode props = data.putObject("properties");
+      props.put("$os", System.getProperty("os.name", "unknown"));
+      props.put("$browser", "oryxos");
+      props.put("$device", "oryxos");
+      webSocket.sendText(MAPPER.writeValueAsString(root), true);
+    } catch (Exception e) {
+      openError = e.getMessage();
+      readyLatch.countDown();
+      LOG.warn("QQ Identify 发送失败: {}", sanitize(e.getMessage()));
+    }
+  }
+
+  private void startHeartbeat(WebSocket webSocket, long intervalMs) {
+    stopHeartbeat();
+    ScheduledThreadPoolExecutor pool =
+        new ScheduledThreadPoolExecutor(
+            1,
+            r -> {
+              Thread t = new Thread(r, "oryxos-qq-heartbeat");
+              t.setDaemon(true);
+              return t;
+            });
+    pool.setRemoveOnCancelPolicy(true);
+    heartbeatScheduler = pool;
+    long delay = Math.max(MIN_HEARTBEAT_MS, intervalMs);
+    heartbeatFuture =
+        pool.scheduleAtFixedRate(
+            () -> sendHeartbeat(webSocket), delay, delay, TimeUnit.MILLISECONDS);
+  }
+
+  private void sendHeartbeat(WebSocket webSocket) {
+    if (webSocket == null || closed.get()) {
+      return;
+    }
+    try {
+      ObjectNode root = MAPPER.createObjectNode();
+      root.put(FIELD_OP, OP_HEARTBEAT);
+      long seq = lastSeq.get();
+      if (seq >= 0) {
+        root.put(FIELD_D, seq);
+      } else {
+        root.putNull(FIELD_D);
+      }
+      webSocket.sendText(MAPPER.writeValueAsString(root), true);
+    } catch (Exception e) {
+      LOG.warn("QQ Heartbeat 发送失败: {}", sanitize(e.getMessage()));
+    }
+  }
+
+  private void stopHeartbeat() {
+    ScheduledFuture<?> future = heartbeatFuture;
+    if (future != null) {
+      future.cancel(false);
+      heartbeatFuture = null;
+    }
+    ScheduledExecutorService scheduler = heartbeatScheduler;
+    if (scheduler != null) {
+      scheduler.shutdownNow();
+      heartbeatScheduler = null;
+    }
+  }
+
+  private void markDisconnected() {
+    closed.set(true);
+    connected.set(false);
+    identified.set(false);
+    stopHeartbeat();
+    readyLatch.countDown();
+  }
+
+  private void notifyDisconnected(QqDisconnectKind kind, String detail) {
+    if (!disconnectNotified.compareAndSet(false, true)) {
+      return;
+    }
+    markDisconnected();
+    onDisconnected.accept(kind);
+    if (detail != null && !detail.isBlank()) {
+      LOG.debug("QQ Gateway 断开: {}", sanitize(detail));
+    }
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqMessageSender.java
+++ b/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqMessageSender.java
@@ -1,0 +1,136 @@
+package io.oryxos.channel.qq;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.OutboundGuard;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * QQ 发信：群 {@code POST /v2/groups/{group_openid}/messages}；单聊 {@code POST
+ * /v2/users/{user_openid}/messages}。
+ *
+ * <p>被动回复带 {@code msg_id} + 递增 {@code msg_seq}；{@code msg_id} 过期时降级为无引用主动发一次。
+ */
+public class QqMessageSender {
+
+  static final int DEFAULT_CHUNK_SIZE = 2000;
+  static final String API_BASE_URL = QqAccessTokenClient.API_BASE_URL;
+  private static final int HTTP_STATUS_OK_MIN = 200;
+  private static final int HTTP_STATUS_OK_MAX_EXCLUSIVE = 300;
+  private static final Duration TIMEOUT = Duration.ofSeconds(20);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String FIELD_MSG_TYPE = "msg_type";
+  private static final String FIELD_CONTENT = "content";
+  private static final String FIELD_MSG_ID = "msg_id";
+  private static final String FIELD_MSG_SEQ = "msg_seq";
+
+  private final HttpClient http;
+  private final OutboundGuard guard;
+  private final QqAccessTokenClient tokens;
+  private final int chunkSize;
+  private final ConcurrentHashMap<String, AtomicInteger> msgSeqById = new ConcurrentHashMap<>();
+
+  public QqMessageSender(OutboundGuard guard, QqAccessTokenClient tokens) {
+    this(
+        HttpClient.newBuilder().connectTimeout(TIMEOUT).build(), guard, tokens, DEFAULT_CHUNK_SIZE);
+  }
+
+  QqMessageSender(HttpClient http, OutboundGuard guard, QqAccessTokenClient tokens, int chunkSize) {
+    this.http = http;
+    this.guard = guard;
+    this.tokens = tokens;
+    this.chunkSize = chunkSize <= 0 ? DEFAULT_CHUNK_SIZE : chunkSize;
+  }
+
+  public void send(String chatId, String text, String replyToMessageId) {
+    guard.check(API_BASE_URL);
+    String openid = QqChatTargets.openid(chatId);
+    boolean group = QqChatTargets.isGroup(chatId);
+    String path =
+        group ? "/v2/groups/" + openid + "/messages" : "/v2/users/" + openid + "/messages";
+    String url = API_BASE_URL + path;
+    for (String chunk : segment(text == null ? "" : text, chunkSize)) {
+      post(url, chunk, replyToMessageId, true);
+    }
+  }
+
+  private void post(String url, String text, String replyToMessageId, boolean allowFallback) {
+    try {
+      ObjectNode body = MAPPER.createObjectNode();
+      body.put(FIELD_MSG_TYPE, 0);
+      body.put(FIELD_CONTENT, text);
+      if (replyToMessageId != null && !replyToMessageId.isBlank()) {
+        body.put(FIELD_MSG_ID, replyToMessageId);
+        body.put(FIELD_MSG_SEQ, nextSeq(replyToMessageId));
+      }
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(url))
+              .timeout(TIMEOUT)
+              .header("Authorization", tokens.authorizationHeader())
+              .header("Content-Type", "application/json; charset=utf-8")
+              .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body)))
+              .build();
+      HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+      if (httpSuccess(response.statusCode())) {
+        return;
+      }
+      String respBody = response.body() == null ? "" : response.body();
+      if (allowFallback
+          && replyToMessageId != null
+          && !replyToMessageId.isBlank()
+          && isMsgIdExpired(respBody)) {
+        post(url, text, null, false);
+        return;
+      }
+      throw new IllegalStateException("QQ 发消息失败: " + sanitize(respBody));
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("QQ 发消息失败: " + e.getMessage(), e);
+    }
+  }
+
+  private int nextSeq(String msgId) {
+    return msgSeqById.computeIfAbsent(msgId, ignored -> new AtomicInteger(1)).getAndIncrement();
+  }
+
+  static boolean isMsgIdExpired(String body) {
+    if (body == null || body.isBlank()) {
+      return false;
+    }
+    String lower = body.toLowerCase(Locale.ROOT);
+    return body.contains("msg_id已过期")
+        || body.contains("msg_id 已过期")
+        || lower.contains("msg_id expired")
+        || lower.contains("msgid expired");
+  }
+
+  static List<String> segment(String text, int chunkSize) {
+    if (text.isEmpty()) {
+      return List.of("");
+    }
+    List<String> parts = new ArrayList<>();
+    for (int i = 0; i < text.length(); i += chunkSize) {
+      parts.add(text.substring(i, Math.min(text.length(), i + chunkSize)));
+    }
+    return parts;
+  }
+
+  private static boolean httpSuccess(int statusCode) {
+    return statusCode >= HTTP_STATUS_OK_MIN && statusCode < HTTP_STATUS_OK_MAX_EXCLUSIVE;
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-qq/src/test/java/io/oryxos/channel/qq/QqChannelContractTest.java
+++ b/oryxos-channel-qq/src/test/java/io/oryxos/channel/qq/QqChannelContractTest.java
@@ -1,0 +1,69 @@
+package io.oryxos.channel.qq;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageServiceContractTestBase;
+import java.util.List;
+
+class QqChannelContractTest extends InboundMessageServiceContractTestBase {
+
+  private final QqEventNormalizer normalizer = new QqEventNormalizer("contract-qq");
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Override
+  protected String channelType() {
+    return "qq";
+  }
+
+  @Override
+  protected InboundMessage p2pMessage(String messageId, String content) {
+    return normalizer.normalize(QqEventNormalizer.EVENT_C2C, c2c(messageId, content)).orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage groupMessage(String messageId, String content) {
+    return normalizer
+        .normalize(QqEventNormalizer.EVENT_GROUP_AT, group(messageId, content))
+        .orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage nonTextualMessage(String messageId) {
+    return normalizer.normalize(QqEventNormalizer.EVENT_C2C, c2c(messageId, "")).orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage imageMessage(String messageId) {
+    return new InboundMessage(
+        "qq",
+        "contract-qq",
+        messageId,
+        ChatKind.P2P,
+        "u1",
+        QqChatTargets.user("u1"),
+        "",
+        false,
+        false,
+        List.of(InboundAttachment.imageReference("img-ref")));
+  }
+
+  private ObjectNode c2c(String messageId, String content) {
+    ObjectNode data = mapper.createObjectNode();
+    data.put("id", messageId);
+    data.put("content", content);
+    data.putObject("author").put("user_openid", "u1");
+    return data;
+  }
+
+  private ObjectNode group(String messageId, String content) {
+    ObjectNode data = mapper.createObjectNode();
+    data.put("id", messageId);
+    data.put("group_openid", "g1");
+    data.put("content", content);
+    data.putObject("author").put("member_openid", "m1");
+    return data;
+  }
+}

--- a/oryxos-channel-qq/src/test/java/io/oryxos/channel/qq/QqEventNormalizerTest.java
+++ b/oryxos-channel-qq/src/test/java/io/oryxos/channel/qq/QqEventNormalizerTest.java
@@ -1,0 +1,91 @@
+package io.oryxos.channel.qq;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class QqEventNormalizerTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private QqEventNormalizer normalizer;
+
+  @BeforeEach
+  void setUp() {
+    normalizer = new QqEventNormalizer("ops-qq");
+  }
+
+  @Test
+  @DisplayName("群 @Bot 文本 → GROUP，剥离 mention")
+  void groupAtMessage() {
+    ObjectNode data = MAPPER.createObjectNode();
+    data.put("id", "msg-g1");
+    data.put("group_openid", "g-open");
+    data.put("content", "<@!12345> 查天气");
+    data.putObject("author").put("member_openid", "m-open");
+    Optional<InboundMessage> msg = normalizer.normalize(QqEventNormalizer.EVENT_GROUP_AT, data);
+    assertTrue(msg.isPresent());
+    InboundMessage m = msg.get();
+    assertEquals(ChatKind.GROUP, m.chatKind());
+    assertTrue(m.mentionedBot());
+    assertEquals("查天气", m.content());
+    assertEquals("group:g-open", m.chatId());
+    assertEquals("m-open", m.userId());
+  }
+
+  @Test
+  @DisplayName("单聊文本 → P2P")
+  void c2cText() {
+    ObjectNode data = MAPPER.createObjectNode();
+    data.put("id", "msg-c1");
+    data.put("content", "hello");
+    data.putObject("author").put("user_openid", "u-open");
+    Optional<InboundMessage> msg = normalizer.normalize(QqEventNormalizer.EVENT_C2C, data);
+    assertTrue(msg.isPresent());
+    InboundMessage m = msg.get();
+    assertEquals(ChatKind.P2P, m.chatKind());
+    assertFalse(m.mentionedBot());
+    assertEquals("hello", m.content());
+    assertEquals("user:u-open", m.chatId());
+  }
+
+  @Test
+  @DisplayName("单聊空内容 → 非文本占位")
+  void c2cNonTextual() {
+    ObjectNode data = MAPPER.createObjectNode();
+    data.put("id", "msg-c2");
+    data.put("content", "");
+    data.putObject("author").put("user_openid", "u-open");
+    Optional<InboundMessage> msg = normalizer.normalize(QqEventNormalizer.EVENT_C2C, data);
+    assertTrue(msg.isPresent());
+    assertFalse(msg.get().textual());
+  }
+
+  @Test
+  @DisplayName("频道等非 MVP 事件 → 丢弃")
+  void guildEventDropped() {
+    ObjectNode data = MAPPER.createObjectNode();
+    data.put("id", "msg-x");
+    data.put("content", "hi");
+    assertTrue(normalizer.normalize("AT_MESSAGE_CREATE", data).isEmpty());
+  }
+
+  @Test
+  @DisplayName("群空内容 → 丢弃")
+  void groupBlankDropped() {
+    ObjectNode data = MAPPER.createObjectNode();
+    data.put("id", "msg-g2");
+    data.put("group_openid", "g-open");
+    data.put("content", "<@!1>   ");
+    data.putObject("author").put("member_openid", "m-open");
+    assertTrue(normalizer.normalize(QqEventNormalizer.EVENT_GROUP_AT, data).isEmpty());
+  }
+}

--- a/oryxos-cli/pom.xml
+++ b/oryxos-cli/pom.xml
@@ -74,6 +74,10 @@
         </dependency>
         <dependency>
             <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-channel-qq</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
             <artifactId>oryxos-provider</artifactId>
         </dependency>
         <dependency>

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -106,6 +106,7 @@ import io.oryxos.tool.notify.MatrixNotifyAdapter;
 import io.oryxos.tool.notify.MattermostNotifyAdapter;
 import io.oryxos.tool.notify.NotifyChannelAdapter;
 import io.oryxos.tool.notify.NotifyPoster;
+import io.oryxos.tool.notify.QqNotifyAdapter;
 import io.oryxos.tool.notify.SlackNotifyAdapter;
 import io.oryxos.tool.notify.TeamsNotifyAdapter;
 import io.oryxos.tool.notify.TelegramNotifyAdapter;
@@ -823,6 +824,7 @@ public class OryxOsRuntime {
     notifyAdapters.put("gchat", new GoogleChatNotifyAdapter(notifyPoster));
     notifyAdapters.put("mattermost", new MattermostNotifyAdapter(notifyPoster));
     notifyAdapters.put("matrix", new MatrixNotifyAdapter(notifyPoster));
+    notifyAdapters.put("qq", new QqNotifyAdapter(notifyPoster));
     registry.register(new NotifyTools(notifyAdapters, sandbox, notifyChannelRegistry));
     // 记忆工具：save_memory / recall_memory（补齐 20 节预留的两工具面），只认门面对后端无感
     registry.registerAnnotated(new MemoryTools(memoryService));
@@ -1100,6 +1102,11 @@ public class OryxOsRuntime {
         io.oryxos.channel.matrix.MatrixChannelAdapter.TYPE,
         resolved ->
             new io.oryxos.channel.matrix.MatrixChannelAdapter(
+                resolved, profileRegistry, inboundMessageService, channelOutboundGuard));
+    factories.put(
+        io.oryxos.channel.qq.QqChannelAdapter.TYPE,
+        resolved ->
+            new io.oryxos.channel.qq.QqChannelAdapter(
                 resolved, profileRegistry, inboundMessageService, channelOutboundGuard));
     return new io.oryxos.core.channel.ChannelAdminService(
         channelConfigLoader, inboundChannelRegistry, profileRegistry, factories);

--- a/oryxos-tool/src/main/java/io/oryxos/tool/notify/QqNotifyAdapter.java
+++ b/oryxos-tool/src/main/java/io/oryxos/tool/notify/QqNotifyAdapter.java
@@ -1,0 +1,57 @@
+package io.oryxos.tool.notify;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * QQ 官方 Bot 出站（type: qq）。
+ *
+ * <p>{@code config.token}（access_token）+ {@code group_openid} 或 {@code user_openid}；若给了 {@code url}
+ * 则 POST 到该地址（联调用）。鉴权头 {@code Authorization: QQBot {token}}。
+ */
+public class QqNotifyAdapter implements NotifyChannelAdapter {
+
+  static final String API_BASE = "https://api.bot.qq.com";
+
+  private final NotifyPoster poster;
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "NotifyPoster is a Spring singleton shared by notify adapters; storing the reference is intentional.")
+  public QqNotifyAdapter(NotifyPoster poster) {
+    this.poster = poster;
+  }
+
+  @Override
+  public void send(NotifyTarget target, String content) {
+    String token = target.config().get("token");
+    String groupOpenid = target.config().get("group_openid");
+    String userOpenid = target.config().get("user_openid");
+    String url = target.config().get("url");
+    if (url == null || url.isBlank()) {
+      if (token == null || token.isBlank()) {
+        throw new IllegalArgumentException("qq 渠道缺少 url，或缺少 token + group_openid/user_openid");
+      }
+      if (hasText(groupOpenid)) {
+        url = API_BASE + "/v2/groups/" + groupOpenid.strip() + "/messages";
+      } else if (hasText(userOpenid)) {
+        url = API_BASE + "/v2/users/" + userOpenid.strip() + "/messages";
+      } else {
+        throw new IllegalArgumentException("qq 渠道缺少 url，或缺少 token + group_openid/user_openid");
+      }
+    }
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("msg_type", 0);
+    body.put("content", content);
+    Map<String, String> headers = new LinkedHashMap<>();
+    if (token != null && !token.isBlank()) {
+      headers.put("Authorization", "QQBot " + token.strip());
+    }
+    poster.postJson(url, body, headers);
+  }
+
+  private static boolean hasText(String value) {
+    return value != null && !value.isBlank();
+  }
+}

--- a/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
+++ b/oryxos-tool/src/test/java/io/oryxos/tool/notify/VendorNotifyAdapterTest.java
@@ -28,7 +28,8 @@ import org.springframework.web.client.RestClientResponseException;
  */
 class VendorNotifyAdapterTest {
 
-  private record ReceivedRequest(String method, String path, String query, String body) {}
+  private record ReceivedRequest(
+      String method, String path, String query, String body, String authorization) {}
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -62,7 +63,8 @@ class VendorNotifyAdapterTest {
             exchange.getRequestMethod(),
             exchange.getRequestURI().getRawPath(),
             exchange.getRequestURI().getQuery(),
-            body));
+            body,
+            exchange.getRequestHeaders().getFirst("Authorization")));
     byte[] payload = responseBody.getBytes(StandardCharsets.UTF_8);
     if (!responseBody.isEmpty()) {
       exchange.getResponseHeaders().add("Content-Type", "application/json; charset=utf-8");
@@ -475,5 +477,28 @@ class VendorNotifyAdapterTest {
     assertEquals("PUT", last.method());
     assertTrue(last.path().contains("%21r%3Ahs"));
     assertTrue(!last.path().contains("%2521"), "房间 ID 不得二次编码");
+  }
+
+  @Test
+  @DisplayName("QQ：缺配置点名拒绝")
+  void qqRejectsMissingTarget() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new QqNotifyAdapter(poster).send(new NotifyTarget("qq", Map.of()), "hi"));
+    assertEquals(0, received.size());
+  }
+
+  @Test
+  @DisplayName("QQ：url + token 体为 msg_type=0 + content")
+  void qqNotifyBody() throws IOException {
+    new QqNotifyAdapter(poster)
+        .send(
+            new NotifyTarget("qq", Map.of("url", url(), "token", "atok", "group_openid", "g1")),
+            "告警");
+    JsonNode body = lastBody();
+    assertEquals(0, body.get("msg_type").asInt());
+    assertEquals("告警", body.get("content").asText());
+    ReceivedRequest last = received.get(received.size() - 1);
+    assertEquals("QQBot atok", last.authorization());
   }
 }

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -1025,10 +1025,10 @@ async function loadNotifyChannels() {
 }
 
 // 新建/编辑表单：editing 存被编辑渠道的 name（此时 name 只读），null 表示新建
-const nc = reactive({ open: false, editing: null, name: '', type: 'feishu', url: '', description: '', host: '', port: '', from: '', to: '', username: '', password: '', subject: '', encryption: '', token: '', chatId: '', channelId: '', phoneNumberId: '', homeserver: '', roomId: '', busy: false, error: null })
+const nc = reactive({ open: false, editing: null, name: '', type: 'feishu', url: '', description: '', host: '', port: '', from: '', to: '', username: '', password: '', subject: '', encryption: '', token: '', chatId: '', channelId: '', phoneNumberId: '', homeserver: '', roomId: '', groupOpenid: '', userOpenid: '', busy: false, error: null })
 
 function notifyNeedsUrl(type) {
-  return !['email', 'telegram', 'slack', 'discord', 'whatsapp', 'matrix'].includes(type)
+  return !['email', 'telegram', 'slack', 'discord', 'whatsapp', 'matrix', 'qq'].includes(type)
 }
 
 function buildNotifyConfig() {
@@ -1045,6 +1045,10 @@ function buildNotifyConfig() {
     if (nc.homeserver) config.homeserver = nc.homeserver
     if (nc.roomId) config.room_id = nc.roomId
   }
+  if (nc.type === 'qq') {
+    if (nc.groupOpenid) config.group_openid = nc.groupOpenid
+    if (nc.userOpenid) config.user_openid = nc.userOpenid
+  }
   return Object.keys(config).length ? config : undefined
 }
 
@@ -1056,6 +1060,7 @@ function notifyFormReady() {
   if (nc.type === 'slack' || nc.type === 'discord') return !!(nc.token && nc.channelId)
   if (nc.type === 'whatsapp') return !!(nc.token && nc.phoneNumberId && nc.to)
   if (nc.type === 'matrix') return !!(nc.homeserver && nc.token && nc.roomId)
+  if (nc.type === 'qq') return !!(nc.token && (nc.groupOpenid || nc.userOpenid))
   return false
 }
 
@@ -1091,6 +1096,7 @@ function editNotifyChannel(row) {
   nc.username = c.username || ''; nc.password = c.password || ''; nc.subject = c.subject || ''; nc.encryption = c.encryption || ''
   nc.token = c.token || ''; nc.chatId = c.chat_id || ''; nc.channelId = c.channel_id || ''
   nc.phoneNumberId = c.phone_number_id || ''; nc.homeserver = c.homeserver || ''; nc.roomId = c.room_id || ''
+  nc.groupOpenid = c.group_openid || ''; nc.userOpenid = c.user_openid || ''
   nc.error = null
   nc.open = true
 }
@@ -1107,6 +1113,7 @@ function cancelNc() {
   nc.open = false; nc.editing = null; nc.name = ''; nc.type = 'feishu'; nc.url = ''; nc.description = ''
   nc.host = ''; nc.port = ''; nc.from = ''; nc.to = ''; nc.username = ''; nc.password = ''; nc.subject = ''; nc.encryption = ''
   nc.token = ''; nc.chatId = ''; nc.channelId = ''; nc.phoneNumberId = ''; nc.homeserver = ''; nc.roomId = ''
+  nc.groupOpenid = ''; nc.userOpenid = ''
   nc.error = null
 }
 
@@ -3298,6 +3305,7 @@ const outputRows = computed(() =>
                     <option value="gchat">gchat</option>
                     <option value="mattermost">mattermost</option>
                     <option value="matrix">matrix</option>
+                    <option value="qq">qq</option>
                   </select>
                   <input v-if="nc.type !== 'email'" v-model="nc.url" class="gen-input" :placeholder="notifyNeedsUrl(nc.type) ? 'Webhook URL' : 'Webhook URL（可选；也可用下方 token 字段）'" />
                   <template v-if="nc.type === 'telegram'">
@@ -3317,6 +3325,11 @@ const outputRows = computed(() =>
                     <input v-model="nc.homeserver" class="gen-input" placeholder="homeserver（https://matrix.example）" />
                     <input v-model="nc.token" class="gen-input" placeholder="access token" />
                     <input v-model="nc.roomId" class="gen-input" placeholder="room_id" />
+                  </template>
+                  <template v-if="nc.type === 'qq'">
+                    <input v-model="nc.token" class="gen-input" placeholder="access_token（建议环境变量占位）" />
+                    <input v-model="nc.groupOpenid" class="gen-input" placeholder="group_openid（群；与 user_openid 二选一）" />
+                    <input v-model="nc.userOpenid" class="gen-input" placeholder="user_openid（单聊；与 group_openid 二选一）" />
                   </template>
                   <template v-if="nc.type === 'email'">
                     <input v-model="nc.host" class="gen-input" placeholder="SMTP host（如 smtp.example.com）" />

--- a/oryxos-web/src/main/java/io/oryxos/web/controller/NotifyChannelApiController.java
+++ b/oryxos-web/src/main/java/io/oryxos/web/controller/NotifyChannelApiController.java
@@ -42,6 +42,7 @@ public class NotifyChannelApiController {
   private static final String TYPE_TELEGRAM = "telegram";
   private static final String TYPE_WHATSAPP = "whatsapp";
   private static final String TYPE_MATRIX = "matrix";
+  private static final String TYPE_QQ = "qq";
   private static final String CFG_URL = "url";
   private static final String CFG_TOKEN = "token";
   private static final String CFG_CHANNEL_ID = "channel_id";
@@ -50,6 +51,8 @@ public class NotifyChannelApiController {
   private static final String CFG_TO = "to";
   private static final String CFG_HOMESERVER = "homeserver";
   private static final String CFG_ROOM_ID = "room_id";
+  private static final String CFG_GROUP_OPENID = "group_openid";
+  private static final String CFG_USER_OPENID = "user_openid";
 
   /** email 渠道 port 的合法上限（TCP 端口最大值）。 */
   private static final int MAX_PORT = 65535;
@@ -68,7 +71,8 @@ public class NotifyChannelApiController {
           "teams",
           "gchat",
           "mattermost",
-          TYPE_MATRIX);
+          TYPE_MATRIX,
+          TYPE_QQ);
 
   private final NotifyChannelRegistry registry;
 
@@ -182,7 +186,21 @@ public class NotifyChannelApiController {
       requireConfigKeys(config, type, CFG_HOMESERVER, CFG_TOKEN, CFG_ROOM_ID);
       return;
     }
+    if (TYPE_QQ.equals(type)) {
+      validateQq(config);
+      return;
+    }
     throw new IllegalArgumentException("渠道 url 为空");
+  }
+
+  private static void validateQq(Map<String, String> config) {
+    if (!hasConfig(config, CFG_TOKEN)) {
+      throw new IllegalArgumentException("qq 渠道缺少 url，或缺少 token + group_openid/user_openid");
+    }
+    if (hasConfig(config, CFG_GROUP_OPENID) || hasConfig(config, CFG_USER_OPENID)) {
+      return;
+    }
+    throw new IllegalArgumentException("qq 渠道缺少 url，或缺少 token + group_openid/user_openid");
   }
 
   private static void requireConfigPair(

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
         <module>oryxos-channel-gchat</module>
         <module>oryxos-channel-mattermost</module>
         <module>oryxos-channel-matrix</module>
+        <module>oryxos-channel-qq</module>
         <module>oryxos-web</module>
         <module>oryxos-storage</module>
         <module>oryxos-cli</module>
@@ -187,6 +188,11 @@
             <dependency>
                 <groupId>io.oryxos</groupId>
                 <artifactId>oryxos-channel-matrix</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.oryxos</groupId>
+                <artifactId>oryxos-channel-qq</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/specs/026-im-channel-roadmap/acceptance.md
+++ b/specs/026-im-channel-roadmap/acceptance.md
@@ -52,4 +52,4 @@
 
 - **继续**：国内飞书/企微/钉钉；已合入的 Slack/Discord/Telegram；Mattermost/Matrix 本机环境。  
 - **暂停**：WhatsApp / Teams / Google Chat 真平台，待 WhatsApp 回调与号路由问题解决后恢复。  
-- **国内后续**：QQ 不在 026 交付波次内；是否单开国内 PLAN 见 `plan.md`「国内后续候选」。
+- **国内后续**：QQ 见 [029](../029-qq-im-channel/plan.md)，不在 026 海外真机队列内交付。

--- a/specs/026-im-channel-roadmap/plan.md
+++ b/specs/026-im-channel-roadmap/plan.md
@@ -66,7 +66,7 @@ OryxOS 入站已有飞书 / 企微 / 钉钉 / Slack / Discord（+ CLI）。出�
 
 | 渠道 | 说明 | 建议 |
 |------|------|------|
-| QQ（开放平台 / 频道机器人等） | 026 主清单未排入；与飞书/企微/钉钉并列的国内 C 端触达面。个人 QQ 协议号不合规，口径同「微信个人号」 | **另开国内 PLAN** 再评估：官方 Bot 面是否够用、Webhook vs 长连接、是否值得新 `oryxos-channel-qq`；**本 PLAN 不实现** |
+| QQ（开放平台官方 Bot） | 026 主清单未排入；国内 C 端/社群触达。个人 QQ 协议号不合规，口径同「微信个人号」 | **已另开 [029](../029-qq-im-channel/plan.md)**：官方 Bot API v2 + Gateway；群 `@Bot` + 单聊 MVP；频道二期。**本 PLAN 不实现、勿双开** |
 
 ## 场景对照（刚需怎么覆盖）
 
@@ -77,7 +77,7 @@ OryxOS 入站已有飞书 / 企微 / 钉钉 / Slack / Discord（+ CLI）。出�
 出海对客 C 端 ──── WhatsApp + Telegram         TG✅；WA 真平台⏸
 私有化 / 不出域 ── Mattermost + Matrix         ✅（本机；#432）
 主动推送 ───────── 各渠道 notify + 已有 email  P0 + 各波次适配器
-国内后续候选 ───── QQ（官方 Bot 面）            ⬜ 见 §D，另开 PLAN
+国内后续候选 ───── QQ（官方 Bot 面）            → [029](../029-qq-im-channel/plan.md)
 ```
 
 同一 Agent 可绑多条 `channels.yaml` 条目（一应用一 Agent）。出海项目典型绑法：
@@ -183,7 +183,7 @@ website/zh/docs/tool.md / profile.md   # 渠道表同步
 - [x] B6 Matrix 入站 + notify + Setup（本机 Synapse + Element；#432）  
 - [ ] 网站文档渠道表与 `channels.yaml.example` 与上表一致  
 - [ ] 不把「未过 Meta/Azure 审核的演示」写成生产就绪  
-- [ ] （非 026）国内 QQ 候选 → 另开 PLAN 评估后再排期  
+- [x] （非 026）国内 QQ → [029](../029-qq-im-channel/plan.md)（另分支落地，不塞进 026 海外真机队列）
 
 ## 建议开工顺序（刚需仍要排队）
 
@@ -191,6 +191,6 @@ website/zh/docs/tool.md / profile.md   # 渠道表同步
 2. ~~**Telegram**~~（已合入 + 真机）。  
 3. **WhatsApp** 真平台恢复后，再 Teams / Google Chat（当前暂停）。  
 4. ~~Mattermost → Matrix~~（本机真机 + #432）。  
-5. 若要补国内 C 端触达：按 §D **另开 QQ PLAN**，勿塞进 026 未完成的海外真机项。
+5. 国内 C 端 QQ：走 **029**，勿塞进 026 未完成的海外真机项。
 
 下一步若恢复海外真机：先解决 Meta Developers 登录与**固定**公网 Callback（避免 quick tunnel 每次换域）；Teams/GChat 补本机 `${ENV}` 后再测。

--- a/specs/026-im-channel-roadmap/research.md
+++ b/specs/026-im-channel-roadmap/research.md
@@ -14,12 +14,8 @@
 
 **决定**：MVP 拆 Bot Framework Activity 并经 `serviceUrl` 回复；边缘 JWT 校验由 Azure Bot Service / 反代承担，不在 core 引入 OpenID 依赖。
 
-## 国内 QQ（026 外候选）
+## 国内 QQ（026 外 → 029）
 
-**现状**：026 主清单未排 QQ；§C 只排除「微信个人号」类无合规协议，未点名 QQ。
+**现状**：已另开 [029](../029-qq-im-channel/plan.md) / [research](../029-qq-im-channel/research.md)。
 
-**倾向（待另开 PLAN 确认）**：
-
-- 只评估 **QQ 开放平台官方机器人面**（如 QQ 频道 / 开放平台文档所载 Bot），不接个人号协议挂机。  
-- 入站形态优先对齐已有 Webhook 接收面或官方长连接（以开放平台当期文档为准）。  
-- 与飞书/企微/钉钉重叠度：国内 B 端已三家；QQ 更偏 C 端/社群，是否刚需由国内 PLAN 的场景表决定，**不塞进 026 海外真机恢复队列**。
+**口径**：只做开放平台官方 Bot（Gateway + `api.bot.qq.com`）；不接个人号；群 `@Bot` + 单聊 MVP；频道二期。**不塞进 026 海外真机恢复队列**。

--- a/specs/029-qq-im-channel/acceptance.md
+++ b/specs/029-qq-im-channel/acceptance.md
@@ -1,0 +1,29 @@
+# 029 验收
+
+**日期**: 2026-09-10  
+**范围**: QQ 官方 Bot 入站 + notify 代码与单测；真机视本机是否有 `QQ_APP_*`。
+
+## 单测
+
+| 项 | 结果 |
+|----|------|
+| `QqEventNormalizer` | 通过（群 @ / C2C / 非 MVP 丢弃 / 空内容） |
+| `QqChannelContractTest` | 通过（`InboundMessageService` 契约档） |
+| `QqNotifyAdapter`（VendorNotify） | 通过（`msg_type=0` + `Authorization: QQBot`；缺配置拒绝） |
+| 模块 `verify`（qq/tool/web/cli） | 通过（含 spotless / checkstyle / spotbugs） |
+
+## 真机
+
+本机 `.env` **无** `QQ_APP_ID` / `QQ_APP_SECRET` → **不宣称 COMPLETE**。清单：
+
+1. 沙箱/测试群：`@Bot` 文本 → Agent 被动回帖（带 `msg_id`）
+2. 单聊文本往返
+3. `notify` 打进指定 `group_openid`（主动消息限额见官方）
+4. 重复 `msg_id` 去重；官方群事件仅推 @Bot
+5. 不宣称：个人号、频道 MVP、富媒体完整对齐
+
+## 非宣称
+
+- NapCat / 个人号协议  
+- QQ 频道子频道消息  
+- 流式 / 图文件完整出站对齐

--- a/specs/029-qq-im-channel/plan.md
+++ b/specs/029-qq-im-channel/plan.md
@@ -1,0 +1,51 @@
+# Implementation Plan: 029 QQ 官方机器人入站 / notify
+
+**Branch**: `feat/029-qq-channel`  
+**Date**: 2026-09-10  
+**Status**: IMPLEMENTED（单测绿；真机待 `QQ_APP_*`）  
+**对照**: [017 入站契约](../017-feishu-im-channel/contracts/inbound-channel-contract.md)、[026 §D](../026-im-channel-roadmap/plan.md)、[004 Notify](../004-notify-outbound/plan.md)
+
+## Summary
+
+接入 [QQ 开放平台官方 Bot API v2](https://bot.q.qq.com/wiki/)：Gateway WebSocket 收事件 + HTTP 发信。新建 `oryxos-channel-qq`，工厂注册 `type: qq`；Notify `QqNotifyAdapter`。
+
+## 决策
+
+| 项 | 决定 |
+|----|------|
+| 协议 | **只做**官方 Bot（`api.bot.qq.com`）；**不做** NapCat / go-cqhttp / 个人号 |
+| MVP 入站 | 群 `GROUP_AT_MESSAGE_CREATE`（事件即 @Bot）+ 单聊 `C2C_MESSAGE_CREATE` |
+| 二期 | QQ 频道 / 子频道——同模块扩展，不另起栈 |
+| 连接 | Gateway 长连接（对齐 Discord）；发信 `Authorization: QQBot {access_token}` |
+| 凭证 | `app_id`=`QQ_APP_ID`，`app_secret`=`QQ_APP_SECRET`；`getAppAccessToken` 换票，不落盘长期 token |
+| Intent | `GROUP_AND_C2C_EVENT`（`1 << 25`） |
+| 群回复 | 被动带 `msg_id`（约 5 分钟窗）；过期可降级无 `msg_id` 主动发（限额见官方） |
+
+## 落点
+
+| 项 | 路径 |
+|----|------|
+| 模块 | `oryxos-channel-qq`：`QqAccessTokenClient` / `QqGatewayClient` / `QqChannelAdapter` / `QqEventNormalizer` / `QqMessageSender` |
+| 注册 | `OryxOsRuntime` `factories.put("qq", …)` + notifyAdapters |
+| POM | 根 modules + DM；cli / boot 依赖 |
+| Notify | `QqNotifyAdapter`；`NotifyChannelApiController.SUPPORTED_TYPES` |
+| 配置 | `channels.yaml.example`；`http.allowed_domains`：`api.bot.qq.com` |
+| 文档 | `docs/QqChannelSetup.md` |
+| 测试 | Normalizer + `InboundMessageService` 契约档 |
+
+## 配置形状
+
+```yaml
+- name: ops-qq
+  type: qq
+  app_id: ${QQ_APP_ID}
+  app_secret: ${QQ_APP_SECRET}
+  agent: demo-agent
+  enabled: true
+```
+
+Notify：`type: qq`，`token`（access_token）+ `group_openid` 或 `user_openid`；联调可给 `url` 打假 HTTP。
+
+## 非目标（MVP）
+
+个人号、频道消息、流式富媒体完整对齐、Webhook 回调模式（本期只用 Gateway）。

--- a/specs/029-qq-im-channel/research.md
+++ b/specs/029-qq-im-channel/research.md
@@ -1,0 +1,37 @@
+# Research: 029 QQ 官方机器人
+
+## 协议面
+
+**决定**：仅 QQ 开放平台官方 Bot API v2（`https://api.bot.qq.com` + Gateway WSS）。
+
+**原因**：与 026「微信个人号不合规」同口径；NapCat / go-cqhttp 属协议号风险，产品线不接。
+
+## 入站形态
+
+**决定**：Gateway WebSocket（Hello → Identify → Heartbeat → Dispatch），不对齐本期 Webhook 回调。
+
+**原因**：对称 Discord/企微长连接；免公网回调 URL，便于本机联调。Webhook（op13 验签）留二期可选。
+
+## Intent
+
+**决定**：只订 `GROUP_AND_C2C_EVENT`（`1 << 25`）。
+
+**原因**：MVP 只要群 `@Bot`（`GROUP_AT_MESSAGE_CREATE`）与单聊（`C2C_MESSAGE_CREATE`）。频道 `PUBLIC_GUILD_MESSAGES` / `AT_MESSAGE_CREATE` 二期再开。
+
+## 鉴权
+
+**决定**：`POST /app/getAppAccessToken`（body: `appId` + `clientSecret`）→ `Authorization: QQBot {access_token}`；Identify 的 `token` 同格式。废弃旧 `Bot {appid}.{token}`。
+
+**原因**：官方文档已弃用 Bot Token；access_token 约 7200s，客户端在过期前刷新即可，不落盘。
+
+## chatId 编码
+
+**决定**：归一化后 `chatId` 为 `group:{group_openid}` 或 `user:{user_openid}`。
+
+**原因**：`sendReply` 接口无 `ChatKind`；群与单聊 REST 路径不同（`/v2/groups/...` vs `/v2/users/...`），必须在 chatId 可解析。
+
+## 去重与被动窗
+
+**决定**：以事件 `d.id` 作 `messageId`（去重键 + 群被动 `msg_id`）；平台可能重推同一 id，依赖 `InboundMessageService` 去重。
+
+**原因**：官方：被动回复带 `msg_id`，约 5 分钟；相同 `msg_id+msg_seq` 不可重复发。Sender 对同一 `msg_id` 递增 `msg_seq`；过期错误时降级去掉 `msg_id` 再试一次。


### PR DESCRIPTION
## Summary
- Add `oryxos-channel-qq`: access_token refresh, Gateway WS (group `@Bot` + C2C), REST reply with passive `msg_id`
- Wire factory/notify (`type: qq`), admin UI, `channels.yaml.example`, `api.bot.qq.com` allowlist, specs 029 + 026 §D link
- Unit/contract tests green; no live COMPLETE without local `QQ_APP_*`

## Test plan
- [x] `QqEventNormalizerTest` / `QqChannelContractTest` / `VendorNotifyAdapterTest` QQ cases
- [x] `mvn -pl oryxos-channel-qq,oryxos-tool,oryxos-web,oryxos-cli -am verify` (spotless/checkstyle/spotbugs)
- [ ] Live: sandbox group `@Bot` + C2C + notify when AppID/Secret available

Made with [Cursor](https://cursor.com)