### PR TITLE
feat(channel-weixin-kf): Weixin Customer Service inbound MVP (033)

### DIFF
--- a/config/channels.yaml.example
+++ b/config/channels.yaml.example
@@ -128,3 +128,16 @@ channels:
   #   app_secret: ${WEIXIN_TOKEN}
   #   agent: demo-agent
   #   enabled: true
+
+  # 微信客服（企业对客，见 docs/WeixinKfChannelSetup.md）
+  # 回调：GET/POST /api/v1/channels/inbound/ops-weixin-kf
+  # - name: ops-weixin-kf
+  #   type: weixin_kf
+  #   app_id: ${WECOM_CORP_ID}
+  #   app_secret: ${WEIXIN_KF_SECRET}
+  #   agent: demo-agent
+  #   extra:
+  #     token: ${WEIXIN_KF_TOKEN}
+  #     encoding_aes_key: ${WEIXIN_KF_AES_KEY}
+  #     open_kfid: ${WEIXIN_KF_OPEN_KFID}
+  #   enabled: true

--- a/docs/WeixinChannelSetup.md
+++ b/docs/WeixinChannelSetup.md
@@ -56,6 +56,6 @@ WEIXIN_TOKEN=...
 |------|------|
 | `weixin`（本渠道） | 个人 Harness |
 | `wecom` | 企微员工协作 |
-| `weixin_kf`（033，未 BUILD） | 企业对客微信客服 |
+| `weixin_kf`（见 [WeixinKfChannelSetup](./WeixinKfChannelSetup.md)） | 企业对客微信客服 |
 
 详见 `specs/035-weixin-ilink-channel/`。

--- a/docs/WeixinKfChannelSetup.md
+++ b/docs/WeixinKfChannelSetup.md
@@ -1,0 +1,53 @@
+# 微信客服渠道（企业微信 `kf/*`）
+
+用户在**微信**里咨询企业客服；OryxOS 通过企微「微信客服」OpenAPI 收发。  
+与现有 `wecom`（企微应用内智能机器人 WS）及 `weixin`（个人 iLink）**不是同一产品**。
+
+## 前置
+
+1. 企业微信已开通**微信客服**，并有客服账号 `open_kfid`
+2. 使用**微信客服 Secret**（非普通应用 secret）换 `access_token`
+3. 回调配置：URL + Token + EncodingAESKey（企微同族加解密）
+4. 公网 HTTPS 可达 OryxOS：`GET/POST /api/v1/channels/inbound/{name}`
+
+## channels.yaml
+
+```yaml
+  - name: ops-weixin-kf
+    type: weixin_kf
+    app_id: ${WECOM_CORP_ID}              # CorpId
+    app_secret: ${WEIXIN_KF_SECRET}       # 微信客服 Secret
+    agent: demo-agent
+    extra:
+      token: ${WEIXIN_KF_TOKEN}
+      encoding_aes_key: ${WEIXIN_KF_AES_KEY}
+      open_kfid: ${WEIXIN_KF_OPEN_KFID}
+    enabled: true
+```
+
+回调地址示例：`https://<host>/api/v1/channels/inbound/ops-weixin-kf`
+
+## 出站白名单
+
+`http.allowed_domains` 需包含 `qyapi.weixin.qq.com`（示例配置已有）。
+
+## 行为摘要
+
+| 步骤 | 说明 |
+|------|------|
+| 入站 | 回调 `kf_msg_or_event`（加密，不带正文）→ `kf/sync_msg` 拉文本 |
+| 会话态 | 尽量转到「智能助手接待」后再编排/发信 |
+| 出站 | `kf/send_msg` 文本；**48h / 每回合最多 5 条**，窗外硬拒绝 |
+| chatId | `kf:{open_kfid}:user:{external_userid}` |
+
+## 与其它微信系对照
+
+| type | 场景 |
+|------|------|
+| `weixin_kf`（本渠道） | 企业对客微信客服 |
+| `wecom` | 企微应用内机器人 |
+| `weixin` | 个人微信 iLink Bot |
+
+## MVP 非目标
+
+媒体入站、多 `open_kfid` 路由、人工排班 UI、服务号/小程序客服。

--- a/oryxos-boot/pom.xml
+++ b/oryxos-boot/pom.xml
@@ -102,6 +102,10 @@
         </dependency>
         <dependency>
             <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-channel-weixin-kf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
             <artifactId>oryxos-web</artifactId>
         </dependency>
         <dependency>

--- a/oryxos-channel-weixin-kf/pom.xml
+++ b/oryxos-channel-weixin-kf/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.oryxos</groupId>
+        <artifactId>oryxos</artifactId>
+        <version>0.1.4-RELEASE</version>
+    </parent>
+    <artifactId>oryxos-channel-weixin-kf</artifactId>
+    <name>OryxOS Channel Weixin KF</name>
+    <description>Weixin Customer Service (企业微信客服) webhook + sync_msg + send_msg</description>
+    <dependencies>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/ChannelWeixinKfModule.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/ChannelWeixinKfModule.java
@@ -1,0 +1,7 @@
+package io.oryxos.channel.weixinkf;
+
+/** Marker for oryxos-channel-weixin-kf. */
+public final class ChannelWeixinKfModule {
+
+  private ChannelWeixinKfModule() {}
+}

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfAccessTokenClient.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfAccessTokenClient.java
@@ -18,6 +18,8 @@ final class WeixinKfAccessTokenClient {
   static final String API_BASE = "https://qyapi.weixin.qq.com";
   private static final Duration TIMEOUT = Duration.ofSeconds(20);
   private static final long SKEW_MS = 120_000L;
+  private static final int HTTP_OK_MIN = 200;
+  private static final int HTTP_OK_MAX_EXCLUSIVE = 300;
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private final HttpClient http;
@@ -66,7 +68,7 @@ final class WeixinKfAccessTokenClient {
       HttpRequest request =
           HttpRequest.newBuilder().uri(URI.create(url)).timeout(TIMEOUT).GET().build();
       HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
-      if (response.statusCode() < 200 || response.statusCode() >= 300) {
+      if (response.statusCode() < HTTP_OK_MIN || response.statusCode() >= HTTP_OK_MAX_EXCLUSIVE) {
         throw new IllegalStateException(
             "微信客服 gettoken HTTP " + response.statusCode() + ": " + sanitize(response.body()));
       }

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfAccessTokenClient.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfAccessTokenClient.java
@@ -1,0 +1,103 @@
+package io.oryxos.channel.weixinkf;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.core.channel.OutboundGuard;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** {@code GET /cgi-bin/gettoken}，按 expires_in 缓存。 */
+final class WeixinKfAccessTokenClient {
+
+  static final String API_BASE = "https://qyapi.weixin.qq.com";
+  private static final Duration TIMEOUT = Duration.ofSeconds(20);
+  private static final long SKEW_MS = 120_000L;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final HttpClient http;
+  private final OutboundGuard guard;
+  private final String corpId;
+  private final String secret;
+  private final AtomicReference<Cached> cached = new AtomicReference<>();
+
+  WeixinKfAccessTokenClient(OutboundGuard guard, String corpId, String secret) {
+    this(HttpClient.newBuilder().connectTimeout(TIMEOUT).build(), guard, corpId, secret);
+  }
+
+  WeixinKfAccessTokenClient(HttpClient http, OutboundGuard guard, String corpId, String secret) {
+    this.http = http;
+    this.guard = guard;
+    this.corpId = corpId;
+    this.secret = secret;
+  }
+
+  String getToken() {
+    Cached hit = cached.get();
+    long now = System.currentTimeMillis();
+    if (hit != null && now < hit.expiresAtMs()) {
+      return hit.token();
+    }
+    synchronized (this) {
+      hit = cached.get();
+      now = System.currentTimeMillis();
+      if (hit != null && now < hit.expiresAtMs()) {
+        return hit.token();
+      }
+      String token = fetch();
+      return token;
+    }
+  }
+
+  private String fetch() {
+    String url =
+        API_BASE
+            + "/cgi-bin/gettoken?corpid="
+            + URLEncoder.encode(corpId, StandardCharsets.UTF_8)
+            + "&corpsecret="
+            + URLEncoder.encode(secret, StandardCharsets.UTF_8);
+    guard.check(url);
+    try {
+      HttpRequest request =
+          HttpRequest.newBuilder().uri(URI.create(url)).timeout(TIMEOUT).GET().build();
+      HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() < 200 || response.statusCode() >= 300) {
+        throw new IllegalStateException(
+            "微信客服 gettoken HTTP " + response.statusCode() + ": " + sanitize(response.body()));
+      }
+      JsonNode root = MAPPER.readTree(response.body() == null ? "{}" : response.body());
+      int errcode = root.path("errcode").asInt(0);
+      if (errcode != 0) {
+        throw new IllegalStateException(
+            "微信客服 gettoken errcode=" + errcode + " errmsg=" + root.path("errmsg").asText());
+      }
+      String token = root.path("access_token").asText(null);
+      if (token == null || token.isBlank()) {
+        throw new IllegalStateException("微信客服 gettoken 未返回 access_token");
+      }
+      long expiresInSec = root.path("expires_in").asLong(7200L);
+      long ttlMs = Math.max(60_000L, expiresInSec * 1000L - SKEW_MS);
+      cached.set(new Cached(token, System.currentTimeMillis() + ttlMs));
+      return token;
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("微信客服 gettoken 失败: " + e.getMessage(), e);
+    }
+  }
+
+  private static String sanitize(String value) {
+    if (value == null) {
+      return "";
+    }
+    String trimmed = value.length() > 200 ? value.substring(0, 200) : value;
+    return trimmed.replace('\r', '_').replace('\n', '_');
+  }
+
+  private record Cached(String token, long expiresAtMs) {}
+}

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfApiClient.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfApiClient.java
@@ -1,0 +1,150 @@
+package io.oryxos.channel.weixinkf;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.OutboundGuard;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+/** 微信客服 OpenAPI：sync_msg / send_msg / service_state。 */
+final class WeixinKfApiClient implements WeixinKfClient {
+
+  static final String API_BASE = WeixinKfAccessTokenClient.API_BASE;
+
+  /** 由智能助手接待。 */
+  static final int STATE_AI = 1;
+
+  /** 未处理（新接入）。 */
+  static final int STATE_UNTREATED = 0;
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(20);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final int HTTP_OK_MIN = 200;
+  private static final int HTTP_OK_MAX = 300;
+
+  private final HttpClient http;
+  private final OutboundGuard guard;
+  private final Supplier<String> accessToken;
+
+  WeixinKfApiClient(OutboundGuard guard, Supplier<String> accessToken) {
+    this(HttpClient.newBuilder().connectTimeout(TIMEOUT).build(), guard, accessToken);
+  }
+
+  WeixinKfApiClient(HttpClient http, OutboundGuard guard, Supplier<String> accessToken) {
+    this.http = http;
+    this.guard = guard;
+    this.accessToken = accessToken;
+  }
+
+  @Override
+  public SyncResult syncMsg(String openKfid, String callbackToken, String cursor) {
+    ObjectNode body = MAPPER.createObjectNode();
+    body.put("open_kfid", openKfid);
+    if (callbackToken != null && !callbackToken.isBlank()) {
+      body.put("token", callbackToken);
+    }
+    if (cursor != null && !cursor.isBlank()) {
+      body.put("cursor", cursor);
+    }
+    body.put("limit", 1000);
+    JsonNode root = postJson("/cgi-bin/kf/sync_msg", body);
+    String nextCursor = root.path("next_cursor").asText("");
+    int hasMore = root.path("has_more").asInt(0);
+    List<JsonNode> messages = new ArrayList<>();
+    JsonNode list = root.path("msg_list");
+    if (list.isArray()) {
+      list.forEach(messages::add);
+    }
+    return new SyncResult(List.copyOf(messages), nextCursor, hasMore == 1);
+  }
+
+  @Override
+  public void sendText(String openKfid, String externalUserId, String text) {
+    ObjectNode body = MAPPER.createObjectNode();
+    body.put("touser", externalUserId);
+    body.put("open_kfid", openKfid);
+    body.put("msgtype", "text");
+    body.putObject("text").put("content", text == null ? "" : text);
+    postJson("/cgi-bin/kf/send_msg", body);
+  }
+
+  int getServiceState(String openKfid, String externalUserId) {
+    ObjectNode body = MAPPER.createObjectNode();
+    body.put("open_kfid", openKfid);
+    body.put("external_userid", externalUserId);
+    JsonNode root = postJson("/cgi-bin/kf/service_state/get", body);
+    return root.path("service_state").asInt(-1);
+  }
+
+  @Override
+  public void ensureAiReception(String openKfid, String externalUserId) {
+    int state = getServiceState(openKfid, externalUserId);
+    if (state == STATE_AI || state == STATE_UNTREATED) {
+      if (state == STATE_UNTREATED) {
+        ObjectNode body = MAPPER.createObjectNode();
+        body.put("open_kfid", openKfid);
+        body.put("external_userid", externalUserId);
+        body.put("service_state", STATE_AI);
+        postJson("/cgi-bin/kf/service_state/trans", body);
+      }
+      return;
+    }
+    if (state < 0) {
+      throw new IllegalStateException("微信客服无法读取会话状态（user=" + externalUserId + "）");
+    }
+    throw new IllegalStateException(
+        "微信客服会话非智能助手/未处理态（state=" + state + "，user=" + externalUserId + "），拒绝 API 发信");
+  }
+
+  private JsonNode postJson(String path, ObjectNode body) {
+    String token = accessToken.get();
+    if (token == null || token.isBlank()) {
+      throw new IllegalStateException("微信客服 access_token 为空");
+    }
+    String url =
+        API_BASE + path + "?access_token=" + URLEncoder.encode(token, StandardCharsets.UTF_8);
+    guard.check(url);
+    try {
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(url))
+              .timeout(TIMEOUT)
+              .header("Content-Type", "application/json; charset=utf-8")
+              .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body)))
+              .build();
+      HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() < HTTP_OK_MIN || response.statusCode() >= HTTP_OK_MAX) {
+        throw new IllegalStateException(
+            "微信客服 " + path + " HTTP " + response.statusCode() + ": " + sanitize(response.body()));
+      }
+      JsonNode root = MAPPER.readTree(response.body() == null ? "{}" : response.body());
+      int errcode = root.path("errcode").asInt(0);
+      if (errcode != 0) {
+        throw new IllegalStateException(
+            "微信客服 " + path + " errcode=" + errcode + " errmsg=" + root.path("errmsg").asText());
+      }
+      return root;
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("微信客服 " + path + " 失败: " + e.getMessage(), e);
+    }
+  }
+
+  private static String sanitize(String value) {
+    if (value == null) {
+      return "";
+    }
+    String trimmed = value.length() > 200 ? value.substring(0, 200) : value;
+    return trimmed.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfApiClient.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfApiClient.java
@@ -46,7 +46,7 @@ final class WeixinKfApiClient implements WeixinKfClient {
   }
 
   @Override
-  public SyncResult syncMsg(String openKfid, String callbackToken, String cursor) {
+  public WeixinKfSyncResult syncMsg(String openKfid, String callbackToken, String cursor) {
     ObjectNode body = MAPPER.createObjectNode();
     body.put("open_kfid", openKfid);
     if (callbackToken != null && !callbackToken.isBlank()) {
@@ -64,7 +64,7 @@ final class WeixinKfApiClient implements WeixinKfClient {
     if (list.isArray()) {
       list.forEach(messages::add);
     }
-    return new SyncResult(List.copyOf(messages), nextCursor, hasMore == 1);
+    return new WeixinKfSyncResult(messages, nextCursor, hasMore == 1);
   }
 
   @Override

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfCallbackXml.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfCallbackXml.java
@@ -1,0 +1,33 @@
+package io.oryxos.channel.weixinkf;
+
+/** 回调 XML 字段抽取（企微加密包 / 明文事件）。 */
+final class WeixinKfCallbackXml {
+
+  private WeixinKfCallbackXml() {}
+
+  static String cdataOrText(String xml, String tag) {
+    if (xml == null || tag == null || tag.isBlank()) {
+      return null;
+    }
+    String openCdata = "<" + tag + "><![CDATA[";
+    int start = xml.indexOf(openCdata);
+    if (start >= 0) {
+      start += openCdata.length();
+      int end = xml.indexOf("]]></" + tag + ">", start);
+      if (end > start) {
+        return xml.substring(start, end).strip();
+      }
+    }
+    String open = "<" + tag + ">";
+    start = xml.indexOf(open);
+    if (start < 0) {
+      return null;
+    }
+    start += open.length();
+    int end = xml.indexOf("</" + tag + ">", start);
+    if (end <= start) {
+      return null;
+    }
+    return xml.substring(start, end).strip();
+  }
+}

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapter.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapter.java
@@ -185,7 +185,7 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
               request.query(QUERY_ECHOSTR));
       return WebhookResponse.text(HTTP_OK, plain);
     } catch (Exception e) {
-      log.warn("微信客服 URL 校验失败: {}", e.getMessage());
+      log.warn("微信客服 URL 校验失败: {}", sanitize(e.getMessage()));
       return WebhookResponse.text(HTTP_UNAUTHORIZED, "verify failed");
     }
   }
@@ -224,7 +224,7 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
       pullAndDispatch(client, activeNormalizer, openKfid, callbackToken);
       return WebhookResponse.text(HTTP_OK, "success");
     } catch (Exception e) {
-      log.warn("微信客服回调处理失败: {}", e.getMessage());
+      log.warn("微信客服回调处理失败: {}", sanitize(e.getMessage()));
       return WebhookResponse.text(HTTP_UNAUTHORIZED, "callback failed");
     }
   }
@@ -240,7 +240,7 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
       int pages = 0;
       while (more && pages < MAX_SYNC_PAGES) {
         pages++;
-        WeixinKfClient.SyncResult page = client.syncMsg(openKfid, callbackToken, cursor);
+        WeixinKfSyncResult page = client.syncMsg(openKfid, callbackToken, cursor);
         for (JsonNode item : page.messages()) {
           Optional<InboundMessage> message = activeNormalizer.normalize(item);
           if (message.isEmpty()) {
@@ -254,7 +254,7 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
           try {
             client.ensureAiReception(WeixinKfChatTargets.parse(m.chatId()).openKfid(), m.userId());
           } catch (RuntimeException e) {
-            log.warn("微信客服确保智能助手接待失败: {}", e.getMessage());
+            log.warn("微信客服确保智能助手接待失败: {}", sanitize(e.getMessage()));
           }
           inboundMessageService.onMessage(m, this);
         }
@@ -286,5 +286,13 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
       }
     }
     return new String(chars);
+  }
+
+  private static String sanitize(String value) {
+    if (value == null) {
+      return "";
+    }
+    String trimmed = value.length() > 200 ? value.substring(0, 200) : value;
+    return trimmed.replace('\r', '_').replace('\n', '_');
   }
 }

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapter.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapter.java
@@ -1,0 +1,289 @@
+package io.oryxos.channel.weixinkf;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.channel.ChannelConfig;
+import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.InboundChannelAdapter;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageService;
+import io.oryxos.core.channel.InboundWebhookHandler;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.channel.WebhookRequest;
+import io.oryxos.core.channel.WebhookResponse;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.time.Clock;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 微信客服（企业微信 {@code kf/*}）：共享 Webhook 唤醒 + {@code sync_msg} 拉信 + {@code send_msg} 回复。
+ *
+ * <p>{@code app_id}=CorpId，{@code app_secret}=微信客服 Secret；{@code extra.token} / {@code
+ * encoding_aes_key} / {@code open_kfid}。
+ */
+public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWebhookHandler {
+
+  public static final String TYPE = "weixin_kf";
+
+  private static final Logger log = LoggerFactory.getLogger(WeixinKfChannelAdapter.class);
+  private static final String EXTRA_TOKEN = "token";
+  private static final String EXTRA_AES_KEY = "encoding_aes_key";
+  private static final String EXTRA_OPEN_KFID = "open_kfid";
+  private static final String METHOD_GET = "get";
+  private static final String EVENT_KF_MSG = "kf_msg_or_event";
+  private static final String QUERY_MSG_SIGNATURE = "msg_signature";
+  private static final String QUERY_TIMESTAMP = "timestamp";
+  private static final String QUERY_NONCE = "nonce";
+  private static final String QUERY_ECHOSTR = "echostr";
+  private static final int HTTP_OK = 200;
+  private static final int HTTP_BAD_REQUEST = 400;
+  private static final int HTTP_UNAUTHORIZED = 401;
+  private final ChannelConfig config;
+  private final ProfileRegistry profileRegistry;
+  private final InboundMessageService inboundMessageService;
+  private final OutboundGuard guard;
+  private final Clock clock;
+  private final WeixinKfReplySessionStore sessions = new WeixinKfReplySessionStore();
+  private final Set<String> seenMsgIds = ConcurrentHashMap.newKeySet();
+  private final Object syncLock = new Object();
+
+  private volatile WeixinKfMsgCrypt crypt;
+  private volatile WeixinKfClient api;
+  private volatile WeixinKfEventNormalizer normalizer;
+  private volatile String syncCursor = "";
+  private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
+
+  public WeixinKfChannelAdapter(
+      ChannelConfig config,
+      ProfileRegistry profileRegistry,
+      InboundMessageService inboundMessageService,
+      OutboundGuard guard) {
+    this(config, profileRegistry, inboundMessageService, guard, Clock.systemUTC());
+  }
+
+  WeixinKfChannelAdapter(
+      ChannelConfig config,
+      ProfileRegistry profileRegistry,
+      InboundMessageService inboundMessageService,
+      OutboundGuard guard,
+      Clock clock) {
+    this.config = config;
+    this.profileRegistry = profileRegistry;
+    this.inboundMessageService = inboundMessageService;
+    this.guard = guard;
+    this.clock = clock;
+  }
+
+  /** 测试注入 API 客户端。 */
+  WeixinKfChannelAdapter(
+      ChannelConfig config,
+      ProfileRegistry profileRegistry,
+      InboundMessageService inboundMessageService,
+      OutboundGuard guard,
+      Clock clock,
+      WeixinKfClient api,
+      WeixinKfMsgCrypt crypt) {
+    this(config, profileRegistry, inboundMessageService, guard, clock);
+    this.api = api;
+    this.crypt = crypt;
+  }
+
+  @Override
+  public String name() {
+    return config.name();
+  }
+
+  @Override
+  public String type() {
+    return TYPE;
+  }
+
+  @Override
+  public String boundAgent() {
+    return config.agent();
+  }
+
+  @Override
+  public synchronized void start() {
+    config.validateCredentialsResolved();
+    requireExtra(EXTRA_TOKEN);
+    requireExtra(EXTRA_AES_KEY);
+    requireExtra(EXTRA_OPEN_KFID);
+    if (profileRegistry.get(config.agent()).isEmpty()) {
+      throw new IllegalArgumentException(
+          "渠道 " + config.name() + " 绑定的 Agent " + config.agent() + " 不存在");
+    }
+    guard.check(WeixinKfApiClient.API_BASE);
+    if (crypt == null) {
+      crypt =
+          new WeixinKfMsgCrypt(
+              config.extra(EXTRA_TOKEN), config.extra(EXTRA_AES_KEY), config.appId());
+    }
+    if (api == null) {
+      WeixinKfAccessTokenClient tokens =
+          new WeixinKfAccessTokenClient(guard, config.appId(), config.appSecret());
+      api = new WeixinKfApiClient(guard, tokens::getToken);
+    }
+    normalizer = new WeixinKfEventNormalizer(config.name());
+    state = ChannelStatus.State.CONNECTED;
+  }
+
+  @Override
+  public synchronized void stop() {
+    state = ChannelStatus.State.DISCONNECTED;
+    normalizer = null;
+    seenMsgIds.clear();
+  }
+
+  @Override
+  public ChannelStatus status() {
+    return ChannelStatus.ok(name(), TYPE, boundAgent(), state);
+  }
+
+  @Override
+  public void sendReply(String chatId, String text, String replyToMessageId) {
+    WeixinKfClient client = api;
+    if (client == null) {
+      throw new IllegalStateException("渠道 " + name() + " 尚未启动");
+    }
+    WeixinKfReplySessionStore.Session session = sessions.requireForReply(chatId, clock.millis());
+    WeixinKfChatTargets.Parsed target = WeixinKfChatTargets.parse(chatId);
+    String configuredKf = config.extra(EXTRA_OPEN_KFID);
+    if (configuredKf != null
+        && !configuredKf.isBlank()
+        && !configuredKf.equals(target.openKfid())) {
+      throw new IllegalStateException("微信客服 chatId open_kfid 与配置不一致（chat=" + chatId + "）");
+    }
+    client.ensureAiReception(target.openKfid(), target.externalUserId());
+    client.sendText(target.openKfid(), target.externalUserId(), text);
+    sessions.markReplied(chatId, session);
+  }
+
+  @Override
+  public WebhookResponse onWebhook(WebhookRequest request) {
+    if (METHOD_GET.equals(asciiLower(request.method()))) {
+      return handleUrlVerify(request);
+    }
+    return handleCallback(request);
+  }
+
+  private WebhookResponse handleUrlVerify(WebhookRequest request) {
+    WeixinKfMsgCrypt active = crypt;
+    if (active == null) {
+      return WebhookResponse.text(HTTP_BAD_REQUEST, "channel not started");
+    }
+    try {
+      String plain =
+          active.verifyUrl(
+              request.query(QUERY_MSG_SIGNATURE),
+              request.query(QUERY_TIMESTAMP),
+              request.query(QUERY_NONCE),
+              request.query(QUERY_ECHOSTR));
+      return WebhookResponse.text(HTTP_OK, plain);
+    } catch (Exception e) {
+      log.warn("微信客服 URL 校验失败: {}", e.getMessage());
+      return WebhookResponse.text(HTTP_UNAUTHORIZED, "verify failed");
+    }
+  }
+
+  private WebhookResponse handleCallback(WebhookRequest request) {
+    WeixinKfMsgCrypt active = crypt;
+    WeixinKfClient client = api;
+    WeixinKfEventNormalizer activeNormalizer = normalizer;
+    if (active == null || client == null || activeNormalizer == null) {
+      return WebhookResponse.text(HTTP_BAD_REQUEST, "channel not started");
+    }
+    try {
+      String encrypt = WeixinKfCallbackXml.cdataOrText(request.body(), "Encrypt");
+      if (encrypt == null || encrypt.isBlank()) {
+        return WebhookResponse.text(HTTP_BAD_REQUEST, "missing Encrypt");
+      }
+      String xml =
+          active.decryptMsg(
+              request.query(QUERY_MSG_SIGNATURE),
+              request.query(QUERY_TIMESTAMP),
+              request.query(QUERY_NONCE),
+              encrypt);
+      String event = WeixinKfCallbackXml.cdataOrText(xml, "Event");
+      if (!EVENT_KF_MSG.equals(event)) {
+        return WebhookResponse.text(HTTP_OK, "success");
+      }
+      String callbackToken = WeixinKfCallbackXml.cdataOrText(xml, "Token");
+      String openKfid = WeixinKfCallbackXml.cdataOrText(xml, "OpenKfId");
+      String configured = config.extra(EXTRA_OPEN_KFID);
+      if (openKfid == null || openKfid.isBlank()) {
+        openKfid = configured;
+      } else if (configured != null && !configured.isBlank() && !configured.equals(openKfid)) {
+        log.warn("微信客服回调 open_kfid 与配置不一致，忽略");
+        return WebhookResponse.text(HTTP_OK, "success");
+      }
+      pullAndDispatch(client, activeNormalizer, openKfid, callbackToken);
+      return WebhookResponse.text(HTTP_OK, "success");
+    } catch (Exception e) {
+      log.warn("微信客服回调处理失败: {}", e.getMessage());
+      return WebhookResponse.text(HTTP_UNAUTHORIZED, "callback failed");
+    }
+  }
+
+  private void pullAndDispatch(
+      WeixinKfClient client,
+      WeixinKfEventNormalizer activeNormalizer,
+      String openKfid,
+      String callbackToken) {
+    synchronized (syncLock) {
+      String cursor = syncCursor;
+      boolean more = true;
+      int pages = 0;
+      while (more && pages < 20) {
+        pages++;
+        WeixinKfClient.SyncResult page = client.syncMsg(openKfid, callbackToken, cursor);
+        for (JsonNode item : page.messages()) {
+          Optional<InboundMessage> message = activeNormalizer.normalize(item);
+          if (message.isEmpty()) {
+            continue;
+          }
+          InboundMessage m = message.get();
+          if (!seenMsgIds.add(m.messageId())) {
+            continue;
+          }
+          sessions.rememberInbound(m.chatId(), clock.millis());
+          try {
+            client.ensureAiReception(WeixinKfChatTargets.parse(m.chatId()).openKfid(), m.userId());
+          } catch (RuntimeException e) {
+            log.warn("微信客服确保智能助手接待失败: {}", e.getMessage());
+          }
+          inboundMessageService.onMessage(m, this);
+        }
+        if (page.nextCursor() != null && !page.nextCursor().isBlank()) {
+          cursor = page.nextCursor();
+          syncCursor = cursor;
+        }
+        more = page.hasMore();
+      }
+    }
+  }
+
+  private void requireExtra(String key) {
+    String value = config.extra(key);
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("渠道 " + config.name() + " 缺少 extra." + key);
+    }
+  }
+
+  private static String asciiLower(String value) {
+    if (value == null || value.isEmpty()) {
+      return value;
+    }
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
+  }
+}

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapter.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapter.java
@@ -41,6 +41,7 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
   private static final int HTTP_OK = 200;
   private static final int HTTP_BAD_REQUEST = 400;
   private static final int HTTP_UNAUTHORIZED = 401;
+  private static final int MAX_SYNC_PAGES = 20;
   private final ChannelConfig config;
   private final ProfileRegistry profileRegistry;
   private final InboundMessageService inboundMessageService;
@@ -237,7 +238,7 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
       String cursor = syncCursor;
       boolean more = true;
       int pages = 0;
-      while (more && pages < 20) {
+      while (more && pages < MAX_SYNC_PAGES) {
         pages++;
         WeixinKfClient.SyncResult page = client.syncMsg(openKfid, callbackToken, cursor);
         for (JsonNode item : page.messages()) {

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChatTargets.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChatTargets.java
@@ -1,0 +1,32 @@
+package io.oryxos.channel.weixinkf;
+
+/** chatId：{@code kf:{open_kfid}:user:{external_userid}}。 */
+final class WeixinKfChatTargets {
+
+  private static final String PREFIX = "kf:";
+  private static final String USER_SEP = ":user:";
+
+  private WeixinKfChatTargets() {}
+
+  static String chatId(String openKfid, String externalUserId) {
+    return PREFIX + openKfid + USER_SEP + externalUserId;
+  }
+
+  static Parsed parse(String chatId) {
+    if (chatId == null || !chatId.startsWith(PREFIX)) {
+      throw new IllegalArgumentException("微信客服 chatId 须为 kf:{open_kfid}:user:{id}，实际: " + chatId);
+    }
+    int idx = chatId.indexOf(USER_SEP);
+    if (idx <= PREFIX.length()) {
+      throw new IllegalArgumentException("微信客服 chatId 格式错误: " + chatId);
+    }
+    String openKfid = chatId.substring(PREFIX.length(), idx).strip();
+    String userId = chatId.substring(idx + USER_SEP.length()).strip();
+    if (openKfid.isEmpty() || userId.isEmpty()) {
+      throw new IllegalArgumentException("微信客服 chatId 缺少 open_kfid/user: " + chatId);
+    }
+    return new Parsed(openKfid, userId);
+  }
+
+  record Parsed(String openKfid, String externalUserId) {}
+}

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfClient.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfClient.java
@@ -1,0 +1,16 @@
+package io.oryxos.channel.weixinkf;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
+/** 微信客服 OpenAPI 面（便于单测注入）。 */
+interface WeixinKfClient {
+
+  SyncResult syncMsg(String openKfid, String callbackToken, String cursor);
+
+  void sendText(String openKfid, String externalUserId, String text);
+
+  void ensureAiReception(String openKfid, String externalUserId);
+
+  record SyncResult(List<JsonNode> messages, String nextCursor, boolean hasMore) {}
+}

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfClient.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfClient.java
@@ -1,16 +1,11 @@
 package io.oryxos.channel.weixinkf;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import java.util.List;
-
 /** 微信客服 OpenAPI 面（便于单测注入）。 */
 interface WeixinKfClient {
 
-  SyncResult syncMsg(String openKfid, String callbackToken, String cursor);
+  WeixinKfSyncResult syncMsg(String openKfid, String callbackToken, String cursor);
 
   void sendText(String openKfid, String externalUserId, String text);
 
   void ensureAiReception(String openKfid, String externalUserId);
-
-  record SyncResult(List<JsonNode> messages, String nextCursor, boolean hasMore) {}
 }

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfEventNormalizer.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfEventNormalizer.java
@@ -1,0 +1,109 @@
+package io.oryxos.channel.weixinkf;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.Optional;
+
+/**
+ * {@code kf/sync_msg} 单条 → {@link InboundMessage}。
+ *
+ * <p>MVP：仅 {@code origin=3}（微信客户）且 {@code msgtype=text}。
+ */
+final class WeixinKfEventNormalizer {
+
+  static final String CHANNEL_TYPE = WeixinKfChannelAdapter.TYPE;
+  static final int ORIGIN_CUSTOMER = 3;
+  private static final String MSG_TEXT = "text";
+
+  private final String channelName;
+
+  WeixinKfEventNormalizer(String channelName) {
+    this.channelName = channelName;
+  }
+
+  Optional<InboundMessage> normalize(JsonNode item) {
+    if (item == null || !item.isObject()) {
+      return Optional.empty();
+    }
+    int origin = item.path("origin").asInt(-1);
+    if (origin != ORIGIN_CUSTOMER) {
+      return Optional.empty();
+    }
+    String msgId = text(item, "msgid");
+    String openKfid = text(item, "open_kfid");
+    String externalUserId = text(item, "external_userid");
+    if (msgId == null || openKfid == null || externalUserId == null) {
+      return Optional.empty();
+    }
+    String chatId = WeixinKfChatTargets.chatId(openKfid, externalUserId);
+    String msgType = asciiLower(text(item, "msgtype"));
+    if (!MSG_TEXT.equals(msgType)) {
+      return Optional.of(
+          new InboundMessage(
+              CHANNEL_TYPE,
+              channelName,
+              msgId,
+              ChatKind.P2P,
+              externalUserId,
+              chatId,
+              "",
+              false,
+              false,
+              java.util.List.of()));
+    }
+    String content = text(item.path("text"), "content");
+    if (content == null || content.isBlank()) {
+      return Optional.of(
+          new InboundMessage(
+              CHANNEL_TYPE,
+              channelName,
+              msgId,
+              ChatKind.P2P,
+              externalUserId,
+              chatId,
+              "",
+              false,
+              false,
+              java.util.List.of()));
+    }
+    return Optional.of(
+        new InboundMessage(
+            CHANNEL_TYPE,
+            channelName,
+            msgId,
+            ChatKind.P2P,
+            externalUserId,
+            chatId,
+            content.strip(),
+            true,
+            false,
+            java.util.List.of()));
+  }
+
+  private static String text(JsonNode node, String field) {
+    if (node == null || !node.isObject()) {
+      return null;
+    }
+    JsonNode v = node.get(field);
+    if (v == null || v.isNull() || !v.isTextual()) {
+      return null;
+    }
+    String s = v.asText();
+    return s == null || s.isBlank() ? null : s;
+  }
+
+  private static String asciiLower(String value) {
+    if (value == null) {
+      return "";
+    }
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
+  }
+}

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfMsgCrypt.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfMsgCrypt.java
@@ -6,9 +6,10 @@ package io.oryxos.channel.weixinkf;
  * <p>协议固定 AES-256-CBC；与媒体临时文件解密不同。
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-    value = "CIPHER_INTEGRITY",
+    value = {"CIPHER_INTEGRITY", "WEAK_MESSAGE_DIGEST_SHA1"},
     justification =
-        "企微/微信客服回调协议固定 AES-256-CBC（官方 WXBizMsgCrypt），无法改用 AEAD；" + "完整性依赖 msg_signature（SHA1）校验。")
+        "企微/微信客服回调协议固定 AES-256-CBC + msg_signature=SHA1（官方 WXBizMsgCrypt），"
+            + "无法改用 AEAD/SHA-256；完整性依赖平台侧签名字段。")
 final class WeixinKfMsgCrypt {
 
   private static final int AES_BLOCK = 16;
@@ -18,6 +19,7 @@ final class WeixinKfMsgCrypt {
   private static final int LENGTH_HEADER_BYTES = 4;
   private static final String TRANSFORMATION = "AES/CBC/NoPadding";
   private static final char BASE64_PAD = '=';
+  private static final java.security.SecureRandom SECURE_RANDOM = new java.security.SecureRandom();
 
   private final byte[] aesKey;
   private final String token;
@@ -62,7 +64,7 @@ final class WeixinKfMsgCrypt {
   /** 单测 / 回环：加密明文 XML。 */
   String encrypt(String plainXml) throws Exception {
     byte[] random = new byte[RANDOM_LEN];
-    new java.security.SecureRandom().nextBytes(random);
+    SECURE_RANDOM.nextBytes(random);
     byte[] xmlBytes = plainXml.getBytes(java.nio.charset.StandardCharsets.UTF_8);
     byte[] receiveBytes = receiveId.getBytes(java.nio.charset.StandardCharsets.UTF_8);
     byte[] raw = new byte[RANDOM_LEN + LENGTH_HEADER_BYTES + xmlBytes.length + receiveBytes.length];

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfMsgCrypt.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfMsgCrypt.java
@@ -1,0 +1,160 @@
+package io.oryxos.channel.weixinkf;
+
+/**
+ * 企微回调同族加解密（WXBizMsgCrypt）：Token + EncodingAESKey + receiveId(CorpId)。
+ *
+ * <p>协议固定 AES-256-CBC；与媒体临时文件解密不同。
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = "CIPHER_INTEGRITY",
+    justification =
+        "企微/微信客服回调协议固定 AES-256-CBC（官方 WXBizMsgCrypt），无法改用 AEAD；" + "完整性依赖 msg_signature（SHA1）校验。")
+final class WeixinKfMsgCrypt {
+
+  private static final int AES_BLOCK = 16;
+  private static final int RANDOM_LEN = 16;
+  private static final String TRANSFORMATION = "AES/CBC/NoPadding";
+
+  private final byte[] aesKey;
+  private final String token;
+  private final String receiveId;
+
+  WeixinKfMsgCrypt(String token, String encodingAesKey, String receiveId) {
+    if (token == null || token.isBlank()) {
+      throw new IllegalArgumentException("callback token 为空");
+    }
+    if (encodingAesKey == null || encodingAesKey.isBlank()) {
+      throw new IllegalArgumentException("encoding_aes_key 为空");
+    }
+    if (receiveId == null || receiveId.isBlank()) {
+      throw new IllegalArgumentException("corpid/receiveId 为空");
+    }
+    String keyB64 = encodingAesKey.strip();
+    while (keyB64.length() % 4 != 0) {
+      keyB64 = keyB64 + "=";
+    }
+    byte[] key = java.util.Base64.getDecoder().decode(keyB64);
+    if (key.length != 32) {
+      throw new IllegalArgumentException("encoding_aes_key 解码后须为 32 字节");
+    }
+    this.aesKey = key;
+    this.token = token.strip();
+    this.receiveId = receiveId.strip();
+  }
+
+  String verifyUrl(String msgSignature, String timestamp, String nonce, String echostr)
+      throws Exception {
+    if (!msgSignature.equals(sha1Signature(timestamp, nonce, echostr))) {
+      throw new IllegalStateException("echostr 签名校验失败");
+    }
+    return decrypt(echostr);
+  }
+
+  String decryptMsg(String msgSignature, String timestamp, String nonce, String encrypt)
+      throws Exception {
+    if (!msgSignature.equals(sha1Signature(timestamp, nonce, encrypt))) {
+      throw new IllegalStateException("回调签名校验失败");
+    }
+    return decrypt(encrypt);
+  }
+
+  /** 单测 / 回环：加密明文 XML。 */
+  String encrypt(String plainXml) throws Exception {
+    byte[] random = new byte[RANDOM_LEN];
+    new java.security.SecureRandom().nextBytes(random);
+    byte[] xmlBytes = plainXml.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    byte[] receiveBytes = receiveId.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    byte[] raw = new byte[RANDOM_LEN + 4 + xmlBytes.length + receiveBytes.length];
+    System.arraycopy(random, 0, raw, 0, RANDOM_LEN);
+    int xmlLen = xmlBytes.length;
+    raw[RANDOM_LEN] = (byte) ((xmlLen >> 24) & 0xff);
+    raw[RANDOM_LEN + 1] = (byte) ((xmlLen >> 16) & 0xff);
+    raw[RANDOM_LEN + 2] = (byte) ((xmlLen >> 8) & 0xff);
+    raw[RANDOM_LEN + 3] = (byte) (xmlLen & 0xff);
+    System.arraycopy(xmlBytes, 0, raw, RANDOM_LEN + 4, xmlBytes.length);
+    System.arraycopy(receiveBytes, 0, raw, RANDOM_LEN + 4 + xmlBytes.length, receiveBytes.length);
+    byte[] padded = pkcs7Pad(raw);
+    javax.crypto.Cipher cipherInst = javax.crypto.Cipher.getInstance(TRANSFORMATION);
+    javax.crypto.spec.SecretKeySpec keySpec = new javax.crypto.spec.SecretKeySpec(aesKey, "AES");
+    javax.crypto.spec.IvParameterSpec iv =
+        new javax.crypto.spec.IvParameterSpec(aesKey, 0, AES_BLOCK);
+    cipherInst.init(javax.crypto.Cipher.ENCRYPT_MODE, keySpec, iv);
+    return java.util.Base64.getEncoder().encodeToString(cipherInst.doFinal(padded));
+  }
+
+  String signature(String timestamp, String nonce, String encrypt) throws Exception {
+    return sha1Signature(timestamp, nonce, encrypt);
+  }
+
+  private String decrypt(String encryptB64) throws Exception {
+    byte[] cipher = java.util.Base64.getDecoder().decode(encryptB64);
+    javax.crypto.Cipher cipherInst = javax.crypto.Cipher.getInstance(TRANSFORMATION);
+    javax.crypto.spec.SecretKeySpec keySpec = new javax.crypto.spec.SecretKeySpec(aesKey, "AES");
+    javax.crypto.spec.IvParameterSpec iv =
+        new javax.crypto.spec.IvParameterSpec(aesKey, 0, AES_BLOCK);
+    cipherInst.init(javax.crypto.Cipher.DECRYPT_MODE, keySpec, iv);
+    byte[] original = pkcs7Unpad(cipherInst.doFinal(cipher));
+    if (original.length < RANDOM_LEN + 4) {
+      throw new IllegalStateException("解密报文过短");
+    }
+    int xmlLen =
+        ((original[RANDOM_LEN] & 0xff) << 24)
+            | ((original[RANDOM_LEN + 1] & 0xff) << 16)
+            | ((original[RANDOM_LEN + 2] & 0xff) << 8)
+            | (original[RANDOM_LEN + 3] & 0xff);
+    int xmlStart = RANDOM_LEN + 4;
+    int xmlEnd = xmlStart + xmlLen;
+    if (xmlLen < 0 || xmlEnd > original.length) {
+      throw new IllegalStateException("解密报文长度非法");
+    }
+    String xml = new String(original, xmlStart, xmlLen, java.nio.charset.StandardCharsets.UTF_8);
+    String fromReceiveId =
+        new String(
+            original, xmlEnd, original.length - xmlEnd, java.nio.charset.StandardCharsets.UTF_8);
+    if (!receiveId.equals(fromReceiveId)) {
+      throw new IllegalStateException("receiveId 不匹配");
+    }
+    return xml;
+  }
+
+  private String sha1Signature(String timestamp, String nonce, String encrypt) throws Exception {
+    String[] arr = {token, timestamp, nonce, encrypt};
+    java.util.Arrays.sort(arr);
+    String raw = arr[0] + arr[1] + arr[2] + arr[3];
+    java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-1");
+    byte[] digest = md.digest(raw.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    StringBuilder sb = new StringBuilder(digest.length * 2);
+    for (byte b : digest) {
+      sb.append(String.format("%02x", b));
+    }
+    return sb.toString();
+  }
+
+  private static byte[] pkcs7Pad(byte[] data) {
+    int pad = AES_BLOCK - (data.length % AES_BLOCK);
+    if (pad == 0) {
+      pad = AES_BLOCK;
+    }
+    byte[] out = new byte[data.length + pad];
+    System.arraycopy(data, 0, out, 0, data.length);
+    for (int i = data.length; i < out.length; i++) {
+      out[i] = (byte) pad;
+    }
+    return out;
+  }
+
+  private static byte[] pkcs7Unpad(byte[] decrypted) {
+    int pad = decrypted[decrypted.length - 1] & 0xff;
+    if (pad < 1 || pad > AES_BLOCK) {
+      return decrypted;
+    }
+    for (int i = 1; i <= pad; i++) {
+      if ((decrypted[decrypted.length - i] & 0xff) != pad) {
+        return decrypted;
+      }
+    }
+    byte[] out = new byte[decrypted.length - pad];
+    System.arraycopy(decrypted, 0, out, 0, out.length);
+    return out;
+  }
+}

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfMsgCrypt.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfMsgCrypt.java
@@ -13,7 +13,11 @@ final class WeixinKfMsgCrypt {
 
   private static final int AES_BLOCK = 16;
   private static final int RANDOM_LEN = 16;
+  private static final int AES_KEY_LEN = 32;
+  private static final int BASE64_PAD_MOD = 4;
+  private static final int LENGTH_HEADER_BYTES = 4;
   private static final String TRANSFORMATION = "AES/CBC/NoPadding";
+  private static final char BASE64_PAD = '=';
 
   private final byte[] aesKey;
   private final String token;
@@ -29,12 +33,9 @@ final class WeixinKfMsgCrypt {
     if (receiveId == null || receiveId.isBlank()) {
       throw new IllegalArgumentException("corpid/receiveId 为空");
     }
-    String keyB64 = encodingAesKey.strip();
-    while (keyB64.length() % 4 != 0) {
-      keyB64 = keyB64 + "=";
-    }
+    String keyB64 = padBase64(encodingAesKey.strip());
     byte[] key = java.util.Base64.getDecoder().decode(keyB64);
-    if (key.length != 32) {
+    if (key.length != AES_KEY_LEN) {
       throw new IllegalArgumentException("encoding_aes_key 解码后须为 32 字节");
     }
     this.aesKey = key;
@@ -64,15 +65,20 @@ final class WeixinKfMsgCrypt {
     new java.security.SecureRandom().nextBytes(random);
     byte[] xmlBytes = plainXml.getBytes(java.nio.charset.StandardCharsets.UTF_8);
     byte[] receiveBytes = receiveId.getBytes(java.nio.charset.StandardCharsets.UTF_8);
-    byte[] raw = new byte[RANDOM_LEN + 4 + xmlBytes.length + receiveBytes.length];
+    byte[] raw = new byte[RANDOM_LEN + LENGTH_HEADER_BYTES + xmlBytes.length + receiveBytes.length];
     System.arraycopy(random, 0, raw, 0, RANDOM_LEN);
     int xmlLen = xmlBytes.length;
     raw[RANDOM_LEN] = (byte) ((xmlLen >> 24) & 0xff);
     raw[RANDOM_LEN + 1] = (byte) ((xmlLen >> 16) & 0xff);
     raw[RANDOM_LEN + 2] = (byte) ((xmlLen >> 8) & 0xff);
     raw[RANDOM_LEN + 3] = (byte) (xmlLen & 0xff);
-    System.arraycopy(xmlBytes, 0, raw, RANDOM_LEN + 4, xmlBytes.length);
-    System.arraycopy(receiveBytes, 0, raw, RANDOM_LEN + 4 + xmlBytes.length, receiveBytes.length);
+    System.arraycopy(xmlBytes, 0, raw, RANDOM_LEN + LENGTH_HEADER_BYTES, xmlBytes.length);
+    System.arraycopy(
+        receiveBytes,
+        0,
+        raw,
+        RANDOM_LEN + LENGTH_HEADER_BYTES + xmlBytes.length,
+        receiveBytes.length);
     byte[] padded = pkcs7Pad(raw);
     javax.crypto.Cipher cipherInst = javax.crypto.Cipher.getInstance(TRANSFORMATION);
     javax.crypto.spec.SecretKeySpec keySpec = new javax.crypto.spec.SecretKeySpec(aesKey, "AES");
@@ -94,7 +100,7 @@ final class WeixinKfMsgCrypt {
         new javax.crypto.spec.IvParameterSpec(aesKey, 0, AES_BLOCK);
     cipherInst.init(javax.crypto.Cipher.DECRYPT_MODE, keySpec, iv);
     byte[] original = pkcs7Unpad(cipherInst.doFinal(cipher));
-    if (original.length < RANDOM_LEN + 4) {
+    if (original.length < RANDOM_LEN + LENGTH_HEADER_BYTES) {
       throw new IllegalStateException("解密报文过短");
     }
     int xmlLen =
@@ -102,7 +108,7 @@ final class WeixinKfMsgCrypt {
             | ((original[RANDOM_LEN + 1] & 0xff) << 16)
             | ((original[RANDOM_LEN + 2] & 0xff) << 8)
             | (original[RANDOM_LEN + 3] & 0xff);
-    int xmlStart = RANDOM_LEN + 4;
+    int xmlStart = RANDOM_LEN + LENGTH_HEADER_BYTES;
     int xmlEnd = xmlStart + xmlLen;
     if (xmlLen < 0 || xmlEnd > original.length) {
       throw new IllegalStateException("解密报文长度非法");
@@ -126,6 +132,18 @@ final class WeixinKfMsgCrypt {
     StringBuilder sb = new StringBuilder(digest.length * 2);
     for (byte b : digest) {
       sb.append(String.format("%02x", b));
+    }
+    return sb.toString();
+  }
+
+  private static String padBase64(String keyB64) {
+    int rem = keyB64.length() % BASE64_PAD_MOD;
+    if (rem == 0) {
+      return keyB64;
+    }
+    StringBuilder sb = new StringBuilder(keyB64);
+    for (int i = 0; i < BASE64_PAD_MOD - rem; i++) {
+      sb.append(BASE64_PAD);
     }
     return sb.toString();
   }

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfReplySessionStore.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfReplySessionStore.java
@@ -1,0 +1,49 @@
+package io.oryxos.channel.weixinkf;
+
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** 微信客服回复窗：用户主动发信后 48h / 每回合最多 5 条企业下行。 */
+final class WeixinKfReplySessionStore {
+
+  static final Duration SESSION_WINDOW = Duration.ofHours(48);
+  static final int MAX_REPLIES_PER_WINDOW = 5;
+
+  record Session(long expiresAtMs, int replyCount) {}
+
+  private final ConcurrentHashMap<String, Session> byChatId = new ConcurrentHashMap<>();
+
+  void rememberInbound(String chatId, long nowMs) {
+    if (chatId == null || chatId.isBlank()) {
+      return;
+    }
+    byChatId.put(chatId, new Session(nowMs + SESSION_WINDOW.toMillis(), 0));
+  }
+
+  Session requireForReply(String chatId, long nowMs) {
+    Session session = byChatId.get(chatId);
+    if (session == null) {
+      throw new IllegalStateException("微信客服会话上下文缺失，需用户先发消息（chat=" + chatId + "）");
+    }
+    if (nowMs > session.expiresAtMs()) {
+      byChatId.remove(chatId, session);
+      throw new IllegalStateException("微信客服 48 小时回复窗已关闭，需用户再发一条消息（chat=" + chatId + "）");
+    }
+    if (session.replyCount() >= MAX_REPLIES_PER_WINDOW) {
+      throw new IllegalStateException(
+          "微信客服回复条数已达上限（" + MAX_REPLIES_PER_WINDOW + "），需用户再发一条消息（chat=" + chatId + "）");
+    }
+    return session;
+  }
+
+  void markReplied(String chatId, Session prior) {
+    byChatId.computeIfPresent(
+        chatId,
+        (k, cur) -> {
+          if (cur != prior && cur.expiresAtMs() != prior.expiresAtMs()) {
+            return cur;
+          }
+          return new Session(cur.expiresAtMs(), cur.replyCount() + 1);
+        });
+  }
+}

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfSyncResult.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfSyncResult.java
@@ -1,0 +1,30 @@
+package io.oryxos.channel.weixinkf;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
+/** {@code kf/sync_msg} 一页结果。 */
+final class WeixinKfSyncResult {
+
+  private final List<JsonNode> messages;
+  private final String nextCursor;
+  private final boolean hasMore;
+
+  WeixinKfSyncResult(List<JsonNode> messages, String nextCursor, boolean hasMore) {
+    this.messages = messages == null ? List.of() : List.copyOf(messages);
+    this.nextCursor = nextCursor == null ? "" : nextCursor;
+    this.hasMore = hasMore;
+  }
+
+  List<JsonNode> messages() {
+    return messages;
+  }
+
+  String nextCursor() {
+    return nextCursor;
+  }
+
+  boolean hasMore() {
+    return hasMore;
+  }
+}

--- a/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapterTest.java
+++ b/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapterTest.java
@@ -165,8 +165,8 @@ class WeixinKfChannelAdapterTest {
     final AtomicInteger sendCalls = new AtomicInteger();
 
     @Override
-    public SyncResult syncMsg(String openKfid, String callbackToken, String cursor) {
-      return new SyncResult(new ArrayList<>(messages), "next", false);
+    public WeixinKfSyncResult syncMsg(String openKfid, String callbackToken, String cursor) {
+      return new WeixinKfSyncResult(new ArrayList<>(messages), "next", false);
     }
 
     @Override

--- a/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapterTest.java
+++ b/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapterTest.java
@@ -1,0 +1,182 @@
+package io.oryxos.channel.weixinkf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.ChannelConfig;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageService;
+import io.oryxos.core.channel.WebhookRequest;
+import io.oryxos.core.channel.WebhookResponse;
+import io.oryxos.core.profile.Profile;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WeixinKfChannelAdapterTest {
+
+  private static final String TOKEN = "QDG6eK";
+  private static final String CORP_ID = "wx5823bf96d3bd56c7";
+  private static final String AES_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+  private static final String OPEN_KFID = "wkOPEN";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private ProfileRegistry profiles;
+  private InboundMessageService inbound;
+  private FakeClient client;
+  private WeixinKfMsgCrypt crypt;
+  private WeixinKfChannelAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    profiles = mock(ProfileRegistry.class);
+    inbound = mock(InboundMessageService.class);
+    when(profiles.get("demo-agent")).thenReturn(Optional.of(mock(Profile.class)));
+    client = new FakeClient();
+    crypt = new WeixinKfMsgCrypt(TOKEN, AES_KEY, CORP_ID);
+    ChannelConfig config =
+        new ChannelConfig(
+            "ops-kf",
+            "weixin_kf",
+            CORP_ID,
+            "secret",
+            "demo-agent",
+            true,
+            Map.of(
+                "token", TOKEN,
+                "encoding_aes_key", AES_KEY,
+                "open_kfid", OPEN_KFID));
+    adapter =
+        new WeixinKfChannelAdapter(
+            config,
+            profiles,
+            inbound,
+            url -> {},
+            Clock.fixed(Instant.parse("2026-09-11T00:00:00Z"), ZoneOffset.UTC),
+            client,
+            crypt);
+    adapter.start();
+  }
+
+  @Test
+  @DisplayName("GET URL 校验回写明文 echostr")
+  void urlVerify() throws Exception {
+    String echoPlain = "hello_echo";
+    String cipher = crypt.encrypt(echoPlain);
+    String ts = "1409659813";
+    String nonce = "1372623149";
+    String sig = crypt.signature(ts, nonce, cipher);
+    WebhookResponse response =
+        adapter.onWebhook(
+            new WebhookRequest(
+                "GET",
+                Map.of(
+                    "msg_signature", sig,
+                    "timestamp", ts,
+                    "nonce", nonce,
+                    "echostr", cipher),
+                Map.of(),
+                ""));
+    assertEquals(200, response.status());
+    assertEquals(echoPlain, response.body());
+  }
+
+  @Test
+  @DisplayName("POST kf_msg_or_event → sync → onMessage")
+  void callbackSync() throws Exception {
+    ObjectNode item = MAPPER.createObjectNode();
+    item.put("msgid", "msg-1");
+    item.put("open_kfid", OPEN_KFID);
+    item.put("external_userid", "wu1");
+    item.put("origin", 3);
+    item.put("msgtype", "text");
+    item.putObject("text").put("content", "你好客服");
+    client.messages = List.of(item);
+
+    String eventXml =
+        "<xml><ToUserName><![CDATA["
+            + CORP_ID
+            + "]]></ToUserName>"
+            + "<CreateTime>1348831860</CreateTime>"
+            + "<MsgType><![CDATA[event]]></MsgType>"
+            + "<Event><![CDATA[kf_msg_or_event]]></Event>"
+            + "<Token><![CDATA[ENC_TOKEN]]></Token>"
+            + "<OpenKfId><![CDATA["
+            + OPEN_KFID
+            + "]]></OpenKfId></xml>";
+    String cipher = crypt.encrypt(eventXml);
+    String ts = "1409659813";
+    String nonce = "1372623149";
+    String sig = crypt.signature(ts, nonce, cipher);
+    String body = "<xml><Encrypt><![CDATA[" + cipher + "]]></Encrypt></xml>";
+    WebhookResponse response =
+        adapter.onWebhook(
+            new WebhookRequest(
+                "POST",
+                Map.of(
+                    "msg_signature", sig,
+                    "timestamp", ts,
+                    "nonce", nonce),
+                Map.of(),
+                body));
+    assertEquals(200, response.status());
+    assertEquals("success", response.body());
+    verify(inbound).onMessage(any(InboundMessage.class), any());
+    assertEquals(1, client.ensureCalls.get());
+  }
+
+  @Test
+  @DisplayName("无会话 sendReply 硬拒绝")
+  void sendWithoutSession() {
+    IllegalStateException e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> adapter.sendReply("kf:" + OPEN_KFID + ":user:wu1", "hi", null));
+    assertTrue(e.getMessage().contains("会话"));
+  }
+
+  @Test
+  @DisplayName("窗内可回复并计数")
+  void sendWithinWindow() throws Exception {
+    callbackSync();
+    adapter.sendReply("kf:" + OPEN_KFID + ":user:wu1", "回复", null);
+    assertEquals(1, client.sendCalls.get());
+  }
+
+  private static final class FakeClient implements WeixinKfClient {
+    List<com.fasterxml.jackson.databind.JsonNode> messages = List.of();
+    final AtomicInteger ensureCalls = new AtomicInteger();
+    final AtomicInteger sendCalls = new AtomicInteger();
+
+    @Override
+    public SyncResult syncMsg(String openKfid, String callbackToken, String cursor) {
+      return new SyncResult(new ArrayList<>(messages), "next", false);
+    }
+
+    @Override
+    public void sendText(String openKfid, String externalUserId, String text) {
+      sendCalls.incrementAndGet();
+    }
+
+    @Override
+    public void ensureAiReception(String openKfid, String externalUserId) {
+      ensureCalls.incrementAndGet();
+    }
+  }
+}

--- a/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfChannelContractTest.java
+++ b/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfChannelContractTest.java
@@ -1,0 +1,73 @@
+package io.oryxos.channel.weixinkf;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageServiceContractTestBase;
+import java.util.List;
+
+class WeixinKfChannelContractTest extends InboundMessageServiceContractTestBase {
+
+  private final WeixinKfEventNormalizer normalizer = new WeixinKfEventNormalizer("contract-kf");
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Override
+  protected String channelType() {
+    return "weixin_kf";
+  }
+
+  @Override
+  protected InboundMessage p2pMessage(String messageId, String content) {
+    return normalizer.normalize(payload(messageId, "text", content)).orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage groupMessage(String messageId, String content) {
+    return new InboundMessage(
+        channelType(),
+        "contract-kf",
+        messageId,
+        ChatKind.GROUP,
+        "user-1",
+        "group:g1",
+        content,
+        true,
+        true,
+        List.of());
+  }
+
+  @Override
+  protected InboundMessage nonTextualMessage(String messageId) {
+    return normalizer.normalize(payload(messageId, "image", null)).orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage imageMessage(String messageId) {
+    return new InboundMessage(
+        channelType(),
+        "contract-kf",
+        messageId,
+        ChatKind.P2P,
+        "wu1",
+        WeixinKfChatTargets.chatId("wk1", "wu1"),
+        "",
+        false,
+        false,
+        List.of(InboundAttachment.imageUrl("https://example.com/a.jpg")));
+  }
+
+  private ObjectNode payload(String messageId, String msgType, String text) {
+    ObjectNode item = mapper.createObjectNode();
+    item.put("msgid", messageId);
+    item.put("open_kfid", "wk1");
+    item.put("external_userid", "wu1");
+    item.put("origin", 3);
+    item.put("msgtype", msgType);
+    if (text != null) {
+      item.putObject("text").put("content", text);
+    }
+    return item;
+  }
+}

--- a/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfEventNormalizerTest.java
+++ b/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfEventNormalizerTest.java
@@ -1,0 +1,62 @@
+package io.oryxos.channel.weixinkf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WeixinKfEventNormalizerTest {
+
+  private final WeixinKfEventNormalizer normalizer = new WeixinKfEventNormalizer("ops-kf");
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  @DisplayName("客户文本 → InboundMessage")
+  void customerText() {
+    ObjectNode item = mapper.createObjectNode();
+    item.put("msgid", "m1");
+    item.put("open_kfid", "wk1");
+    item.put("external_userid", "wu1");
+    item.put("origin", 3);
+    item.put("msgtype", "text");
+    item.putObject("text").put("content", "你好客服");
+    Optional<InboundMessage> msg = normalizer.normalize(item);
+    assertTrue(msg.isPresent());
+    assertEquals("你好客服", msg.get().content());
+    assertTrue(msg.get().textual());
+    assertEquals("kf:wk1:user:wu1", msg.get().chatId());
+  }
+
+  @Test
+  @DisplayName("非客户来源丢弃")
+  void ignoreSystem() {
+    ObjectNode item = mapper.createObjectNode();
+    item.put("msgid", "m2");
+    item.put("open_kfid", "wk1");
+    item.put("external_userid", "wu1");
+    item.put("origin", 4);
+    item.put("msgtype", "text");
+    item.putObject("text").put("content", "sys");
+    assertTrue(normalizer.normalize(item).isEmpty());
+  }
+
+  @Test
+  @DisplayName("非文本 → textual=false")
+  void nonText() {
+    ObjectNode item = mapper.createObjectNode();
+    item.put("msgid", "m3");
+    item.put("open_kfid", "wk1");
+    item.put("external_userid", "wu1");
+    item.put("origin", 3);
+    item.put("msgtype", "image");
+    Optional<InboundMessage> msg = normalizer.normalize(item);
+    assertTrue(msg.isPresent());
+    assertFalse(msg.get().textual());
+  }
+}

--- a/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfMsgCryptTest.java
+++ b/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfMsgCryptTest.java
@@ -1,0 +1,44 @@
+package io.oryxos.channel.weixinkf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WeixinKfMsgCryptTest {
+
+  private static final String TOKEN = "QDG6eK";
+  private static final String CORP_ID = "wx5823bf96d3bd56c7";
+  // 32 字节全 0 的 EncodingAESKey（去 padding，43 字符）
+  private static final String AES_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+  @Test
+  @DisplayName("encrypt/decrypt 回环 + 签名")
+  void roundTrip() throws Exception {
+    WeixinKfMsgCrypt crypt = new WeixinKfMsgCrypt(TOKEN, AES_KEY, CORP_ID);
+    String xml =
+        "<xml><ToUserName><![CDATA["
+            + CORP_ID
+            + "]]></ToUserName><Event><![CDATA[kf_msg_or_event]]></Event>"
+            + "<Token><![CDATA[ENCABCDEF]]></Token>"
+            + "<OpenKfId><![CDATA[wkOPEN]]></OpenKfId></xml>";
+    String cipher = crypt.encrypt(xml);
+    String ts = "1409659813";
+    String nonce = "1372623149";
+    String sig = crypt.signature(ts, nonce, cipher);
+    String plain = crypt.decryptMsg(sig, ts, nonce, cipher);
+    assertTrue(plain.contains("kf_msg_or_event"));
+    assertTrue(plain.contains("ENCABCDEF"));
+    assertEquals(xml, plain);
+  }
+
+  @Test
+  @DisplayName("签名错误拒绝")
+  void badSignature() throws Exception {
+    WeixinKfMsgCrypt crypt = new WeixinKfMsgCrypt(TOKEN, AES_KEY, CORP_ID);
+    String cipher = crypt.encrypt("<xml>hi</xml>");
+    assertThrows(IllegalStateException.class, () -> crypt.decryptMsg("deadbeef", "1", "2", cipher));
+  }
+}

--- a/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfReplySessionStoreTest.java
+++ b/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfReplySessionStoreTest.java
@@ -1,0 +1,38 @@
+package io.oryxos.channel.weixinkf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WeixinKfReplySessionStoreTest {
+
+  @Test
+  @DisplayName("窗外与超 5 条硬拒绝")
+  void windowAndCap() {
+    WeixinKfReplySessionStore store = new WeixinKfReplySessionStore();
+    String chat = "kf:wk1:user:u1";
+    long t0 = 1_000_000L;
+    store.rememberInbound(chat, t0);
+    WeixinKfReplySessionStore.Session s = store.requireForReply(chat, t0 + 1000);
+    for (int i = 0; i < 5; i++) {
+      store.markReplied(chat, store.requireForReply(chat, t0 + 1000 + i));
+    }
+    IllegalStateException over =
+        assertThrows(IllegalStateException.class, () -> store.requireForReply(chat, t0 + 2000));
+    assertTrue(over.getMessage().contains("上限"));
+
+    store.rememberInbound(chat, t0);
+    IllegalStateException expired =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                store.requireForReply(
+                    chat, t0 + WeixinKfReplySessionStore.SESSION_WINDOW.toMillis() + 1));
+    assertTrue(expired.getMessage().contains("48"));
+    assertEquals(5, WeixinKfReplySessionStore.MAX_REPLIES_PER_WINDOW);
+    assertEquals(s.replyCount(), 0);
+  }
+}

--- a/oryxos-cli/pom.xml
+++ b/oryxos-cli/pom.xml
@@ -86,6 +86,10 @@
         </dependency>
         <dependency>
             <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-channel-weixin-kf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
             <artifactId>oryxos-provider</artifactId>
         </dependency>
         <dependency>

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -1162,6 +1162,11 @@ public class OryxOsRuntime {
         resolved ->
             new io.oryxos.channel.weixin.WeixinChannelAdapter(
                 resolved, profileRegistry, inboundMessageService, channelOutboundGuard));
+    factories.put(
+        io.oryxos.channel.weixinkf.WeixinKfChannelAdapter.TYPE,
+        resolved ->
+            new io.oryxos.channel.weixinkf.WeixinKfChannelAdapter(
+                resolved, profileRegistry, inboundMessageService, channelOutboundGuard));
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <module>oryxos-channel-qq</module>
         <module>oryxos-channel-douyin</module>
         <module>oryxos-channel-weixin</module>
+        <module>oryxos-channel-weixin-kf</module>
         <module>oryxos-web</module>
         <module>oryxos-storage</module>
         <module>oryxos-cli</module>
@@ -205,6 +206,11 @@
             <dependency>
                 <groupId>io.oryxos</groupId>
                 <artifactId>oryxos-channel-weixin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.oryxos</groupId>
+                <artifactId>oryxos-channel-weixin-kf</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/specs/033-weixin-kf-channel/acceptance.md
+++ b/specs/033-weixin-kf-channel/acceptance.md
@@ -6,10 +6,10 @@
 
 - [x] 与 `wecom` 应用机器人区分写清  
 - [x] 入站/出站 API 与 48h/5 条钉死  
-- [ ] 产品确认可 BUILD  
+- [x] 产品确认可 BUILD  
 
-## BUILD（未开始）
+## BUILD
 
-- [ ] 模块 + 单测  
-- [ ] Setup + example  
-- [ ] 真机（有资质）  
+- [x] 模块 `oryxos-channel-weixin-kf` + 单测（验签加解密、sync 归一化、窗外/超 5 条、契约档）  
+- [x] Setup + `channels.yaml.example` + Runtime `type: weixin_kf`  
+- [ ] 真机（有企微+微信客服资质时）  

--- a/specs/033-weixin-kf-channel/plan.md
+++ b/specs/033-weixin-kf-channel/plan.md
@@ -2,7 +2,7 @@
 
 **Branch（BUILD 时）**: `feat/033-weixin-kf-channel`  
 **Date**: 2026-09-11  
-**Status**: PLANNED（**未 BUILD**）  
+**Status**: BUILT（单测绿；真机待资质）  
 **对照**: [research](./research.md)、[030](../030-cn-c-im-roadmap/plan.md)、[017 契约](../017-feishu-im-channel/contracts/inbound-channel-contract.md)
 
 ## Summary


### PR DESCRIPTION
## Summary
- 新增 `oryxos-channel-weixin-kf`（`type: weixin_kf`）：企微微信客服回调验签解密 → `kf/sync_msg` 拉文本 → 编排 → `kf/send_msg`
- 会话窗 48h / 每回合最多 5 条硬拒绝；尽量转到「智能助手接待」；与 `wecom` / `weixin` 并列不合并
- Setup + `channels.yaml.example` + Runtime/cli/boot 接线；单测覆盖加解密、归一化、窗外拒绝、契约档

## Test plan
- [x] `mvn -pl oryxos-channel-weixin-kf test`
- [x] `mvn -pl oryxos-cli -am compile -DskipTests`
- [ ] 真机：有企微微信客服资质时配置回调，微信侧发文本收 Agent 回复

Made with [Cursor](https://cursor.com)