### PR TITLE
feat(channel-weixin-mini): mini-program customer-message MVP (037)

### DIFF
--- a/config/channels.yaml.example
+++ b/config/channels.yaml.example
@@ -153,3 +153,15 @@ channels:
   #     token: ${WEIXIN_MP_TOKEN}
   #     encoding_aes_key: ${WEIXIN_MP_AES_KEY}
   #   enabled: true
+
+  # 微信小程序客服（消息推送 + custom/send，见 docs/WeixinMiniChannelSetup.md）
+  # 回调：GET/POST /api/v1/channels/inbound/ops-weixin-mini
+  # - name: ops-weixin-mini
+  #   type: weixin_mini
+  #   app_id: ${WEIXIN_MINI_APP_ID}
+  #   app_secret: ${WEIXIN_MINI_APP_SECRET}
+  #   agent: demo-agent
+  #   extra:
+  #     token: ${WEIXIN_MINI_TOKEN}
+  #     encoding_aes_key: ${WEIXIN_MINI_AES_KEY}
+  #   enabled: true

--- a/docs/WeixinKfChannelSetup.md
+++ b/docs/WeixinKfChannelSetup.md
@@ -49,6 +49,7 @@
 |------|------|
 | `weixin_kf`（本渠道） | 企业对客微信客服 |
 | `weixin_mp` | 认证服务号粉丝会话（见 `WeixinMpChannelSetup.md`） |
+| `weixin_mini` | 小程序内客服会话（见 `WeixinMiniChannelSetup.md`） |
 | `wecom` | 企微应用内机器人 |
 | `weixin` | 个人微信 iLink Bot |
 

--- a/docs/WeixinMiniChannelSetup.md
+++ b/docs/WeixinMiniChannelSetup.md
@@ -1,0 +1,63 @@
+# 微信小程序客服渠道（`message/custom/send`）
+
+用户在**小程序内**通过 `<button open-type="contact">` 或客服会话发消息；OryxOS 通过小程序「消息推送」URL 收信，经 `message/custom/send` 回复。  
+与 `weixin_mp`（服务号）、`weixin_kf`（企微微信客服）、`wecom`（企微应用）、`weixin`（个人 iLink）**不是同一产品**。
+
+## 前置
+
+1. 已注册**小程序**（企业主体），已开通客服消息能力
+2. 小程序后台 → 开发管理 → 开发设置：AppId + AppSecret
+3. 开发管理 → 消息推送：URL + Token + EncodingAESKey（**推荐安全模式 / AES**，数据格式 **XML**）
+4. 公网 HTTPS 可达 OryxOS：`GET/POST /api/v1/channels/inbound/{name}`
+
+## channels.yaml
+
+```yaml
+  - name: ops-weixin-mini
+    type: weixin_mini
+    app_id: ${WEIXIN_MINI_APP_ID}              # 小程序 AppId
+    app_secret: ${WEIXIN_MINI_APP_SECRET}      # AppSecret
+    agent: demo-agent
+    extra:
+      token: ${WEIXIN_MINI_TOKEN}
+      encoding_aes_key: ${WEIXIN_MINI_AES_KEY}
+    enabled: true
+```
+
+回调地址示例：`https://<host>/api/v1/channels/inbound/ops-weixin-mini`
+
+## 出站白名单
+
+`http.allowed_domains` 需包含 `api.weixin.qq.com`（示例配置已有）。
+
+## 行为摘要
+
+| 步骤 | 说明 |
+|------|------|
+| URL 验证 | GET：`signature` + `timestamp` + `nonce` + `echostr` → SHA1(token,ts,nonce) 验签后**原样回写 echostr**（明文，不解密） |
+| 入站 | POST 加密 XML → `msg_signature` 验签解密；`MsgType=text` 时读 `FromUserName`（OpenID）、`Content`、`MsgId` |
+| ACK | 5 秒内回 `success`；Agent 异步编排 |
+| 事件/媒体 | 进入客服会话/图片等 MVP **不进 Agent**，仍回 `success` |
+| 出站 | `POST /cgi-bin/message/custom/send` 文本；**48h / 每回合最多 5 条**，窗外 fail-loud |
+| chatId | `mini:{appId}:user:{openId}` |
+
+## 与服务号 GET 验签差异
+
+| | `weixin_mini`（本渠道） | `weixin_mp` |
+|--|------------------------|-------------|
+| GET 参数 | `signature` | `msg_signature` |
+| echostr | 明文原样返回 | 加密 echostr，验签后解密回写 |
+
+## 与其它微信系对照
+
+| type | 场景 |
+|------|------|
+| `weixin_mini`（本渠道） | 小程序内客服会话 |
+| `weixin_mp` | 认证服务号粉丝会话（见 `WeixinMpChannelSetup.md`） |
+| `weixin_kf` | 企业对客微信客服（企微 `kf/*`） |
+| `wecom` | 企微应用内机器人 |
+| `weixin` | 个人微信 iLink Bot |
+
+## MVP 非目标
+
+JSON 入站格式、媒体消息、订阅/模板消息、云函数/云托管唯一入站、人工 `transfer_customer_service`。

--- a/docs/WeixinMpChannelSetup.md
+++ b/docs/WeixinMpChannelSetup.md
@@ -46,10 +46,11 @@
 | type | 场景 |
 |------|------|
 | `weixin_mp`（本渠道） | 认证服务号粉丝会话 |
+| `weixin_mini` | 小程序内客服会话（见 `WeixinMiniChannelSetup.md`） |
 | `weixin_kf` | 企业对客微信客服（企微 `kf/*`） |
 | `wecom` | 企微应用内机器人 |
 | `weixin` | 个人微信 iLink Bot |
 
 ## MVP 非目标
 
-小程序客服（W3）、媒体消息、模板/群发、多客服人工台。
+媒体消息、模板/群发、多客服人工台。

--- a/oryxos-boot/pom.xml
+++ b/oryxos-boot/pom.xml
@@ -110,6 +110,10 @@
         </dependency>
         <dependency>
             <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-channel-weixin-mini</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
             <artifactId>oryxos-web</artifactId>
         </dependency>
         <dependency>

--- a/oryxos-channel-weixin-mini/pom.xml
+++ b/oryxos-channel-weixin-mini/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.oryxos</groupId>
+        <artifactId>oryxos</artifactId>
+        <version>0.1.5-RELEASE</version>
+    </parent>
+    <artifactId>oryxos-channel-weixin-mini</artifactId>
+    <name>OryxOS Channel Weixin Mini</name>
+    <description>Weixin Mini Program customer-message webhook + message/custom/send</description>
+    <dependencies>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/ChannelWeixinMiniModule.java
+++ b/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/ChannelWeixinMiniModule.java
@@ -1,0 +1,7 @@
+package io.oryxos.channel.weixinmini;
+
+/** Marker for oryxos-channel-weixin-mini. */
+public final class ChannelWeixinMiniModule {
+
+  private ChannelWeixinMiniModule() {}
+}

--- a/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniAccessTokenClient.java
+++ b/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniAccessTokenClient.java
@@ -1,0 +1,104 @@
+package io.oryxos.channel.weixinmini;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oryxos.core.channel.OutboundGuard;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** {@code GET /cgi-bin/token}，按 expires_in 缓存。 */
+final class WeixinMiniAccessTokenClient {
+
+  static final String API_BASE = "https://api.weixin.qq.com";
+  private static final Duration TIMEOUT = Duration.ofSeconds(20);
+  private static final long SKEW_MS = 120_000L;
+  private static final int HTTP_OK_MIN = 200;
+  private static final int HTTP_OK_MAX_EXCLUSIVE = 300;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final HttpClient http;
+  private final OutboundGuard guard;
+  private final String appId;
+  private final String secret;
+  private final AtomicReference<Cached> cached = new AtomicReference<>();
+
+  WeixinMiniAccessTokenClient(OutboundGuard guard, String appId, String secret) {
+    this(HttpClient.newBuilder().connectTimeout(TIMEOUT).build(), guard, appId, secret);
+  }
+
+  WeixinMiniAccessTokenClient(HttpClient http, OutboundGuard guard, String appId, String secret) {
+    this.http = http;
+    this.guard = guard;
+    this.appId = appId;
+    this.secret = secret;
+  }
+
+  String getToken() {
+    Cached hit = cached.get();
+    long now = System.currentTimeMillis();
+    if (hit != null && now < hit.expiresAtMs()) {
+      return hit.token();
+    }
+    synchronized (this) {
+      hit = cached.get();
+      now = System.currentTimeMillis();
+      if (hit != null && now < hit.expiresAtMs()) {
+        return hit.token();
+      }
+      return fetch();
+    }
+  }
+
+  private String fetch() {
+    String url =
+        API_BASE
+            + "/cgi-bin/token?grant_type=client_credential&appid="
+            + URLEncoder.encode(appId, StandardCharsets.UTF_8)
+            + "&secret="
+            + URLEncoder.encode(secret, StandardCharsets.UTF_8);
+    guard.check(url);
+    try {
+      HttpRequest request =
+          HttpRequest.newBuilder().uri(URI.create(url)).timeout(TIMEOUT).GET().build();
+      HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() < HTTP_OK_MIN || response.statusCode() >= HTTP_OK_MAX_EXCLUSIVE) {
+        throw new IllegalStateException(
+            "小程序 token HTTP " + response.statusCode() + ": " + sanitize(response.body()));
+      }
+      JsonNode root = MAPPER.readTree(response.body() == null ? "{}" : response.body());
+      int errcode = root.path("errcode").asInt(0);
+      if (errcode != 0) {
+        throw new IllegalStateException(
+            "小程序 token errcode=" + errcode + " errmsg=" + root.path("errmsg").asText());
+      }
+      String token = root.path("access_token").asText(null);
+      if (token == null || token.isBlank()) {
+        throw new IllegalStateException("小程序 token 未返回 access_token");
+      }
+      long expiresInSec = root.path("expires_in").asLong(7200L);
+      long ttlMs = Math.max(60_000L, expiresInSec * 1000L - SKEW_MS);
+      cached.set(new Cached(token, System.currentTimeMillis() + ttlMs));
+      return token;
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("小程序 token 失败: " + e.getMessage(), e);
+    }
+  }
+
+  private static String sanitize(String value) {
+    if (value == null) {
+      return "";
+    }
+    String trimmed = value.length() > 200 ? value.substring(0, 200) : value;
+    return trimmed.replace('\r', '_').replace('\n', '_');
+  }
+
+  private record Cached(String token, long expiresAtMs) {}
+}

--- a/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniApiClient.java
+++ b/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniApiClient.java
@@ -1,0 +1,94 @@
+package io.oryxos.channel.weixinmini;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.oryxos.core.channel.OutboundGuard;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.function.Supplier;
+
+/** 小程序 {@code message/custom/send} 文本客服消息。 */
+final class WeixinMiniApiClient implements WeixinMiniClient {
+
+  static final String API_BASE = WeixinMiniAccessTokenClient.API_BASE;
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(20);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final int HTTP_OK_MIN = 200;
+  private static final int HTTP_OK_MAX = 300;
+
+  private final HttpClient http;
+  private final OutboundGuard guard;
+  private final Supplier<String> accessToken;
+
+  WeixinMiniApiClient(OutboundGuard guard, Supplier<String> accessToken) {
+    this(HttpClient.newBuilder().connectTimeout(TIMEOUT).build(), guard, accessToken);
+  }
+
+  WeixinMiniApiClient(HttpClient http, OutboundGuard guard, Supplier<String> accessToken) {
+    this.http = http;
+    this.guard = guard;
+    this.accessToken = accessToken;
+  }
+
+  @Override
+  public void sendText(String openId, String text) {
+    if (openId == null || openId.isBlank()) {
+      throw new IllegalArgumentException("openId 为空");
+    }
+    ObjectNode body = MAPPER.createObjectNode();
+    body.put("touser", openId);
+    body.put("msgtype", "text");
+    body.putObject("text").put("content", text == null ? "" : text);
+    postJson("/cgi-bin/message/custom/send", body);
+  }
+
+  private JsonNode postJson(String path, ObjectNode body) {
+    String token = accessToken.get();
+    if (token == null || token.isBlank()) {
+      throw new IllegalStateException("小程序 access_token 为空");
+    }
+    String url =
+        API_BASE + path + "?access_token=" + URLEncoder.encode(token, StandardCharsets.UTF_8);
+    guard.check(url);
+    try {
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(url))
+              .timeout(TIMEOUT)
+              .header("Content-Type", "application/json; charset=utf-8")
+              .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body)))
+              .build();
+      HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() < HTTP_OK_MIN || response.statusCode() >= HTTP_OK_MAX) {
+        throw new IllegalStateException(
+            "小程序 " + path + " HTTP " + response.statusCode() + ": " + sanitize(response.body()));
+      }
+      JsonNode root = MAPPER.readTree(response.body() == null ? "{}" : response.body());
+      int errcode = root.path("errcode").asInt(0);
+      if (errcode != 0) {
+        throw new IllegalStateException(
+            "小程序 " + path + " errcode=" + errcode + " errmsg=" + root.path("errmsg").asText());
+      }
+      return root;
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("小程序 " + path + " 失败: " + e.getMessage(), e);
+    }
+  }
+
+  private static String sanitize(String value) {
+    if (value == null) {
+      return "";
+    }
+    String trimmed = value.length() > 200 ? value.substring(0, 200) : value;
+    return trimmed.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniCallbackXml.java
+++ b/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniCallbackXml.java
@@ -1,0 +1,33 @@
+package io.oryxos.channel.weixinmini;
+
+/** 回调 XML 字段抽取（小程序加密包 / 明文消息）。 */
+final class WeixinMiniCallbackXml {
+
+  private WeixinMiniCallbackXml() {}
+
+  static String cdataOrText(String xml, String tag) {
+    if (xml == null || tag == null || tag.isBlank()) {
+      return null;
+    }
+    String openCdata = "<" + tag + "><![CDATA[";
+    int start = xml.indexOf(openCdata);
+    if (start >= 0) {
+      start += openCdata.length();
+      int end = xml.indexOf("]]></" + tag + ">", start);
+      if (end > start) {
+        return xml.substring(start, end).strip();
+      }
+    }
+    String open = "<" + tag + ">";
+    start = xml.indexOf(open);
+    if (start < 0) {
+      return null;
+    }
+    start += open.length();
+    int end = xml.indexOf("</" + tag + ">", start);
+    if (end <= start) {
+      return null;
+    }
+    return xml.substring(start, end).strip();
+  }
+}

--- a/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniChannelAdapter.java
+++ b/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniChannelAdapter.java
@@ -1,0 +1,255 @@
+package io.oryxos.channel.weixinmini;
+
+import io.oryxos.core.channel.ChannelConfig;
+import io.oryxos.core.channel.ChannelStatus;
+import io.oryxos.core.channel.InboundChannelAdapter;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageService;
+import io.oryxos.core.channel.InboundWebhookHandler;
+import io.oryxos.core.channel.OutboundGuard;
+import io.oryxos.core.channel.WebhookRequest;
+import io.oryxos.core.channel.WebhookResponse;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.time.Clock;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 微信小程序客服：消息推送 URL 验签/解密 → 文本归一化 → 快速 success → Agent → {@code message/custom/send}。
+ *
+ * <p>{@code app_id}=小程序 AppId，{@code app_secret}=AppSecret；{@code extra.token} / {@code
+ * encoding_aes_key}。
+ */
+public class WeixinMiniChannelAdapter implements InboundChannelAdapter, InboundWebhookHandler {
+
+  public static final String TYPE = "weixin_mini";
+
+  private static final Logger log = LoggerFactory.getLogger(WeixinMiniChannelAdapter.class);
+  private static final String EXTRA_TOKEN = "token";
+  private static final String EXTRA_AES_KEY = "encoding_aes_key";
+  private static final String METHOD_GET = "get";
+  private static final String QUERY_SIGNATURE = "signature";
+  private static final String QUERY_MSG_SIGNATURE = "msg_signature";
+  private static final String QUERY_TIMESTAMP = "timestamp";
+  private static final String QUERY_NONCE = "nonce";
+  private static final String QUERY_ECHOSTR = "echostr";
+  private static final String TAG_ENCRYPT = "Encrypt";
+  private static final int HTTP_OK = 200;
+  private static final int HTTP_BAD_REQUEST = 400;
+  private static final int HTTP_UNAUTHORIZED = 401;
+  private static final String ACK_SUCCESS = "success";
+
+  private final ChannelConfig config;
+  private final ProfileRegistry profileRegistry;
+  private final InboundMessageService inboundMessageService;
+  private final OutboundGuard guard;
+  private final Clock clock;
+  private final WeixinMiniReplySessionStore sessions = new WeixinMiniReplySessionStore();
+
+  private volatile WeixinMiniMsgCrypt crypt;
+  private volatile WeixinMiniClient api;
+  private volatile WeixinMiniEventNormalizer normalizer;
+  private volatile ChannelStatus.State state = ChannelStatus.State.DISCONNECTED;
+
+  public WeixinMiniChannelAdapter(
+      ChannelConfig config,
+      ProfileRegistry profileRegistry,
+      InboundMessageService inboundMessageService,
+      OutboundGuard guard) {
+    this(config, profileRegistry, inboundMessageService, guard, Clock.systemUTC());
+  }
+
+  WeixinMiniChannelAdapter(
+      ChannelConfig config,
+      ProfileRegistry profileRegistry,
+      InboundMessageService inboundMessageService,
+      OutboundGuard guard,
+      Clock clock) {
+    this.config = config;
+    this.profileRegistry = profileRegistry;
+    this.inboundMessageService = inboundMessageService;
+    this.guard = guard;
+    this.clock = clock;
+  }
+
+  /** 测试注入 API 客户端与加解密。 */
+  WeixinMiniChannelAdapter(
+      ChannelConfig config,
+      ProfileRegistry profileRegistry,
+      InboundMessageService inboundMessageService,
+      OutboundGuard guard,
+      Clock clock,
+      WeixinMiniClient api,
+      WeixinMiniMsgCrypt crypt) {
+    this(config, profileRegistry, inboundMessageService, guard, clock);
+    this.api = api;
+    this.crypt = crypt;
+  }
+
+  @Override
+  public String name() {
+    return config.name();
+  }
+
+  @Override
+  public String type() {
+    return TYPE;
+  }
+
+  @Override
+  public String boundAgent() {
+    return config.agent();
+  }
+
+  @Override
+  public synchronized void start() {
+    config.validateCredentialsResolved();
+    requireExtra(EXTRA_TOKEN);
+    requireExtra(EXTRA_AES_KEY);
+    if (profileRegistry.get(config.agent()).isEmpty()) {
+      throw new IllegalArgumentException(
+          "渠道 " + config.name() + " 绑定的 Agent " + config.agent() + " 不存在");
+    }
+    guard.check(WeixinMiniApiClient.API_BASE);
+    if (crypt == null) {
+      crypt =
+          new WeixinMiniMsgCrypt(
+              config.extra(EXTRA_TOKEN), config.extra(EXTRA_AES_KEY), config.appId());
+    }
+    if (api == null) {
+      WeixinMiniAccessTokenClient tokens =
+          new WeixinMiniAccessTokenClient(guard, config.appId(), config.appSecret());
+      api = new WeixinMiniApiClient(guard, tokens::getToken);
+    }
+    normalizer = new WeixinMiniEventNormalizer(config.name(), config.appId());
+    state = ChannelStatus.State.CONNECTED;
+  }
+
+  @Override
+  public synchronized void stop() {
+    state = ChannelStatus.State.DISCONNECTED;
+    normalizer = null;
+  }
+
+  @Override
+  public ChannelStatus status() {
+    return ChannelStatus.ok(name(), TYPE, boundAgent(), state);
+  }
+
+  @Override
+  public void sendReply(String chatId, String text, String replyToMessageId) {
+    WeixinMiniClient client = api;
+    if (client == null) {
+      throw new IllegalStateException("渠道 " + name() + " 尚未启动");
+    }
+    WeixinMiniReplySessionStore.Session session = sessions.requireForReply(chatId, clock.millis());
+    WeixinMiniChatTargets.Parsed target = WeixinMiniChatTargets.parse(chatId);
+    String configuredAppId = config.appId();
+    if (configuredAppId != null
+        && !configuredAppId.isBlank()
+        && !configuredAppId.equals(target.appId())) {
+      throw new IllegalStateException("小程序 chatId appId 与配置不一致（chat=" + chatId + "）");
+    }
+    client.sendText(target.openId(), text);
+    sessions.markReplied(chatId, session);
+  }
+
+  @Override
+  public WebhookResponse onWebhook(WebhookRequest request) {
+    if (METHOD_GET.equals(asciiLower(request.method()))) {
+      return handleUrlVerify(request);
+    }
+    return handleCallback(request);
+  }
+
+  private WebhookResponse handleUrlVerify(WebhookRequest request) {
+    WeixinMiniMsgCrypt active = crypt;
+    if (active == null) {
+      return WebhookResponse.text(HTTP_BAD_REQUEST, "channel not started");
+    }
+    try {
+      String echostr =
+          active.verifyUrlPlain(
+              request.query(QUERY_SIGNATURE),
+              request.query(QUERY_TIMESTAMP),
+              request.query(QUERY_NONCE),
+              request.query(QUERY_ECHOSTR));
+      return WebhookResponse.text(HTTP_OK, echostr);
+    } catch (Exception e) {
+      log.warn("小程序 URL 校验失败: {}", sanitize(e.getMessage()));
+      return WebhookResponse.text(HTTP_UNAUTHORIZED, "verify failed");
+    }
+  }
+
+  private WebhookResponse handleCallback(WebhookRequest request) {
+    WeixinMiniMsgCrypt active = crypt;
+    WeixinMiniEventNormalizer activeNormalizer = normalizer;
+    if (active == null || activeNormalizer == null) {
+      return WebhookResponse.text(HTTP_BAD_REQUEST, "channel not started");
+    }
+    try {
+      String encrypt = WeixinMiniCallbackXml.cdataOrText(request.body(), TAG_ENCRYPT);
+      if (encrypt == null || encrypt.isBlank()) {
+        return WebhookResponse.text(HTTP_BAD_REQUEST, "missing Encrypt");
+      }
+      String xml =
+          active.decryptMsg(
+              request.query(QUERY_MSG_SIGNATURE),
+              request.query(QUERY_TIMESTAMP),
+              request.query(QUERY_NONCE),
+              encrypt);
+      Optional<InboundMessage> message = activeNormalizer.normalize(xml);
+      message.ifPresent(
+          m -> {
+            sessions.rememberInbound(m.chatId(), clock.millis());
+            dispatchOne(m);
+          });
+      return WebhookResponse.text(HTTP_OK, ACK_SUCCESS);
+    } catch (Exception e) {
+      log.warn("小程序回调处理失败: {}", sanitize(e.getMessage()));
+      return WebhookResponse.text(HTTP_UNAUTHORIZED, "callback failed");
+    }
+  }
+
+  private void dispatchOne(InboundMessage m) {
+    try {
+      if (!inboundMessageService.tryClaim(m.channelName(), m.messageId())) {
+        log.info("渠道 {} 重复消息已忽略: {}", sanitize(m.channelName()), sanitize(m.messageId()));
+        return;
+      }
+      inboundMessageService.onClaimedMessage(m, this);
+    } catch (RuntimeException e) {
+      log.warn("小程序消息分发失败（messageId={}）: {}", sanitize(m.messageId()), sanitize(e.getMessage()));
+    }
+  }
+
+  private void requireExtra(String key) {
+    String value = config.extra(key);
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("渠道 " + config.name() + " 缺少 extra." + key);
+    }
+  }
+
+  private static String asciiLower(String value) {
+    if (value == null || value.isEmpty()) {
+      return value;
+    }
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
+  }
+
+  private static String sanitize(String value) {
+    if (value == null) {
+      return "";
+    }
+    String trimmed = value.length() > 200 ? value.substring(0, 200) : value;
+    return trimmed.replace('\r', '_').replace('\n', '_');
+  }
+}

--- a/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniChatTargets.java
+++ b/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniChatTargets.java
@@ -1,0 +1,32 @@
+package io.oryxos.channel.weixinmini;
+
+/** chatId：{@code mini:{appId}:user:{openId}}。 */
+final class WeixinMiniChatTargets {
+
+  private static final String PREFIX = "mini:";
+  private static final String USER_SEP = ":user:";
+
+  private WeixinMiniChatTargets() {}
+
+  static String chatId(String appId, String openId) {
+    return PREFIX + appId + USER_SEP + openId;
+  }
+
+  static Parsed parse(String chatId) {
+    if (chatId == null || !chatId.startsWith(PREFIX)) {
+      throw new IllegalArgumentException("小程序 chatId 须为 mini:{appId}:user:{openId}，实际: " + chatId);
+    }
+    int idx = chatId.indexOf(USER_SEP);
+    if (idx <= PREFIX.length()) {
+      throw new IllegalArgumentException("小程序 chatId 格式错误: " + chatId);
+    }
+    String appId = chatId.substring(PREFIX.length(), idx).strip();
+    String openId = chatId.substring(idx + USER_SEP.length()).strip();
+    if (appId.isEmpty() || openId.isEmpty()) {
+      throw new IllegalArgumentException("小程序 chatId 缺少 appId/openId: " + chatId);
+    }
+    return new Parsed(appId, openId);
+  }
+
+  record Parsed(String appId, String openId) {}
+}

--- a/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniClient.java
+++ b/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniClient.java
@@ -1,0 +1,7 @@
+package io.oryxos.channel.weixinmini;
+
+/** 小程序出站 API（MVP 仅文本客服消息）。 */
+interface WeixinMiniClient {
+
+  void sendText(String openId, String text);
+}

--- a/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniEventNormalizer.java
+++ b/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniEventNormalizer.java
@@ -1,0 +1,73 @@
+package io.oryxos.channel.weixinmini;
+
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import java.util.List;
+import java.util.Optional;
+
+/** 明文 XML 文本消息 → {@link InboundMessage}。 */
+final class WeixinMiniEventNormalizer {
+
+  static final String CHANNEL_TYPE = WeixinMiniChannelAdapter.TYPE;
+  private static final String MSG_TEXT = "text";
+  private static final String TAG_MSG_TYPE = "MsgType";
+  private static final String TAG_FROM_USER = "FromUserName";
+  private static final String TAG_CONTENT = "Content";
+  private static final String TAG_MSG_ID = "MsgId";
+  private static final String TAG_CREATE_TIME = "CreateTime";
+
+  private final String channelName;
+  private final String appId;
+
+  WeixinMiniEventNormalizer(String channelName, String appId) {
+    this.channelName = channelName;
+    this.appId = appId;
+  }
+
+  Optional<InboundMessage> normalize(String xml) {
+    if (xml == null || xml.isBlank()) {
+      return Optional.empty();
+    }
+    String msgType = asciiLower(WeixinMiniCallbackXml.cdataOrText(xml, TAG_MSG_TYPE));
+    if (!MSG_TEXT.equals(msgType)) {
+      return Optional.empty();
+    }
+    String fromUser = WeixinMiniCallbackXml.cdataOrText(xml, TAG_FROM_USER);
+    String content = WeixinMiniCallbackXml.cdataOrText(xml, TAG_CONTENT);
+    if (fromUser == null || fromUser.isBlank() || content == null || content.isBlank()) {
+      return Optional.empty();
+    }
+    String msgId = WeixinMiniCallbackXml.cdataOrText(xml, TAG_MSG_ID);
+    if (msgId == null || msgId.isBlank()) {
+      String createTime = WeixinMiniCallbackXml.cdataOrText(xml, TAG_CREATE_TIME);
+      msgId = fromUser + ":" + (createTime != null ? createTime : "0");
+    }
+    String chatId = WeixinMiniChatTargets.chatId(appId, fromUser);
+    return Optional.of(
+        new InboundMessage(
+            CHANNEL_TYPE,
+            channelName,
+            msgId,
+            ChatKind.P2P,
+            fromUser,
+            chatId,
+            content.strip(),
+            true,
+            false,
+            List.of()));
+  }
+
+  private static String asciiLower(String value) {
+    if (value == null) {
+      return "";
+    }
+    char[] chars = value.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (c >= 'A' && c <= 'Z') {
+        chars[i] = (char) (c + ('a' - 'A'));
+      }
+    }
+    return new String(chars);
+  }
+}

--- a/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniMsgCrypt.java
+++ b/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniMsgCrypt.java
@@ -1,0 +1,206 @@
+package io.oryxos.channel.weixinmini;
+
+/**
+ * 小程序消息推送加解密（WXBizMsgCrypt）：Token + EncodingAESKey + receiveId(小程序 AppId)。
+ *
+ * <p>GET URL 验签为明文 {@code signature}=SHA1(token,timestamp,nonce)；POST 安全模式与公众平台同族。
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+    value = {"CIPHER_INTEGRITY", "WEAK_MESSAGE_DIGEST_SHA1"},
+    justification =
+        "小程序消息推送协议固定 AES-256-CBC + msg_signature=SHA1（官方 WXBizMsgCrypt），"
+            + "无法改用 AEAD/SHA-256；完整性依赖平台侧签名字段。")
+final class WeixinMiniMsgCrypt {
+
+  private static final int AES_BLOCK = 16;
+
+  /** 公众平台官方 WXBizMsgCrypt PKCS#7 块长为 32（非 AES 16）。 */
+  private static final int PKCS7_BLOCK = 32;
+
+  private static final int RANDOM_LEN = 16;
+  private static final int AES_KEY_LEN = 32;
+  private static final int BASE64_PAD_MOD = 4;
+  private static final int LENGTH_HEADER_BYTES = 4;
+  private static final String TRANSFORMATION = "AES/CBC/NoPadding";
+  private static final char BASE64_PAD = '=';
+  private static final java.security.SecureRandom SECURE_RANDOM = new java.security.SecureRandom();
+
+  private final byte[] aesKey;
+  private final String token;
+  private final String receiveId;
+
+  WeixinMiniMsgCrypt(String token, String encodingAesKey, String receiveId) {
+    if (token == null || token.isBlank()) {
+      throw new IllegalArgumentException("callback token 为空");
+    }
+    if (encodingAesKey == null || encodingAesKey.isBlank()) {
+      throw new IllegalArgumentException("encoding_aes_key 为空");
+    }
+    if (receiveId == null || receiveId.isBlank()) {
+      throw new IllegalArgumentException("appId/receiveId 为空");
+    }
+    String keyB64 = padBase64(encodingAesKey.strip());
+    byte[] key = java.util.Base64.getDecoder().decode(keyB64);
+    if (key.length != AES_KEY_LEN) {
+      throw new IllegalArgumentException("encoding_aes_key 解码后须为 32 字节");
+    }
+    this.aesKey = key;
+    this.token = token.strip();
+    this.receiveId = receiveId.strip();
+  }
+
+  /** 小程序 GET URL 验签：{@code signature}=SHA1(sorted token,timestamp,nonce)，原样返回 echostr（不解密）。 */
+  String verifyUrlPlain(String signature, String timestamp, String nonce, String echostr)
+      throws Exception {
+    if (!signature.equals(plainSha1Signature(timestamp, nonce))) {
+      throw new IllegalStateException("echostr 明文签名校验失败");
+    }
+    return echostr;
+  }
+
+  String decryptMsg(String msgSignature, String timestamp, String nonce, String encrypt)
+      throws Exception {
+    if (!msgSignature.equals(sha1Signature(timestamp, nonce, encrypt))) {
+      throw new IllegalStateException("回调签名校验失败");
+    }
+    return decrypt(encrypt);
+  }
+
+  /** 单测 / 回环：加密明文 XML。 */
+  String encrypt(String plainXml) throws Exception {
+    byte[] random = new byte[RANDOM_LEN];
+    SECURE_RANDOM.nextBytes(random);
+    byte[] xmlBytes = plainXml.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    byte[] receiveBytes = receiveId.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    byte[] raw = new byte[RANDOM_LEN + LENGTH_HEADER_BYTES + xmlBytes.length + receiveBytes.length];
+    System.arraycopy(random, 0, raw, 0, RANDOM_LEN);
+    int xmlLen = xmlBytes.length;
+    raw[RANDOM_LEN] = (byte) ((xmlLen >> 24) & 0xff);
+    raw[RANDOM_LEN + 1] = (byte) ((xmlLen >> 16) & 0xff);
+    raw[RANDOM_LEN + 2] = (byte) ((xmlLen >> 8) & 0xff);
+    raw[RANDOM_LEN + 3] = (byte) (xmlLen & 0xff);
+    System.arraycopy(xmlBytes, 0, raw, RANDOM_LEN + LENGTH_HEADER_BYTES, xmlBytes.length);
+    System.arraycopy(
+        receiveBytes,
+        0,
+        raw,
+        RANDOM_LEN + LENGTH_HEADER_BYTES + xmlBytes.length,
+        receiveBytes.length);
+    byte[] padded = pkcs7Pad(raw);
+    javax.crypto.Cipher cipherInst = javax.crypto.Cipher.getInstance(TRANSFORMATION);
+    javax.crypto.spec.SecretKeySpec keySpec = new javax.crypto.spec.SecretKeySpec(aesKey, "AES");
+    javax.crypto.spec.IvParameterSpec iv =
+        new javax.crypto.spec.IvParameterSpec(aesKey, 0, AES_BLOCK);
+    cipherInst.init(javax.crypto.Cipher.ENCRYPT_MODE, keySpec, iv);
+    return java.util.Base64.getEncoder().encodeToString(cipherInst.doFinal(padded));
+  }
+
+  String signature(String timestamp, String nonce, String encrypt) throws Exception {
+    return sha1Signature(timestamp, nonce, encrypt);
+  }
+
+  String plainSignature(String timestamp, String nonce) throws Exception {
+    return plainSha1Signature(timestamp, nonce);
+  }
+
+  private String decrypt(String encryptB64) throws Exception {
+    byte[] cipher = java.util.Base64.getDecoder().decode(encryptB64);
+    javax.crypto.Cipher cipherInst = javax.crypto.Cipher.getInstance(TRANSFORMATION);
+    javax.crypto.spec.SecretKeySpec keySpec = new javax.crypto.spec.SecretKeySpec(aesKey, "AES");
+    javax.crypto.spec.IvParameterSpec iv =
+        new javax.crypto.spec.IvParameterSpec(aesKey, 0, AES_BLOCK);
+    cipherInst.init(javax.crypto.Cipher.DECRYPT_MODE, keySpec, iv);
+    byte[] original = pkcs7Unpad(cipherInst.doFinal(cipher));
+    if (original.length < RANDOM_LEN + LENGTH_HEADER_BYTES) {
+      throw new IllegalStateException("解密报文过短");
+    }
+    int xmlLen =
+        ((original[RANDOM_LEN] & 0xff) << 24)
+            | ((original[RANDOM_LEN + 1] & 0xff) << 16)
+            | ((original[RANDOM_LEN + 2] & 0xff) << 8)
+            | (original[RANDOM_LEN + 3] & 0xff);
+    int xmlStart = RANDOM_LEN + LENGTH_HEADER_BYTES;
+    int xmlEnd = xmlStart + xmlLen;
+    if (xmlLen < 0 || xmlEnd > original.length) {
+      throw new IllegalStateException("解密报文长度非法");
+    }
+    String xml = new String(original, xmlStart, xmlLen, java.nio.charset.StandardCharsets.UTF_8);
+    String fromReceiveId =
+        new String(
+            original, xmlEnd, original.length - xmlEnd, java.nio.charset.StandardCharsets.UTF_8);
+    if (!receiveId.equals(fromReceiveId)) {
+      throw new IllegalStateException(
+          "receiveId 不匹配（期望=" + receiveId + " 实际=" + fromReceiveId + "）");
+    }
+    return xml;
+  }
+
+  /** POST 安全模式：SHA1(sorted token,timestamp,nonce,encrypt)。 */
+  private String sha1Signature(String timestamp, String nonce, String encrypt) throws Exception {
+    String[] arr = {token, timestamp, nonce, encrypt};
+    java.util.Arrays.sort(arr);
+    String raw = arr[0] + arr[1] + arr[2] + arr[3];
+    return sha1Hex(raw);
+  }
+
+  /** GET 明文验签：SHA1(sorted token,timestamp,nonce)。 */
+  private String plainSha1Signature(String timestamp, String nonce) throws Exception {
+    String[] arr = {token, timestamp, nonce};
+    java.util.Arrays.sort(arr);
+    String raw = arr[0] + arr[1] + arr[2];
+    return sha1Hex(raw);
+  }
+
+  private static String sha1Hex(String raw) throws Exception {
+    java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-1");
+    byte[] digest = md.digest(raw.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    StringBuilder sb = new StringBuilder(digest.length * 2);
+    for (byte b : digest) {
+      sb.append(String.format("%02x", b));
+    }
+    return sb.toString();
+  }
+
+  private static String padBase64(String keyB64) {
+    int rem = keyB64.length() % BASE64_PAD_MOD;
+    if (rem == 0) {
+      return keyB64;
+    }
+    StringBuilder sb = new StringBuilder(keyB64);
+    for (int i = 0; i < BASE64_PAD_MOD - rem; i++) {
+      sb.append(BASE64_PAD);
+    }
+    return sb.toString();
+  }
+
+  private static byte[] pkcs7Pad(byte[] data) {
+    int pad = PKCS7_BLOCK - (data.length % PKCS7_BLOCK);
+    if (pad == 0) {
+      pad = PKCS7_BLOCK;
+    }
+    byte[] out = new byte[data.length + pad];
+    System.arraycopy(data, 0, out, 0, data.length);
+    for (int i = data.length; i < out.length; i++) {
+      out[i] = (byte) pad;
+    }
+    return out;
+  }
+
+  private static byte[] pkcs7Unpad(byte[] decrypted) {
+    if (decrypted.length == 0) {
+      throw new IllegalStateException("解密报文为空");
+    }
+    int pad = decrypted[decrypted.length - 1] & 0xff;
+    if (pad < 1 || pad > PKCS7_BLOCK || pad > decrypted.length) {
+      throw new IllegalStateException("PKCS7 填充非法: " + pad);
+    }
+    for (int i = 1; i <= pad; i++) {
+      if ((decrypted[decrypted.length - i] & 0xff) != pad) {
+        throw new IllegalStateException("PKCS7 填充校验失败");
+      }
+    }
+    byte[] out = new byte[decrypted.length - pad];
+    System.arraycopy(decrypted, 0, out, 0, out.length);
+    return out;
+  }
+}

--- a/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniReplySessionStore.java
+++ b/oryxos-channel-weixin-mini/src/main/java/io/oryxos/channel/weixinmini/WeixinMiniReplySessionStore.java
@@ -1,0 +1,49 @@
+package io.oryxos.channel.weixinmini;
+
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** 小程序客服回复窗：用户主动发信后 48h / 每回合最多 5 条下行。 */
+final class WeixinMiniReplySessionStore {
+
+  static final Duration SESSION_WINDOW = Duration.ofHours(48);
+  static final int MAX_REPLIES_PER_WINDOW = 5;
+
+  record Session(long expiresAtMs, int replyCount) {}
+
+  private final ConcurrentHashMap<String, Session> byChatId = new ConcurrentHashMap<>();
+
+  void rememberInbound(String chatId, long nowMs) {
+    if (chatId == null || chatId.isBlank()) {
+      return;
+    }
+    byChatId.put(chatId, new Session(nowMs + SESSION_WINDOW.toMillis(), 0));
+  }
+
+  Session requireForReply(String chatId, long nowMs) {
+    Session session = byChatId.get(chatId);
+    if (session == null) {
+      throw new IllegalStateException("小程序客服会话上下文缺失，需用户先发消息（chat=" + chatId + "）");
+    }
+    if (nowMs > session.expiresAtMs()) {
+      byChatId.remove(chatId, session);
+      throw new IllegalStateException("小程序客服 48 小时回复窗已关闭，需用户再发一条消息（chat=" + chatId + "）");
+    }
+    if (session.replyCount() >= MAX_REPLIES_PER_WINDOW) {
+      throw new IllegalStateException(
+          "小程序客服回复条数已达上限（" + MAX_REPLIES_PER_WINDOW + "），需用户再发一条消息（chat=" + chatId + "）");
+    }
+    return session;
+  }
+
+  void markReplied(String chatId, Session prior) {
+    byChatId.computeIfPresent(
+        chatId,
+        (k, cur) -> {
+          if (cur != prior && cur.expiresAtMs() != prior.expiresAtMs()) {
+            return cur;
+          }
+          return new Session(cur.expiresAtMs(), cur.replyCount() + 1);
+        });
+  }
+}

--- a/oryxos-channel-weixin-mini/src/test/java/io/oryxos/channel/weixinmini/WeixinMiniChannelAdapterTest.java
+++ b/oryxos-channel-weixin-mini/src/test/java/io/oryxos/channel/weixinmini/WeixinMiniChannelAdapterTest.java
@@ -1,0 +1,183 @@
+package io.oryxos.channel.weixinmini;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.oryxos.core.channel.ChannelConfig;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageService;
+import io.oryxos.core.channel.WebhookRequest;
+import io.oryxos.core.channel.WebhookResponse;
+import io.oryxos.core.profile.Profile;
+import io.oryxos.core.profile.ProfileRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WeixinMiniChannelAdapterTest {
+
+  private static final String TOKEN = "QDG6eK";
+  private static final String APP_ID = "wx5823bf96d3bd56c7";
+  private static final String AES_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+  private ProfileRegistry profiles;
+  private InboundMessageService inbound;
+  private FakeClient client;
+  private WeixinMiniMsgCrypt crypt;
+  private WeixinMiniChannelAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    profiles = mock(ProfileRegistry.class);
+    inbound = mock(InboundMessageService.class);
+    when(profiles.get("demo-agent")).thenReturn(Optional.of(mock(Profile.class)));
+    client = new FakeClient();
+    crypt = new WeixinMiniMsgCrypt(TOKEN, AES_KEY, APP_ID);
+    ChannelConfig config =
+        new ChannelConfig(
+            "ops-mini",
+            "weixin_mini",
+            APP_ID,
+            "secret",
+            "demo-agent",
+            true,
+            Map.of(
+                "token", TOKEN,
+                "encoding_aes_key", AES_KEY));
+    adapter =
+        new WeixinMiniChannelAdapter(
+            config,
+            profiles,
+            inbound,
+            url -> {},
+            Clock.fixed(Instant.parse("2026-09-11T00:00:00Z"), ZoneOffset.UTC),
+            client,
+            crypt);
+    adapter.start();
+  }
+
+  @Test
+  @DisplayName("GET URL 明文验签原样回 echostr")
+  void urlVerify() throws Exception {
+    String echoPlain = "hello_echo";
+    String ts = "1409659813";
+    String nonce = "1372623149";
+    String sig = crypt.plainSignature(ts, nonce);
+    WebhookResponse response =
+        adapter.onWebhook(
+            new WebhookRequest(
+                "GET",
+                Map.of(
+                    "signature", sig,
+                    "timestamp", ts,
+                    "nonce", nonce,
+                    "echostr", echoPlain),
+                Map.of(),
+                ""));
+    assertEquals(200, response.status());
+    assertEquals(echoPlain, response.body());
+  }
+
+  @Test
+  @DisplayName("POST 加密文本 → success + onClaimedMessage")
+  void callbackText() throws Exception {
+    String textXml =
+        "<xml>"
+            + "<ToUserName><![CDATA[gh_xxx]]></ToUserName>"
+            + "<FromUserName><![CDATA[OPENID1]]></FromUserName>"
+            + "<CreateTime>1348831860</CreateTime>"
+            + "<MsgType><![CDATA[text]]></MsgType>"
+            + "<Content><![CDATA[你好小程序]]></Content>"
+            + "<MsgId>1234567890123456</MsgId>"
+            + "</xml>";
+    String cipher = crypt.encrypt(textXml);
+    String ts = "1409659813";
+    String nonce = "1372623149";
+    String sig = crypt.signature(ts, nonce, cipher);
+    String body = "<xml><Encrypt><![CDATA[" + cipher + "]]></Encrypt></xml>";
+    when(inbound.tryClaim(any(), any())).thenReturn(true);
+    WebhookResponse response =
+        adapter.onWebhook(
+            new WebhookRequest(
+                "POST",
+                Map.of(
+                    "msg_signature", sig,
+                    "timestamp", ts,
+                    "nonce", nonce),
+                Map.of(),
+                body));
+    assertEquals(200, response.status());
+    assertEquals("success", response.body());
+    verify(inbound).onClaimedMessage(any(InboundMessage.class), any());
+  }
+
+  @Test
+  @DisplayName("POST 事件消息忽略但仍 success")
+  void callbackEventIgnored() throws Exception {
+    String eventXml =
+        "<xml>"
+            + "<ToUserName><![CDATA["
+            + APP_ID
+            + "]]></ToUserName>"
+            + "<FromUserName><![CDATA[OPENID2]]></FromUserName>"
+            + "<CreateTime>1348831860</CreateTime>"
+            + "<MsgType><![CDATA[event]]></MsgType>"
+            + "<Event><![CDATA[user_enter_tempsession]]></Event>"
+            + "</xml>";
+    String cipher = crypt.encrypt(eventXml);
+    String ts = "1409659813";
+    String nonce = "1372623149";
+    String sig = crypt.signature(ts, nonce, cipher);
+    String body = "<xml><Encrypt><![CDATA[" + cipher + "]]></Encrypt></xml>";
+    WebhookResponse response =
+        adapter.onWebhook(
+            new WebhookRequest(
+                "POST",
+                Map.of(
+                    "msg_signature", sig,
+                    "timestamp", ts,
+                    "nonce", nonce),
+                Map.of(),
+                body));
+    assertEquals(200, response.status());
+    assertEquals("success", response.body());
+  }
+
+  @Test
+  @DisplayName("无会话 sendReply 硬拒绝")
+  void sendWithoutSession() {
+    IllegalStateException e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> adapter.sendReply("mini:" + APP_ID + ":user:OPENID1", "hi", null));
+    assertTrue(e.getMessage().contains("会话"));
+  }
+
+  @Test
+  @DisplayName("窗内可回复并计数")
+  void sendWithinWindow() throws Exception {
+    callbackText();
+    adapter.sendReply("mini:" + APP_ID + ":user:OPENID1", "回复", null);
+    assertEquals(1, client.sendCalls.get());
+  }
+
+  private static final class FakeClient implements WeixinMiniClient {
+    final AtomicInteger sendCalls = new AtomicInteger();
+
+    @Override
+    public void sendText(String openId, String text) {
+      sendCalls.incrementAndGet();
+    }
+  }
+}

--- a/oryxos-channel-weixin-mini/src/test/java/io/oryxos/channel/weixinmini/WeixinMiniChannelContractTest.java
+++ b/oryxos-channel-weixin-mini/src/test/java/io/oryxos/channel/weixinmini/WeixinMiniChannelContractTest.java
@@ -1,0 +1,79 @@
+package io.oryxos.channel.weixinmini;
+
+import io.oryxos.core.channel.ChatKind;
+import io.oryxos.core.channel.InboundMessage;
+import io.oryxos.core.channel.InboundMessageServiceContractTestBase;
+import java.util.List;
+
+class WeixinMiniChannelContractTest extends InboundMessageServiceContractTestBase {
+
+  private static final String APP_ID = "wx5823bf96d3bd56c7";
+  private final WeixinMiniEventNormalizer normalizer =
+      new WeixinMiniEventNormalizer("contract-mini", APP_ID);
+
+  @Override
+  protected String channelType() {
+    return "weixin_mini";
+  }
+
+  @Override
+  protected InboundMessage p2pMessage(String messageId, String content) {
+    String xml =
+        "<xml>"
+            + "<FromUserName><![CDATA[OPENID1]]></FromUserName>"
+            + "<MsgType><![CDATA[text]]></MsgType>"
+            + "<Content><![CDATA["
+            + content
+            + "]]></Content>"
+            + "<MsgId>"
+            + messageId
+            + "</MsgId>"
+            + "</xml>";
+    return normalizer.normalize(xml).orElseThrow();
+  }
+
+  @Override
+  protected InboundMessage groupMessage(String messageId, String content) {
+    return new InboundMessage(
+        channelType(),
+        "contract-mini",
+        messageId,
+        ChatKind.GROUP,
+        "user-1",
+        "group:g1",
+        content,
+        true,
+        true,
+        List.of());
+  }
+
+  @Override
+  protected InboundMessage nonTextualMessage(String messageId) {
+    return new InboundMessage(
+        channelType(),
+        "contract-mini",
+        messageId,
+        ChatKind.P2P,
+        "OPENID1",
+        WeixinMiniChatTargets.chatId(APP_ID, "OPENID1"),
+        "",
+        false,
+        false,
+        List.of());
+  }
+
+  @Override
+  protected InboundMessage imageMessage(String messageId) {
+    return new InboundMessage(
+        channelType(),
+        "contract-mini",
+        messageId,
+        ChatKind.P2P,
+        "OPENID1",
+        WeixinMiniChatTargets.chatId(APP_ID, "OPENID1"),
+        "",
+        false,
+        false,
+        List.of(io.oryxos.core.channel.InboundAttachment.imageUrl("https://example.com/a.jpg")));
+  }
+}

--- a/oryxos-channel-weixin-mini/src/test/java/io/oryxos/channel/weixinmini/WeixinMiniEventNormalizerTest.java
+++ b/oryxos-channel-weixin-mini/src/test/java/io/oryxos/channel/weixinmini/WeixinMiniEventNormalizerTest.java
@@ -1,0 +1,85 @@
+package io.oryxos.channel.weixinmini;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.oryxos.core.channel.InboundMessage;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WeixinMiniEventNormalizerTest {
+
+  private static final String APP_ID = "wx5823bf96d3bd56c7";
+  private final WeixinMiniEventNormalizer normalizer =
+      new WeixinMiniEventNormalizer("ops-mini", APP_ID);
+
+  @Test
+  @DisplayName("文本 XML → InboundMessage")
+  void textMessage() {
+    String xml =
+        "<xml>"
+            + "<ToUserName><![CDATA[gh_xxx]]></ToUserName>"
+            + "<FromUserName><![CDATA[OPENID1]]></FromUserName>"
+            + "<CreateTime>1348831860</CreateTime>"
+            + "<MsgType><![CDATA[text]]></MsgType>"
+            + "<Content><![CDATA[this is a test]]></Content>"
+            + "<MsgId>1234567890123456</MsgId>"
+            + "</xml>";
+    Optional<InboundMessage> msg = normalizer.normalize(xml);
+    assertTrue(msg.isPresent());
+    assertEquals("this is a test", msg.get().content());
+    assertTrue(msg.get().textual());
+    assertEquals("1234567890123456", msg.get().messageId());
+    assertEquals("mini:" + APP_ID + ":user:OPENID1", msg.get().chatId());
+    assertEquals("OPENID1", msg.get().userId());
+  }
+
+  @Test
+  @DisplayName("缺 MsgId 时用 FromUserName+CreateTime")
+  void fallbackMessageId() {
+    String xml =
+        "<xml>"
+            + "<FromUserName><![CDATA[OPENID2]]></FromUserName>"
+            + "<CreateTime>1348831860</CreateTime>"
+            + "<MsgType><![CDATA[text]]></MsgType>"
+            + "<Content><![CDATA[hi]]></Content>"
+            + "</xml>";
+    Optional<InboundMessage> msg = normalizer.normalize(xml);
+    assertTrue(msg.isPresent());
+    assertEquals("OPENID2:1348831860", msg.get().messageId());
+  }
+
+  @Test
+  @DisplayName("事件/非文本丢弃")
+  void ignoreNonText() {
+    String eventXml =
+        "<xml>"
+            + "<FromUserName><![CDATA[OPENID3]]></FromUserName>"
+            + "<MsgType><![CDATA[event]]></MsgType>"
+            + "<Event><![CDATA[user_enter_tempsession]]></Event>"
+            + "</xml>";
+    assertTrue(normalizer.normalize(eventXml).isEmpty());
+
+    String imageXml =
+        "<xml>"
+            + "<FromUserName><![CDATA[OPENID4]]></FromUserName>"
+            + "<MsgType><![CDATA[image]]></MsgType>"
+            + "<PicUrl><![CDATA[http://example.com/a.jpg]]></PicUrl>"
+            + "</xml>";
+    assertTrue(normalizer.normalize(imageXml).isEmpty());
+  }
+
+  @Test
+  @DisplayName("空内容丢弃")
+  void ignoreBlankContent() {
+    String xml =
+        "<xml>"
+            + "<FromUserName><![CDATA[OPENID5]]></FromUserName>"
+            + "<MsgType><![CDATA[text]]></MsgType>"
+            + "<Content><![CDATA[   ]]></Content>"
+            + "<MsgId>99</MsgId>"
+            + "</xml>";
+    assertTrue(normalizer.normalize(xml).isEmpty());
+  }
+}

--- a/oryxos-channel-weixin-mini/src/test/java/io/oryxos/channel/weixinmini/WeixinMiniMsgCryptTest.java
+++ b/oryxos-channel-weixin-mini/src/test/java/io/oryxos/channel/weixinmini/WeixinMiniMsgCryptTest.java
@@ -1,0 +1,80 @@
+package io.oryxos.channel.weixinmini;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WeixinMiniMsgCryptTest {
+
+  private static final String TOKEN = "QDG6eK";
+  private static final String APP_ID = "wx5823bf96d3bd56c7";
+  private static final String AES_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+  @Test
+  @DisplayName("GET 明文验签 + 原样 echostr")
+  void plainUrlVerify() throws Exception {
+    WeixinMiniMsgCrypt crypt = new WeixinMiniMsgCrypt(TOKEN, AES_KEY, APP_ID);
+    String ts = "1409659813";
+    String nonce = "1372623149";
+    String echostr = "hello_echo_plain";
+    String sig = crypt.plainSignature(ts, nonce);
+    String returned = crypt.verifyUrlPlain(sig, ts, nonce, echostr);
+    assertEquals(echostr, returned);
+  }
+
+  @Test
+  @DisplayName("GET 明文验签错误拒绝")
+  void plainUrlVerifyBadSig() throws Exception {
+    WeixinMiniMsgCrypt crypt = new WeixinMiniMsgCrypt(TOKEN, AES_KEY, APP_ID);
+    assertThrows(
+        IllegalStateException.class,
+        () -> crypt.verifyUrlPlain("deadbeef", "1409659813", "1372623149", "hello"));
+  }
+
+  @Test
+  @DisplayName("encrypt/decrypt 回环 + msg_signature")
+  void roundTrip() throws Exception {
+    WeixinMiniMsgCrypt crypt = new WeixinMiniMsgCrypt(TOKEN, AES_KEY, APP_ID);
+    String xml =
+        "<xml><ToUserName><![CDATA["
+            + APP_ID
+            + "]]></ToUserName><MsgType><![CDATA[text]]></MsgType>"
+            + "<FromUserName><![CDATA[OPENID]]></FromUserName>"
+            + "<Content><![CDATA[hello]]></Content></xml>";
+    String cipher = crypt.encrypt(xml);
+    String ts = "1409659813";
+    String nonce = "1372623149";
+    String sig = crypt.signature(ts, nonce, cipher);
+    String plain = crypt.decryptMsg(sig, ts, nonce, cipher);
+    assertTrue(plain.contains("text"));
+    assertTrue(plain.contains("OPENID"));
+    assertEquals(xml, plain);
+  }
+
+  @Test
+  @DisplayName("长明文（PKCS7 填充>16）仍能回环")
+  void longPlaintextRoundTrip() throws Exception {
+    WeixinMiniMsgCrypt crypt = new WeixinMiniMsgCrypt(TOKEN, AES_KEY, APP_ID);
+    StringBuilder sb =
+        new StringBuilder("<xml><MsgType><![CDATA[text]]></MsgType><Content><![CDATA[");
+    for (int i = 0; i < 200; i++) {
+      sb.append('A');
+    }
+    sb.append("]]></Content><FromUserName><![CDATA[OPENID]]></FromUserName></xml>");
+    String xml = sb.toString();
+    String cipher = crypt.encrypt(xml);
+    String plain = crypt.decryptMsg(crypt.signature("1", "2", cipher), "1", "2", cipher);
+    assertEquals(xml, plain);
+  }
+
+  @Test
+  @DisplayName("msg_signature 错误拒绝")
+  void badSignature() throws Exception {
+    WeixinMiniMsgCrypt crypt = new WeixinMiniMsgCrypt(TOKEN, AES_KEY, APP_ID);
+    String cipher = crypt.encrypt("<xml>hi</xml>");
+    assertThrows(IllegalStateException.class, () -> crypt.decryptMsg("deadbeef", "1", "2", cipher));
+  }
+}

--- a/oryxos-channel-weixin-mini/src/test/java/io/oryxos/channel/weixinmini/WeixinMiniReplySessionStoreTest.java
+++ b/oryxos-channel-weixin-mini/src/test/java/io/oryxos/channel/weixinmini/WeixinMiniReplySessionStoreTest.java
@@ -1,0 +1,38 @@
+package io.oryxos.channel.weixinmini;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WeixinMiniReplySessionStoreTest {
+
+  @Test
+  @DisplayName("窗外与超 5 条硬拒绝")
+  void windowAndCap() {
+    WeixinMiniReplySessionStore store = new WeixinMiniReplySessionStore();
+    String chat = "mini:wxapp:user:u1";
+    long t0 = 1_000_000L;
+    store.rememberInbound(chat, t0);
+    WeixinMiniReplySessionStore.Session s = store.requireForReply(chat, t0 + 1000);
+    for (int i = 0; i < 5; i++) {
+      store.markReplied(chat, store.requireForReply(chat, t0 + 1000 + i));
+    }
+    IllegalStateException over =
+        assertThrows(IllegalStateException.class, () -> store.requireForReply(chat, t0 + 2000));
+    assertTrue(over.getMessage().contains("上限"));
+
+    store.rememberInbound(chat, t0);
+    IllegalStateException expired =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                store.requireForReply(
+                    chat, t0 + WeixinMiniReplySessionStore.SESSION_WINDOW.toMillis() + 1));
+    assertTrue(expired.getMessage().contains("48"));
+    assertEquals(5, WeixinMiniReplySessionStore.MAX_REPLIES_PER_WINDOW);
+    assertEquals(s.replyCount(), 0);
+  }
+}

--- a/oryxos-cli/pom.xml
+++ b/oryxos-cli/pom.xml
@@ -94,6 +94,10 @@
         </dependency>
         <dependency>
             <groupId>io.oryxos</groupId>
+            <artifactId>oryxos-channel-weixin-mini</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.oryxos</groupId>
             <artifactId>oryxos-provider</artifactId>
         </dependency>
         <dependency>

--- a/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
+++ b/oryxos-cli/src/main/java/io/oryxos/cli/OryxOsRuntime.java
@@ -1172,6 +1172,11 @@ public class OryxOsRuntime {
         resolved ->
             new io.oryxos.channel.weixinmp.WeixinMpChannelAdapter(
                 resolved, profileRegistry, inboundMessageService, channelOutboundGuard));
+    factories.put(
+        io.oryxos.channel.weixinmini.WeixinMiniChannelAdapter.TYPE,
+        resolved ->
+            new io.oryxos.channel.weixinmini.WeixinMiniChannelAdapter(
+                resolved, profileRegistry, inboundMessageService, channelOutboundGuard));
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <module>oryxos-channel-weixin</module>
         <module>oryxos-channel-weixin-kf</module>
         <module>oryxos-channel-weixin-mp</module>
+        <module>oryxos-channel-weixin-mini</module>
         <module>oryxos-web</module>
         <module>oryxos-storage</module>
         <module>oryxos-cli</module>
@@ -217,6 +218,11 @@
             <dependency>
                 <groupId>io.oryxos</groupId>
                 <artifactId>oryxos-channel-weixin-mp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.oryxos</groupId>
+                <artifactId>oryxos-channel-weixin-mini</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/specs/030-cn-c-im-roadmap/plan.md
+++ b/specs/030-cn-c-im-roadmap/plan.md
@@ -115,7 +115,7 @@ OryxOS 已覆盖的与本表边界：
 |----|--------|--------------------------|--------|------|
 | W1 | **微信客服**（`kf.weixin.qq.com` / 企微 `kf/*`） | 用户在**微信**里咨询企业；企业用 API 收发 | ✅ | 与现有 `wecom` 应用会话**不是同一产品**。已合入：文本 MVP + 多模态媒体（#440/#442/#443）→ [033](../033-weixin-kf-channel/acceptance.md) |
 | W2 | 服务号客服消息 | 用户互动后 48h `message/custom/send`（用户消息触发：5 条/48h） | ✅ | 已合入：[036](../036-weixin-mp-channel/acceptance.md)（#446） |
-| W3 | 小程序客服消息 | 消息推送 URL + `message/custom/send`（用户发消息：5 条/48h） | ✅ Ready | Research + PLAN：[037](../037-weixin-mini-channel/research.md)；**BUILD 待确认**；勿与 `weixin_mp` 混 type |
+| W3 | 小程序客服消息 | 消息推送 URL + `message/custom/send`（用户发消息：5 条/48h） | ✅ | BUILD 已开工：[037](../037-weixin-mini-channel/acceptance.md)（`weixin_mini`）；勿与 `weixin_mp` 混 type |
 | W4 | 微信小店自研客服 | 回调 + `commkf/sendmsg`；48h/5 条 | 🔶 | **仅商家自研**，第三方 ISV 受限 → OS 多租户要慎 |
 
 **个人微信 / 个微协议**：❌ Won’t（逆向/协议号）。  
@@ -157,7 +157,7 @@ OryxOS 已覆盖的与本表边界：
 | P1 | **W1 微信客服** | ✅ [033](../033-weixin-kf-channel/acceptance.md) 已合入（含媒体 follow-up） |
 | P1 | **E1 淘宝/天猫** | 🔶 [034 research](../034-taobao-im-channel/research.md) **路径已钉死**；BUILD 等 `cloudAppId`/入驻 |
 | P2 | W2 服务号客服 | ✅ [036](../036-weixin-mp-channel/acceptance.md) 已合入 |
-| P2 | W3 小程序客服 | ✅ research + PLAN：[037](../037-weixin-mini-channel/plan.md) — BUILD 另确认 |
+| P2 | W3 小程序客服 | ✅ BUILD 已开工：[037](../037-weixin-mini-channel/acceptance.md)（`oryxos-channel-weixin-mini`） |
 | P2 | C2 支付宝 | 🔶/⏸ [032 research](../032-alipay-im-channel/research.md) 已收口；默认不 BUILD |
 | P3 | 拼多多 / 京东 / 快手 | 未开 |
 | P4 | 外卖订单 vs 客服 IM | 边界已写；不排渠道 BUILD |

--- a/specs/037-weixin-mini-channel/acceptance.md
+++ b/specs/037-weixin-mini-channel/acceptance.md
@@ -6,10 +6,10 @@
 
 - [x] 与 `weixin_mp` / `weixin_kf` 区分写清（含 GET 验签差异）  
 - [x] 入站推送 + `custom/send` + 48h/5 条钉死  
-- [ ] 产品确认可 BUILD  
+- [x] 产品确认可 BUILD  
 
 ## BUILD
 
-- [ ] 模块 + 单测  
-- [ ] Setup + Runtime type  
+- [x] 模块 + 单测  
+- [x] Setup + Runtime type  
 - [ ] 真机文本往返  

--- a/specs/037-weixin-mini-channel/plan.md
+++ b/specs/037-weixin-mini-channel/plan.md
@@ -2,7 +2,7 @@
 
 **Branch（BUILD 时）**: `feat/037-weixin-mini-channel`  
 **Date**: 2026-09-12  
-**Status**: RESEARCH/PLAN — **BUILD 待确认**  
+**Status**: BUILD 已开工（模块/单测/Setup/Runtime 已落；真机待验）  
 **对照**: [research](./research.md)、[030](../030-cn-c-im-roadmap/plan.md)、[036](../036-weixin-mp-channel/plan.md)、[017 契约](../017-feishu-im-channel/contracts/inbound-channel-contract.md)
 
 ## Summary
@@ -37,6 +37,6 @@
 
 ## 验收（BUILD 后）
 
-- [ ] 单测绿  
-- [ ] Setup 可跟做  
+- [x] 单测绿  
+- [x] Setup 可跟做  
 - [ ] 真机：小程序客服会话发文本 ↔ Agent 回复  


### PR DESCRIPTION
## Summary
- New `oryxos-channel-weixin-mini` (`type: weixin_mini`): 小程序消息推送 → 文本 → `success` → `message/custom/send`
- **GET verify** uses plain `signature` + raw `echostr` (unlike `weixin_mp` encrypted echostr)
- POST safe-mode XML + AES (PKCS7=32, receiveId=AppId); reply window **48h / 5** fail-loud
- Wire Runtime/POM + `WeixinMiniChannelSetup.md`; distinct from `weixin_mp` / `weixin_kf`

## Test plan
- [x] `mvn -pl oryxos-channel-weixin-mini spotless:apply test pmd:check spotbugs:check` (25 tests)
- [ ] CI green
- [ ] Live: 小程序客服会话文本往返（有小程序时）
