### PR TITLE
feat(channel-qq): inbound image/PDF/voice/video media

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -109,6 +109,10 @@ http:
     - "*.discordapp.com"        # Discord CDN 子域
     - "*.discordapp.net"        # Discord 媒体子域
     - api.bot.qq.com            # QQ 官方 Bot OpenAPI + Gateway
+    - multimedia.nt.qq.com.cn   # QQ 入站附件 CDN
+    - "*.qq.com.cn"             # QQ 媒体子域
+    - "*.myqcloud.com"          # 腾讯云 COS 临时链（附件下载）
+    - "*.ugcimg.cn"             # QQ 语音 WAV（voice_wav_url，如 qqbot.ugcimg.cn）
     - api.open-meteo.com        # 天气 Agent 免 key 天气源（31 节 Demo 一）
     - hn.algolia.com            # 科技日报 Agent 新闻源（31 节 Demo 二）
     - api.github.com            # GitHub 日报脚本子进程网络（31 节 Demo 三）

--- a/docs/QqChannelSetup.md
+++ b/docs/QqChannelSetup.md
@@ -42,11 +42,14 @@ channels:
 | 场景 | 行为 |
 |------|------|
 | 群 `@Bot` 文本 | 进编排；回复带被动 `msg_id`（约 5 分钟窗） |
-| 单聊文本 | 进编排；无私聊 @ 要求；回复走 `/v2/users/{openid}/messages` |
+| 单聊文本 | 进编排；无私聊 @ 要求 |
+| 单聊/群 图片、PDF、语音、视频 | `attachments[].url` 鉴权下载落盘；语音优先 `voice_wav_url`（可选 `asr_refer_text`）；视频 `video/mp4` → Vision / ASR / `read_file` |
 | 重复 `msg_id` | 去重，只答一次 |
 | 频道消息 | MVP 不处理 |
 
 内部 `chatId` 形如 `group:{group_openid}` / `user:{user_openid}`（发信路径编码，对用户不可见）。
+
+`http.allowed_domains` 另需 `multimedia.nt.qq.com.cn`、`*.qq.com.cn`、`*.myqcloud.com`、`*.ugcimg.cn`（入站附件 / 语音 WAV CDN）。
 
 ## 四、Notify
 

--- a/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqChannelAdapter.java
+++ b/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqChannelAdapter.java
@@ -3,13 +3,17 @@ package io.oryxos.channel.qq;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.oryxos.core.channel.ChannelConfig;
 import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.ChatKind;
 import io.oryxos.core.channel.InboundChannelAdapter;
+import io.oryxos.core.channel.InboundMediaRoots;
 import io.oryxos.core.channel.InboundMessage;
 import io.oryxos.core.channel.InboundMessageService;
 import io.oryxos.core.channel.OutboundGuard;
 import io.oryxos.core.profile.ProfileRegistry;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -21,11 +25,12 @@ import org.slf4j.LoggerFactory;
 /**
  * QQ 官方机器人入站：一实例 = 一条 Gateway 长连接。
  *
- * <p>凭证：{@code app_id}=AppID，{@code app_secret}=AppSecret（换 access_token）。
+ * <p>凭证：{@code app_id}=AppID，{@code app_secret}=AppSecret（换 access_token）。入站图/文件落盘对齐飞书/Discord。
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
-    justification = "gateway/normalizer/sender/tokens 在 start() 内初始化；sendReply 有显式空判。")
+    justification =
+        "gateway/normalizer/sender/tokens/mediaResolver 在 start() 内初始化；sendReply 有显式空判。")
 public class QqChannelAdapter implements InboundChannelAdapter {
 
   private static final Logger LOG = LoggerFactory.getLogger(QqChannelAdapter.class);
@@ -36,6 +41,7 @@ public class QqChannelAdapter implements InboundChannelAdapter {
   private static final long RECONNECT_BASE_MS = 2_000L;
   private static final long RECONNECT_MAX_MS = 60_000L;
   private static final int RECONNECT_MAX_SHIFT = 5;
+  private static final String MEDIA_DIR_PREFIX = "oryxos-qq-media-";
 
   private final ChannelConfig config;
   private final ProfileRegistry profileRegistry;
@@ -46,6 +52,7 @@ public class QqChannelAdapter implements InboundChannelAdapter {
   private volatile QqAccessTokenClient tokens;
   private volatile QqMessageSender sender;
   private volatile QqEventNormalizer normalizer;
+  private volatile QqInboundMediaResolver mediaResolver;
   private volatile QqDisconnectKind lastDisconnectKind = QqDisconnectKind.ABRUPT;
   private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
   private volatile String lastError;
@@ -121,6 +128,7 @@ public class QqChannelAdapter implements InboundChannelAdapter {
     }
     sender = null;
     normalizer = null;
+    mediaResolver = null;
     tokens = null;
     state = ChannelStatus.State.DISCONNECTED;
   }
@@ -173,6 +181,14 @@ public class QqChannelAdapter implements InboundChannelAdapter {
     }
     if (sender == null) {
       sender = new QqMessageSender(guard, tokens);
+    }
+    if (mediaResolver == null) {
+      QqAccessTokenClient tokenClient = tokens;
+      mediaResolver =
+          new QqInboundMediaResolver(
+              tokenClient::authorizationHeader,
+              InboundMediaRoots.forChannel(config.name(), MEDIA_DIR_PREFIX),
+              config.name());
     }
   }
 
@@ -285,10 +301,80 @@ public class QqChannelAdapter implements InboundChannelAdapter {
 
   private void handleDispatch(String eventName, JsonNode data) {
     try {
+      if (QqEventNormalizer.EVENT_C2C.equals(eventName)
+          || QqEventNormalizer.EVENT_GROUP_AT.equals(eventName)) {
+        LOG.info(
+            "QQ 渠道 {} 收到 {}（{}）",
+            sanitize(config.name()),
+            sanitize(eventName),
+            summarizeAttachments(data));
+      }
       Optional<InboundMessage> msg = normalizer.normalize(eventName, data);
-      msg.ifPresent(m -> inboundMessageService.onMessage(m, this));
+      msg.ifPresent(this::dispatchClaimed);
     } catch (RuntimeException e) {
       LOG.error("QQ 渠道 {} 事件处理异常: {}", sanitize(config.name()), sanitize(e.getMessage()));
+    }
+  }
+
+  /** 仅摘要 content_type / 是否有 url·wav，不落完整 URL。 */
+  static String summarizeAttachments(JsonNode data) {
+    if (data == null || !data.isObject()) {
+      return "attachments=0";
+    }
+    JsonNode arr = data.path("attachments");
+    if (!arr.isArray() || arr.isEmpty()) {
+      return "attachments=0";
+    }
+    StringBuilder sb = new StringBuilder("attachments=").append(arr.size()).append('[');
+    for (int i = 0; i < arr.size(); i++) {
+      if (i > 0) {
+        sb.append(',');
+      }
+      JsonNode a = arr.get(i);
+      String ct = a.path("content_type").asText("?");
+      String fn = a.path("filename").asText("");
+      boolean hasUrl = a.hasNonNull("url") && !a.path("url").asText("").isBlank();
+      boolean hasWav =
+          a.hasNonNull("voice_wav_url") && !a.path("voice_wav_url").asText("").isBlank();
+      sb.append(sanitize(ct));
+      if (!fn.isBlank()) {
+        int dot = fn.lastIndexOf('.');
+        if (dot >= 0 && dot < fn.length() - 1) {
+          sb.append(sanitize(fn.substring(dot).toLowerCase(Locale.ROOT)));
+        }
+      }
+      sb.append(hasUrl ? "+url" : "-url");
+      if (hasWav) {
+        sb.append("+wav");
+      }
+    }
+    sb.append(']');
+    return sb.toString();
+  }
+
+  private void dispatchClaimed(InboundMessage m) {
+    if (!inboundMessageService.tryClaim(m.channelName(), m.messageId())) {
+      LOG.info("渠道 {} 重复事件已忽略: {}", sanitize(m.channelName()), sanitize(m.messageId()));
+      return;
+    }
+    String replyTo = m.chatKind() == ChatKind.GROUP ? m.messageId() : null;
+    CountDownLatch slowWork = null;
+    if (QqInboundMediaResolver.hasDownloadableMedia(m)) {
+      slowWork = inboundMessageService.beginSlowWork(this, m.chatId(), replyTo);
+    }
+    try {
+      QqInboundMediaResolver resolver = mediaResolver;
+      InboundMessage enriched = resolver == null ? m : resolver.resolve(m);
+      if (slowWork != null) {
+        inboundMessageService.onClaimedMessage(enriched, this, slowWork);
+      } else {
+        inboundMessageService.onClaimedMessage(enriched, this);
+      }
+    } catch (RuntimeException e) {
+      if (slowWork != null) {
+        slowWork.countDown();
+      }
+      throw e;
     }
   }
 

--- a/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqChannelAdapter.java
+++ b/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqChannelAdapter.java
@@ -11,7 +11,6 @@ import io.oryxos.core.channel.InboundMessageService;
 import io.oryxos.core.channel.OutboundGuard;
 import io.oryxos.core.profile.ProfileRegistry;
 import java.time.Duration;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
@@ -340,7 +339,7 @@ public class QqChannelAdapter implements InboundChannelAdapter {
       if (!fn.isBlank()) {
         int dot = fn.lastIndexOf('.');
         if (dot >= 0 && dot < fn.length() - 1) {
-          sb.append(sanitize(fn.substring(dot).toLowerCase(Locale.ROOT)));
+          sb.append(sanitize(asciiLower(fn.substring(dot))));
         }
       }
       sb.append(hasUrl ? "+url" : "-url");
@@ -380,5 +379,16 @@ public class QqChannelAdapter implements InboundChannelAdapter {
 
   private static String sanitize(String value) {
     return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+
+  private static String asciiLower(String value) {
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
   }
 }

--- a/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqEventNormalizer.java
+++ b/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqEventNormalizer.java
@@ -2,15 +2,19 @@ package io.oryxos.channel.qq;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
 /**
  * QQ Gateway Dispatch → {@link InboundMessage}。
  *
- * <p>MVP：{@code GROUP_AT_MESSAGE_CREATE}（事件即 @Bot）+ {@code C2C_MESSAGE_CREATE}。频道事件丢弃。
+ * <p>事件：{@code GROUP_AT_MESSAGE_CREATE}、{@code C2C_MESSAGE_CREATE}。附件见 {@code attachments[]}（url +
+ * content_type）；语音优先 {@code voice_wav_url}，可选 {@code asr_refer_text}。
  */
 public class QqEventNormalizer {
 
@@ -25,6 +29,21 @@ public class QqEventNormalizer {
   private static final String FIELD_GROUP_OPENID = "group_openid";
   private static final String FIELD_MEMBER_OPENID = "member_openid";
   private static final String FIELD_USER_OPENID = "user_openid";
+  private static final String FIELD_ATTACHMENTS = "attachments";
+  private static final String FIELD_URL = "url";
+  private static final String FIELD_FILENAME = "filename";
+  private static final String FIELD_CONTENT_TYPE = "content_type";
+  private static final String FIELD_VOICE_WAV_URL = "voice_wav_url";
+  private static final String FIELD_ASR_REFER_TEXT = "asr_refer_text";
+  private static final String MIME_IMAGE_PREFIX = "image/";
+  private static final String MIME_AUDIO = "voice";
+  private static final String MIME_AUDIO_PREFIX = "audio/";
+  private static final String MIME_VIDEO_PREFIX = "video/";
+  private static final String MIME_PDF = "application/pdf";
+  private static final String EXT_PDF = ".pdf";
+  private static final String EXT_MP4 = ".mp4";
+  private static final String EXT_MOV = ".mov";
+  private static final String DEFAULT_VOICE_WAV_NAME = "voice.wav";
 
   private final String channelName;
 
@@ -53,8 +72,9 @@ public class QqEventNormalizer {
     if (messageId == null || groupOpenid == null || userId == null) {
       return Optional.empty();
     }
-    String content = stripMentions(data.path(FIELD_CONTENT).asText("")).strip();
-    if (content.isBlank()) {
+    AttachmentExtract extracted = extractAttachments(data.path(FIELD_ATTACHMENTS));
+    String content = resolveContent(data.path(FIELD_CONTENT).asText(""), extracted.asrReferText());
+    if (content.isBlank() && extracted.attachments().isEmpty()) {
       return Optional.empty();
     }
     return Optional.of(
@@ -66,9 +86,9 @@ public class QqEventNormalizer {
             userId,
             QqChatTargets.group(groupOpenid),
             content,
+            !content.isBlank(),
             true,
-            true,
-            List.of()));
+            extracted.attachments()));
   }
 
   private Optional<InboundMessage> normalizeC2c(JsonNode data) {
@@ -78,8 +98,9 @@ public class QqEventNormalizer {
     if (messageId == null || userId == null) {
       return Optional.empty();
     }
-    String content = stripMentions(data.path(FIELD_CONTENT).asText("")).strip();
-    if (content.isBlank()) {
+    AttachmentExtract extracted = extractAttachments(data.path(FIELD_ATTACHMENTS));
+    String content = resolveContent(data.path(FIELD_CONTENT).asText(""), extracted.asrReferText());
+    if (content.isBlank() && extracted.attachments().isEmpty()) {
       return Optional.of(
           new InboundMessage(
               CHANNEL_TYPE,
@@ -102,9 +123,84 @@ public class QqEventNormalizer {
             userId,
             QqChatTargets.user(userId),
             content,
-            true,
+            !content.isBlank(),
             false,
-            List.of()));
+            extracted.attachments()));
+  }
+
+  private static String resolveContent(String rawContent, String asrReferText) {
+    String content = stripMentions(rawContent == null ? "" : rawContent).strip();
+    if (!content.isBlank()) {
+      return content;
+    }
+    if (asrReferText == null || asrReferText.isBlank()) {
+      return "";
+    }
+    return asrReferText.strip();
+  }
+
+  /** 附件列表 + 语音平台 ASR 参考文（可拼入正文）。 */
+  record AttachmentExtract(List<InboundAttachment> attachments, String asrReferText) {}
+
+  static AttachmentExtract extractAttachments(JsonNode attachments) {
+    List<InboundAttachment> out = new ArrayList<>();
+    StringBuilder asr = new StringBuilder();
+    if (attachments == null || !attachments.isArray()) {
+      return new AttachmentExtract(out, null);
+    }
+    for (JsonNode file : attachments) {
+      if (file == null || !file.isObject()) {
+        continue;
+      }
+      String fileName = text(file, FIELD_FILENAME);
+      String contentType = text(file, FIELD_CONTENT_TYPE);
+      String mime = contentType == null ? "" : contentType.toLowerCase(Locale.ROOT);
+      boolean voice = MIME_AUDIO.equals(mime) || mime.startsWith(MIME_AUDIO_PREFIX);
+      String voiceWav = text(file, FIELD_VOICE_WAV_URL);
+      String url = text(file, FIELD_URL);
+      // 官方文档：语音优先 WAV（SILK/AMR 原链 ffmpeg 常无法解码）
+      if (voice && voiceWav != null) {
+        url = voiceWav;
+        if (fileName == null || !endsWithIgnoreCase(fileName, ".wav")) {
+          fileName = DEFAULT_VOICE_WAV_NAME;
+        }
+      }
+      if (url == null) {
+        continue;
+      }
+      String refer = text(file, FIELD_ASR_REFER_TEXT);
+      if (refer != null) {
+        if (asr.length() > 0) {
+          asr.append(' ');
+        }
+        asr.append(refer.strip());
+      }
+      if (mime.startsWith(MIME_IMAGE_PREFIX) || hasImageDimensions(file)) {
+        out.add(new InboundAttachment(InboundAttachment.TYPE_IMAGE, url, null, fileName));
+      } else if (voice) {
+        out.add(new InboundAttachment(InboundAttachment.TYPE_AUDIO, url, null, fileName));
+      } else if (mime.startsWith(MIME_VIDEO_PREFIX)
+          || endsWithIgnoreCase(fileName, EXT_MP4)
+          || endsWithIgnoreCase(fileName, EXT_MOV)) {
+        out.add(new InboundAttachment(InboundAttachment.TYPE_VIDEO, url, null, fileName));
+      } else if (MIME_PDF.equals(mime) || endsWithIgnoreCase(fileName, EXT_PDF)) {
+        out.add(InboundAttachment.fileUrl(url, fileName == null ? "document.pdf" : fileName));
+      } else {
+        out.add(InboundAttachment.fileUrl(url, fileName));
+      }
+    }
+    return new AttachmentExtract(out, asr.length() == 0 ? null : asr.toString());
+  }
+
+  private static boolean hasImageDimensions(JsonNode file) {
+    return file.has("width") && file.has("height") && file.path("width").asInt(0) > 0;
+  }
+
+  private static boolean endsWithIgnoreCase(String name, String suffix) {
+    if (name == null || suffix == null) {
+      return false;
+    }
+    return name.toLowerCase(Locale.ROOT).endsWith(suffix);
   }
 
   static String stripMentions(String content) {

--- a/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqEventNormalizer.java
+++ b/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqEventNormalizer.java
@@ -6,7 +6,6 @@ import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -154,7 +153,7 @@ public class QqEventNormalizer {
       }
       String fileName = text(file, FIELD_FILENAME);
       String contentType = text(file, FIELD_CONTENT_TYPE);
-      String mime = contentType == null ? "" : contentType.toLowerCase(Locale.ROOT);
+      String mime = contentType == null ? "" : asciiLower(contentType);
       boolean voice = MIME_AUDIO.equals(mime) || mime.startsWith(MIME_AUDIO_PREFIX);
       String voiceWav = text(file, FIELD_VOICE_WAV_URL);
       String url = text(file, FIELD_URL);
@@ -200,7 +199,18 @@ public class QqEventNormalizer {
     if (name == null || suffix == null) {
       return false;
     }
-    return name.toLowerCase(Locale.ROOT).endsWith(suffix);
+    return asciiLower(name).endsWith(asciiLower(suffix));
+  }
+
+  private static String asciiLower(String value) {
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
   }
 
   static String stripMentions(String content) {

--- a/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqInboundMediaResolver.java
+++ b/oryxos-channel-qq/src/main/java/io/oryxos/channel/qq/QqInboundMediaResolver.java
@@ -1,0 +1,308 @@
+package io.oryxos.channel.qq;
+
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMediaHttp;
+import io.oryxos.core.channel.InboundMediaJanitor;
+import io.oryxos.core.channel.InboundMediaLimits;
+import io.oryxos.core.channel.InboundMediaPaths;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.LimitedMediaWriter;
+import io.oryxos.core.session.ImageMime;
+import io.oryxos.core.session.InboundMediaExt;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * QQ 入站图片/文件：{@code attachments[].url} 带 {@code Authorization: QQBot …} 下载落盘，对齐飞书/Discord。
+ *
+ * <p>失败保留原远程 URL（不阻断编排）。
+ */
+final class QqInboundMediaResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(QqInboundMediaResolver.class);
+
+  private static final String DEFAULT_EXTENSION = ".bin";
+  private static final String DEFAULT_AUDIO_EXTENSION = ".wav";
+  private static final String DEFAULT_VIDEO_EXTENSION = ".mp4";
+  private static final String EXT_DOT = ".";
+  private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
+  private static final int DOWNLOAD_ATTEMPTS = 2;
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(20);
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(120);
+  private static final String HEADER_AUTHORIZATION = "Authorization";
+  private static final String SCHEME_HTTPS = "https";
+  private static final String HOST_MULTIMEDIA = "multimedia.nt.qq.com.cn";
+  private static final String HOST_SUFFIX_NT_QQ = ".nt.qq.com.cn";
+  private static final String HOST_SUFFIX_QQ_COM_CN = ".qq.com.cn";
+  private static final String HOST_SUFFIX_QQ_COM = ".qq.com";
+  private static final String HOST_SUFFIX_MYQCLOUD = ".myqcloud.com";
+
+  /** 官方语音 WAV（voice_wav_url）常见 CDN，如 qqbot.ugcimg.cn */
+  private static final String HOST_SUFFIX_UGCIMG = ".ugcimg.cn";
+
+  private final Supplier<String> authorizationHeader;
+  private final Path mediaRoot;
+  private final String channelName;
+  private final InboundMediaJanitor janitor;
+
+  QqInboundMediaResolver(Supplier<String> authorizationHeader, Path mediaRoot, String channelName) {
+    this(authorizationHeader, mediaRoot, channelName, InboundMediaJanitor.fromEnv());
+  }
+
+  QqInboundMediaResolver(
+      Supplier<String> authorizationHeader,
+      Path mediaRoot,
+      String channelName,
+      InboundMediaJanitor janitor) {
+    this.authorizationHeader = authorizationHeader;
+    this.mediaRoot = mediaRoot;
+    this.channelName = channelName;
+    this.janitor = janitor == null ? InboundMediaJanitor.fromEnv() : janitor;
+  }
+
+  InboundMessage resolve(InboundMessage message) {
+    if (message == null || message.attachments().isEmpty()) {
+      return message;
+    }
+    janitor.sweepIfDue(mediaRoot);
+    List<InboundAttachment> resolved = new ArrayList<>(message.attachments().size());
+    boolean changed = false;
+    for (InboundAttachment attachment : message.attachments()) {
+      if (!needsDownload(attachment)) {
+        resolved.add(attachment);
+        continue;
+      }
+      InboundAttachment next = downloadOrKeep(message.messageId(), attachment);
+      changed |= next != attachment;
+      resolved.add(next);
+    }
+    if (!changed) {
+      return message;
+    }
+    return new InboundMessage(
+        message.channelType(),
+        message.channelName(),
+        message.messageId(),
+        message.chatKind(),
+        message.userId(),
+        message.chatId(),
+        message.content(),
+        message.textual(),
+        message.mentionedBot(),
+        resolved);
+  }
+
+  static boolean needsDownload(InboundAttachment attachment) {
+    if (attachment == null || attachment.url() == null || attachment.url().isBlank()) {
+      return false;
+    }
+    String type = attachment.type();
+    return InboundAttachment.TYPE_IMAGE.equals(type)
+        || InboundAttachment.TYPE_FILE.equals(type)
+        || InboundAttachment.TYPE_AUDIO.equals(type)
+        || InboundAttachment.TYPE_VIDEO.equals(type);
+  }
+
+  static boolean hasDownloadableMedia(InboundMessage message) {
+    if (message == null) {
+      return false;
+    }
+    for (InboundAttachment attachment : message.attachments()) {
+      if (needsDownload(attachment)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private InboundAttachment downloadOrKeep(String messageId, InboundAttachment attachment) {
+    String remoteUrl = attachment.url().strip();
+    Exception last = null;
+    for (int attempt = 1; attempt <= DOWNLOAD_ATTEMPTS; attempt++) {
+      long started = System.nanoTime();
+      try {
+        Path path = writeToMediaRoot(messageId, remoteUrl, attachment);
+        LOG.info(
+            "QQ 渠道 {} 媒体已落盘（messageId={}, type={}, {}ms）",
+            sanitize(channelName),
+            sanitize(messageId),
+            sanitize(attachment.type()),
+            (System.nanoTime() - started) / 1_000_000L);
+        return new InboundAttachment(
+            attachment.type(), path.toAbsolutePath().toString(), remoteUrl, attachment.fileName());
+      } catch (Exception e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
+        last = e;
+        LOG.warn(
+            "QQ 渠道 {} 下载媒体失败尝试 {}/{}（messageId={}, host={}, {}ms）：{}",
+            sanitize(channelName),
+            attempt,
+            DOWNLOAD_ATTEMPTS,
+            sanitize(messageId),
+            sanitize(hostOf(remoteUrl)),
+            (System.nanoTime() - started) / 1_000_000L,
+            sanitize(e.getMessage()));
+      }
+    }
+    LOG.warn(
+        "QQ 渠道 {} 下载媒体最终失败（messageId={}）：{}，保留远程 URL",
+        sanitize(channelName),
+        sanitize(messageId),
+        sanitize(last == null ? null : last.getMessage()));
+    return attachment;
+  }
+
+  private Path writeToMediaRoot(String messageId, String remoteUrl, InboundAttachment attachment)
+      throws Exception {
+    URI uri = URI.create(remoteUrl);
+    if (!isAllowedMediaUri(uri)) {
+      throw new IllegalStateException("拒绝非 QQ 媒体下载地址: " + sanitize(uri.getHost()));
+    }
+    Map<String, String> headers = Map.of(HEADER_AUTHORIZATION, authorizationHeader.get());
+    byte[] bytes =
+        InboundMediaHttp.getBytesFollowingAllowlist(
+            uri,
+            CONNECT_TIMEOUT,
+            READ_TIMEOUT,
+            InboundMediaLimits.MAX_FILE_BYTES,
+            this::isAllowedMediaUri,
+            headers);
+    if (bytes == null || bytes.length == 0) {
+      throw new IllegalStateException("下载临时文件为空");
+    }
+    String ext = extensionFor(attachment, remoteUrl);
+    Path dir = mediaRoot.resolve(safeSegment(messageId));
+    Files.createDirectories(dir);
+    String stem = "qq-media";
+    Path target = dir.resolve(stem + ext);
+    janitor.ensureQuotaOrThrow(mediaRoot);
+    LimitedMediaWriter.writeLimited(bytes, target, InboundMediaLimits.MAX_FILE_BYTES);
+    if (InboundAttachment.TYPE_IMAGE.equals(attachment.type())
+        && DEFAULT_EXTENSION.equals(ext)
+        && ImageMime.hasRecognizedMagic(target)) {
+      String betterExt = ImageMime.extensionFor(ImageMime.probeFile(target));
+      if (betterExt != null && !DEFAULT_EXTENSION.equals(betterExt) && !betterExt.equals(ext)) {
+        Path renamed = dir.resolve(stem + betterExt);
+        try {
+          Files.move(target, renamed);
+          return renamed;
+        } catch (Exception ignored) {
+          // 保留原扩展名
+        }
+      }
+    }
+    String better = InboundMediaExt.betterFileExtension(target, ext);
+    if (better != null && !better.equals(ext)) {
+      Path renamed = dir.resolve(stem + better);
+      try {
+        Files.move(target, renamed);
+        return renamed;
+      } catch (Exception ignored) {
+        // 保留原扩展名
+      }
+    }
+    return target;
+  }
+
+  private static String extensionFor(InboundAttachment attachment, String remoteUrl) {
+    if (attachment.fileName() != null && attachment.fileName().contains(EXT_DOT)) {
+      String fromName = extensionOf(attachment.fileName());
+      if (fromName != null) {
+        return fromName;
+      }
+    }
+    String fromUrl = extensionOf(remoteUrl);
+    if (fromUrl != null) {
+      return fromUrl;
+    }
+    if (InboundAttachment.TYPE_AUDIO.equals(attachment.type())) {
+      return DEFAULT_AUDIO_EXTENSION;
+    }
+    if (InboundAttachment.TYPE_VIDEO.equals(attachment.type())) {
+      return DEFAULT_VIDEO_EXTENSION;
+    }
+    if (InboundAttachment.TYPE_IMAGE.equals(attachment.type())) {
+      return ".jpg";
+    }
+    return DEFAULT_EXTENSION;
+  }
+
+  private static String extensionOf(String nameOrUrl) {
+    if (nameOrUrl == null || nameOrUrl.isBlank()) {
+      return null;
+    }
+    String path = nameOrUrl;
+    int q = path.indexOf('?');
+    if (q >= 0) {
+      path = path.substring(0, q);
+    }
+    int slash = path.lastIndexOf('/');
+    if (slash >= 0) {
+      path = path.substring(slash + 1);
+    }
+    int dot = path.lastIndexOf(EXT_DOT);
+    if (dot < 0 || dot == path.length() - 1) {
+      return null;
+    }
+    String ext = asciiLower(path.substring(dot));
+    if (!ext.matches(SAFE_EXTENSION_PATTERN)) {
+      return null;
+    }
+    return ext;
+  }
+
+  boolean isAllowedMediaUri(URI uri) {
+    if (uri == null || uri.getScheme() == null || uri.getHost() == null) {
+      return false;
+    }
+    String scheme = asciiLower(uri.getScheme());
+    if (!SCHEME_HTTPS.equals(scheme)) {
+      return false;
+    }
+    String host = asciiLower(uri.getHost());
+    return HOST_MULTIMEDIA.equals(host)
+        || host.endsWith(HOST_SUFFIX_NT_QQ)
+        || host.endsWith(HOST_SUFFIX_QQ_COM_CN)
+        || host.endsWith(HOST_SUFFIX_QQ_COM)
+        || host.endsWith(HOST_SUFFIX_MYQCLOUD)
+        || host.endsWith(HOST_SUFFIX_UGCIMG);
+  }
+
+  private static String asciiLower(String value) {
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
+  }
+
+  private static String safeSegment(String messageId) {
+    return InboundMediaPaths.safeSegment(messageId);
+  }
+
+  private static String hostOf(String url) {
+    try {
+      String host = URI.create(url).getHost();
+      return host == null ? "" : host;
+    } catch (IllegalArgumentException e) {
+      return "";
+    }
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-qq/src/test/java/io/oryxos/channel/qq/QqChannelContractTest.java
+++ b/oryxos-channel-qq/src/test/java/io/oryxos/channel/qq/QqChannelContractTest.java
@@ -2,11 +2,8 @@ package io.oryxos.channel.qq;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.oryxos.core.channel.ChatKind;
-import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
 import io.oryxos.core.channel.InboundMessageServiceContractTestBase;
-import java.util.List;
 
 class QqChannelContractTest extends InboundMessageServiceContractTestBase {
 
@@ -37,17 +34,18 @@ class QqChannelContractTest extends InboundMessageServiceContractTestBase {
 
   @Override
   protected InboundMessage imageMessage(String messageId) {
-    return new InboundMessage(
-        "qq",
-        "contract-qq",
-        messageId,
-        ChatKind.P2P,
-        "u1",
-        QqChatTargets.user("u1"),
-        "",
-        false,
-        false,
-        List.of(InboundAttachment.imageReference("img-ref")));
+    ObjectNode data = mapper.createObjectNode();
+    data.put("id", messageId);
+    data.put("content", "");
+    data.putObject("author").put("user_openid", "u1");
+    data.putArray("attachments")
+        .addObject()
+        .put("url", "https://multimedia.nt.qq.com.cn/download?id=img")
+        .put("filename", "img.jpg")
+        .put("content_type", "image/jpeg")
+        .put("width", 100)
+        .put("height", 100);
+    return normalizer.normalize(QqEventNormalizer.EVENT_C2C, data).orElseThrow();
   }
 
   private ObjectNode c2c(String messageId, String content) {

--- a/oryxos-channel-qq/src/test/java/io/oryxos/channel/qq/QqEventNormalizerTest.java
+++ b/oryxos-channel-qq/src/test/java/io/oryxos/channel/qq/QqEventNormalizerTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,7 +59,7 @@ class QqEventNormalizerTest {
   }
 
   @Test
-  @DisplayName("单聊空内容 → 非文本占位")
+  @DisplayName("单聊空内容无附件 → 非文本占位")
   void c2cNonTextual() {
     ObjectNode data = MAPPER.createObjectNode();
     data.put("id", "msg-c2");
@@ -67,6 +68,107 @@ class QqEventNormalizerTest {
     Optional<InboundMessage> msg = normalizer.normalize(QqEventNormalizer.EVENT_C2C, data);
     assertTrue(msg.isPresent());
     assertFalse(msg.get().textual());
+    assertTrue(msg.get().attachments().isEmpty());
+  }
+
+  @Test
+  @DisplayName("单聊图片附件 → TYPE_IMAGE")
+  void c2cImageAttachment() {
+    ObjectNode data = MAPPER.createObjectNode();
+    data.put("id", "msg-img");
+    data.put("content", "");
+    data.putObject("author").put("user_openid", "u-open");
+    data.putArray("attachments")
+        .addObject()
+        .put("url", "https://multimedia.nt.qq.com.cn/download?x=1")
+        .put("filename", "photo.jpg")
+        .put("content_type", "image/jpeg")
+        .put("width", 800)
+        .put("height", 600);
+    Optional<InboundMessage> msg = normalizer.normalize(QqEventNormalizer.EVENT_C2C, data);
+    assertTrue(msg.isPresent());
+    assertEquals(1, msg.get().attachments().size());
+    assertEquals(InboundAttachment.TYPE_IMAGE, msg.get().attachments().get(0).type());
+    assertTrue(msg.get().attachments().get(0).url().contains("multimedia.nt.qq.com.cn"));
+  }
+
+  @Test
+  @DisplayName("单聊 PDF → TYPE_FILE")
+  void c2cPdfAttachment() {
+    ObjectNode data = MAPPER.createObjectNode();
+    data.put("id", "msg-pdf");
+    data.put("content", "看看文档");
+    data.putObject("author").put("user_openid", "u-open");
+    data.putArray("attachments")
+        .addObject()
+        .put("url", "https://multimedia.nt.qq.com.cn/download?f=pdf")
+        .put("filename", "report.pdf")
+        .put("content_type", "application/pdf");
+    Optional<InboundMessage> msg = normalizer.normalize(QqEventNormalizer.EVENT_C2C, data);
+    assertTrue(msg.isPresent());
+    assertEquals(InboundAttachment.TYPE_FILE, msg.get().attachments().get(0).type());
+    assertEquals("report.pdf", msg.get().attachments().get(0).fileName());
+  }
+
+  @Test
+  @DisplayName("群仅附件无正文 → 保留")
+  void groupAttachmentOnly() {
+    ObjectNode data = MAPPER.createObjectNode();
+    data.put("id", "msg-g-img");
+    data.put("group_openid", "g-open");
+    data.put("content", "<@!1>");
+    data.putObject("author").put("member_openid", "m-open");
+    data.putArray("attachments")
+        .addObject()
+        .put("url", "https://multimedia.nt.qq.com.cn/download?x=2")
+        .put("content_type", "image/png")
+        .put("filename", "a.png")
+        .put("width", 10)
+        .put("height", 10);
+    Optional<InboundMessage> msg = normalizer.normalize(QqEventNormalizer.EVENT_GROUP_AT, data);
+    assertTrue(msg.isPresent());
+    assertEquals(1, msg.get().attachments().size());
+  }
+
+  @Test
+  @DisplayName("单聊语音优先 voice_wav_url，并采用 asr_refer_text")
+  void c2cVoicePrefersWavAndAsr() {
+    ObjectNode data = MAPPER.createObjectNode();
+    data.put("id", "msg-voice");
+    data.put("content", "");
+    data.putObject("author").put("user_openid", "u-open");
+    data.putArray("attachments")
+        .addObject()
+        .put("url", "https://multimedia.nt.qq.com.cn/download?silk=1")
+        .put("voice_wav_url", "https://multimedia.nt.qq.com.cn/download?wav=1")
+        .put("asr_refer_text", "今天天气不错")
+        .put("filename", "voice.amr")
+        .put("content_type", "voice");
+    Optional<InboundMessage> msg = normalizer.normalize(QqEventNormalizer.EVENT_C2C, data);
+    assertTrue(msg.isPresent());
+    assertEquals("今天天气不错", msg.get().content());
+    assertEquals(1, msg.get().attachments().size());
+    InboundAttachment a = msg.get().attachments().get(0);
+    assertEquals(InboundAttachment.TYPE_AUDIO, a.type());
+    assertTrue(a.url().contains("wav=1"));
+    assertEquals("voice.wav", a.fileName());
+  }
+
+  @Test
+  @DisplayName("单聊 video/mp4 → TYPE_VIDEO")
+  void c2cVideoAttachment() {
+    ObjectNode data = MAPPER.createObjectNode();
+    data.put("id", "msg-vid");
+    data.put("content", "");
+    data.putObject("author").put("user_openid", "u-open");
+    data.putArray("attachments")
+        .addObject()
+        .put("url", "https://multimedia.nt.qq.com.cn/download?v=1")
+        .put("filename", "clip.mp4")
+        .put("content_type", "video/mp4");
+    Optional<InboundMessage> msg = normalizer.normalize(QqEventNormalizer.EVENT_C2C, data);
+    assertTrue(msg.isPresent());
+    assertEquals(InboundAttachment.TYPE_VIDEO, msg.get().attachments().get(0).type());
   }
 
   @Test
@@ -79,7 +181,7 @@ class QqEventNormalizerTest {
   }
 
   @Test
-  @DisplayName("群空内容 → 丢弃")
+  @DisplayName("群空内容无附件 → 丢弃")
   void groupBlankDropped() {
     ObjectNode data = MAPPER.createObjectNode();
     data.put("id", "msg-g2");

--- a/specs/029-qq-im-channel/acceptance.md
+++ b/specs/029-qq-im-channel/acceptance.md
@@ -1,29 +1,29 @@
 # 029 验收
 
 **日期**: 2026-09-10  
-**范围**: QQ 官方 Bot 入站 + notify 代码与单测；真机视本机是否有 `QQ_APP_*`。
+**范围**: QQ 官方 Bot 入站 + notify + 真机单聊图/PDF。
 
 ## 单测
 
 | 项 | 结果 |
 |----|------|
-| `QqEventNormalizer` | 通过（群 @ / C2C / 非 MVP 丢弃 / 空内容） |
-| `QqChannelContractTest` | 通过（`InboundMessageService` 契约档） |
-| `QqNotifyAdapter`（VendorNotify） | 通过（`msg_type=0` + `Authorization: QQBot`；缺配置拒绝） |
-| 模块 `verify`（qq/tool/web/cli） | 通过（含 spotless / checkstyle / spotbugs） |
+| `QqEventNormalizer`（含 attachments） | 通过 |
+| `QqChannelContractTest` | 通过 |
+| `QqNotifyAdapter` | 通过 |
 
 ## 真机
 
-本机 `.env` **无** `QQ_APP_ID` / `QQ_APP_SECRET` → **不宣称 COMPLETE**。清单：
-
-1. 沙箱/测试群：`@Bot` 文本 → Agent 被动回帖（带 `msg_id`）
-2. 单聊文本往返
-3. `notify` 打进指定 `group_openid`（主动消息限额见官方）
-4. 重复 `msg_id` 去重；官方群事件仅推 @Bot
-5. 不宣称：个人号、频道 MVP、富媒体完整对齐
+| 项 | 结果 |
+|----|------|
+| 换票 / Gateway CONNECTED | 通过 |
+| 单聊文本 | 通过（20:48） |
+| 单聊图片 | **通过**（21:41 落盘 `qq-media.jpg` + Vision） |
+| 单聊 PDF | **通过**（21:42 落盘约 17MB + `read_file` success） |
+| 群 `@Bot` | 阻塞：个人认证入群待腾讯灰度 |
+| notify | 待测 |
 
 ## 非宣称
 
-- NapCat / 个人号协议  
-- QQ 频道子频道消息  
-- 流式 / 图文件完整出站对齐
+- NapCat / 个人号  
+- 频道消息  
+- 出站富媒体完整对齐  


### PR DESCRIPTION
## Summary
- QQ 入站附件鉴权下载落盘（图 / PDF / 语音 / 视频），对齐飞书等渠道
- 语音优先 `voice_wav_url`，可选 `asr_refer_text`；允许 `*.ugcimg.cn`（WAV CDN）
- 单聊真机：图 / PDF / 视频 / WAV 语音均 SUCCESS

## Test plan
- [x] `QqEventNormalizerTest` / `QqChannelContractTest`
- [x] 本机 C2C 图片 Vision
- [x] 本机 C2C PDF `read_file`
- [x] 本机 C2C 视频落盘 + 编排
- [x] 本机 C2C 语音 WAV 落盘（`qqbot.ugcimg.cn`）
- [ ] CI 全绿后 squash merge
