### PR TITLE
fix(channel-weixin): SpotBugs after 035 CI

### DIFF
--- a/oryxos-channel-weixin/src/main/java/io/oryxos/channel/weixin/WeixinAesCdn.java
+++ b/oryxos-channel-weixin/src/main/java/io/oryxos/channel/weixin/WeixinAesCdn.java
@@ -8,6 +8,11 @@ import javax.crypto.spec.SecretKeySpec;
 /**
  * iLink CDN：AES-128-ECB + PKCS7（对齐 Hermes {@code _aes128_ecb_decrypt} / {@code _parse_aes_key}）。
  */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = {"CIPHER_INTEGRITY", "ECB_MODE"},
+    justification =
+        "腾讯 iLink Bot 媒体 CDN 协议固定 AES-128-ECB（Hermes/OpenClaw 同路），无法改用 AEAD；"
+            + "密钥为每文件独立 aes_key，仅解密平台侧已加密的临时资源。")
 final class WeixinAesCdn {
 
   private static final String TRANSFORMATION = "AES/ECB/NoPadding";

--- a/oryxos-channel-weixin/src/main/java/io/oryxos/channel/weixin/WeixinChannelAdapter.java
+++ b/oryxos-channel-weixin/src/main/java/io/oryxos/channel/weixin/WeixinChannelAdapter.java
@@ -23,8 +23,10 @@ import org.slf4j.LoggerFactory;
  * app_id}=ilink_bot_id，{@code app_secret}=bot_token。支持私聊文本与图/语音/文件/视频入站。
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-    value = "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
-    justification = "client/normalizer/sender/mediaResolver 在 start() 内初始化；sendReply 有显式空判。")
+    value = {"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", "EI_EXPOSE_REP2"},
+    justification =
+        "client/normalizer/sender/mediaResolver 在 start() 内初始化；sendReply 有显式空判。"
+            + "构造注入的 registry/service/guard 为 Spring/运行时单例，不对外再暴露可变副本。")
 public class WeixinChannelAdapter implements InboundChannelAdapter {
 
   private static final Logger LOG = LoggerFactory.getLogger(WeixinChannelAdapter.class);
@@ -193,7 +195,7 @@ public class WeixinChannelAdapter implements InboundChannelAdapter {
           return;
         }
         lastError = sanitize(e.getMessage());
-        LOG.warn("微信渠道 {} 轮询异常: {}", sanitize(config.name()), lastError);
+        LOG.warn("微信渠道 {} 轮询异常: {}", sanitize(config.name()), sanitize(lastError));
         sleepQuietly(2_000L);
       }
     }

--- a/oryxos-channel-weixin/src/main/java/io/oryxos/channel/weixin/WeixinInboundMediaResolver.java
+++ b/oryxos-channel-weixin/src/main/java/io/oryxos/channel/weixin/WeixinInboundMediaResolver.java
@@ -16,7 +16,6 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -178,7 +177,7 @@ final class WeixinInboundMediaResolver {
       throw new IllegalStateException("下载临时文件为空");
     }
     byte[] plain = WeixinAesCdn.decryptIfNeeded(encrypted, attachment.reference());
-    if (plain == null || plain.length == 0) {
+    if (plain.length == 0) {
       throw new IllegalStateException("解密后媒体为空");
     }
     String ext = extensionFor(attachment, remoteUrl);
@@ -219,11 +218,11 @@ final class WeixinInboundMediaResolver {
     if (uri == null || uri.getScheme() == null || uri.getHost() == null) {
       return false;
     }
-    String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+    String scheme = asciiLower(uri.getScheme());
     if (!SCHEME_HTTPS.equals(scheme)) {
       return false;
     }
-    String host = uri.getHost().toLowerCase(Locale.ROOT);
+    String host = asciiLower(uri.getHost());
     return HOST_CDN.equals(host)
         || HOST_ILINK.equals(host)
         || host.endsWith(HOST_SUFFIX_WEIXIN)
@@ -233,6 +232,17 @@ final class WeixinInboundMediaResolver {
         || HOST_MMBIZ_QPIC.equals(host)
         || HOST_MMBIZ_QLOGO.equals(host)
         || (host.endsWith(HOST_SUFFIX_QQ) && host.contains("wx"));
+  }
+
+  private static String asciiLower(String value) {
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
   }
 
   private static String extensionFor(InboundAttachment attachment, String remoteUrl) {
@@ -275,7 +285,7 @@ final class WeixinInboundMediaResolver {
     if (dot < 0 || dot == path.length() - 1) {
       return null;
     }
-    String ext = path.substring(dot).toLowerCase(Locale.ROOT);
+    String ext = asciiLower(path.substring(dot));
     if (!ext.matches(SAFE_EXTENSION_PATTERN)) {
       return null;
     }

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -1043,11 +1043,42 @@ public class OryxOsRuntime {
       ProfileRegistry profileRegistry,
       io.oryxos.core.channel.InboundMessageService inboundMessageService,
       io.oryxos.core.channel.OutboundGuard channelOutboundGuard) {
+    return new io.oryxos.core.channel.ChannelAdminService(
+        channelConfigLoader,
+        inboundChannelRegistry,
+        profileRegistry,
+        inboundChannelFactories(profileRegistry, inboundMessageService, channelOutboundGuard));
+  }
+
+  private static Map<
+          String,
+          java.util.function.Function<
+              io.oryxos.core.channel.ChannelConfig, io.oryxos.core.channel.InboundChannelAdapter>>
+      inboundChannelFactories(
+          ProfileRegistry profileRegistry,
+          io.oryxos.core.channel.InboundMessageService inboundMessageService,
+          io.oryxos.core.channel.OutboundGuard channelOutboundGuard) {
     Map<
             String,
             java.util.function.Function<
                 io.oryxos.core.channel.ChannelConfig, io.oryxos.core.channel.InboundChannelAdapter>>
         factories = new LinkedHashMap<>();
+    registerEnterpriseChannelFactories(
+        factories, profileRegistry, inboundMessageService, channelOutboundGuard);
+    registerConsumerChannelFactories(
+        factories, profileRegistry, inboundMessageService, channelOutboundGuard);
+    return factories;
+  }
+
+  private static void registerEnterpriseChannelFactories(
+      Map<
+              String,
+              java.util.function.Function<
+                  io.oryxos.core.channel.ChannelConfig, io.oryxos.core.channel.InboundChannelAdapter>>
+          factories,
+      ProfileRegistry profileRegistry,
+      io.oryxos.core.channel.InboundMessageService inboundMessageService,
+      io.oryxos.core.channel.OutboundGuard channelOutboundGuard) {
     factories.put(
         io.oryxos.channel.feishu.FeishuChannelAdapter.TYPE,
         resolved ->
@@ -1078,6 +1109,17 @@ public class OryxOsRuntime {
         resolved ->
             new io.oryxos.channel.telegram.TelegramChannelAdapter(
                 resolved, profileRegistry, inboundMessageService, channelOutboundGuard));
+  }
+
+  private static void registerConsumerChannelFactories(
+      Map<
+              String,
+              java.util.function.Function<
+                  io.oryxos.core.channel.ChannelConfig, io.oryxos.core.channel.InboundChannelAdapter>>
+          factories,
+      ProfileRegistry profileRegistry,
+      io.oryxos.core.channel.InboundMessageService inboundMessageService,
+      io.oryxos.core.channel.OutboundGuard channelOutboundGuard) {
     factories.put(
         io.oryxos.channel.whatsapp.WhatsAppChannelAdapter.TYPE,
         resolved ->
@@ -1118,8 +1160,6 @@ public class OryxOsRuntime {
         resolved ->
             new io.oryxos.channel.weixin.WeixinChannelAdapter(
                 resolved, profileRegistry, inboundMessageService, channelOutboundGuard));
-    return new io.oryxos.core.channel.ChannelAdminService(
-        channelConfigLoader, inboundChannelRegistry, profileRegistry, factories);
   }
 
   /**

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -1074,7 +1074,8 @@ public class OryxOsRuntime {
       Map<
               String,
               java.util.function.Function<
-                  io.oryxos.core.channel.ChannelConfig, io.oryxos.core.channel.InboundChannelAdapter>>
+                  io.oryxos.core.channel.ChannelConfig,
+                  io.oryxos.core.channel.InboundChannelAdapter>>
           factories,
       ProfileRegistry profileRegistry,
       io.oryxos.core.channel.InboundMessageService inboundMessageService,
@@ -1115,7 +1116,8 @@ public class OryxOsRuntime {
       Map<
               String,
               java.util.function.Function<
-                  io.oryxos.core.channel.ChannelConfig, io.oryxos.core.channel.InboundChannelAdapter>>
+                  io.oryxos.core.channel.ChannelConfig,
+                  io.oryxos.core.channel.InboundChannelAdapter>>
           factories,
       ProfileRegistry profileRegistry,
       io.oryxos.core.channel.InboundMessageService inboundMessageService,


### PR DESCRIPTION
## Summary
- Clear SpotBugs `ECB_MODE` / `CIPHER_INTEGRITY` (iLink CDN protocol), `CRLF_INJECTION_LOGS`, `EI_EXPOSE_REP2`, `IMPROPER_UNICODE`, redundant nullcheck
- Follow-up to #437 / #438 Build & quality gate

## Test plan
- [x] `mvn -pl oryxos-channel-weixin test pmd:check spotbugs:check`
- [ ] CI green then merge


Made with [Cursor](https://cursor.com)