### PR TITLE
feat(channel-weixin-kf): multimodal media + AMR voice (033 follow-up)

### DIFF
--- a/docs/WeixinKfChannelSetup.md
+++ b/docs/WeixinKfChannelSetup.md
@@ -35,8 +35,10 @@
 
 | 步骤 | 说明 |
 |------|------|
-| 入站 | 回调 `kf_msg_or_event`（加密，不带正文）→ `kf/sync_msg` 拉文本 |
-| 会话态 | 尽量转到「智能助手接待」后再编排/发信 |
+| 入站 | 回调 `kf_msg_or_event` → `kf/sync_msg` 拉消息（文本 + 图/文件/语音/视频）；语音 `voice_format=0`（AMR，便于本机 ffmpeg→Whisper） |
+| 媒体 | `media_id` → `GET /cgi-bin/media/get` 落盘；先回「处理中」，再编排（Vision / `read_file` / Whisper） |
+| 会话 | 私聊连续记忆（与其它 IM 一致）；`/new` 仅可选手动清空 |
+| 会话态 | 尽量转到「智能助手接待」后再编排/发信；`service_state` 无权限（48002）时跳过仍尝试 `send_msg` |
 | 出站 | `kf/send_msg` 文本；**48h / 每回合最多 5 条**，窗外硬拒绝 |
 | chatId | `kf:{open_kfid}:user:{external_userid}` |
 
@@ -50,4 +52,4 @@
 
 ## MVP 非目标
 
-媒体入站、多 `open_kfid` 路由、人工排班 UI、服务号/小程序客服。
+出站发图/文件；多 `open_kfid` 路由；人工排班 UI；服务号/小程序客服。

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfApiClient.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfApiClient.java
@@ -199,6 +199,9 @@ final class WeixinKfApiClient implements WeixinKfClient {
     return new String(body, StandardCharsets.UTF_8);
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification = "仅对 ASCII Content-Disposition 关键字 filename=/filename*= 做 Locale.ROOT 小写匹配")
   private static String fileNameFromDisposition(java.util.Optional<String> header) {
     if (header == null || header.isEmpty()) {
       return null;

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfApiClient.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfApiClient.java
@@ -56,6 +56,8 @@ final class WeixinKfApiClient implements WeixinKfClient {
       body.put("cursor", cursor);
     }
     body.put("limit", 1000);
+    // 0=AMR：本机 ffmpeg（Gyan full 等）可解 AMR-NB/WB；1=Silk 时官方 ffmpeg 无解码器，ASR 必失败。
+    body.put("voice_format", 0);
     JsonNode root = postJson("/cgi-bin/kf/sync_msg", body);
     String nextCursor = root.path("next_cursor").asText("");
     int hasMore = root.path("has_more").asInt(0);
@@ -87,7 +89,16 @@ final class WeixinKfApiClient implements WeixinKfClient {
 
   @Override
   public void ensureAiReception(String openKfid, String externalUserId) {
-    int state = getServiceState(openKfid, externalUserId);
+    final int state;
+    try {
+      state = getServiceState(openKfid, externalUserId);
+    } catch (IllegalStateException e) {
+      // 48002：企业未开通/无权限调用会话状态 API；仍尝试 send_msg（入站已能 sync）。
+      if (e.getMessage() != null && e.getMessage().contains("errcode=48002")) {
+        return;
+      }
+      throw e;
+    }
     if (state == STATE_AI || state == STATE_UNTREATED) {
       if (state == STATE_UNTREATED) {
         ObjectNode body = MAPPER.createObjectNode();
@@ -103,6 +114,111 @@ final class WeixinKfApiClient implements WeixinKfClient {
     }
     throw new IllegalStateException(
         "微信客服会话非智能助手/未处理态（state=" + state + "，user=" + externalUserId + "），拒绝 API 发信");
+  }
+
+  @Override
+  public WeixinKfMediaBlob downloadMedia(String mediaId) {
+    if (mediaId == null || mediaId.isBlank()) {
+      throw new IllegalArgumentException("media_id 为空");
+    }
+    String token = accessToken.get();
+    if (token == null || token.isBlank()) {
+      throw new IllegalStateException("微信客服 access_token 为空");
+    }
+    String url =
+        API_BASE
+            + "/cgi-bin/media/get?access_token="
+            + URLEncoder.encode(token, StandardCharsets.UTF_8)
+            + "&media_id="
+            + URLEncoder.encode(mediaId.strip(), StandardCharsets.UTF_8);
+    guard.check(url);
+    try {
+      HttpRequest request =
+          HttpRequest.newBuilder().uri(URI.create(url)).timeout(TIMEOUT).GET().build();
+      HttpResponse<byte[]> response = http.send(request, HttpResponse.BodyHandlers.ofByteArray());
+      if (response.statusCode() < HTTP_OK_MIN || response.statusCode() >= HTTP_OK_MAX) {
+        throw new IllegalStateException(
+            "微信客服 /cgi-bin/media/get HTTP "
+                + response.statusCode()
+                + ": "
+                + sanitize(bodyAsText(response.body())));
+      }
+      byte[] body = response.body() == null ? new byte[0] : response.body();
+      String contentType =
+          response.headers().firstValue("Content-Type").orElse("application/octet-stream");
+      if (looksLikeJsonError(contentType, body)) {
+        JsonNode root = MAPPER.readTree(body);
+        throw new IllegalStateException(
+            "微信客服 /cgi-bin/media/get errcode="
+                + root.path("errcode").asInt()
+                + " errmsg="
+                + root.path("errmsg").asText());
+      }
+      String fileName =
+          fileNameFromDisposition(
+              response
+                  .headers()
+                  .firstValue("Content-Disposition")
+                  .or(() -> response.headers().firstValue("Content-disposition")));
+      return new WeixinKfMediaBlob(body, contentType, fileName);
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("微信客服 /cgi-bin/media/get 失败: " + e.getMessage(), e);
+    }
+  }
+
+  private static boolean looksLikeJsonError(String contentType, byte[] body) {
+    if (body == null || body.length == 0) {
+      return false;
+    }
+    if (contentType != null && contentType.toLowerCase(java.util.Locale.ROOT).contains("json")) {
+      return true;
+    }
+    // 部分错误响应仍是 application/octet-stream，以 JSON 开头
+    int i = 0;
+    while (i < body.length && Character.isWhitespace(body[i])) {
+      i++;
+    }
+    return i < body.length && body[i] == '{';
+  }
+
+  private static String bodyAsText(byte[] body) {
+    if (body == null || body.length == 0) {
+      return "";
+    }
+    return new String(body, StandardCharsets.UTF_8);
+  }
+
+  private static String fileNameFromDisposition(java.util.Optional<String> header) {
+    if (header == null || header.isEmpty()) {
+      return null;
+    }
+    String raw = header.get();
+    if (raw == null || raw.isBlank()) {
+      return null;
+    }
+    // filename="a.pdf" 或 filename*=UTF-8''a.pdf
+    int star = raw.toLowerCase(java.util.Locale.ROOT).indexOf("filename*=");
+    if (star >= 0) {
+      String part = raw.substring(star + "filename*=".length()).trim();
+      int q = part.indexOf("''");
+      if (q >= 0) {
+        part = part.substring(q + 2);
+      }
+      part = part.replace("\"", "").trim();
+      return part.isEmpty() ? null : part;
+    }
+    int idx = raw.toLowerCase(java.util.Locale.ROOT).indexOf("filename=");
+    if (idx < 0) {
+      return null;
+    }
+    String part = raw.substring(idx + "filename=".length()).trim().replace("\"", "");
+    int semi = part.indexOf(';');
+    if (semi >= 0) {
+      part = part.substring(0, semi).trim();
+    }
+    return part.isEmpty() ? null : part;
   }
 
   private JsonNode postJson(String path, ObjectNode body) {

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfApiClient.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfApiClient.java
@@ -31,6 +31,14 @@ final class WeixinKfApiClient implements WeixinKfClient {
   private static final int HTTP_OK_MIN = 200;
   private static final int HTTP_OK_MAX = 300;
 
+  /** 企微：无权限调用会话状态相关接口。 */
+  private static final String ERRCODE_NO_PRIVILEGE = "errcode=48002";
+
+  private static final String CONTENT_TYPE_JSON = "json";
+
+  /** sync_msg：0=AMR（本机 ffmpeg 可解）。 */
+  private static final int VOICE_FORMAT_AMR = 0;
+
   private final HttpClient http;
   private final OutboundGuard guard;
   private final Supplier<String> accessToken;
@@ -56,8 +64,8 @@ final class WeixinKfApiClient implements WeixinKfClient {
       body.put("cursor", cursor);
     }
     body.put("limit", 1000);
-    // 0=AMR：本机 ffmpeg（Gyan full 等）可解 AMR-NB/WB；1=Silk 时官方 ffmpeg 无解码器，ASR 必失败。
-    body.put("voice_format", 0);
+    // AMR：本机 ffmpeg（Gyan full 等）可解；Silk 时官方 ffmpeg 无解码器，ASR 必失败。
+    body.put("voice_format", VOICE_FORMAT_AMR);
     JsonNode root = postJson("/cgi-bin/kf/sync_msg", body);
     String nextCursor = root.path("next_cursor").asText("");
     int hasMore = root.path("has_more").asInt(0);
@@ -94,7 +102,7 @@ final class WeixinKfApiClient implements WeixinKfClient {
       state = getServiceState(openKfid, externalUserId);
     } catch (IllegalStateException e) {
       // 48002：企业未开通/无权限调用会话状态 API；仍尝试 send_msg（入站已能 sync）。
-      if (e.getMessage() != null && e.getMessage().contains("errcode=48002")) {
+      if (e.getMessage() != null && e.getMessage().contains(ERRCODE_NO_PRIVILEGE)) {
         return;
       }
       throw e;
@@ -172,7 +180,8 @@ final class WeixinKfApiClient implements WeixinKfClient {
     if (body == null || body.length == 0) {
       return false;
     }
-    if (contentType != null && contentType.toLowerCase(java.util.Locale.ROOT).contains("json")) {
+    if (contentType != null
+        && contentType.toLowerCase(java.util.Locale.ROOT).contains(CONTENT_TYPE_JSON)) {
       return true;
     }
     // 部分错误响应仍是 application/octet-stream，以 JSON 开头

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapter.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapter.java
@@ -388,7 +388,7 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
         return "";
       }
       String raw = java.nio.file.Files.readString(file).strip();
-      return raw == null ? "" : raw;
+      return raw;
     } catch (Exception e) {
       log.warn("读取微信客服 sync cursor 失败: {}", sanitize(e.getMessage()));
       return "";
@@ -401,7 +401,10 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
     }
     try {
       Path file = syncCursorFile();
-      java.nio.file.Files.createDirectories(file.getParent());
+      Path parent = file.getParent();
+      if (parent != null) {
+        java.nio.file.Files.createDirectories(parent);
+      }
       java.nio.file.Files.writeString(file, cursor);
     } catch (Exception e) {
       log.warn("保存微信客服 sync cursor 失败: {}", sanitize(e.getMessage()));

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapter.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapter.java
@@ -3,7 +3,9 @@ package io.oryxos.channel.weixinkf;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.oryxos.core.channel.ChannelConfig;
 import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundChannelAdapter;
+import io.oryxos.core.channel.InboundMediaRoots;
 import io.oryxos.core.channel.InboundMessage;
 import io.oryxos.core.channel.InboundMessageService;
 import io.oryxos.core.channel.InboundWebhookHandler;
@@ -11,10 +13,13 @@ import io.oryxos.core.channel.OutboundGuard;
 import io.oryxos.core.channel.WebhookRequest;
 import io.oryxos.core.channel.WebhookResponse;
 import io.oryxos.core.profile.ProfileRegistry;
+import java.nio.file.Path;
 import java.time.Clock;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +47,8 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
   private static final int HTTP_BAD_REQUEST = 400;
   private static final int HTTP_UNAUTHORIZED = 401;
   private static final int MAX_SYNC_PAGES = 20;
+  private static final String MEDIA_DIR_PREFIX = "weixin-kf";
+
   private final ChannelConfig config;
   private final ProfileRegistry profileRegistry;
   private final InboundMessageService inboundMessageService;
@@ -54,6 +61,7 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
   private volatile WeixinKfMsgCrypt crypt;
   private volatile WeixinKfClient api;
   private volatile WeixinKfEventNormalizer normalizer;
+  private volatile WeixinKfInboundMediaResolver mediaResolver;
   private volatile String syncCursor = "";
   private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
 
@@ -129,6 +137,14 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
       api = new WeixinKfApiClient(guard, tokens::getToken);
     }
     normalizer = new WeixinKfEventNormalizer(config.name());
+    mediaResolver = new WeixinKfInboundMediaResolver(api, createMediaRoot(), config.name());
+    syncCursor = loadSyncCursor();
+    try {
+      // 启动时排空积压：重启后 cursor 若过旧，不把历史 HI/图再丢进 Agent（否则刷屏并撞 5 条上限）
+      drainSyncCursor(api, config.extra(EXTRA_OPEN_KFID));
+    } catch (RuntimeException e) {
+      log.warn("微信客服启动排空 sync 游标失败（将在首次回调时继续）: {}", sanitize(e.getMessage()));
+    }
     state = ChannelStatus.State.CONNECTED;
   }
 
@@ -136,7 +152,9 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
   public synchronized void stop() {
     state = ChannelStatus.State.DISCONNECTED;
     normalizer = null;
+    mediaResolver = null;
     seenMsgIds.clear();
+    saveSyncCursor(syncCursor);
   }
 
   @Override
@@ -238,6 +256,7 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
       String cursor = syncCursor;
       boolean more = true;
       int pages = 0;
+      List<InboundMessage> batch = new java.util.ArrayList<>();
       while (more && pages < MAX_SYNC_PAGES) {
         pages++;
         WeixinKfSyncResult page = client.syncMsg(openKfid, callbackToken, cursor);
@@ -250,13 +269,7 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
           if (!seenMsgIds.add(m.messageId())) {
             continue;
           }
-          sessions.rememberInbound(m.chatId(), clock.millis());
-          try {
-            client.ensureAiReception(WeixinKfChatTargets.parse(m.chatId()).openKfid(), m.userId());
-          } catch (RuntimeException e) {
-            log.warn("微信客服确保智能助手接待失败: {}", sanitize(e.getMessage()));
-          }
-          inboundMessageService.onMessage(m, this);
+          batch.add(m);
         }
         if (page.nextCursor() != null && !page.nextCursor().isBlank()) {
           cursor = page.nextCursor();
@@ -264,7 +277,191 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
         }
         more = page.hasMore();
       }
+      saveSyncCursor(syncCursor);
+      for (InboundMessage m : coalesceSameChatMedia(batch)) {
+        sessions.rememberInbound(m.chatId(), clock.millis());
+        try {
+          client.ensureAiReception(WeixinKfChatTargets.parse(m.chatId()).openKfid(), m.userId());
+        } catch (RuntimeException e) {
+          log.warn("微信客服确保智能助手接待失败: {}", sanitize(e.getMessage()));
+        }
+        dispatchOne(m);
+      }
     }
+  }
+
+  /** 同一 sync 批次、同一会话的连续媒体合并为一条，避免 2 图 → 2 次闲聊并撞 5 条上限。 */
+  static List<InboundMessage> coalesceSameChatMedia(List<InboundMessage> batch) {
+    if (batch == null || batch.isEmpty()) {
+      return List.of();
+    }
+    List<InboundMessage> out = new java.util.ArrayList<>();
+    for (InboundMessage m : batch) {
+      if (out.isEmpty()) {
+        out.add(m);
+        continue;
+      }
+      InboundMessage last = out.get(out.size() - 1);
+      if (canMergeMedia(last, m)) {
+        out.set(out.size() - 1, mergeMedia(last, m));
+      } else {
+        out.add(m);
+      }
+    }
+    return out;
+  }
+
+  private static boolean canMergeMedia(InboundMessage a, InboundMessage b) {
+    if (!a.chatId().equals(b.chatId())) {
+      return false;
+    }
+    if (a.textual() || b.textual()) {
+      return false;
+    }
+    if (a.attachments().isEmpty() || b.attachments().isEmpty()) {
+      return false;
+    }
+    return (a.content() == null || a.content().isBlank())
+        && (b.content() == null || b.content().isBlank());
+  }
+
+  private static InboundMessage mergeMedia(InboundMessage a, InboundMessage b) {
+    List<InboundAttachment> merged = new java.util.ArrayList<>(a.attachments());
+    merged.addAll(b.attachments());
+    return new InboundMessage(
+        a.channelType(),
+        a.channelName(),
+        a.messageId() + "+" + b.messageId(),
+        a.chatKind(),
+        a.userId(),
+        a.chatId(),
+        "",
+        false,
+        a.mentionedBot() || b.mentionedBot(),
+        merged);
+  }
+
+  /** 推进游标、不编排（启动排空 / 丢弃积压）。 */
+  private void drainSyncCursor(WeixinKfClient client, String openKfid) {
+    synchronized (syncLock) {
+      String cursor = syncCursor;
+      boolean more = true;
+      int pages = 0;
+      int discarded = 0;
+      while (more && pages < MAX_SYNC_PAGES) {
+        pages++;
+        WeixinKfSyncResult page = client.syncMsg(openKfid, null, cursor);
+        discarded += page.messages().size();
+        for (JsonNode item : page.messages()) {
+          String msgId = item.path("msgid").asText(null);
+          if (msgId != null && !msgId.isBlank()) {
+            seenMsgIds.add(msgId);
+          }
+        }
+        if (page.nextCursor() != null && !page.nextCursor().isBlank()) {
+          cursor = page.nextCursor();
+          syncCursor = cursor;
+        }
+        more = page.hasMore();
+      }
+      saveSyncCursor(syncCursor);
+      if (discarded > 0) {
+        log.info(
+            "微信客服渠道 {} 启动排空 sync 积压 {} 条（cursor 已推进，避免历史回放）", sanitize(config.name()), discarded);
+      }
+    }
+  }
+
+  private Path syncCursorFile() {
+    return Path.of(".oryxos", "weixin-kf-sync-cursor-" + config.name() + ".txt");
+  }
+
+  private String loadSyncCursor() {
+    try {
+      Path file = syncCursorFile();
+      if (!java.nio.file.Files.isRegularFile(file)) {
+        return "";
+      }
+      String raw = java.nio.file.Files.readString(file).strip();
+      return raw == null ? "" : raw;
+    } catch (Exception e) {
+      log.warn("读取微信客服 sync cursor 失败: {}", sanitize(e.getMessage()));
+      return "";
+    }
+  }
+
+  private void saveSyncCursor(String cursor) {
+    if (cursor == null) {
+      return;
+    }
+    try {
+      Path file = syncCursorFile();
+      java.nio.file.Files.createDirectories(file.getParent());
+      java.nio.file.Files.writeString(file, cursor);
+    } catch (Exception e) {
+      log.warn("保存微信客服 sync cursor 失败: {}", sanitize(e.getMessage()));
+    }
+  }
+
+  /** 对齐企微/飞书慢路径：需 {@code media/get} 时先 {@code beginSlowWork}（立刻「处理中」），落盘后再编排。 */
+  private void dispatchOne(InboundMessage m) {
+    CountDownLatch slowWork = null;
+    try {
+      if (!inboundMessageService.tryClaim(m.channelName(), m.messageId())) {
+        log.info("渠道 {} 重复消息已忽略: {}", sanitize(m.channelName()), sanitize(m.messageId()));
+        return;
+      }
+      // 合并消息 id 也分别占用，避免拆条重放
+      if (m.messageId().contains("+")) {
+        for (String part : m.messageId().split("\\+")) {
+          if (!part.isBlank()) {
+            inboundMessageService.tryClaim(m.channelName(), part);
+          }
+        }
+      }
+      if (needsMediaDownload(m)) {
+        slowWork = inboundMessageService.beginSlowWork(this, m.chatId(), null);
+      }
+      WeixinKfInboundMediaResolver resolver = mediaResolver;
+      InboundMessage enriched = resolver == null ? m : resolver.resolve(m);
+      if (slowWork != null) {
+        inboundMessageService.onClaimedMessage(enriched, this, slowWork);
+      } else {
+        inboundMessageService.onClaimedMessage(enriched, this);
+      }
+    } catch (RuntimeException e) {
+      if (slowWork != null) {
+        slowWork.countDown();
+      }
+      log.warn("微信客服消息分发失败（messageId={}）: {}", sanitize(m.messageId()), sanitize(e.getMessage()));
+    }
+  }
+
+  private static boolean needsMediaDownload(InboundMessage message) {
+    for (InboundAttachment attachment : message.attachments()) {
+      if (isUnresolvedMediaAttachment(attachment)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isUnresolvedMediaAttachment(InboundAttachment attachment) {
+    String type = attachment.type();
+    if (!InboundAttachment.TYPE_IMAGE.equals(type)
+        && !InboundAttachment.TYPE_FILE.equals(type)
+        && !InboundAttachment.TYPE_AUDIO.equals(type)
+        && !InboundAttachment.TYPE_VIDEO.equals(type)) {
+      return false;
+    }
+    if (attachment.url() != null && !attachment.url().isBlank()) {
+      return false;
+    }
+    return attachment.reference() != null && !attachment.reference().isBlank();
+  }
+
+  private Path createMediaRoot() {
+    return InboundMediaRoots.forChannel(config.name(), MEDIA_DIR_PREFIX);
   }
 
   private void requireExtra(String key) {

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapter.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapter.java
@@ -49,6 +49,11 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
   private static final int MAX_SYNC_PAGES = 20;
   private static final String MEDIA_DIR_PREFIX = "weixin-kf";
 
+  /** 同批合并媒体的 messageId 连接符（与 {@link #coalesceSameChatMedia} 一致）。 */
+  private static final String MERGED_MSG_ID_JOIN = "+";
+
+  private static final String MERGED_MSG_ID_SPLIT = "\\+";
+
   private final ChannelConfig config;
   private final ProfileRegistry profileRegistry;
   private final InboundMessageService inboundMessageService;
@@ -331,7 +336,7 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
     return new InboundMessage(
         a.channelType(),
         a.channelName(),
-        a.messageId() + "+" + b.messageId(),
+        a.messageId() + MERGED_MSG_ID_JOIN + b.messageId(),
         a.chatKind(),
         a.userId(),
         a.chatId(),
@@ -412,8 +417,8 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
         return;
       }
       // 合并消息 id 也分别占用，避免拆条重放
-      if (m.messageId().contains("+")) {
-        for (String part : m.messageId().split("\\+")) {
+      if (m.messageId().contains(MERGED_MSG_ID_JOIN)) {
+        for (String part : m.messageId().split(MERGED_MSG_ID_SPLIT)) {
           if (!part.isBlank()) {
             inboundMessageService.tryClaim(m.channelName(), part);
           }

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfClient.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfClient.java
@@ -8,4 +8,7 @@ interface WeixinKfClient {
   void sendText(String openKfid, String externalUserId, String text);
 
   void ensureAiReception(String openKfid, String externalUserId);
+
+  /** {@code GET /cgi-bin/media/get} 临时素材。 */
+  WeixinKfMediaBlob downloadMedia(String mediaId);
 }

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfEventNormalizer.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfEventNormalizer.java
@@ -2,19 +2,25 @@ package io.oryxos.channel.weixinkf;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
+import java.util.List;
 import java.util.Optional;
 
 /**
  * {@code kf/sync_msg} 单条 → {@link InboundMessage}。
  *
- * <p>MVP：仅 {@code origin=3}（微信客户）且 {@code msgtype=text}。
+ * <p>客户来源（{@code origin=3}）：文本 + 图/文件/语音/视频（{@code media_id} → attachment reference）。
  */
 final class WeixinKfEventNormalizer {
 
   static final String CHANNEL_TYPE = WeixinKfChannelAdapter.TYPE;
   static final int ORIGIN_CUSTOMER = 3;
   private static final String MSG_TEXT = "text";
+  private static final String MSG_IMAGE = "image";
+  private static final String MSG_VOICE = "voice";
+  private static final String MSG_VIDEO = "video";
+  private static final String MSG_FILE = "file";
 
   private final String channelName;
 
@@ -38,47 +44,91 @@ final class WeixinKfEventNormalizer {
     }
     String chatId = WeixinKfChatTargets.chatId(openKfid, externalUserId);
     String msgType = asciiLower(text(item, "msgtype"));
-    if (!MSG_TEXT.equals(msgType)) {
+    if (MSG_TEXT.equals(msgType)) {
+      return normalizeText(item, msgId, externalUserId, chatId);
+    }
+    if (MSG_IMAGE.equals(msgType)) {
+      return normalizeMedia(
+          item, msgId, externalUserId, chatId, "image", InboundAttachment::imageReference);
+    }
+    if (MSG_VOICE.equals(msgType)) {
+      return normalizeMedia(
+          item, msgId, externalUserId, chatId, "voice", InboundAttachment::audioReference);
+    }
+    if (MSG_VIDEO.equals(msgType)) {
+      return normalizeMedia(
+          item,
+          msgId,
+          externalUserId,
+          chatId,
+          "video",
+          mediaId -> InboundAttachment.videoReference(mediaId, null));
+    }
+    if (MSG_FILE.equals(msgType)) {
+      String mediaId = text(item.path("file"), "media_id");
+      if (mediaId == null) {
+        return Optional.empty();
+      }
+      String fileName = text(item.path("file"), "filename");
+      if (fileName == null) {
+        fileName = text(item.path("file"), "file_name");
+      }
       return Optional.of(
-          new InboundMessage(
-              CHANNEL_TYPE,
-              channelName,
+          baseMessage(
               msgId,
-              ChatKind.P2P,
               externalUserId,
               chatId,
               "",
               false,
-              false,
-              java.util.List.of()));
+              List.of(InboundAttachment.fileReference(mediaId, fileName))));
     }
+    // 其它类型（菜单/位置等）丢弃，避免刷能力说明或闲聊
+    return Optional.empty();
+  }
+
+  private Optional<InboundMessage> normalizeText(
+      JsonNode item, String msgId, String externalUserId, String chatId) {
     String content = text(item.path("text"), "content");
     if (content == null || content.isBlank()) {
-      return Optional.of(
-          new InboundMessage(
-              CHANNEL_TYPE,
-              channelName,
-              msgId,
-              ChatKind.P2P,
-              externalUserId,
-              chatId,
-              "",
-              false,
-              false,
-              java.util.List.of()));
+      return Optional.empty();
     }
     return Optional.of(
-        new InboundMessage(
-            CHANNEL_TYPE,
-            channelName,
-            msgId,
-            ChatKind.P2P,
-            externalUserId,
-            chatId,
-            content.strip(),
-            true,
-            false,
-            java.util.List.of()));
+        baseMessage(msgId, externalUserId, chatId, content.strip(), true, List.of()));
+  }
+
+  private Optional<InboundMessage> normalizeMedia(
+      JsonNode item,
+      String msgId,
+      String externalUserId,
+      String chatId,
+      String field,
+      java.util.function.Function<String, InboundAttachment> factory) {
+    String mediaId = text(item.path(field), "media_id");
+    if (mediaId == null) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        baseMessage(msgId, externalUserId, chatId, "", false, List.of(factory.apply(mediaId))));
+  }
+
+  private InboundMessage baseMessage(
+      String msgId,
+      String externalUserId,
+      String chatId,
+      String content,
+      boolean textual,
+      List<InboundAttachment> attachments) {
+    return new InboundMessage(
+        CHANNEL_TYPE,
+        channelName,
+        msgId,
+        ChatKind.P2P,
+        externalUserId,
+        chatId,
+        content,
+        textual,
+        false,
+        attachments);
   }
 
   private static String text(JsonNode node, String field) {

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfInboundMediaResolver.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfInboundMediaResolver.java
@@ -195,6 +195,9 @@ final class WeixinKfInboundMediaResolver {
     return target;
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification = "仅对 ASCII MIME 子串做 Locale.ROOT 小写匹配以选扩展名，不参与安全/身份比较")
   private static String defaultExtForType(String type, String contentType) {
     if (contentType != null) {
       String ct = contentType.toLowerCase(Locale.ROOT);
@@ -237,6 +240,9 @@ final class WeixinKfInboundMediaResolver {
     return DEFAULT_EXTENSION;
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification = "仅对 ASCII 扩展名做 Locale.ROOT 小写与正则匹配")
   private static String extensionOf(String fileName) {
     if (fileName == null || fileName.isBlank()) {
       return DEFAULT_EXTENSION;

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfInboundMediaResolver.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfInboundMediaResolver.java
@@ -27,6 +27,24 @@ final class WeixinKfInboundMediaResolver {
   private static final Logger LOG = LoggerFactory.getLogger(WeixinKfInboundMediaResolver.class);
 
   private static final String DEFAULT_EXTENSION = ".bin";
+  private static final String EXT_JPG = ".jpg";
+  private static final String EXT_PNG = ".png";
+  private static final String EXT_GIF = ".gif";
+  private static final String EXT_WEBP = ".webp";
+  private static final String EXT_PDF = ".pdf";
+  private static final String EXT_MP4 = ".mp4";
+  private static final String EXT_SILK = ".silk";
+  private static final String EXT_AMR = ".amr";
+  private static final String CT_JPEG = "jpeg";
+  private static final String CT_JPG = "jpg";
+  private static final String CT_PNG = "png";
+  private static final String CT_GIF = "gif";
+  private static final String CT_WEBP = "webp";
+  private static final String CT_PDF = "pdf";
+  private static final String CT_MP4 = "mp4";
+  private static final String CT_SILK = "silk";
+  private static final String CT_OCTET = "octet-stream";
+  private static final String CT_AMR = "amr";
   private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
   private static final int DOWNLOAD_ATTEMPTS = 2;
 
@@ -180,41 +198,41 @@ final class WeixinKfInboundMediaResolver {
   private static String defaultExtForType(String type, String contentType) {
     if (contentType != null) {
       String ct = contentType.toLowerCase(Locale.ROOT);
-      if (ct.contains("jpeg") || ct.contains("jpg")) {
-        return ".jpg";
+      if (ct.contains(CT_JPEG) || ct.contains(CT_JPG)) {
+        return EXT_JPG;
       }
-      if (ct.contains("png")) {
-        return ".png";
+      if (ct.contains(CT_PNG)) {
+        return EXT_PNG;
       }
-      if (ct.contains("gif")) {
-        return ".gif";
+      if (ct.contains(CT_GIF)) {
+        return EXT_GIF;
       }
-      if (ct.contains("webp")) {
-        return ".webp";
+      if (ct.contains(CT_WEBP)) {
+        return EXT_WEBP;
       }
-      if (ct.contains("pdf")) {
-        return ".pdf";
+      if (ct.contains(CT_PDF)) {
+        return EXT_PDF;
       }
-      if (ct.contains("mp4")) {
-        return ".mp4";
+      if (ct.contains(CT_MP4)) {
+        return EXT_MP4;
       }
-      if (ct.contains("silk") || ct.contains("octet-stream")) {
+      if (ct.contains(CT_SILK) || ct.contains(CT_OCTET)) {
         if (InboundAttachment.TYPE_AUDIO.equals(type)) {
-          return ".silk";
+          return EXT_SILK;
         }
       }
-      if (ct.contains("amr")) {
-        return ".amr";
+      if (ct.contains(CT_AMR)) {
+        return EXT_AMR;
       }
     }
     if (InboundAttachment.TYPE_IMAGE.equals(type)) {
       return DEFAULT_EXTENSION;
     }
     if (InboundAttachment.TYPE_AUDIO.equals(type)) {
-      return ".silk";
+      return EXT_SILK;
     }
     if (InboundAttachment.TYPE_VIDEO.equals(type)) {
-      return ".mp4";
+      return EXT_MP4;
     }
     return DEFAULT_EXTENSION;
   }

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfInboundMediaResolver.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfInboundMediaResolver.java
@@ -1,0 +1,280 @@
+package io.oryxos.channel.weixinkf;
+
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMediaJanitor;
+import io.oryxos.core.channel.InboundMediaLimits;
+import io.oryxos.core.channel.InboundMediaPaths;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.LimitedMediaWriter;
+import io.oryxos.core.session.ImageMime;
+import io.oryxos.core.session.InboundMediaExt;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 微信客服入站媒体：{@code media_id} → {@code /cgi-bin/media/get} 落盘，写入 {@link InboundAttachment#url()}。
+ *
+ * <p>失败保留原 reference（降级，不阻断编排）。
+ */
+final class WeixinKfInboundMediaResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WeixinKfInboundMediaResolver.class);
+
+  private static final String DEFAULT_EXTENSION = ".bin";
+  private static final String SAFE_EXTENSION_PATTERN = "\\.[a-z0-9]{1,8}";
+  private static final int DOWNLOAD_ATTEMPTS = 2;
+
+  private final WeixinKfClient client;
+  private final Path mediaRoot;
+  private final String channelName;
+  private final InboundMediaJanitor janitor;
+
+  WeixinKfInboundMediaResolver(WeixinKfClient client, Path mediaRoot, String channelName) {
+    this(client, mediaRoot, channelName, InboundMediaJanitor.fromEnv());
+  }
+
+  WeixinKfInboundMediaResolver(
+      WeixinKfClient client, Path mediaRoot, String channelName, InboundMediaJanitor janitor) {
+    this.client = client;
+    this.mediaRoot = mediaRoot;
+    this.channelName = channelName;
+    this.janitor = janitor == null ? InboundMediaJanitor.fromEnv() : janitor;
+  }
+
+  InboundMessage resolve(InboundMessage message) {
+    janitor.sweepIfDue(mediaRoot);
+    if (message.attachments().isEmpty()) {
+      return message;
+    }
+    List<InboundAttachment> resolved = new ArrayList<>(message.attachments().size());
+    boolean changed = false;
+    for (InboundAttachment attachment : message.attachments()) {
+      if (!needsDownload(attachment)) {
+        resolved.add(attachment);
+        continue;
+      }
+      InboundAttachment next = downloadOrKeep(message.messageId(), attachment);
+      changed |= next != attachment;
+      resolved.add(next);
+    }
+    if (!changed) {
+      return message;
+    }
+    return new InboundMessage(
+        message.channelType(),
+        message.channelName(),
+        message.messageId(),
+        message.chatKind(),
+        message.userId(),
+        message.chatId(),
+        message.content(),
+        message.textual(),
+        message.mentionedBot(),
+        resolved);
+  }
+
+  private static boolean needsDownload(InboundAttachment attachment) {
+    if (attachment.reference() == null || attachment.reference().isBlank()) {
+      return false;
+    }
+    if (attachment.url() != null && !attachment.url().isBlank()) {
+      return false;
+    }
+    String type = attachment.type();
+    return InboundAttachment.TYPE_IMAGE.equals(type)
+        || InboundAttachment.TYPE_FILE.equals(type)
+        || InboundAttachment.TYPE_AUDIO.equals(type)
+        || InboundAttachment.TYPE_VIDEO.equals(type);
+  }
+
+  private InboundAttachment downloadOrKeep(String messageId, InboundAttachment attachment) {
+    String mediaId = attachment.reference();
+    String kind = kindLabel(attachment.type());
+    Exception last = null;
+    for (int attempt = 1; attempt <= DOWNLOAD_ATTEMPTS; attempt++) {
+      try {
+        WeixinKfMediaBlob blob = client.downloadMedia(mediaId);
+        Path path = writeToMediaRoot(messageId, mediaId, blob, attachment);
+        return new InboundAttachment(
+            attachment.type(),
+            path.toAbsolutePath().toString(),
+            mediaId,
+            firstNonBlank(attachment.fileName(), blob.fileName()));
+      } catch (Exception e) {
+        last = e;
+        if (attempt < DOWNLOAD_ATTEMPTS && isTransientTimeout(e)) {
+          LOG.warn(
+              "微信客服渠道 {} 下载{}超时重试 {}/{}（messageId={}, mediaId={}）：{}",
+              sanitize(channelName),
+              sanitize(kind),
+              attempt,
+              DOWNLOAD_ATTEMPTS,
+              sanitize(messageId),
+              sanitize(mediaId),
+              sanitize(e.getMessage()));
+          continue;
+        }
+        break;
+      }
+    }
+    LOG.warn(
+        "微信客服渠道 {} 下载{}失败（messageId={}, mediaId={}）：{}，保留原引用",
+        sanitize(channelName),
+        sanitize(kind),
+        sanitize(messageId),
+        sanitize(mediaId),
+        sanitize(last == null ? null : last.getMessage()));
+    return attachment;
+  }
+
+  private Path writeToMediaRoot(
+      String messageId, String mediaId, WeixinKfMediaBlob blob, InboundAttachment attachment)
+      throws IOException {
+    String fileName = firstNonBlank(attachment.fileName(), blob.fileName());
+    String ext = extensionOf(fileName);
+    if (DEFAULT_EXTENSION.equals(ext)) {
+      ext = defaultExtForType(attachment.type(), blob.contentType());
+    }
+    Path dir = mediaRoot.resolve(InboundMediaPaths.safeSegment(messageId));
+    Files.createDirectories(dir);
+    Path target = dir.resolve(InboundMediaPaths.safeSegment(mediaId) + ext);
+    janitor.ensureQuotaOrThrow(mediaRoot);
+    LimitedMediaWriter.writeLimited(blob.bytes(), target, InboundMediaLimits.MAX_FILE_BYTES);
+    boolean fileLike =
+        InboundAttachment.TYPE_FILE.equals(attachment.type())
+            || InboundAttachment.TYPE_AUDIO.equals(attachment.type())
+            || InboundAttachment.TYPE_VIDEO.equals(attachment.type());
+    if (!fileLike && DEFAULT_EXTENSION.equals(ext)) {
+      String sniffed = ImageMime.probeFile(target);
+      String betterExt = ImageMime.extensionFor(sniffed);
+      if (!DEFAULT_EXTENSION.equals(betterExt) && !betterExt.equals(ext)) {
+        Path renamed = dir.resolve(InboundMediaPaths.safeSegment(mediaId) + betterExt);
+        try {
+          Files.move(target, renamed);
+          return renamed;
+        } catch (IOException moveFailed) {
+          LOG.debug("微信客服图片重命名扩展名失败，保留原文件: {}", sanitize(moveFailed.getMessage()));
+        }
+      }
+    } else if (fileLike) {
+      String better = InboundMediaExt.betterFileExtension(target, ext);
+      if (better != null) {
+        Path renamed = dir.resolve(InboundMediaPaths.safeSegment(mediaId) + better);
+        try {
+          Files.move(target, renamed);
+          return renamed;
+        } catch (IOException moveFailed) {
+          LOG.debug("微信客服文件扩展名重命名失败，保留原文件: {}", sanitize(moveFailed.getMessage()));
+        }
+      }
+    }
+    return target;
+  }
+
+  private static String defaultExtForType(String type, String contentType) {
+    if (contentType != null) {
+      String ct = contentType.toLowerCase(Locale.ROOT);
+      if (ct.contains("jpeg") || ct.contains("jpg")) {
+        return ".jpg";
+      }
+      if (ct.contains("png")) {
+        return ".png";
+      }
+      if (ct.contains("gif")) {
+        return ".gif";
+      }
+      if (ct.contains("webp")) {
+        return ".webp";
+      }
+      if (ct.contains("pdf")) {
+        return ".pdf";
+      }
+      if (ct.contains("mp4")) {
+        return ".mp4";
+      }
+      if (ct.contains("silk") || ct.contains("octet-stream")) {
+        if (InboundAttachment.TYPE_AUDIO.equals(type)) {
+          return ".silk";
+        }
+      }
+      if (ct.contains("amr")) {
+        return ".amr";
+      }
+    }
+    if (InboundAttachment.TYPE_IMAGE.equals(type)) {
+      return DEFAULT_EXTENSION;
+    }
+    if (InboundAttachment.TYPE_AUDIO.equals(type)) {
+      return ".silk";
+    }
+    if (InboundAttachment.TYPE_VIDEO.equals(type)) {
+      return ".mp4";
+    }
+    return DEFAULT_EXTENSION;
+  }
+
+  private static String extensionOf(String fileName) {
+    if (fileName == null || fileName.isBlank()) {
+      return DEFAULT_EXTENSION;
+    }
+    int dot = fileName.lastIndexOf('.');
+    if (dot < 0 || dot == fileName.length() - 1) {
+      return DEFAULT_EXTENSION;
+    }
+    String ext = fileName.substring(dot).toLowerCase(Locale.ROOT);
+    if (!ext.matches(SAFE_EXTENSION_PATTERN)) {
+      return DEFAULT_EXTENSION;
+    }
+    return ext;
+  }
+
+  private static String kindLabel(String type) {
+    if (InboundAttachment.TYPE_AUDIO.equals(type)) {
+      return "语音";
+    }
+    if (InboundAttachment.TYPE_VIDEO.equals(type)) {
+      return "视频";
+    }
+    if (InboundAttachment.TYPE_FILE.equals(type)) {
+      return "文件";
+    }
+    return "图片";
+  }
+
+  private static boolean isTransientTimeout(Throwable error) {
+    for (Throwable t = error; t != null; t = t.getCause()) {
+      String name = t.getClass().getName();
+      if (name.contains("Timeout") || name.contains("InterruptedIO")) {
+        return true;
+      }
+      String msg = t.getMessage();
+      if (msg != null) {
+        String lower = msg.toLowerCase(Locale.ROOT);
+        if (lower.contains("timeout") || lower.contains("timed out")) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static String firstNonBlank(String a, String b) {
+    if (a != null && !a.isBlank()) {
+      return a;
+    }
+    if (b != null && !b.isBlank()) {
+      return b;
+    }
+    return null;
+  }
+
+  private static String sanitize(String value) {
+    return value == null ? "" : value.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfMediaBlob.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfMediaBlob.java
@@ -1,0 +1,11 @@
+package io.oryxos.channel.weixinkf;
+
+/** {@code /cgi-bin/media/get} 下载结果。 */
+record WeixinKfMediaBlob(byte[] bytes, String contentType, String fileName) {
+
+  WeixinKfMediaBlob {
+    if (bytes == null) {
+      throw new IllegalArgumentException("bytes 为空");
+    }
+  }
+}

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfMsgCrypt.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfMsgCrypt.java
@@ -13,6 +13,10 @@ package io.oryxos.channel.weixinkf;
 final class WeixinKfMsgCrypt {
 
   private static final int AES_BLOCK = 16;
+
+  /** 企微官方 WXBizMsgCrypt PKCS#7 块长为 32（非 AES 16）。 */
+  private static final int PKCS7_BLOCK = 32;
+
   private static final int RANDOM_LEN = 16;
   private static final int AES_KEY_LEN = 32;
   private static final int BASE64_PAD_MOD = 4;
@@ -120,7 +124,8 @@ final class WeixinKfMsgCrypt {
         new String(
             original, xmlEnd, original.length - xmlEnd, java.nio.charset.StandardCharsets.UTF_8);
     if (!receiveId.equals(fromReceiveId)) {
-      throw new IllegalStateException("receiveId 不匹配");
+      throw new IllegalStateException(
+          "receiveId 不匹配（期望=" + receiveId + " 实际=" + fromReceiveId + "）");
     }
     return xml;
   }
@@ -151,9 +156,9 @@ final class WeixinKfMsgCrypt {
   }
 
   private static byte[] pkcs7Pad(byte[] data) {
-    int pad = AES_BLOCK - (data.length % AES_BLOCK);
+    int pad = PKCS7_BLOCK - (data.length % PKCS7_BLOCK);
     if (pad == 0) {
-      pad = AES_BLOCK;
+      pad = PKCS7_BLOCK;
     }
     byte[] out = new byte[data.length + pad];
     System.arraycopy(data, 0, out, 0, data.length);
@@ -164,13 +169,16 @@ final class WeixinKfMsgCrypt {
   }
 
   private static byte[] pkcs7Unpad(byte[] decrypted) {
+    if (decrypted.length == 0) {
+      throw new IllegalStateException("解密报文为空");
+    }
     int pad = decrypted[decrypted.length - 1] & 0xff;
-    if (pad < 1 || pad > AES_BLOCK) {
-      return decrypted;
+    if (pad < 1 || pad > PKCS7_BLOCK || pad > decrypted.length) {
+      throw new IllegalStateException("PKCS7 填充非法: " + pad);
     }
     for (int i = 1; i <= pad; i++) {
       if ((decrypted[decrypted.length - i] & 0xff) != pad) {
-        return decrypted;
+        throw new IllegalStateException("PKCS7 填充校验失败");
       }
     }
     byte[] out = new byte[decrypted.length - pad];

--- a/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapterTest.java
+++ b/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapterTest.java
@@ -98,7 +98,7 @@ class WeixinKfChannelAdapterTest {
   }
 
   @Test
-  @DisplayName("POST kf_msg_or_event → sync → onMessage")
+  @DisplayName("POST kf_msg_or_event → sync → onClaimedMessage")
   void callbackSync() throws Exception {
     ObjectNode item = MAPPER.createObjectNode();
     item.put("msgid", "msg-1");
@@ -125,6 +125,7 @@ class WeixinKfChannelAdapterTest {
     String nonce = "1372623149";
     String sig = crypt.signature(ts, nonce, cipher);
     String body = "<xml><Encrypt><![CDATA[" + cipher + "]]></Encrypt></xml>";
+    when(inbound.tryClaim(any(), any())).thenReturn(true);
     WebhookResponse response =
         adapter.onWebhook(
             new WebhookRequest(
@@ -137,7 +138,7 @@ class WeixinKfChannelAdapterTest {
                 body));
     assertEquals(200, response.status());
     assertEquals("success", response.body());
-    verify(inbound).onMessage(any(InboundMessage.class), any());
+    verify(inbound).onClaimedMessage(any(InboundMessage.class), any());
     assertEquals(1, client.ensureCalls.get());
   }
 
@@ -159,6 +160,40 @@ class WeixinKfChannelAdapterTest {
     assertEquals(1, client.sendCalls.get());
   }
 
+  @Test
+  @DisplayName("同会话连续媒体合并为一条")
+  void coalesceMedia() {
+    InboundMessage a =
+        new InboundMessage(
+            "weixin_kf",
+            "ops-kf",
+            "m1",
+            io.oryxos.core.channel.ChatKind.P2P,
+            "u1",
+            "kf:wk:user:u1",
+            "",
+            false,
+            false,
+            List.of(io.oryxos.core.channel.InboundAttachment.imageReference("A")));
+    InboundMessage b =
+        new InboundMessage(
+            "weixin_kf",
+            "ops-kf",
+            "m2",
+            io.oryxos.core.channel.ChatKind.P2P,
+            "u1",
+            "kf:wk:user:u1",
+            "",
+            false,
+            false,
+            List.of(io.oryxos.core.channel.InboundAttachment.imageReference("B")));
+    List<InboundMessage> out = WeixinKfChannelAdapter.coalesceSameChatMedia(List.of(a, b));
+    assertEquals(1, out.size());
+    assertEquals(2, out.get(0).attachments().size());
+    assertTrue(out.get(0).messageId().contains("m1"));
+    assertTrue(out.get(0).messageId().contains("m2"));
+  }
+
   private static final class FakeClient implements WeixinKfClient {
     List<com.fasterxml.jackson.databind.JsonNode> messages = List.of();
     final AtomicInteger ensureCalls = new AtomicInteger();
@@ -177,6 +212,11 @@ class WeixinKfChannelAdapterTest {
     @Override
     public void ensureAiReception(String openKfid, String externalUserId) {
       ensureCalls.incrementAndGet();
+    }
+
+    @Override
+    public WeixinKfMediaBlob downloadMedia(String mediaId) {
+      return new WeixinKfMediaBlob(new byte[] {1, 2, 3}, "image/jpeg", "a.jpg");
     }
   }
 }

--- a/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfChannelContractTest.java
+++ b/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfChannelContractTest.java
@@ -40,7 +40,18 @@ class WeixinKfChannelContractTest extends InboundMessageServiceContractTestBase 
 
   @Override
   protected InboundMessage nonTextualMessage(String messageId) {
-    return normalizer.normalize(payload(messageId, "image", null)).orElseThrow();
+    // 无附件的非文本：契约 B7 能力说明（正常路径下缺 media_id 的 image 会被 normalizer 丢弃）
+    return new InboundMessage(
+        channelType(),
+        "contract-kf",
+        messageId,
+        ChatKind.P2P,
+        "wu1",
+        WeixinKfChatTargets.chatId("wk1", "wu1"),
+        "",
+        false,
+        false,
+        List.of());
   }
 
   @Override

--- a/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfEventNormalizerTest.java
+++ b/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfEventNormalizerTest.java
@@ -47,16 +47,31 @@ class WeixinKfEventNormalizerTest {
   }
 
   @Test
-  @DisplayName("非文本 → textual=false")
-  void nonText() {
+  @DisplayName("图片 → attachment reference=media_id")
+  void imageMedia() {
     ObjectNode item = mapper.createObjectNode();
     item.put("msgid", "m3");
     item.put("open_kfid", "wk1");
     item.put("external_userid", "wu1");
     item.put("origin", 3);
     item.put("msgtype", "image");
+    item.putObject("image").put("media_id", "MEDIAIMG");
     Optional<InboundMessage> msg = normalizer.normalize(item);
     assertTrue(msg.isPresent());
     assertFalse(msg.get().textual());
+    assertEquals(1, msg.get().attachments().size());
+    assertEquals("MEDIAIMG", msg.get().attachments().get(0).reference());
+  }
+
+  @Test
+  @DisplayName("图片缺 media_id → 丢弃")
+  void imageWithoutMediaId() {
+    ObjectNode item = mapper.createObjectNode();
+    item.put("msgid", "m4");
+    item.put("open_kfid", "wk1");
+    item.put("external_userid", "wu1");
+    item.put("origin", 3);
+    item.put("msgtype", "image");
+    assertTrue(normalizer.normalize(item).isEmpty());
   }
 }

--- a/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfInboundMediaResolverTest.java
+++ b/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfInboundMediaResolverTest.java
@@ -1,0 +1,62 @@
+package io.oryxos.channel.weixinkf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundAttachment;
+import io.oryxos.core.channel.InboundMessage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WeixinKfInboundMediaResolverTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  @DisplayName("media_id 下载后写入本地 url")
+  void downloadsToLocalUrl() {
+    WeixinKfClient client =
+        new WeixinKfClient() {
+          @Override
+          public WeixinKfSyncResult syncMsg(String openKfid, String callbackToken, String cursor) {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public void sendText(String openKfid, String externalUserId, String text) {}
+
+          @Override
+          public void ensureAiReception(String openKfid, String externalUserId) {}
+
+          @Override
+          public WeixinKfMediaBlob downloadMedia(String mediaId) {
+            return new WeixinKfMediaBlob("%PDF-1.4".getBytes(), "application/pdf", "doc.pdf");
+          }
+        };
+    WeixinKfInboundMediaResolver resolver =
+        new WeixinKfInboundMediaResolver(client, tempDir, "ops-kf");
+    InboundMessage in =
+        new InboundMessage(
+            "weixin_kf",
+            "ops-kf",
+            "mid-1",
+            ChatKind.P2P,
+            "wu1",
+            "kf:wk1:user:wu1",
+            "",
+            false,
+            false,
+            List.of(InboundAttachment.fileReference("MEDIA1", "doc.pdf")));
+    InboundMessage out = resolver.resolve(in);
+    assertEquals(1, out.attachments().size());
+    String url = out.attachments().get(0).url();
+    assertTrue(url != null && !url.isBlank());
+    assertTrue(Files.exists(Path.of(url)));
+    assertEquals("MEDIA1", out.attachments().get(0).reference());
+  }
+}

--- a/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfMsgCryptTest.java
+++ b/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfMsgCryptTest.java
@@ -35,6 +35,22 @@ class WeixinKfMsgCryptTest {
   }
 
   @Test
+  @DisplayName("长明文（PKCS7 填充>16）仍能回环")
+  void longPlaintextRoundTrip() throws Exception {
+    WeixinKfMsgCrypt crypt = new WeixinKfMsgCrypt(TOKEN, AES_KEY, CORP_ID);
+    StringBuilder sb =
+        new StringBuilder("<xml><Event><![CDATA[kf_msg_or_event]]></Event><Token><![CDATA[");
+    for (int i = 0; i < 200; i++) {
+      sb.append('A');
+    }
+    sb.append("]]></Token><OpenKfId><![CDATA[wkOPEN]]></OpenKfId></xml>");
+    String xml = sb.toString();
+    String cipher = crypt.encrypt(xml);
+    String plain = crypt.decryptMsg(crypt.signature("1", "2", cipher), "1", "2", cipher);
+    assertEquals(xml, plain);
+  }
+
+  @Test
   @DisplayName("签名错误拒绝")
   void badSignature() throws Exception {
     WeixinKfMsgCrypt crypt = new WeixinKfMsgCrypt(TOKEN, AES_KEY, CORP_ID);

--- a/oryxos-core/src/main/java/io/oryxos/core/session/InboundMediaExt.java
+++ b/oryxos-core/src/main/java/io/oryxos/core/session/InboundMediaExt.java
@@ -38,6 +38,9 @@ public final class InboundMediaExt {
   /** 腾讯/飞书常见 Silk：{@code #!SILK_V3}。 */
   private static final byte[] SILK_MAGIC = "#!SILK_V3".getBytes(StandardCharsets.US_ASCII);
 
+  /** 微信客服等偶发：首字节 {@code 0x02} 后再跟 {@code #!SILK_V3}。 */
+  private static final int SILK_TX_PREFIX = 0x02;
+
   /** AMR-NB：{@code #!AMR\n}；AMR-WB：{@code #!AMR-WB\n}。 */
   private static final byte[] AMR_MAGIC = "#!AMR".getBytes(StandardCharsets.US_ASCII);
 
@@ -75,12 +78,18 @@ public final class InboundMediaExt {
 
   /** 本地文件头是否为 Silk。 */
   public static boolean isSilkMagic(Path file) {
-    return magicMatches(file, SILK_MAGIC.length, InboundMediaExt::isSilkMagic);
+    return magicMatches(file, SILK_MAGIC.length + 1, InboundMediaExt::isSilkMagic);
   }
 
-  /** 字节头是否为 Silk（{@code #!SILK_V3}）。 */
+  /** 字节头是否为 Silk（{@code #!SILK_V3}，或腾讯前缀 {@code 0x02#!SILK_V3}）。 */
   public static boolean isSilkMagic(byte[] header) {
-    return startsWith(header, SILK_MAGIC);
+    if (startsWith(header, SILK_MAGIC)) {
+      return true;
+    }
+    return header != null
+        && header.length >= SILK_MAGIC.length + 1
+        && (header[0] & 0xFF) == SILK_TX_PREFIX
+        && startsWithOffset(header, 1, SILK_MAGIC);
   }
 
   /** 本地文件头是否为 AMR。 */
@@ -128,11 +137,22 @@ public final class InboundMediaExt {
     return name.toString().toLowerCase(Locale.ROOT).endsWith(EXT_PDF);
   }
 
-  /** 入站落盘后：若当前扩展名为占位（{@code .bin}/{@code .file} 或空白）且内容可识别，返回更好扩展名；否则 {@code null}。 */
+  /**
+   * 入站落盘后：若当前扩展名为占位（{@code .bin}/{@code .file} 或空白），或语音扩展名与魔数矛盾（如误标 {@code .amr} 实为
+   * Silk），返回更好扩展名；否则 {@code null}。
+   */
   public static String betterFileExtension(Path file, String currentExt) {
-    if (!isPlaceholderExt(currentExt)) {
+    String detected = detectExtensionFromMagic(file);
+    if (detected == null) {
       return null;
     }
+    if (isPlaceholderExt(currentExt) || audioExtContradicts(currentExt, detected)) {
+      return sameExt(currentExt, detected) ? null : detected;
+    }
+    return null;
+  }
+
+  private static String detectExtensionFromMagic(Path file) {
     if (isPdfMagic(file)) {
       return EXT_PDF;
     }
@@ -151,12 +171,39 @@ public final class InboundMediaExt {
     return null;
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification = "仅对 ASCII 音频扩展名做 Locale.ROOT 小写匹配")
+  private static boolean audioExtContradicts(String currentExt, String detected) {
+    if (currentExt == null || currentExt.isBlank() || detected == null) {
+      return false;
+    }
+    String cur = currentExt.toLowerCase(Locale.ROOT);
+    if (!EXT_SILK.equals(cur) && !EXT_AMR.equals(cur)) {
+      return false;
+    }
+    return (EXT_SILK.equals(detected) || EXT_AMR.equals(detected)) && !cur.equals(detected);
+  }
+
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "IMPROPER_UNICODE",
+      justification = "仅对 ASCII 扩展名做 Locale.ROOT 小写比较")
+  private static boolean sameExt(String currentExt, String detected) {
+    return currentExt != null
+        && detected != null
+        && currentExt.toLowerCase(Locale.ROOT).equals(detected.toLowerCase(Locale.ROOT));
+  }
+
   private static boolean startsWith(byte[] header, byte[] magic) {
-    if (header == null || header.length < magic.length) {
+    return startsWithOffset(header, 0, magic);
+  }
+
+  private static boolean startsWithOffset(byte[] header, int offset, byte[] magic) {
+    if (header == null || magic == null || offset < 0 || header.length < offset + magic.length) {
       return false;
     }
     for (int i = 0; i < magic.length; i++) {
-      if (header[i] != magic[i]) {
+      if (header[offset + i] != magic[i]) {
         return false;
       }
     }

--- a/oryxos-core/src/test/java/io/oryxos/core/session/InboundMediaExtTest.java
+++ b/oryxos-core/src/test/java/io/oryxos/core/session/InboundMediaExtTest.java
@@ -46,6 +46,19 @@ class InboundMediaExtTest {
   }
 
   @Test
+  @DisplayName("腾讯前缀 0x02 + #!SILK_V3 识别为 Silk，并纠正误标 .amr")
+  void detectsTxPrefixedSilkAndFixesAmrExt() throws IOException {
+    Path silk = dir.resolve("voice.amr");
+    byte[] body = new byte[1 + "#!SILK_V3....".length()];
+    body[0] = 0x02;
+    System.arraycopy(
+        "#!SILK_V3....".getBytes(StandardCharsets.US_ASCII), 0, body, 1, body.length - 1);
+    Files.write(silk, body);
+    assertTrue(InboundMediaExt.isSilkMagic(silk));
+    assertEquals(InboundMediaExt.EXT_SILK, InboundMediaExt.betterFileExtension(silk, ".amr"));
+  }
+
+  @Test
   @DisplayName("AMR 魔数识别为 .amr")
   void detectsAmrMagic() throws IOException {
     Path amr = dir.resolve("voice.bin");

--- a/specs/033-weixin-kf-channel/acceptance.md
+++ b/specs/033-weixin-kf-channel/acceptance.md
@@ -12,4 +12,6 @@
 
 - [x] 模块 `oryxos-channel-weixin-kf` + 单测（验签加解密、sync 归一化、窗外/超 5 条、契约档）  
 - [x] Setup + `channels.yaml.example` + Runtime `type: weixin_kf`  
-- [ ] 真机（有企微+微信客服资质时）  
+- [x] 媒体：`media/get` 落盘 + Vision / `read_file` / Whisper；`voice_format=0`（AMR）；sync cursor 排空；同会话连续媒体合并  
+- [x] 真机：文本 / 图 / PDF / 视频音轨 / 语音（AMR）往返 OK（PKCS#7=32、`service_state` 48002 软跳过）  
+


### PR DESCRIPTION
## Summary
- After MVP (#440): download image/file/voice/video via `media/get`, resolve to `.oryxos/inbound-media/`, then Vision / `read_file` / Whisper (with「处理中」slow path).
- `sync_msg` uses `voice_format=0` (AMR) so stock ffmpeg can decode; Soft-skip `service_state` 48002; PKCS#7 block size 32 for message decrypt.
- Persist sync cursor + drain on start; coalesce consecutive same-chat media in one sync batch to avoid 5-reply spam.
- Live-tested: text / image / PDF / video / voice OK.

## Test plan
- [ ] CI Build & quality gate green
- [x] Unit: InboundMediaExt / WeixinKf* media + crypt + adapter tests
- [x] Live Weixin KF: text, image, PDF, video, AMR voice round-trip
