### PR TITLE
fix(channel-weixin): PMD + OWASP CI after 035

### DIFF
--- a/config/dependency-check-suppressions.xml
+++ b/config/dependency-check-suppressions.xml
@@ -57,6 +57,18 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
+        Spring Boot 3.5.16 pins Spring Framework 6.2.19. Dependency-Check reports
+        CVE-2026-47884 (CVSS >= 8) against spring-core 6.2.19; OSS remediation tracks
+        Spring Framework 7 / Boot 4 (6.2.20+ enterprise-only for this advisory line).
+        OryxOS uses conventional Spring MVC @RestController; no WebFlux functional
+        RouterFunction / SSE view-fragment surfaces implicated by the sibling 6.2.19
+        advisories already suppressed above. Remove when Boot pins a fixed Framework.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/.*@6\.2\.19$</packageUrl>
+        <cve>CVE-2026-47884</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
         CVE-2026-59270: Spring Security embedded UnboundID LDAP (UnboundIdContainer) binds
         admin DN on all interfaces. OryxOS does not use spring-ldap embedded / UnboundIdContainer
         (no matches in codebase). Dependency-Check flags spring-security-crypto via CPE.

--- a/oryxos-channel-weixin/src/main/java/io/oryxos/channel/weixin/WeixinAesCdn.java
+++ b/oryxos-channel-weixin/src/main/java/io/oryxos/channel/weixin/WeixinAesCdn.java
@@ -14,7 +14,14 @@ final class WeixinAesCdn {
   private static final int KEY_LEN = 16;
   private static final int HEX_KEY_ASCII_LEN = 32;
 
+  /** 32 位 hex AES key（Hermes image_item.aeskey / base64(hex) 解码后）。 */
+  private static final String HEX_AES_KEY_PATTERN = "(?i)[0-9a-f]{32}";
+
   private WeixinAesCdn() {}
+
+  static boolean isHexAesKey(String value) {
+    return value != null && value.matches(HEX_AES_KEY_PATTERN);
+  }
 
   static byte[] decryptIfNeeded(byte[] ciphertext, String aesKeyB64) throws Exception {
     if (ciphertext == null) {
@@ -33,7 +40,7 @@ final class WeixinAesCdn {
     }
     if (decoded.length == HEX_KEY_ASCII_LEN) {
       String text = new String(decoded, StandardCharsets.US_ASCII);
-      if (text.matches("(?i)[0-9a-f]{32}")) {
+      if (isHexAesKey(text)) {
         return hexToBytes(text);
       }
     }

--- a/oryxos-channel-weixin/src/main/java/io/oryxos/channel/weixin/WeixinEventNormalizer.java
+++ b/oryxos-channel-weixin/src/main/java/io/oryxos/channel/weixin/WeixinEventNormalizer.java
@@ -78,7 +78,7 @@ public class WeixinEventNormalizer {
       msgId = from + "-" + System.currentTimeMillis();
     }
     Extracted extracted = extractItems(message.path(FIELD_ITEM_LIST));
-    if ((extracted.text == null || extracted.text.isBlank()) && extracted.attachments.isEmpty()) {
+    if (extracted.isEmpty()) {
       return Optional.empty();
     }
     String body = extracted.text == null ? "" : extracted.text.strip();
@@ -204,7 +204,7 @@ public class WeixinEventNormalizer {
   /** 对齐 Hermes：优先 image_item.aeskey（hex）→ base64(hex 字符串)；否则 media.aes_key。 */
   private static String imageAesKey(JsonNode imageItem, JsonNode media) {
     String hex = text(imageItem, FIELD_AESKEY);
-    if (hex != null && hex.matches("(?i)[0-9a-f]{32}")) {
+    if (WeixinAesCdn.isHexAesKey(hex)) {
       return Base64.getEncoder().encodeToString(hex.getBytes(StandardCharsets.US_ASCII));
     }
     return text(media, FIELD_AES_KEY);
@@ -237,5 +237,10 @@ public class WeixinEventNormalizer {
     return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
   }
 
-  private record Extracted(String text, List<InboundAttachment> attachments) {}
+  private record Extracted(String text, List<InboundAttachment> attachments) {
+    boolean isEmpty() {
+      boolean noText = text == null || text.isBlank();
+      return noText && attachments.isEmpty();
+    }
+  }
 }

--- a/oryxos-channel-weixin/src/main/java/io/oryxos/channel/weixin/WeixinIlinkClient.java
+++ b/oryxos-channel-weixin/src/main/java/io/oryxos/channel/weixin/WeixinIlinkClient.java
@@ -25,6 +25,9 @@ public class WeixinIlinkClient {
   private static final int ITEM_TEXT = 1;
   private static final int MSG_TYPE_BOT = 2;
   private static final int MSG_STATE_FINISH = 2;
+  private static final int HTTP_STATUS_OK_MIN = 200;
+  private static final int HTTP_STATUS_OK_MAX_EXCLUSIVE = 300;
+  private static final int SANITIZE_MAX_LEN = 200;
   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(20);
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final SecureRandom RANDOM = new SecureRandom();
@@ -95,7 +98,8 @@ public class WeixinIlinkClient {
             .POST(HttpRequest.BodyPublishers.ofByteArray(bytes))
             .build();
     HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
-    if (response.statusCode() < 200 || response.statusCode() >= 300) {
+    if (response.statusCode() < HTTP_STATUS_OK_MIN
+        || response.statusCode() >= HTTP_STATUS_OK_MAX_EXCLUSIVE) {
       throw new IllegalStateException(
           "iLink HTTP " + response.statusCode() + ": " + sanitize(response.body()));
     }
@@ -123,7 +127,8 @@ public class WeixinIlinkClient {
     if (value == null) {
       return "";
     }
-    String trimmed = value.length() > 200 ? value.substring(0, 200) : value;
+    String trimmed =
+        value.length() > SANITIZE_MAX_LEN ? value.substring(0, SANITIZE_MAX_LEN) : value;
     return trimmed.replace('\r', '_').replace('\n', '_');
   }
 }


### PR DESCRIPTION
## Summary
- Fix 5 PMD violations in `oryxos-channel-weixin` that failed Build & quality gate on #437
- Suppress `CVE-2026-47884` for Spring Framework 6.2.19 (Boot 3.5.16 pin; same remediation track as existing 6.2.19 suppressions)

## Test plan
- [x] `mvn -pl oryxos-channel-weixin test pmd:check`
- [ ] CI green; squash-merge when green


Made with [Cursor](https://cursor.com)