### PR TITLE
fix(channel-weixin-kf): address #442 review nits

### DIFF
--- a/docs/WeixinKfChannelSetup.md
+++ b/docs/WeixinKfChannelSetup.md
@@ -36,7 +36,8 @@
 | 步骤 | 说明 |
 |------|------|
 | 入站 | 回调 `kf_msg_or_event` → `kf/sync_msg` 拉消息（文本 + 图/文件/语音/视频）；语音 `voice_format=0`（AMR，便于本机 ffmpeg→Whisper） |
-| 媒体 | `media_id` → `GET /cgi-bin/media/get` 落盘；先回「处理中」，再编排（Vision / `read_file` / Whisper） |
+| sync 游标 | 持久化 `.oryxos/weixin-kf-sync-cursor-{name}.txt`。**启动时排空积压**（推进 cursor、不进 Agent）。进程宕机期间到达的消息会因此丢弃——刻意取舍，防止历史 HI/图回放刷屏并撞每回合 5 条上限 |
+| 媒体 | `media_id` → `GET /cgi-bin/media/get` 落盘；先回「处理中」，再编排（Vision / `read_file` / Whisper）。sync 拉批与 cursor 更新在锁内，下载/编排放锁外，避免大文件拖住其它回调 |
 | 会话 | 私聊连续记忆（与其它 IM 一致）；`/new` 仅可选手动清空 |
 | 会话态 | 尽量转到「智能助手接待」后再编排/发信；`service_state` 无权限（48002）时跳过仍尝试 `send_msg` |
 | 出站 | `kf/send_msg` 文本；**48h / 每回合最多 5 条**，窗外硬拒绝 |

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapter.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapter.java
@@ -257,6 +257,8 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
       WeixinKfEventNormalizer activeNormalizer,
       String openKfid,
       String callbackToken) {
+    // 锁内只做 sync + cursor + 去重；media/get 与编排放锁外，避免大文件拖住其它回调。
+    List<InboundMessage> toDispatch;
     synchronized (syncLock) {
       String cursor = syncCursor;
       boolean more = true;
@@ -283,15 +285,16 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
         more = page.hasMore();
       }
       saveSyncCursor(syncCursor);
-      for (InboundMessage m : coalesceSameChatMedia(batch)) {
-        sessions.rememberInbound(m.chatId(), clock.millis());
-        try {
-          client.ensureAiReception(WeixinKfChatTargets.parse(m.chatId()).openKfid(), m.userId());
-        } catch (RuntimeException e) {
-          log.warn("微信客服确保智能助手接待失败: {}", sanitize(e.getMessage()));
-        }
-        dispatchOne(m);
+      toDispatch = coalesceSameChatMedia(batch);
+    }
+    for (InboundMessage m : toDispatch) {
+      sessions.rememberInbound(m.chatId(), clock.millis());
+      try {
+        client.ensureAiReception(WeixinKfChatTargets.parse(m.chatId()).openKfid(), m.userId());
+      } catch (RuntimeException e) {
+        log.warn("微信客服确保智能助手接待失败: {}", sanitize(e.getMessage()));
       }
+      dispatchOne(m);
     }
   }
 
@@ -372,7 +375,9 @@ public class WeixinKfChannelAdapter implements InboundChannelAdapter, InboundWeb
       saveSyncCursor(syncCursor);
       if (discarded > 0) {
         log.info(
-            "微信客服渠道 {} 启动排空 sync 积压 {} 条（cursor 已推进，避免历史回放）", sanitize(config.name()), discarded);
+            "微信客服渠道 {} 启动排空 sync 积压 {} 条（cursor 已推进；宕机期间未处理消息将丢弃，避免历史回放刷屏并撞 5 条上限）",
+            sanitize(config.name()),
+            discarded);
       }
     }
   }

--- a/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfInboundMediaResolver.java
+++ b/oryxos-channel-weixin-kf/src/main/java/io/oryxos/channel/weixinkf/WeixinKfInboundMediaResolver.java
@@ -33,7 +33,6 @@ final class WeixinKfInboundMediaResolver {
   private static final String EXT_WEBP = ".webp";
   private static final String EXT_PDF = ".pdf";
   private static final String EXT_MP4 = ".mp4";
-  private static final String EXT_SILK = ".silk";
   private static final String EXT_AMR = ".amr";
   private static final String CT_JPEG = "jpeg";
   private static final String CT_JPG = "jpg";
@@ -221,7 +220,8 @@ final class WeixinKfInboundMediaResolver {
       }
       if (ct.contains(CT_SILK) || ct.contains(CT_OCTET)) {
         if (InboundAttachment.TYPE_AUDIO.equals(type)) {
-          return EXT_SILK;
+          // sync_msg 默认 voice_format=AMR；octet-stream 优先按 AMR，魔数可再纠正为 Silk
+          return EXT_AMR;
         }
       }
       if (ct.contains(CT_AMR)) {
@@ -232,7 +232,7 @@ final class WeixinKfInboundMediaResolver {
       return DEFAULT_EXTENSION;
     }
     if (InboundAttachment.TYPE_AUDIO.equals(type)) {
-      return EXT_SILK;
+      return EXT_AMR;
     }
     if (InboundAttachment.TYPE_VIDEO.equals(type)) {
       return EXT_MP4;

--- a/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapterTest.java
+++ b/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfChannelAdapterTest.java
@@ -194,10 +194,60 @@ class WeixinKfChannelAdapterTest {
     assertTrue(out.get(0).messageId().contains("m2"));
   }
 
+  @Test
+  @DisplayName("图片回调：beginSlowWork + 下载后 onClaimedMessage(latch)")
+  void imageCallbackUsesSlowWork() throws Exception {
+    ObjectNode item = MAPPER.createObjectNode();
+    item.put("msgid", "img-1");
+    item.put("open_kfid", OPEN_KFID);
+    item.put("external_userid", "wu1");
+    item.put("origin", 3);
+    item.put("msgtype", "image");
+    item.putObject("image").put("media_id", "MEDIA_IMG");
+    client.messages = List.of(item);
+
+    String eventXml =
+        "<xml><ToUserName><![CDATA["
+            + CORP_ID
+            + "]]></ToUserName>"
+            + "<CreateTime>1348831860</CreateTime>"
+            + "<MsgType><![CDATA[event]]></MsgType>"
+            + "<Event><![CDATA[kf_msg_or_event]]></Event>"
+            + "<Token><![CDATA[ENC_TOKEN]]></Token>"
+            + "<OpenKfId><![CDATA["
+            + OPEN_KFID
+            + "]]></OpenKfId></xml>";
+    String cipher = crypt.encrypt(eventXml);
+    String ts = "1409659813";
+    String nonce = "1372623149";
+    String sig = crypt.signature(ts, nonce, cipher);
+    String body = "<xml><Encrypt><![CDATA[" + cipher + "]]></Encrypt></xml>";
+    when(inbound.tryClaim(any(), any())).thenReturn(true);
+    when(inbound.beginSlowWork(any(), any(), any()))
+        .thenReturn(new java.util.concurrent.CountDownLatch(1));
+    WebhookResponse response =
+        adapter.onWebhook(
+            new WebhookRequest(
+                "POST",
+                Map.of(
+                    "msg_signature", sig,
+                    "timestamp", ts,
+                    "nonce", nonce),
+                Map.of(),
+                body));
+    assertEquals(200, response.status());
+    verify(inbound).beginSlowWork(any(), any(), any());
+    verify(inbound)
+        .onClaimedMessage(
+            any(InboundMessage.class), any(), any(java.util.concurrent.CountDownLatch.class));
+    assertEquals(1, client.downloadCalls.get());
+  }
+
   private static final class FakeClient implements WeixinKfClient {
     List<com.fasterxml.jackson.databind.JsonNode> messages = List.of();
     final AtomicInteger ensureCalls = new AtomicInteger();
     final AtomicInteger sendCalls = new AtomicInteger();
+    final AtomicInteger downloadCalls = new AtomicInteger();
 
     @Override
     public WeixinKfSyncResult syncMsg(String openKfid, String callbackToken, String cursor) {
@@ -216,7 +266,9 @@ class WeixinKfChannelAdapterTest {
 
     @Override
     public WeixinKfMediaBlob downloadMedia(String mediaId) {
-      return new WeixinKfMediaBlob(new byte[] {1, 2, 3}, "image/jpeg", "a.jpg");
+      downloadCalls.incrementAndGet();
+      return new WeixinKfMediaBlob(
+          new byte[] {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF}, "image/jpeg", "a.jpg");
     }
   }
 }

--- a/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfInboundMediaResolverTest.java
+++ b/oryxos-channel-weixin-kf/src/test/java/io/oryxos/channel/weixinkf/WeixinKfInboundMediaResolverTest.java
@@ -1,14 +1,17 @@
 package io.oryxos.channel.weixinkf;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.oryxos.core.channel.ChatKind;
 import io.oryxos.core.channel.InboundAttachment;
 import io.oryxos.core.channel.InboundMessage;
+import java.net.http.HttpTimeoutException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -21,42 +24,95 @@ class WeixinKfInboundMediaResolverTest {
   @DisplayName("media_id 下载后写入本地 url")
   void downloadsToLocalUrl() {
     WeixinKfClient client =
-        new WeixinKfClient() {
-          @Override
-          public WeixinKfSyncResult syncMsg(String openKfid, String callbackToken, String cursor) {
-            throw new UnsupportedOperationException();
-          }
-
-          @Override
-          public void sendText(String openKfid, String externalUserId, String text) {}
-
-          @Override
-          public void ensureAiReception(String openKfid, String externalUserId) {}
-
-          @Override
-          public WeixinKfMediaBlob downloadMedia(String mediaId) {
-            return new WeixinKfMediaBlob("%PDF-1.4".getBytes(), "application/pdf", "doc.pdf");
-          }
-        };
+        client(
+            mediaId -> new WeixinKfMediaBlob("%PDF-1.4".getBytes(), "application/pdf", "doc.pdf"));
     WeixinKfInboundMediaResolver resolver =
         new WeixinKfInboundMediaResolver(client, tempDir, "ops-kf");
-    InboundMessage in =
-        new InboundMessage(
-            "weixin_kf",
-            "ops-kf",
-            "mid-1",
-            ChatKind.P2P,
-            "wu1",
-            "kf:wk1:user:wu1",
-            "",
-            false,
-            false,
-            List.of(InboundAttachment.fileReference("MEDIA1", "doc.pdf")));
+    InboundMessage in = fileMessage("mid-1", InboundAttachment.fileReference("MEDIA1", "doc.pdf"));
     InboundMessage out = resolver.resolve(in);
     assertEquals(1, out.attachments().size());
     String url = out.attachments().get(0).url();
     assertTrue(url != null && !url.isBlank());
     assertTrue(Files.exists(Path.of(url)));
     assertEquals("MEDIA1", out.attachments().get(0).reference());
+  }
+
+  @Test
+  @DisplayName("下载失败保留原 reference、不写 url")
+  void downloadFailureKeepsReference() {
+    WeixinKfClient client =
+        client(
+            mediaId -> {
+              throw new IllegalStateException("微信客服 /cgi-bin/media/get errcode=40007");
+            });
+    WeixinKfInboundMediaResolver resolver =
+        new WeixinKfInboundMediaResolver(client, tempDir, "ops-kf");
+    InboundMessage in =
+        fileMessage("mid-fail", InboundAttachment.fileReference("BAD_MEDIA", "x.pdf"));
+    InboundMessage out = resolver.resolve(in);
+    assertEquals(1, out.attachments().size());
+    assertEquals("BAD_MEDIA", out.attachments().get(0).reference());
+    assertNull(out.attachments().get(0).url());
+  }
+
+  @Test
+  @DisplayName("超时可重试一次后成功")
+  void timeoutThenRetrySucceeds() {
+    AtomicInteger attempts = new AtomicInteger();
+    WeixinKfClient client =
+        client(
+            mediaId -> {
+              if (attempts.incrementAndGet() == 1) {
+                throw new IllegalStateException(
+                    "微信客服 /cgi-bin/media/get 失败", new HttpTimeoutException("timed out"));
+              }
+              return new WeixinKfMediaBlob("%PDF-1.4".getBytes(), "application/pdf", "ok.pdf");
+            });
+    WeixinKfInboundMediaResolver resolver =
+        new WeixinKfInboundMediaResolver(client, tempDir, "ops-kf");
+    InboundMessage out =
+        resolver.resolve(
+            fileMessage("mid-retry", InboundAttachment.fileReference("MEDIA_R", "ok.pdf")));
+    assertEquals(2, attempts.get());
+    assertTrue(out.attachments().get(0).url() != null && !out.attachments().get(0).url().isBlank());
+  }
+
+  private static InboundMessage fileMessage(String messageId, InboundAttachment attachment) {
+    return new InboundMessage(
+        "weixin_kf",
+        "ops-kf",
+        messageId,
+        ChatKind.P2P,
+        "wu1",
+        "kf:wk1:user:wu1",
+        "",
+        false,
+        false,
+        List.of(attachment));
+  }
+
+  @FunctionalInterface
+  private interface DownloadFn {
+    WeixinKfMediaBlob download(String mediaId);
+  }
+
+  private static WeixinKfClient client(DownloadFn download) {
+    return new WeixinKfClient() {
+      @Override
+      public WeixinKfSyncResult syncMsg(String openKfid, String callbackToken, String cursor) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void sendText(String openKfid, String externalUserId, String text) {}
+
+      @Override
+      public void ensureAiReception(String openKfid, String externalUserId) {}
+
+      @Override
+      public WeixinKfMediaBlob downloadMedia(String mediaId) {
+        return download.download(mediaId);
+      }
+    };
   }
 }


### PR DESCRIPTION
## Summary
- Split `pullAndDispatch` so sync/cursor/dedup stay under `syncLock`, while `ensureAiReception` + media download/`dispatchOne` run outside the lock
- Document and log that startup drain intentionally discards downtime backlog (avoid HI/media replay + 5-msg/turn cap)
- Expand resolver/adapter tests (fail keeps reference; timeout retry; image path with `beginSlowWork`); default `audio/*`/`octet-stream` ext to `.amr` (aligned with `voice_format=0`)

## Test plan
- [x] `mvn -pl oryxos-channel-weixin-kf -am -Dsurefire.failIfNoSpecifiedTests=false spotless:apply test -Dtest=WeixinKfInboundMediaResolverTest,WeixinKfChannelAdapterTest pmd:check spotbugs:check`
- [ ] CI green on this PR
