### PR TITLE
release: 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,41 @@
 本文件记录 OryxOS 的版本变更。格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [0.1.5-RELEASE] - 2026-09-11
+
+### Added
+- 可插拔存储：Flyway 收编 schema 演进 + PostgreSQL 部署选项（025，#409）。
+- 容器沙箱：docker 档最小闭环（024，#406/#362/#383）。
+- Provider 失败按序切换备用 Provider，并导出业务指标（023，#377）。
+- 密钥加密存储：落库凭证 AES-GCM，`ORYXOS_MASTER_KEY` / `master.key`（022，#351）。
+- 审计 Trace：单轮处理串联 `trace_id`（021，#350）。
+- 人格库：7 字段人格 + agency-agents 导入 + CRUD（#378）。
+- Docker 镜像分发：Dockerfile / entrypoint / GHCR 多架构推送（#331）。
+- 全球 IM 渠道波次：Telegram / WhatsApp / Teams / Google Chat / Mattermost / Matrix 入站与 notify；Slack / Discord notify 补齐（026，#429/#430）。
+- Slack Socket Mode 入站 MVP 与图片/文件下载（#420/#421）。
+- Discord Gateway 文本与图片/语音/视频入站（#422–#427）。
+- 飞书 / 企微 / 钉钉：入站文件、音视频加深、进度流与交互体验（#414/#415/#411/#405 等）。
+- 入站图片以多模态 Media 交给 LLM（#385）；IM `/new`、群 `/stop`、进度卡片与 ASR/PDF 抽取（#391/#412/#414 等）。
+- QQ 官方 Bot 入站与 notify；入站图片/PDF/语音/视频（029，#434/#435）。
+- 抖音私信 webhook 入站 MVP（031，#436）。
+- 微信个人号 iLink 入站与多模态媒体（035，#437）。
+- 微信客服入站 MVP（033，#440）。
+- Agent 流式运行管理工作台（#219）；新建/编辑 Agent 时已安装 Skill 筛选（028）。
+- `web_search` DuckDuckGo HTML 回退；默认工具脚手架含 `web_search`（#419 相关）。
+
+### Fixed
+- 凭证掩码：MCP / notify-channel 视图不再回显明文（#358）。
+- Web/core 硬化余项：知识库命名空间、客户端错误映射、Skill 导入流式边界等（#360）。
+- 飞书 WS close 有界，停机不再卡约 32s（#417）；`WorkspaceWatcher` SIGTERM 优雅退出（#333）。
+- 企微启动失败关闭 WS（#349）；工具超时与边界（#356）；知识库索引生命周期（#357）。
+- Actuator 门禁与默认关闭 Swagger（#314）。
+- 入站媒体 SSRF / Whisper / TTL / 进度 UX 硬化与渠道对齐修复（#416/#413/#408 等）。
+- 依赖：PostgreSQL JDBC 42.7.12 修复 CVE-2026-54291；Spring 相关 CVE 门禁处理。
+
+### Docs
+- 026 IM 渠道路线与真机验收记录；Demo 默认模型示例更新为 `deepseek-v4-flash`（#336）。
+- README 版本徽章升级至 0.1.5。
+
 ## [0.1.4-RELEASE] - 2026-08-31
 
 ### Added
@@ -164,6 +199,7 @@
 - Web REST API（`/api/v1`）与 CLI 子命令（`init`/`chat`/`serve`/`gateway` 等）。
 - SQLite 持久化与 `tool_invocations` / `llm_calls` 审计表 Day-One 写入。
 
+[0.1.5-RELEASE]: https://github.com/oryx-labs/oryxos/compare/v0.1.4-RELEASE...v0.1.5-RELEASE
 [0.1.4-RELEASE]: https://github.com/oryx-labs/oryxos/compare/v0.1.3-RELEASE...v0.1.4-RELEASE
 [0.1.3-RELEASE]: https://github.com/oryx-labs/oryxos/compare/v0.1.2-RELEASE...v0.1.3-RELEASE
 [0.1.2-RELEASE]: https://github.com/oryx-labs/oryxos/compare/v0.1.1-RELEASE...v0.1.2-RELEASE

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/oryx-labs/oryxos/releases"><img src="https://img.shields.io/badge/version-0.1.4-orange?style=flat-square" alt="version"/></a>
+  <a href="https://github.com/oryx-labs/oryxos/releases"><img src="https://img.shields.io/badge/version-0.1.5-orange?style=flat-square" alt="version"/></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-native-8A2BE2?style=flat-square" alt="MCP native"/></a>
   <a href="https://www.apache.org/licenses/LICENSE-2.0"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0"/></a>
 </p>

--- a/bin/start-im-test.ps1
+++ b/bin/start-im-test.ps1
@@ -12,7 +12,7 @@ Get-Content $EnvFile -Encoding UTF8 | ForEach-Object {
   }
 }
 $java = if ($env:JAVA_HOME) { Join-Path $env:JAVA_HOME "bin\java.exe" } else { "java" }
-$jar = Join-Path $Root "oryxos-boot\target\oryxos-boot-0.1.4-RELEASE.jar"
+$jar = Join-Path $Root "oryxos-boot\target\oryxos-boot-0.1.5-RELEASE.jar"
 if (-not (Test-Path $jar)) { throw "Missing jar: $jar — run mvn package first" }
 $port = if ($args.Count -ge 1) { $args[0] } else { "8081" }
 Set-Location $Root

--- a/oryxos-boot/pom.xml
+++ b/oryxos-boot/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-boot</artifactId>

--- a/oryxos-boot/src/test/java/io/oryxos/boot/TraceE2ETest.java
+++ b/oryxos-boot/src/test/java/io/oryxos/boot/TraceE2ETest.java
@@ -292,9 +292,14 @@ class TraceE2ETest {
           rest.getForEntity("/api/v1/agents/agent-a/executions", String.class);
       assertEquals(HttpStatus.OK, response.getStatusCode());
       for (JsonNode row : readJson(response.getBody()).get("data")) {
-        if (row.get("id").asLong() == executionId
-            && !"RUNNING".equals(row.get("status").asText())) {
-          assertEquals("SUCCESS", row.get("status").asText());
+        if (row.get("id").asLong() != executionId) {
+          continue;
+        }
+        // QUEUED / RUNNING / CANCELLING 都是进行中——不能把非 RUNNING 当成终态
+        // （否则 trigger 刚落库为 QUEUED 时会立刻 assert SUCCESS 失败）
+        String status = row.get("status").asText();
+        if ("SUCCESS".equals(status) || "FAILED".equals(status) || "CANCELLED".equals(status)) {
+          assertEquals("SUCCESS", status);
           return row;
         }
       }

--- a/oryxos-channel-cli/pom.xml
+++ b/oryxos-channel-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-channel-cli</artifactId>

--- a/oryxos-channel-dingtalk/pom.xml
+++ b/oryxos-channel-dingtalk/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-channel-dingtalk</artifactId>

--- a/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkStreamClient.java
+++ b/oryxos-channel-dingtalk/src/main/java/io/oryxos/channel/dingtalk/DingTalkStreamClient.java
@@ -244,7 +244,7 @@ final class DingTalkStreamClient implements WebSocket.Listener {
     body.put("clientId", clientId);
     body.put("clientSecret", clientSecret);
     body.set("subscriptions", subscriptions);
-    body.put("ua", "oryxos-channel-dingtalk/0.1.4-RELEASE");
+    body.put("ua", "oryxos-channel-dingtalk/0.1.5-RELEASE");
     HttpClient client = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
     HttpRequest request =
         HttpRequest.newBuilder()

--- a/oryxos-channel-discord/pom.xml
+++ b/oryxos-channel-discord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-channel-discord</artifactId>

--- a/oryxos-channel-douyin/pom.xml
+++ b/oryxos-channel-douyin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
     <artifactId>oryxos-channel-douyin</artifactId>
     <name>OryxOS Channel Douyin</name>

--- a/oryxos-channel-feishu/pom.xml
+++ b/oryxos-channel-feishu/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-channel-feishu</artifactId>

--- a/oryxos-channel-gchat/pom.xml
+++ b/oryxos-channel-gchat/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
     <artifactId>oryxos-channel-gchat</artifactId>
     <name>OryxOS Channel Google Chat</name>

--- a/oryxos-channel-matrix/pom.xml
+++ b/oryxos-channel-matrix/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
     <artifactId>oryxos-channel-matrix</artifactId>
     <name>OryxOS Channel Matrix</name>

--- a/oryxos-channel-mattermost/pom.xml
+++ b/oryxos-channel-mattermost/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
     <artifactId>oryxos-channel-mattermost</artifactId>
     <name>OryxOS Channel Mattermost</name>

--- a/oryxos-channel-qq/pom.xml
+++ b/oryxos-channel-qq/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-channel-qq</artifactId>

--- a/oryxos-channel-slack/pom.xml
+++ b/oryxos-channel-slack/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-channel-slack</artifactId>

--- a/oryxos-channel-teams/pom.xml
+++ b/oryxos-channel-teams/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
     <artifactId>oryxos-channel-teams</artifactId>
     <name>OryxOS Channel Teams</name>

--- a/oryxos-channel-telegram/pom.xml
+++ b/oryxos-channel-telegram/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-channel-telegram</artifactId>

--- a/oryxos-channel-wecom/pom.xml
+++ b/oryxos-channel-wecom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-channel-wecom</artifactId>

--- a/oryxos-channel-weixin-kf/pom.xml
+++ b/oryxos-channel-weixin-kf/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
     <artifactId>oryxos-channel-weixin-kf</artifactId>
     <name>OryxOS Channel Weixin KF</name>

--- a/oryxos-channel-weixin/pom.xml
+++ b/oryxos-channel-weixin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
     <artifactId>oryxos-channel-weixin</artifactId>
     <name>OryxOS Channel Weixin</name>

--- a/oryxos-channel-whatsapp/pom.xml
+++ b/oryxos-channel-whatsapp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
     <artifactId>oryxos-channel-whatsapp</artifactId>
     <name>OryxOS Channel WhatsApp</name>

--- a/oryxos-cli/pom.xml
+++ b/oryxos-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-cli</artifactId>

--- a/oryxos-core/pom.xml
+++ b/oryxos-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-core</artifactId>

--- a/oryxos-knowledge/pom.xml
+++ b/oryxos-knowledge/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-knowledge</artifactId>

--- a/oryxos-memory/pom.xml
+++ b/oryxos-memory/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-memory</artifactId>

--- a/oryxos-persona/pom.xml
+++ b/oryxos-persona/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-persona</artifactId>

--- a/oryxos-provider/pom.xml
+++ b/oryxos-provider/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-provider</artifactId>

--- a/oryxos-storage/pom.xml
+++ b/oryxos-storage/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-storage</artifactId>

--- a/oryxos-tool/pom.xml
+++ b/oryxos-tool/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-tool</artifactId>

--- a/oryxos-web/pom.xml
+++ b/oryxos-web/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.oryxos</groupId>
         <artifactId>oryxos</artifactId>
-        <version>0.1.4-RELEASE</version>
+        <version>0.1.5-RELEASE</version>
     </parent>
 
     <artifactId>oryxos-web</artifactId>

--- a/oryxos-web/src/main/frontend/src/App.vue
+++ b/oryxos-web/src/main/frontend/src/App.vue
@@ -157,7 +157,7 @@ const overviewCards = computed(() => [
 const overview = {
   tagline: '装在你自己基础设施上的分布式 AI Agent 操作系统 —— 统一底座运行多个业务 Agent',
   status: '运行中',
-  version: 'v0.1.4 · RELEASE',
+  version: 'v0.1.5 · RELEASE',
   capabilities: [
     { name: '对接 LLM', desc: '显式 Provider 映射，多家协议统一' },
     { name: 'ReAct 循环', desc: '自实现推理–行动循环，完全可控' },

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.oryxos</groupId>
     <artifactId>oryxos</artifactId>
-    <version>0.1.4-RELEASE</version>
+    <version>0.1.5-RELEASE</version>
     <packaging>pom</packaging>
 
     <name>OryxOS</name>

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -12,7 +12,7 @@ install.ps1 — Windows 下安装 OryxOS CLI（构建 jar + 注册 PowerShell �
 
 说明：
   • 幂等可重复运行：$PROFILE 中旧函数块（begin/end 标记之间）会被替换为最新版本。
-    • jar 文件名带版本号（如 oryxos-boot-0.1.4-RELEASE.jar），函数内用通配符动态
+    • jar 文件名带版本号（如 oryxos-boot-0.1.5-RELEASE.jar），函数内用通配符动态
     解析最新产物，且排除 spring-boot repackage 留下的 *.jar.original。
 #>
 

--- a/specs/013-overview-dynamic-data/data-model.md
+++ b/specs/013-overview-dynamic-data/data-model.md
@@ -74,7 +74,7 @@ public SessionStats stats() {
 const overview = reactive({
   tagline: '装在你自己基础设施上的分布式 AI Agent 操作系统...',
   status: '运行中',
-  version: 'v0.1.4 · RELEASE',
+  version: 'v0.1.5 · RELEASE',
   stats: {
     agents: { value: null, loading: true, error: null },
     tools: { value: null, loading: true, error: null },


### PR DESCRIPTION
## Summary

- Bump all Maven modules from `0.1.4-RELEASE` to `0.1.5-RELEASE`
- Add `CHANGELOG.md` section for 0.1.5 (pluggable storage / Flyway+PG, container sandbox, provider fallback, secret encryption, audit trace, persona library, Docker/GHCR, global IM channels including Slack/Discord/Telegram/WhatsApp/Teams/GChat/Mattermost/Matrix, QQ/Douyin/Weixin channels, IM media & progress UX, and related fixes since 0.1.4)
- Sync README version badge, admin overview version (`App.vue`), `install.ps1` / `start-im-test.ps1` jar examples, DingTalk UA string, and spec data-model example

Merging this PR triggers [`.github/workflows/release.yml`](.github/workflows/release.yml) to build `dist/oryxos-0.1.5-RELEASE.tar.gz`, publish GitHub Release `v0.1.5-RELEASE`, and push `ghcr.io/oryx-labs/oryxos:v0.1.5-RELEASE` (+ `:latest`).

> Same-repo branch (`oryx-labs/oryxos:release/0.1.5`) to avoid fork-PR Release 403 (see #185/#186/#330).

## Test plan

- [x] `mvn clean verify` locally (passed)
- [ ] CI Build & quality gate / OWASP / Docker / VitePress green
- [ ] After merge: Release workflow success; tag `v0.1.5-RELEASE` with tarball; GHCR image present


Made with [Cursor](https://cursor.com)